### PR TITLE
[Merged by Bors] - chore(ring_theory/local_properties): remove coercions from `ring_hom` to `monoid_hom`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -401,8 +401,8 @@ lemma algebra_map_of_subring_apply {R : Type*} [comm_ring R] (S : subring R) (x 
 /-- Explicit characterization of the submonoid map in the case of an algebra.
 `S` is made explicit to help with type inference -/
 def algebra_map_submonoid (S : Type*) [semiring S] [algebra R S]
-  (M : submonoid R) : (submonoid S) :=
-submonoid.map (algebra_map R S : R →* S) M
+  (M : submonoid R) : submonoid S :=
+M.map (algebra_map R S)
 
 lemma mem_algebra_map_submonoid_of_mem {S : Type*} [semiring S] [algebra R S] {M : submonoid R}
   (x : M) : (algebra_map R S x) ∈ algebra_map_submonoid S M :=

--- a/src/number_theory/bernoulli_polynomials.lean
+++ b/src/number_theory/bernoulli_polynomials.lean
@@ -216,7 +216,7 @@ begin
   set u : units ℚ := ⟨(n+1)!, (n+1)!⁻¹,
     mul_inv_cancel (by exact_mod_cast factorial_ne_zero (n+1)),
       inv_mul_cancel (by exact_mod_cast factorial_ne_zero (n+1))⟩ with hu,
-  rw ←units.mul_right_inj (units.map (algebra_map ℚ A).to_monoid_hom u),
+  rw ←units.mul_right_inj (units.map (algebra_map ℚ A) u),
   -- now tidy up unit mess and generally do trivial rearrangements
   -- to make RHS (n+1)*t^n
   rw [units.coe_map, mul_left_comm, ring_hom.to_monoid_hom_eq_coe,

--- a/src/number_theory/bernoulli_polynomials.lean
+++ b/src/number_theory/bernoulli_polynomials.lean
@@ -213,14 +213,10 @@ begin
   simp only [ring_hom.map_sub, tsub_self, constant_coeff_one, constant_coeff_exp,
     coeff_zero_eq_constant_coeff, mul_zero, sub_self, add_zero],
   -- Let's multiply both sides by (n+1)! (OK because it's a unit)
-  set u : units ℚ := ⟨(n+1)!, (n+1)!⁻¹,
-    mul_inv_cancel (by exact_mod_cast factorial_ne_zero (n+1)),
-      inv_mul_cancel (by exact_mod_cast factorial_ne_zero (n+1))⟩ with hu,
-  rw ←units.mul_right_inj (units.map (algebra_map ℚ A) u),
-  -- now tidy up unit mess and generally do trivial rearrangements
-  -- to make RHS (n+1)*t^n
-  rw [units.coe_map, mul_left_comm, ring_hom.to_monoid_hom_eq_coe,
-      ring_hom.coe_monoid_hom, ←ring_hom.map_mul, hu, units.coe_mk],
+  have hnp1 : is_unit ((n+1)! : ℚ) := is_unit.mk0 _ (by exact_mod_cast factorial_ne_zero (n+1)),
+  rw ←(hnp1.map (algebra_map ℚ A)).mul_right_inj,
+  -- do trivial rearrangements to make RHS (n+1)*t^n
+  rw [mul_left_comm, ←ring_hom.map_mul],
   change _ = t^n * algebra_map ℚ A (((n+1)*n! : ℕ)*(1/n!)),
   rw [cast_mul, mul_assoc, mul_one_div_cancel
     (show (n! : ℚ) ≠ 0, from cast_ne_zero.2 (factorial_ne_zero n)), mul_one, mul_comm (t^n),
@@ -235,7 +231,7 @@ begin
   -- deal with coefficients of e^X-1
   simp only [nat.cast_choose ℚ (mem_range_le hi), coeff_mk,
     if_neg (mem_range_sub_ne_zero hi), one_div, alg_hom.map_smul, power_series.coeff_one,
-    units.coe_mk, coeff_exp, sub_zero, linear_map.map_sub, algebra.smul_mul_assoc, algebra.smul_def,
+    coeff_exp, sub_zero, linear_map.map_sub, algebra.smul_mul_assoc, algebra.smul_def,
     mul_right_comm _ ((aeval t) _), ←mul_assoc, ← ring_hom.map_mul, succ_eq_add_one,
     ← polynomial.C_eq_algebra_map, polynomial.aeval_mul, polynomial.aeval_C],
   -- finally cancel the Bernoulli polynomial and the algebra_map

--- a/src/ring_theory/local_properties.lean
+++ b/src/ring_theory/local_properties.lean
@@ -403,16 +403,16 @@ span of `finset_integer_multiple _ s` over `R`.
 -/
 lemma is_localization.smul_mem_finset_integer_multiple_span [algebra R S]
   [algebra R S'] [is_scalar_tower R S S']
-  [is_localization (M.map (algebra_map R S : R →* S)) S'] (x : S)
+  [is_localization (M.map (algebra_map R S)) S'] (x : S)
   (s : finset S') (hx : algebra_map S S' x ∈ submodule.span R (s : set S')) :
     ∃ m : M, m • x ∈ submodule.span R
-      (is_localization.finset_integer_multiple (M.map (algebra_map R S : R →* S)) s : set S) :=
+      (is_localization.finset_integer_multiple (M.map (algebra_map R S)) s : set S) :=
 begin
   let g : S →ₐ[R] S' := alg_hom.mk' (algebra_map S S')
     (λ c x, by simp [algebra.algebra_map_eq_smul_one]),
 
   -- We first obtain the `y' ∈ M` such that `s' = y' • s` is falls in the image of `S` in `S'`.
-  let y := is_localization.common_denom_of_finset (M.map (algebra_map R S : R →* S)) s,
+  let y := is_localization.common_denom_of_finset (M.map (algebra_map R S)) s,
   have hx₁ : (y : S) • ↑s = g '' _ := (is_localization.finset_integer_multiple_image _ s).symm,
   obtain ⟨y', hy', e : algebra_map R S y' = y⟩ := y.prop,
   have : algebra_map R S y' • (s : set S') = y' • s :=
@@ -428,10 +428,10 @@ begin
   -- Thus `a • (y' • x) = a • x' ∈ span s'` in `S` for some `a ∈ M`.
   obtain ⟨x', hx', hx'' : algebra_map _ _ _ = _⟩ := hx,
   obtain ⟨⟨_, a, ha₁, rfl⟩, ha₂⟩ := (is_localization.eq_iff_exists
-    (M.map (algebra_map R S : R →* S)) S').mp hx'',
+    (M.map (algebra_map R S)) S').mp hx'',
   use (⟨a, ha₁⟩ : M) * (⟨y', hy'⟩ : M),
   convert (submodule.span R (is_localization.finset_integer_multiple
-    (submonoid.map (algebra_map R S : R →* S) M) s : set S)).smul_mem a hx' using 1,
+    (submonoid.map (algebra_map R S) M) s : set S)).smul_mem a hx' using 1,
   convert ha₂.symm,
   { rw [mul_comm (y' • x), subtype.coe_mk, submonoid.smul_def, submonoid.coe_mul, ← smul_smul],
     exact algebra.smul_def _ _ },
@@ -488,7 +488,7 @@ begin
   resetI,
   letI := f.to_algebra,
   letI := λ (r : s), (localization.away_map f r).to_algebra,
-  haveI : ∀ r : s, is_localization ((submonoid.powers (r : R)).map (algebra_map R S : R →* S))
+  haveI : ∀ r : s, is_localization ((submonoid.powers (r : R)).map (algebra_map R S))
     (localization.away (f r)),
   { intro r, rw submonoid.map_powers, exact localization.is_localization },
   haveI : ∀ r : s, is_scalar_tower R (localization.away (r : R)) (localization.away (f r)) :=
@@ -519,12 +519,9 @@ begin
   obtain ⟨⟨_, n₂, rfl⟩, hn₂⟩ := is_localization.smul_mem_finset_integer_multiple_span
     (submonoid.powers (r : R)) (localization.away (f r)) _ (s₁ r) hn₁,
   rw [submonoid.smul_def, ← algebra.smul_def, smul_smul, subtype.coe_mk, ← pow_add] at hn₂,
+  simp_rw submonoid.map_powers at hn₂,
   use n₂ + n₁,
-  refine le_supr (λ (x : s), submodule.span R (sf x : set S)) r _,
-  change _ ∈ submodule.span R
-    ((is_localization.finset_integer_multiple _ (s₁ r) : finset S) : set S),
-  convert hn₂,
-  rw submonoid.map_powers, refl,
+  exact le_supr (λ (x : s), submodule.span R (sf x : set S)) r hn₂,
 end
 
 end finite
@@ -609,13 +606,13 @@ adjoin of `finset_integer_multiple _ s` over `R`.
 -/
 lemma is_localization.lift_mem_adjoin_finset_integer_multiple [algebra R S]
   [algebra R S'] [is_scalar_tower R S S']
-  [is_localization (M.map (algebra_map R S : R →* S)) S'] (x : S)
+  [is_localization (M.map (algebra_map R S)) S'] (x : S)
   (s : finset S') (hx : algebra_map S S' x ∈ algebra.adjoin R (s : set S')) :
     ∃ m : M, m • x ∈ algebra.adjoin R
-      (is_localization.finset_integer_multiple (M.map (algebra_map R S : R →* S)) s : set S) :=
+      (is_localization.finset_integer_multiple (M.map (algebra_map R S)) s : set S) :=
 begin
   obtain ⟨⟨_, a, ha, rfl⟩, e⟩ := is_localization.exists_smul_mem_of_mem_adjoin
-    (M.map (algebra_map R S : R →* S)) x s (algebra.adjoin R _) algebra.subset_adjoin _ hx,
+    (M.map (algebra_map R S)) x s (algebra.adjoin R _) algebra.subset_adjoin _ hx,
   { exact ⟨⟨a, ha⟩, by simpa [submonoid.smul_def] using e⟩ },
 { rintros _ ⟨a, ha, rfl⟩, exact subalgebra.algebra_map_mem _ a }
 end
@@ -628,7 +625,7 @@ begin
   resetI,
   letI := f.to_algebra,
   letI := λ (r : s), (localization.away_map f r).to_algebra,
-  haveI : ∀ r : s, is_localization ((submonoid.powers (r : R)).map (algebra_map R S : R →* S))
+  haveI : ∀ r : s, is_localization ((submonoid.powers (r : R)).map (algebra_map R S))
     (localization.away (f r)),
   { intro r, rw submonoid.map_powers, exact localization.is_localization },
   haveI : ∀ r : s, is_scalar_tower R (localization.away (r : R)) (localization.away (f r)) :=
@@ -653,13 +650,9 @@ begin
   obtain ⟨⟨_, n₂, rfl⟩, hn₂⟩ := is_localization.lift_mem_adjoin_finset_integer_multiple
     (submonoid.powers (r : R)) _ (s₁ r) hn₁,
   rw [submonoid.smul_def, ← algebra.smul_def, smul_smul, subtype.coe_mk, ← pow_add] at hn₂,
+  simp_rw submonoid.map_powers at hn₂,
   use n₂ + n₁,
-  refine le_supr (λ (x : s), algebra.adjoin R (sf x : set S)) r _,
-  change _ ∈ algebra.adjoin R
-    ((is_localization.finset_integer_multiple _ (s₁ r) : finset S) : set S),
-  convert hn₂,
-  rw submonoid.map_powers,
-  refl,
+  exact le_supr (λ (x : s), algebra.adjoin R (sf x : set S)) r hn₂
 end
 
 end finite_type

--- a/src/ring_theory/localization/basic.lean
+++ b/src/ring_theory/localization/basic.lean
@@ -710,7 +710,7 @@ variables (M S)
 include M
 
 lemma non_zero_divisors_le_comap [is_localization M S] :
-    non_zero_divisors R ≤ (non_zero_divisors S).comap (algebra_map R S)  :=
+  non_zero_divisors R ≤ (non_zero_divisors S).comap (algebra_map R S)  :=
 begin
   rintros a ha b (e : b * algebra_map R S a = 0),
   obtain ⟨x, s, rfl⟩ := mk'_surjective M b,
@@ -723,7 +723,7 @@ begin
 end
 
 lemma map_non_zero_divisors_le [is_localization M S] :
-    (non_zero_divisors R).map (algebra_map R S).to_monoid_hom ≤ non_zero_divisors S  :=
+  (non_zero_divisors R).map (algebra_map R S) ≤ non_zero_divisors S  :=
 submonoid.map_le_iff_le_comap.mpr (non_zero_divisors_le_comap M S)
 
 end is_localization

--- a/src/ring_theory/localization/inv_submonoid.lean
+++ b/src/ring_theory/localization/inv_submonoid.lean
@@ -38,17 +38,17 @@ section inv_submonoid
 variables (M S)
 
 /-- The submonoid of `S = M⁻¹R` consisting of `{ 1 / x | x ∈ M }`. -/
-def inv_submonoid : submonoid S := (M.map (algebra_map R S : R →* S)).left_inv
+def inv_submonoid : submonoid S := (M.map (algebra_map R S)).left_inv
 
 variable [is_localization M S]
 
-lemma submonoid_map_le_is_unit : M.map (algebra_map R S : R →* S) ≤ is_unit.submonoid S :=
+lemma submonoid_map_le_is_unit : M.map (algebra_map R S) ≤ is_unit.submonoid S :=
 by { rintros _ ⟨a, ha, rfl⟩, exact is_localization.map_units S ⟨_, ha⟩ }
 
 /-- There is an equivalence of monoids between the image of `M` and `inv_submonoid`. -/
 noncomputable
-abbreviation equiv_inv_submonoid : M.map (algebra_map R S : R →* S) ≃* inv_submonoid M S :=
-((M.map (algebra_map R S : R →* S)).left_inv_equiv (submonoid_map_le_is_unit M S)).symm
+abbreviation equiv_inv_submonoid : M.map (algebra_map R S) ≃* inv_submonoid M S :=
+((M.map (algebra_map R S)).left_inv_equiv (submonoid_map_le_is_unit M S)).symm
 
 /-- There is a canonical map from `M` to `inv_submonoid` sending `x` to `1 / x`. -/
 noncomputable

--- a/src/ring_theory/localization/localization_localization.lean
+++ b/src/ring_theory/localization/localization_localization.lean
@@ -203,7 +203,7 @@ localization_algebra_of_submonoid_le _ _ x.prime_compl (non_zero_divisors R)
 lemma is_localization_of_submonoid_le
   (M N : submonoid R) (h : M ≤ N) [is_localization M S] [is_localization N T]
   [algebra S T] [is_scalar_tower R S T] :
-  is_localization (N.map (algebra_map R S).to_monoid_hom) T :=
+  is_localization (N.map (algebra_map R S)) T :=
 { map_units := begin
     rintro ⟨_, ⟨y, hy, rfl⟩⟩,
     convert is_localization.map_units T ⟨y, hy⟩,


### PR DESCRIPTION
Now that `submonoid.map` takes `monoid_hom_class`, these aren't necessary. Also golfs a pair of proofs.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
