### PR TITLE
[Merged by Bors] - chore(number_theory/legendre_symbol/*): move zmod.{legendre|jacobi}_sym* to other namespaces

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -21,8 +21,8 @@
 7:
   title  : Law of Quadratic Reciprocity
   decls  :
-    - legendre_sym_quadratic_reciprocity
-    - jacobi_sym_quadratic_reciprocity
+    - legendre_sym.quadratic_reciprocity
+    - jacobi_sym.quadratic_reciprocity
   author : Chris Hughes (first) and Michael Stoll (second)
 8:
   title  : The Impossibility of Trisecting the Angle and Doubling the Cube

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -20,8 +20,10 @@
   title  : Godel’s Incompleteness Theorem
 7:
   title  : Law of Quadratic Reciprocity
-  decl   : zmod.quadratic_reciprocity
-  author : Chris Hughes
+  decls  :
+    - legendre_sym_quadratic_reciprocity
+    - jacobi_sym_quadratic_reciprocity
+  author : Chris Hughes (first) and Michael Stoll (second)
 8:
   title  : The Impossibility of Trisecting the Angle and Doubling the Cube
 9:

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -17,7 +17,7 @@
 5:
   title  : Prime Number Theorem
 6:
-  title  : Godel’s Incompleteness Theorem
+  title  : Gödel’s Incompleteness Theorem
 7:
   title  : Law of Quadratic Reciprocity
   decls  :

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -127,7 +127,7 @@ General algebra:
   Number theory:
     sum of two squares: 'nat.prime.sq_add_sq'
     sum of four squares: 'nat.sum_four_squares'
-    quadratic reciprocity: 'legendre_sym_quadratic_reciprocity'
+    quadratic reciprocity: 'legendre_sym.quadratic_reciprocity'
     "solutions to Pell's equation": 'pell.pell'
     "Matiyasevič's theorem": 'pell.matiyasevic'
     arithmetic functions: 'nat.arithmetic_function'

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -127,7 +127,7 @@ General algebra:
   Number theory:
     sum of two squares: 'nat.prime.sq_add_sq'
     sum of four squares: 'nat.sum_four_squares'
-    quadratic reciprocity: 'zmod.quadratic_reciprocity'
+    quadratic reciprocity: 'legendre_sym_quadratic_reciprocity'
     "solutions to Pell's equation": 'pell.pell'
     "Matiyasevič's theorem": 'pell.matiyasevic'
     arithmetic functions: 'nat.arithmetic_function'

--- a/src/number_theory/legendre_symbol/gauss_eisenstein_lemmas.lean
+++ b/src/number_theory/legendre_symbol/gauss_eisenstein_lemmas.lean
@@ -9,9 +9,8 @@ import number_theory.legendre_symbol.quadratic_reciprocity
 # Lemmas of Gauss and Eisenstein
 
 This file contains code for the proof of the Lemmas of Gauss and Eisenstein
-on the Legendre symbol. The main results are `gauss_lemma_aux` and
-`eisenstein_lemma_aux`; they are used in `quadratic_reciprocity.lean`
-to prove `gauss_lemma` and `eisenstein_lemma`, respectively.
+on the Legendre symbol. The main results are `zmod.gauss_lemma_aux` and
+`zmod.eisenstein_lemma_aux`.
 -/
 
 open function finset nat finite_field zmod
@@ -65,7 +64,7 @@ end zmod
 
 section gauss_eisenstein
 
-namespace legendre_symbol
+namespace zmod
 
 /-- The image of the map sending a non zero natural number `x ≤ p / 2` to the absolute value
   of the element of interger in the interval `(-p/2, p/2]` congruent to `a * x` mod p is the set
@@ -161,7 +160,7 @@ begin
   haveI hp' : fact (p % 2 = 1) := ⟨nat.prime.mod_two_eq_one_iff_ne_two.mpr hp⟩,
   have : (legendre_sym p a : zmod p) = (((-1)^((Ico 1 (p / 2).succ).filter
     (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card : ℤ) : zmod p) :=
-    by { rw [legendre_sym_eq_pow, legendre_symbol.gauss_lemma_aux p ha0]; simp },
+    by { rw [legendre_sym_eq_pow, gauss_lemma_aux p ha0]; simp },
   cases legendre_sym_eq_one_or_neg_one p ha0;
   cases neg_one_pow_eq_or ℤ ((Ico 1 (p / 2).succ).filter
     (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card;
@@ -299,9 +298,9 @@ begin
   have ha0' : ((a : ℤ) : zmod p) ≠ 0 := by { norm_cast, exact ha0 },
   rw [neg_one_pow_eq_pow_mod_two, gauss_lemma hp ha0', neg_one_pow_eq_pow_mod_two,
       (by norm_cast : ((a : ℤ) : zmod p) = (a : zmod p)),
-      show _ = _, from legendre_symbol.eisenstein_lemma_aux p ha1 ha0]
+      show _ = _, from eisenstein_lemma_aux p ha1 ha0]
 end
 
-end legendre_symbol
+end zmod
 
 end gauss_eisenstein

--- a/src/number_theory/legendre_symbol/gauss_eisenstein_lemmas.lean
+++ b/src/number_theory/legendre_symbol/gauss_eisenstein_lemmas.lean
@@ -159,8 +159,8 @@ begin
   haveI hp' : fact (p % 2 = 1) := ⟨nat.prime.mod_two_eq_one_iff_ne_two.mpr hp⟩,
   have : (legendre_sym p a : zmod p) = (((-1)^((Ico 1 (p / 2).succ).filter
     (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card : ℤ) : zmod p) :=
-    by { rw [legendre_sym_eq_pow, gauss_lemma_aux p ha0]; simp },
-  cases legendre_sym_eq_one_or_neg_one p ha0;
+    by { rw [legendre_sym.eq_pow, gauss_lemma_aux p ha0]; simp },
+  cases legendre_sym.eq_one_or_neg_one p ha0;
   cases neg_one_pow_eq_or ℤ ((Ico 1 (p / 2).succ).filter
     (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card;
   simp [*, ne_neg_self p one_ne_zero, (ne_neg_self p one_ne_zero).symm] at *

--- a/src/number_theory/legendre_symbol/gauss_eisenstein_lemmas.lean
+++ b/src/number_theory/legendre_symbol/gauss_eisenstein_lemmas.lean
@@ -22,7 +22,6 @@ section wilson
 
 variables (p : ℕ) [fact p.prime]
 
--- One can probably deduce the following from `finite_field.prod_univ_units_id_eq_neg_one`
 /-- **Wilson's Lemma**: the product of `1`, ..., `p-1` is `-1` modulo `p`. -/
 @[simp] lemma wilsons_lemma : ((p - 1)! : zmod p) = -1 :=
 begin

--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -60,11 +60,11 @@ section jacobi
 /-!
 ### Definition of the Jacobi symbol
 
-We define the Jacobi symbol $\Bigl(\frac{a}{b}\Bigr)$ for integers `a` and natural numbers `b` as the
-product of the Legendre symbols $(\Bigl\frac{a}{p}\Bigr)$, where `p` runs through the prime divisors
-(with multiplicity) of `b`, as provided by `b.factors`. This agrees with the Jacobi symbol
-when `b` is odd and gives less meaningful values when it is not (e.g., the symbol is `1`
-when `b = 0`). This is called `jacobi_sym a b`.
+We define the Jacobi symbol $\Bigl(\frac{a}{b}\Bigr)$ for integers `a` and natural numbers `b`
+as the product of the Legendre symbols $(\Bigl\frac{a}{p}\Bigr)$, where `p` runs through the
+prime divisors (with multiplicity) of `b`, as provided by `b.factors`. This agrees with the
+Jacobi symbol when `b` is odd and gives less meaningful values when it is not (e.g., the symbol
+is `1` when `b = 0`). This is called `jacobi_sym a b`.
 
 We define localized notation (locale `number_theory_symbols`) `J(a | b)` for the Jacobi
 symbol `jacobi_sym a b`. (Unfortunately, there is no subscript "J" in unicode.)

--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -124,18 +124,19 @@ end
 
 /-- The symbol `J(1 | b)` has the value `1`. -/
 @[simp] lemma jacobi_sym_one_left (b : ℕ) : J(1 | b) = 1 :=
-list.prod_eq_one (λ z hz, let ⟨p, hp, he⟩ := list.mem_pmap.1 hz in by rw [← he, legendre_sym_one])
+list.prod_eq_one (λ z hz,
+                  let ⟨p, hp, he⟩ := list.mem_pmap.1 hz in by rw [← he, legendre_sym.at_one])
 
 /-- The Jacobi symbol is multiplicative in its first argument. -/
 lemma jacobi_sym_mul_left (a₁ a₂ : ℤ) (b : ℕ) : J(a₁ * a₂ | b) = J(a₁ | b) * J(a₂ | b) :=
-by { simp_rw [jacobi_sym, list.pmap_eq_map_attach, legendre_sym_mul], exact list.prod_map_mul }
+by { simp_rw [jacobi_sym, list.pmap_eq_map_attach, legendre_sym.mul], exact list.prod_map_mul }
 
 /-- The symbol `J(a | b)` vanishes iff `a` and `b` are not coprime (assuming `b ≠ 0`). -/
 lemma jacobi_sym_eq_zero_iff_not_coprime {a : ℤ} {b : ℕ} [ne_zero b] :
   J(a | b) = 0 ↔ a.gcd b ≠ 1 :=
 list.prod_eq_zero_iff.trans begin
   rw [list.mem_pmap, int.gcd_eq_nat_abs, ne, prime.not_coprime_iff_dvd],
-  simp_rw [legendre_sym_eq_zero_iff, int_coe_zmod_eq_zero_iff_dvd, mem_factors (ne_zero.ne b),
+  simp_rw [legendre_sym.eq_zero_iff, int_coe_zmod_eq_zero_iff_dvd, mem_factors (ne_zero.ne b),
     ← int.coe_nat_dvd_left, int.coe_nat_dvd, exists_prop, and_assoc, and_comm],
 end
 
@@ -193,8 +194,8 @@ by rw [jacobi_sym_pow_left, jacobi_sym_sq_one h]
 lemma jacobi_sym_mod_left (a : ℤ) (b : ℕ) : J(a | b) = J(a % b | b) :=
 congr_arg list.prod $ list.pmap_congr _ begin
   rintro p hp _ _,
-  conv_rhs { rw [legendre_sym_mod, int.mod_mod_of_dvd _
-    (int.coe_nat_dvd.2 $ dvd_of_mem_factors hp), ← legendre_sym_mod] },
+  conv_rhs { rw [legendre_sym.mod, int.mod_mod_of_dvd _
+    (int.coe_nat_dvd.2 $ dvd_of_mem_factors hp), ← legendre_sym.mod] },
 end
 
 /-- The symbol `J(a | b)` depends only on `a` mod `b`. -/
@@ -214,7 +215,7 @@ end
 /-- If `p` is prime, then `J(a | p)` is `-1` iff `a` is not a square modulo `p`. -/
 lemma zmod.nonsquare_iff_jacobi_sym_eq_neg_one {a : ℤ} {p : ℕ} [fact p.prime] :
   J(a | p) = -1 ↔ ¬ is_square (a : zmod p) :=
-by { rw [← legendre_sym.to_jacobi_sym], exact legendre_sym_eq_neg_one_iff p }
+by { rw [← legendre_sym.to_jacobi_sym], exact legendre_sym.eq_neg_one_iff p }
 
 /-- If `p` is prime and `J(a | p) = 1`, then `a` is q square mod `p`. -/
 lemma zmod.is_square_of_jacobi_sym_eq_one {a : ℤ} {p : ℕ} [fact p.prime] (h : J(a | p) = 1) :
@@ -240,7 +241,7 @@ end
 
 /-- If `b` is odd, then `J(-1 | b)` is given by `χ₄ b`. -/
 lemma jacobi_sym_neg_one {b : ℕ} (hb : odd b) : J(-1 | b) = χ₄ b :=
-jacobi_sym_value (-1) χ₄ (λ p pp, @legendre_sym_neg_one p ⟨pp⟩) hb
+jacobi_sym_value (-1) χ₄ (λ p pp, @legendre_sym.at_neg_one p ⟨pp⟩) hb
 
 /-- If `b` is odd, then `J(-a | b) = χ₄ b * J(a | b)`. -/
 lemma jacobi_sym_neg (a : ℤ) {b : ℕ} (hb : odd b) : J(-a | b) = χ₄ b * J(a | b) :=
@@ -248,11 +249,11 @@ by rw [neg_eq_neg_one_mul, jacobi_sym_mul_left, jacobi_sym_neg_one hb]
 
 /-- If `b` is odd, then `J(2 | b)` is given by `χ₈ b`. -/
 lemma jacobi_sym_two {b : ℕ} (hb : odd b) : J(2 | b) = χ₈ b :=
-jacobi_sym_value 2 χ₈ (λ p pp, @legendre_sym_two p ⟨pp⟩) hb
+jacobi_sym_value 2 χ₈ (λ p pp, @legendre_sym.at_two p ⟨pp⟩) hb
 
 /-- If `b` is odd, then `J(-2 | b)` is given by `χ₈' b`. -/
 lemma jacobi_sym_neg_two {b : ℕ} (hb : odd b) : J(-2 | b) = χ₈' b :=
-jacobi_sym_value (-2) χ₈' (λ p pp, @legendre_sym_neg_two p ⟨pp⟩) hb
+jacobi_sym_value (-2) χ₈' (λ p pp, @legendre_sym.at_neg_two p ⟨pp⟩) hb
 
 
 /-!
@@ -313,7 +314,7 @@ begin
   refine jacobi_sym_value p (rhs p) (λ q pq hq, _) ha,
   have hqo := pq.eq_two_or_odd'.resolve_left hq,
   rw [rhs_apply, nat.cast_id, ← @legendre_sym.to_jacobi_sym p ⟨pp⟩, qr_sign_symm hqo hpo,
-      qr_sign_neg_one_pow hpo hqo, @legendre_sym_quadratic_reciprocity' p q ⟨pp⟩ ⟨pq⟩ hp hq],
+      qr_sign_neg_one_pow hpo hqo, @legendre_sym.quadratic_reciprocity' p q ⟨pp⟩ ⟨pq⟩ hp hq],
 end
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol -/

--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -33,9 +33,9 @@ We prove the main properties of the Jacobi symbol, including the following.
   (`jacobi_sym.eq_zero_iff`)
 
 * If the symbol has the value `-1`, then `a : zmod b` is not a square
-  (`nonsquare_of_jacobi_sym_eq_neg_one`); the converse holds when `b = p` is a prime
-  (`nonsquare_iff_jacobi_sym_eq_neg_one`); in particular, in this case `a` is a
-  square mod `p` when the symbol has the value `1` (`is_square_of_jacobi_sym_eq_one`).
+  (`zmod.nonsquare_of_jacobi_sym_eq_neg_one`); the converse holds when `b = p` is a prime
+  (`zmod.nonsquare_iff_jacobi_sym_eq_neg_one`); in particular, in this case `a` is a
+  square mod `p` when the symbol has the value `1` (`zmod.is_square_of_jacobi_sym_eq_one`).
 
 * Quadratic reciprocity (`jacobi_sym.quadratic_reciprocity`,
   `jacobi_sym.quadratic_reciprocity_one_mod_four`,
@@ -95,7 +95,7 @@ by simp only [jacobi_sym, factors_one, list.prod_nil, list.pmap]
 
 /-- The Legendre symbol `legendre_sym p a` with an integer `a` and a prime number `p`
 is the same as the Jacobi symbol `J(a | p)`. -/
-lemma legendre_sym.to_jacobi_sym {p : ℕ} [fp : fact p.prime] {a : ℤ} :
+lemma _root_.legendre_sym.to_jacobi_sym {p : ℕ} [fp : fact p.prime] {a : ℤ} :
   legendre_sym p a = J(a | p) :=
 by simp only [jacobi_sym, factors_prime fp.1, list.prod_cons, list.prod_nil, mul_one, list.pmap]
 
@@ -133,8 +133,7 @@ lemma mul_left (a₁ a₂ : ℤ) (b : ℕ) : J(a₁ * a₂ | b) = J(a₁ | b) * 
 by { simp_rw [jacobi_sym, list.pmap_eq_map_attach, legendre_sym.mul], exact list.prod_map_mul }
 
 /-- The symbol `J(a | b)` vanishes iff `a` and `b` are not coprime (assuming `b ≠ 0`). -/
-lemma eq_zero_iff_not_coprime {a : ℤ} {b : ℕ} [ne_zero b] :
-  J(a | b) = 0 ↔ a.gcd b ≠ 1 :=
+lemma eq_zero_iff_not_coprime {a : ℤ} {b : ℕ} [ne_zero b] : J(a | b) = 0 ↔ a.gcd b ≠ 1 :=
 list.prod_eq_zero_iff.trans begin
   rw [list.mem_pmap, int.gcd_eq_nat_abs, ne, prime.not_coprime_iff_dvd],
   simp_rw [legendre_sym.eq_zero_iff, int_coe_zmod_eq_zero_iff_dvd, mem_factors (ne_zero.ne b),
@@ -165,8 +164,7 @@ lemma zero_left {b : ℕ} (hb : 1 < b) : J(0 | b) = 0 :=
   by { rw [int.gcd_zero_left, int.nat_abs_of_nat], exact hb.ne' }
 
 /-- The symbol `J(a | b)` takes the value `1` or `-1` if `a` and `b` are coprime. -/
-lemma eq_one_or_neg_one {a : ℤ} {b : ℕ} (h : a.gcd b = 1) :
-  J(a | b) = 1 ∨ J(a | b) = -1 :=
+lemma eq_one_or_neg_one {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a | b) = 1 ∨ J(a | b) = -1 :=
 (trichotomy a b).resolve_left $ jacobi_sym.ne_zero h
 
 /-- We have that `J(a^e | b) = J(a | b)^e`. -/
@@ -268,6 +266,7 @@ value_at 2 χ₈ (λ p pp, @legendre_sym.at_two p ⟨pp⟩) hb
 lemma at_neg_two {b : ℕ} (hb : odd b) : J(-2 | b) = χ₈' b :=
 value_at (-2) χ₈' (λ p pp, @legendre_sym.at_neg_two p ⟨pp⟩) hb
 
+end jacobi_sym
 
 /-!
 ### Quadratic Reciprocity
@@ -276,39 +275,45 @@ value_at (-2) χ₈' (λ p pp, @legendre_sym.at_neg_two p ⟨pp⟩) hb
 /-- The bi-multiplicative map giving the sign in the Law of Quadratic Reciprocity -/
 def qr_sign (m n : ℕ) : ℤ := J(χ₄ m | n)
 
+namespace qr_sign
+
 /-- We can express `qr_sign m n` as a power of `-1` when `m` and `n` are odd. -/
-lemma qr_sign.neg_one_pow {m n : ℕ} (hm : odd m) (hn : odd n) :
+lemma neg_one_pow {m n : ℕ} (hm : odd m) (hn : odd n) :
   qr_sign m n = (-1) ^ ((m / 2) * (n / 2)) :=
 begin
   rw [qr_sign, pow_mul, ← χ₄_eq_neg_one_pow (odd_iff.mp hm)],
   cases odd_mod_four_iff.mp (odd_iff.mp hm) with h h,
-  { rw [χ₄_nat_one_mod_four h, one_left, one_pow], },
-  { rw [χ₄_nat_three_mod_four h, ← χ₄_eq_neg_one_pow (odd_iff.mp hn), at_neg_one hn], }
+  { rw [χ₄_nat_one_mod_four h, jacobi_sym.one_left, one_pow], },
+  { rw [χ₄_nat_three_mod_four h, ← χ₄_eq_neg_one_pow (odd_iff.mp hn), jacobi_sym.at_neg_one hn], }
 end
 
 /-- When `m` and `n` are odd, then the square of `qr_sign m n` is `1`. -/
-lemma qr_sign.sq_eq_one {m n : ℕ} (hm : odd m) (hn : odd n) : (qr_sign m n) ^ 2 = 1 :=
-by rw [qr_sign.neg_one_pow hm hn, ← pow_mul, mul_comm, pow_mul, neg_one_sq, one_pow]
+lemma sq_eq_one {m n : ℕ} (hm : odd m) (hn : odd n) : (qr_sign m n) ^ 2 = 1 :=
+by rw [neg_one_pow hm hn, ← pow_mul, mul_comm, pow_mul, neg_one_sq, one_pow]
 
 /-- `qr_sign` is multiplicative in the first argument. -/
-lemma qr_sign.mul_left (m₁ m₂ n : ℕ) : qr_sign (m₁ * m₂) n = qr_sign m₁ n * qr_sign m₂ n :=
-by simp_rw [qr_sign, nat.cast_mul, map_mul, mul_left]
+lemma mul_left (m₁ m₂ n : ℕ) : qr_sign (m₁ * m₂) n = qr_sign m₁ n * qr_sign m₂ n :=
+by simp_rw [qr_sign, nat.cast_mul, map_mul, jacobi_sym.mul_left]
 
 /-- `qr_sign` is multiplicative in the second argument. -/
-lemma qr_sign.mul_right (m n₁ n₂ : ℕ) [ne_zero n₁] [ne_zero n₂] :
+lemma mul_right (m n₁ n₂ : ℕ) [ne_zero n₁] [ne_zero n₂] :
   qr_sign m (n₁ * n₂) = qr_sign m n₁ * qr_sign m n₂ :=
-mul_right (χ₄ m) n₁ n₂
+jacobi_sym.mul_right (χ₄ m) n₁ n₂
 
 /-- `qr_sign` is symmetric when both arguments are odd. -/
 protected
-lemma qr_sign.symm {m n : ℕ} (hm : odd m) (hn : odd n) : qr_sign m n = qr_sign n m :=
-by rw [qr_sign.neg_one_pow hm hn, qr_sign.neg_one_pow hn hm, mul_comm (m / 2)]
+lemma symm {m n : ℕ} (hm : odd m) (hn : odd n) : qr_sign m n = qr_sign n m :=
+by rw [neg_one_pow hm hn, neg_one_pow hn hm, mul_comm (m / 2)]
 
 /-- We can move `qr_sign m n` from one side of an equality to the other when `m` and `n` are odd. -/
-lemma qr_sign.eq_iff_eq {m n : ℕ} (hm : odd m) (hn : odd n) (x y : ℤ) :
+lemma eq_iff_eq {m n : ℕ} (hm : odd m) (hn : odd n) (x y : ℤ) :
   qr_sign m n * x = y ↔ x = qr_sign m n * y :=
 by refine ⟨λ h', let h := h'.symm in _, λ h, _⟩;
-   rw [h, ← mul_assoc, ← pow_two, qr_sign.sq_eq_one hm hn, one_mul]
+   rw [h, ← mul_assoc, ← pow_two, sq_eq_one hm hn, one_mul]
+
+end qr_sign
+
+namespace jacobi_sym
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol, version with `qr_sign` -/
 lemma quadratic_reciprocity' {a b : ℕ} (ha : odd a) (hb : odd b) :
@@ -351,8 +356,7 @@ theorem quadratic_reciprocity_one_mod_four' {a b : ℕ} (ha : odd a) (hb : b % 4
 
 /-- The Law of Quadratic Reciprocityfor the Jacobi symbol: if `a` and `b` are natural numbers
 both congruent to `3` mod `4`, then `J(a | b) = -J(b | a)`. -/
-theorem quadratic_reciprocity_three_mod_four
-  {a b : ℕ} (ha : a % 4 = 3) (hb : b % 4 = 3) :
+theorem quadratic_reciprocity_three_mod_four {a b : ℕ} (ha : a % 4 = 3) (hb : b % 4 = 3) :
   J(a | b) = - J(b | a) :=
 let nop := @neg_one_pow_div_two_of_three_mod_four in begin
   rw [quadratic_reciprocity, pow_mul, nop ha, nop hb, neg_one_mul];
@@ -368,15 +372,13 @@ begin
   rcases exists_eq_pow_mul_and_not_dvd ha₀ 2 (by norm_num) with ⟨e, a', ha₁', ha₂⟩,
   have ha₁ := odd_iff.mpr (two_dvd_ne_zero.mp ha₁'),
   nth_rewrite 1 [ha₂], nth_rewrite 0 [ha₂],
-  rw [nat.cast_mul, mul_left, mul_left,
-      quadratic_reciprocity' ha₁ hb, quadratic_reciprocity' ha₁ hb',
-      nat.cast_pow, pow_left, pow_left,
-      (show ((2 : ℕ) : ℤ) = 2, by refl), at_two hb, at_two hb'],
+  rw [nat.cast_mul, mul_left, mul_left, quadratic_reciprocity' ha₁ hb,
+      quadratic_reciprocity' ha₁ hb', nat.cast_pow, pow_left, pow_left,
+      nat.cast_two, at_two hb, at_two hb'],
   congr' 1, swap, congr' 1,
   { simp_rw [qr_sign],
     rw [χ₄_nat_mod_four, χ₄_nat_mod_four (b % (4 * a)), mod_mod_of_dvd b (dvd_mul_right 4 a) ] },
-  { rw [mod_left ↑(b % _), mod_left b, int.coe_nat_mod,
-        int.mod_mod_of_dvd b],
+  { rw [mod_left ↑(b % _), mod_left b, int.coe_nat_mod, int.mod_mod_of_dvd b],
     simp only [ha₂, nat.cast_mul, ← mul_assoc],
     exact dvd_mul_left a' _, },
   cases e, { refl },

--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -14,7 +14,7 @@ We define the Jacobi symbol and prove its main properties.
 ## Main definitions
 
 We define the Jacobi symbol, `jacobi_sym a b`, for integers `a` and natural numbers `b`
-as the product over the prime factors `p` of `b` of the Legendre symbols `zmod.legendre_sym p a`.
+as the product over the prime factors `p` of `b` of the Legendre symbols `legendre_sym p a`.
 This agrees with the mathematical definition when `b` is odd.
 
 The prime factors are obtained via `nat.factors`. Since `nat.factors 0 = []`,
@@ -83,13 +83,14 @@ localized "notation `J(` a ` | ` b `)` := jacobi_sym a b" in number_theory_symbo
 /-!
 ### Properties of the Jacobi symbol
 -/
+namespace jacobi_sym
 
 /-- The symbol `J(a | 0)` has the value `1`. -/
-@[simp] lemma jacobi_sym.zero_right (a : ℤ) : J(a | 0) = 1 :=
+@[simp] lemma zero_right (a : ℤ) : J(a | 0) = 1 :=
 by simp only [jacobi_sym, factors_zero, list.prod_nil, list.pmap]
 
 /-- The symbol `J(a | 1)` has the value `1`. -/
-@[simp] lemma jacobi_sym.one_right (a : ℤ) : J(a | 1) = 1 :=
+@[simp] lemma one_right (a : ℤ) : J(a | 1) = 1 :=
 by simp only [jacobi_sym, factors_one, list.prod_nil, list.pmap]
 
 /-- The Legendre symbol `legendre_sym p a` with an integer `a` and a prime number `p`
@@ -99,7 +100,7 @@ lemma legendre_sym.to_jacobi_sym {p : ℕ} [fp : fact p.prime] {a : ℤ} :
 by simp only [jacobi_sym, factors_prime fp.1, list.prod_cons, list.prod_nil, mul_one, list.pmap]
 
 /-- The Jacobi symbol is multiplicative in its second argument. -/
-lemma jacobi_sym.mul_right' (a : ℤ) {b₁ b₂ : ℕ} (hb₁ : b₁ ≠ 0) (hb₂ : b₂ ≠ 0) :
+lemma mul_right' (a : ℤ) {b₁ b₂ : ℕ} (hb₁ : b₁ ≠ 0) (hb₂ : b₂ ≠ 0) :
   J(a | b₁ * b₂) = J(a | b₁) * J(a | b₂) :=
 begin
   rw [jacobi_sym, ((perm_factors_mul hb₁ hb₂).pmap _).prod_eq, list.pmap_append, list.prod_append],
@@ -107,12 +108,12 @@ begin
 end
 
 /-- The Jacobi symbol is multiplicative in its second argument. -/
-lemma jacobi_sym.mul_right (a : ℤ) (b₁ b₂ : ℕ) [ne_zero b₁] [ne_zero b₂] :
+lemma mul_right (a : ℤ) (b₁ b₂ : ℕ) [ne_zero b₁] [ne_zero b₂] :
   J(a | b₁ * b₂) = J(a | b₁) * J(a | b₂) :=
-jacobi_sym.mul_right' a (ne_zero.ne b₁) (ne_zero.ne b₂)
+mul_right' a (ne_zero.ne b₁) (ne_zero.ne b₂)
 
 /-- The Jacobi symbol takes only the values `0`, `1` and `-1`. -/
-lemma jacobi_sym.trichotomy (a : ℤ) (b : ℕ) : J(a | b) = 0 ∨ J(a | b) = 1 ∨ J(a | b) = -1 :=
+lemma trichotomy (a : ℤ) (b : ℕ) : J(a | b) = 0 ∨ J(a | b) = 1 ∨ J(a | b) = -1 :=
 ((@sign_type.cast_hom ℤ _ _).to_monoid_hom.mrange.copy {0, 1, -1} $
   by {rw set.pair_comm, exact (sign_type.range_eq sign_type.cast_hom).symm}).list_prod_mem
 begin
@@ -123,16 +124,16 @@ begin
 end
 
 /-- The symbol `J(1 | b)` has the value `1`. -/
-@[simp] lemma jacobi_sym.one_left (b : ℕ) : J(1 | b) = 1 :=
+@[simp] lemma one_left (b : ℕ) : J(1 | b) = 1 :=
 list.prod_eq_one (λ z hz,
                   let ⟨p, hp, he⟩ := list.mem_pmap.1 hz in by rw [← he, legendre_sym.at_one])
 
 /-- The Jacobi symbol is multiplicative in its first argument. -/
-lemma jacobi_sym.mul_left (a₁ a₂ : ℤ) (b : ℕ) : J(a₁ * a₂ | b) = J(a₁ | b) * J(a₂ | b) :=
+lemma mul_left (a₁ a₂ : ℤ) (b : ℕ) : J(a₁ * a₂ | b) = J(a₁ | b) * J(a₂ | b) :=
 by { simp_rw [jacobi_sym, list.pmap_eq_map_attach, legendre_sym.mul], exact list.prod_map_mul }
 
 /-- The symbol `J(a | b)` vanishes iff `a` and `b` are not coprime (assuming `b ≠ 0`). -/
-lemma jacobi_sym.eq_zero_iff_not_coprime {a : ℤ} {b : ℕ} [ne_zero b] :
+lemma eq_zero_iff_not_coprime {a : ℤ} {b : ℕ} [ne_zero b] :
   J(a | b) = 0 ↔ a.gcd b ≠ 1 :=
 list.prod_eq_zero_iff.trans begin
   rw [list.mem_pmap, int.gcd_eq_nat_abs, ne, prime.not_coprime_iff_dvd],
@@ -142,57 +143,57 @@ end
 
 /-- The symbol `J(a | b)` is nonzero when `a` and `b` are coprime. -/
 protected
-lemma jacobi_sym.ne_zero {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a | b) ≠ 0 :=
+lemma ne_zero {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a | b) ≠ 0 :=
 begin
   casesI eq_zero_or_ne_zero b with hb,
-  { rw [hb, jacobi_sym.zero_right],
+  { rw [hb, zero_right],
     exact one_ne_zero },
-  { contrapose! h, exact jacobi_sym.eq_zero_iff_not_coprime.1 h },
+  { contrapose! h, exact eq_zero_iff_not_coprime.1 h },
 end
 
 /-- The symbol `J(a | b)` vanishes if and only if `b ≠ 0` and `a` and `b` are not coprime. -/
-lemma jacobi_sym.eq_zero_iff {a : ℤ} {b : ℕ} : J(a | b) = 0 ↔ b ≠ 0 ∧ a.gcd b ≠ 1 :=
+lemma eq_zero_iff {a : ℤ} {b : ℕ} : J(a | b) = 0 ↔ b ≠ 0 ∧ a.gcd b ≠ 1 :=
 ⟨λ h, begin
   casesI eq_or_ne b 0 with hb hb,
-  { rw [hb, jacobi_sym.zero_right] at h, cases h },
+  { rw [hb, zero_right] at h, cases h },
   exact ⟨hb, mt jacobi_sym.ne_zero $ not_not.2 h⟩,
-end, λ ⟨hb, h⟩, by { rw ← ne_zero_iff at hb, exactI jacobi_sym.eq_zero_iff_not_coprime.2 h }⟩
+end, λ ⟨hb, h⟩, by { rw ← ne_zero_iff at hb, exactI eq_zero_iff_not_coprime.2 h }⟩
 
 /-- The symbol `J(0 | b)` vanishes when `b > 1`. -/
-lemma jacobi_sym.zero_left {b : ℕ} (hb : 1 < b) : J(0 | b) = 0 :=
-(@jacobi_sym.eq_zero_iff_not_coprime 0 b ⟨ne_zero_of_lt hb⟩).mpr $
+lemma zero_left {b : ℕ} (hb : 1 < b) : J(0 | b) = 0 :=
+(@eq_zero_iff_not_coprime 0 b ⟨ne_zero_of_lt hb⟩).mpr $
   by { rw [int.gcd_zero_left, int.nat_abs_of_nat], exact hb.ne' }
 
 /-- The symbol `J(a | b)` takes the value `1` or `-1` if `a` and `b` are coprime. -/
-lemma jacobi_sym.eq_one_or_neg_one {a : ℤ} {b : ℕ} (h : a.gcd b = 1) :
+lemma eq_one_or_neg_one {a : ℤ} {b : ℕ} (h : a.gcd b = 1) :
   J(a | b) = 1 ∨ J(a | b) = -1 :=
-(jacobi_sym.trichotomy a b).resolve_left $ jacobi_sym.ne_zero h
+(trichotomy a b).resolve_left $ jacobi_sym.ne_zero h
 
 /-- We have that `J(a^e | b) = J(a | b)^e`. -/
-lemma jacobi_sym.pow_left (a : ℤ) (e b : ℕ) : J(a ^ e | b) = J(a | b) ^ e :=
-nat.rec_on e (by rw [pow_zero, pow_zero, jacobi_sym.one_left]) $
-  λ _ ih, by rw [pow_succ, pow_succ, jacobi_sym.mul_left, ih]
+lemma pow_left (a : ℤ) (e b : ℕ) : J(a ^ e | b) = J(a | b) ^ e :=
+nat.rec_on e (by rw [pow_zero, pow_zero, one_left]) $
+  λ _ ih, by rw [pow_succ, pow_succ, mul_left, ih]
 
 /-- We have that `J(a | b^e) = J(a | b)^e`. -/
-lemma jacobi_sym.pow_right (a : ℤ) (b e : ℕ) : J(a | b ^ e) = J(a | b) ^ e :=
+lemma pow_right (a : ℤ) (b e : ℕ) : J(a | b ^ e) = J(a | b) ^ e :=
 begin
   induction e with e ih,
-  { rw [pow_zero, pow_zero, jacobi_sym.one_right], },
+  { rw [pow_zero, pow_zero, one_right], },
   { casesI eq_zero_or_ne_zero b with hb,
-    { rw [hb, zero_pow (succ_pos e), jacobi_sym.zero_right, one_pow], },
-    { rw [pow_succ, pow_succ, jacobi_sym.mul_right, ih], } }
+    { rw [hb, zero_pow (succ_pos e), zero_right, one_pow], },
+    { rw [pow_succ, pow_succ, mul_right, ih], } }
 end
 
 /-- The square of `J(a | b)` is `1` when `a` and `b` are coprime. -/
-lemma jacobi_sym.sq_one {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a | b) ^ 2 = 1 :=
-by cases jacobi_sym.eq_one_or_neg_one h with h₁ h₁; rw h₁; refl
+lemma sq_one {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a | b) ^ 2 = 1 :=
+by cases eq_one_or_neg_one h with h₁ h₁; rw h₁; refl
 
 /-- The symbol `J(a^2 | b)` is `1` when `a` and `b` are coprime. -/
-lemma jacobi_sym.sq_one' {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a ^ 2 | b) = 1 :=
-by rw [jacobi_sym.pow_left, jacobi_sym.sq_one h]
+lemma sq_one' {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a ^ 2 | b) = 1 :=
+by rw [pow_left, sq_one h]
 
 /-- The symbol `J(a | b)` depends only on `a` mod `b`. -/
-lemma jacobi_sym.mod_left (a : ℤ) (b : ℕ) : J(a | b) = J(a % b | b) :=
+lemma mod_left (a : ℤ) (b : ℕ) : J(a | b) = J(a % b | b) :=
 congr_arg list.prod $ list.pmap_congr _ begin
   rintro p hp _ _,
   conv_rhs { rw [legendre_sym.mod, int.mod_mod_of_dvd _
@@ -200,37 +201,47 @@ congr_arg list.prod $ list.pmap_congr _ begin
 end
 
 /-- The symbol `J(a | b)` depends only on `a` mod `b`. -/
-lemma jacobi_sym.mod_left' {a₁ a₂ : ℤ} {b : ℕ} (h : a₁ % b = a₂ % b) : J(a₁ | b) = J(a₂ | b) :=
-by rw [jacobi_sym.mod_left, h, ← jacobi_sym.mod_left]
+lemma mod_left' {a₁ a₂ : ℤ} {b : ℕ} (h : a₁ % b = a₂ % b) : J(a₁ | b) = J(a₂ | b) :=
+by rw [mod_left, h, ← mod_left]
+
+end jacobi_sym
+
+namespace zmod
+
+open jacobi_sym
 
 /-- If `J(a | b)` is `-1`, then `a` is not a square modulo `b`. -/
-lemma zmod.nonsquare_of_jacobi_sym_eq_neg_one {a : ℤ} {b : ℕ} (h : J(a | b) = -1) :
+lemma nonsquare_of_jacobi_sym_eq_neg_one {a : ℤ} {b : ℕ} (h : J(a | b) = -1) :
   ¬ is_square (a : zmod b) :=
 λ ⟨r, ha⟩, begin
   rw [← r.coe_val_min_abs, ← int.cast_mul, int_coe_eq_int_coe_iff', ← sq] at ha,
   apply (by norm_num : ¬ (0 : ℤ) ≤ -1),
-  rw [← h, jacobi_sym.mod_left, ha, ← jacobi_sym.mod_left, jacobi_sym.pow_left],
+  rw [← h, mod_left, ha, ← mod_left, pow_left],
   apply sq_nonneg,
 end
 
 /-- If `p` is prime, then `J(a | p)` is `-1` iff `a` is not a square modulo `p`. -/
-lemma zmod.nonsquare_iff_jacobi_sym_eq_neg_one {a : ℤ} {p : ℕ} [fact p.prime] :
+lemma nonsquare_iff_jacobi_sym_eq_neg_one {a : ℤ} {p : ℕ} [fact p.prime] :
   J(a | p) = -1 ↔ ¬ is_square (a : zmod p) :=
 by { rw [← legendre_sym.to_jacobi_sym], exact legendre_sym.eq_neg_one_iff p }
 
 /-- If `p` is prime and `J(a | p) = 1`, then `a` is q square mod `p`. -/
-lemma zmod.is_square_of_jacobi_sym_eq_one {a : ℤ} {p : ℕ} [fact p.prime] (h : J(a | p) = 1) :
+lemma is_square_of_jacobi_sym_eq_one {a : ℤ} {p : ℕ} [fact p.prime] (h : J(a | p) = 1) :
   is_square (a : zmod p) :=
-not_not.mp $ mt zmod.nonsquare_iff_jacobi_sym_eq_neg_one.mpr $
+not_not.mp $ mt nonsquare_iff_jacobi_sym_eq_neg_one.mpr $
   λ hf, one_ne_zero $ neg_eq_self_iff.mp $ hf.symm.trans h
+
+end zmod
 
 /-!
 ### Values at `-1`, `2` and `-2`
 -/
 
+namespace jacobi_sym
+
 /-- If `χ` is a multiplicative function such that `J(a | p) = χ p` for all odd primes `p`,
 then `J(a | b)` equals `χ b` for all odd natural numbers `b`. -/
-lemma jacobi_sym.value_at (a : ℤ) {R : Type*} [comm_semiring R] (χ : R →* ℤ)
+lemma value_at (a : ℤ) {R : Type*} [comm_semiring R] (χ : R →* ℤ)
   (hp : ∀ (p : ℕ) (pp : p.prime) (h2 : p ≠ 2), @legendre_sym p ⟨pp⟩ a = χ p) {b : ℕ} (hb : odd b) :
   J(a | b) = χ b :=
 begin
@@ -241,21 +252,21 @@ begin
 end
 
 /-- If `b` is odd, then `J(-1 | b)` is given by `χ₄ b`. -/
-lemma jacobi_sym.at_neg_one {b : ℕ} (hb : odd b) : J(-1 | b) = χ₄ b :=
-jacobi_sym.value_at (-1) χ₄ (λ p pp, @legendre_sym.at_neg_one p ⟨pp⟩) hb
+lemma at_neg_one {b : ℕ} (hb : odd b) : J(-1 | b) = χ₄ b :=
+value_at (-1) χ₄ (λ p pp, @legendre_sym.at_neg_one p ⟨pp⟩) hb
 
 /-- If `b` is odd, then `J(-a | b) = χ₄ b * J(a | b)`. -/
 protected
-lemma jacobi_sym.neg (a : ℤ) {b : ℕ} (hb : odd b) : J(-a | b) = χ₄ b * J(a | b) :=
-by rw [neg_eq_neg_one_mul, jacobi_sym.mul_left, jacobi_sym.at_neg_one hb]
+lemma neg (a : ℤ) {b : ℕ} (hb : odd b) : J(-a | b) = χ₄ b * J(a | b) :=
+by rw [neg_eq_neg_one_mul, mul_left, at_neg_one hb]
 
 /-- If `b` is odd, then `J(2 | b)` is given by `χ₈ b`. -/
-lemma jacobi_sym.at_two {b : ℕ} (hb : odd b) : J(2 | b) = χ₈ b :=
-jacobi_sym.value_at 2 χ₈ (λ p pp, @legendre_sym.at_two p ⟨pp⟩) hb
+lemma at_two {b : ℕ} (hb : odd b) : J(2 | b) = χ₈ b :=
+value_at 2 χ₈ (λ p pp, @legendre_sym.at_two p ⟨pp⟩) hb
 
 /-- If `b` is odd, then `J(-2 | b)` is given by `χ₈' b`. -/
-lemma jacobi_sym.at_neg_two {b : ℕ} (hb : odd b) : J(-2 | b) = χ₈' b :=
-jacobi_sym.value_at (-2) χ₈' (λ p pp, @legendre_sym.at_neg_two p ⟨pp⟩) hb
+lemma at_neg_two {b : ℕ} (hb : odd b) : J(-2 | b) = χ₈' b :=
+value_at (-2) χ₈' (λ p pp, @legendre_sym.at_neg_two p ⟨pp⟩) hb
 
 
 /-!
@@ -271,8 +282,8 @@ lemma qr_sign.neg_one_pow {m n : ℕ} (hm : odd m) (hn : odd n) :
 begin
   rw [qr_sign, pow_mul, ← χ₄_eq_neg_one_pow (odd_iff.mp hm)],
   cases odd_mod_four_iff.mp (odd_iff.mp hm) with h h,
-  { rw [χ₄_nat_one_mod_four h, jacobi_sym.one_left, one_pow], },
-  { rw [χ₄_nat_three_mod_four h, ← χ₄_eq_neg_one_pow (odd_iff.mp hn), jacobi_sym.at_neg_one hn], }
+  { rw [χ₄_nat_one_mod_four h, one_left, one_pow], },
+  { rw [χ₄_nat_three_mod_four h, ← χ₄_eq_neg_one_pow (odd_iff.mp hn), at_neg_one hn], }
 end
 
 /-- When `m` and `n` are odd, then the square of `qr_sign m n` is `1`. -/
@@ -281,12 +292,12 @@ by rw [qr_sign.neg_one_pow hm hn, ← pow_mul, mul_comm, pow_mul, neg_one_sq, on
 
 /-- `qr_sign` is multiplicative in the first argument. -/
 lemma qr_sign.mul_left (m₁ m₂ n : ℕ) : qr_sign (m₁ * m₂) n = qr_sign m₁ n * qr_sign m₂ n :=
-by simp_rw [qr_sign, nat.cast_mul, map_mul, jacobi_sym.mul_left]
+by simp_rw [qr_sign, nat.cast_mul, map_mul, mul_left]
 
 /-- `qr_sign` is multiplicative in the second argument. -/
 lemma qr_sign.mul_right (m n₁ n₂ : ℕ) [ne_zero n₁] [ne_zero n₂] :
   qr_sign m (n₁ * n₂) = qr_sign m n₁ * qr_sign m n₂ :=
-jacobi_sym.mul_right (χ₄ m) n₁ n₂
+mul_right (χ₄ m) n₁ n₂
 
 /-- `qr_sign` is symmetric when both arguments are odd. -/
 protected
@@ -300,56 +311,56 @@ by refine ⟨λ h', let h := h'.symm in _, λ h, _⟩;
    rw [h, ← mul_assoc, ← pow_two, qr_sign.sq_eq_one hm hn, one_mul]
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol, version with `qr_sign` -/
-lemma jacobi_sym.quadratic_reciprocity' {a b : ℕ} (ha : odd a) (hb : odd b) :
+lemma quadratic_reciprocity' {a b : ℕ} (ha : odd a) (hb : odd b) :
   J(a | b) = qr_sign b a * J(b | a) :=
 begin
   -- define the right hand side for fixed `a` as a `ℕ →* ℤ`
   let rhs : ℕ → ℕ →* ℤ := λ a,
   { to_fun := λ x, qr_sign x a * J(x | a),
-    map_one' := by { convert ← mul_one _, symmetry, all_goals { apply jacobi_sym.one_left } },
-    map_mul' := λ x y, by rw [qr_sign.mul_left, nat.cast_mul, jacobi_sym.mul_left,
+    map_one' := by { convert ← mul_one _, symmetry, all_goals { apply one_left } },
+    map_mul' := λ x y, by rw [qr_sign.mul_left, nat.cast_mul, mul_left,
                               mul_mul_mul_comm] },
   have rhs_apply : ∀ (a b : ℕ), rhs a b = qr_sign b a * J(b | a) := λ a b, rfl,
-  refine jacobi_sym.value_at a (rhs a) (λ p pp hp, eq.symm _) hb,
+  refine value_at a (rhs a) (λ p pp hp, eq.symm _) hb,
   have hpo := pp.eq_two_or_odd'.resolve_left hp,
   rw [@legendre_sym.to_jacobi_sym p ⟨pp⟩, rhs_apply, nat.cast_id,
       qr_sign.eq_iff_eq hpo ha, qr_sign.symm hpo ha],
-  refine jacobi_sym.value_at p (rhs p) (λ q pq hq, _) ha,
+  refine value_at p (rhs p) (λ q pq hq, _) ha,
   have hqo := pq.eq_two_or_odd'.resolve_left hq,
   rw [rhs_apply, nat.cast_id, ← @legendre_sym.to_jacobi_sym p ⟨pp⟩, qr_sign.symm hqo hpo,
       qr_sign.neg_one_pow hpo hqo, @legendre_sym.quadratic_reciprocity' p q ⟨pp⟩ ⟨pq⟩ hp hq],
 end
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol -/
-lemma jacobi_sym.quadratic_reciprocity {a b : ℕ} (ha : odd a) (hb : odd b) :
+lemma quadratic_reciprocity {a b : ℕ} (ha : odd a) (hb : odd b) :
   J(a | b) = (-1) ^ ((a / 2) * (b / 2)) * J(b | a) :=
-by rw [← qr_sign.neg_one_pow ha hb, qr_sign.symm ha hb, jacobi_sym.quadratic_reciprocity' ha hb]
+by rw [← qr_sign.neg_one_pow ha hb, qr_sign.symm ha hb, quadratic_reciprocity' ha hb]
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol: if `a` and `b` are natural numbers
 with `a % 4 = 1` and `b` odd, then `J(a | b) = J(b | a)`. -/
-theorem jacobi_sym.quadratic_reciprocity_one_mod_four {a b : ℕ} (ha : a % 4 = 1) (hb : odd b) :
+theorem quadratic_reciprocity_one_mod_four {a b : ℕ} (ha : a % 4 = 1) (hb : odd b) :
   J(a | b) = J(b | a) :=
-by rw [jacobi_sym.quadratic_reciprocity (odd_iff.mpr (odd_of_mod_four_eq_one ha)) hb,
+by rw [quadratic_reciprocity (odd_iff.mpr (odd_of_mod_four_eq_one ha)) hb,
        pow_mul, neg_one_pow_div_two_of_one_mod_four ha, one_pow, one_mul]
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol: if `a` and `b` are natural numbers
 with `a` odd and `b % 4 = 1`, then `J(a | b) = J(b | a)`. -/
-theorem jacobi_sym.quadratic_reciprocity_one_mod_four' {a b : ℕ} (ha : odd a) (hb : b % 4 = 1) :
+theorem quadratic_reciprocity_one_mod_four' {a b : ℕ} (ha : odd a) (hb : b % 4 = 1) :
   J(a | b) = J(b | a) :=
-(jacobi_sym.quadratic_reciprocity_one_mod_four hb ha).symm
+(quadratic_reciprocity_one_mod_four hb ha).symm
 
 /-- The Law of Quadratic Reciprocityfor the Jacobi symbol: if `a` and `b` are natural numbers
 both congruent to `3` mod `4`, then `J(a | b) = -J(b | a)`. -/
-theorem jacobi_sym.quadratic_reciprocity_three_mod_four
+theorem quadratic_reciprocity_three_mod_four
   {a b : ℕ} (ha : a % 4 = 3) (hb : b % 4 = 3) :
   J(a | b) = - J(b | a) :=
 let nop := @neg_one_pow_div_two_of_three_mod_four in begin
-  rw [jacobi_sym.quadratic_reciprocity, pow_mul, nop ha, nop hb, neg_one_mul];
+  rw [quadratic_reciprocity, pow_mul, nop ha, nop hb, neg_one_mul];
   rwa [odd_iff, odd_of_mod_four_eq_three],
 end
 
 /-- The Jacobi symbol `J(a | b)` depends only on `b` mod `4*a` (version for `a : ℕ`). -/
-lemma jacobi_sym.mod_right' (a : ℕ) {b : ℕ} (hb : odd b) : J(a | b) = J(a | b % (4 * a)) :=
+lemma mod_right' (a : ℕ) {b : ℕ} (hb : odd b) : J(a | b) = J(a | b % (4 * a)) :=
 begin
   rcases eq_or_ne a 0 with rfl | ha₀,
   { rw [mul_zero, mod_zero], },
@@ -357,14 +368,14 @@ begin
   rcases exists_eq_pow_mul_and_not_dvd ha₀ 2 (by norm_num) with ⟨e, a', ha₁', ha₂⟩,
   have ha₁ := odd_iff.mpr (two_dvd_ne_zero.mp ha₁'),
   nth_rewrite 1 [ha₂], nth_rewrite 0 [ha₂],
-  rw [nat.cast_mul, jacobi_sym.mul_left, jacobi_sym.mul_left,
-      jacobi_sym.quadratic_reciprocity' ha₁ hb, jacobi_sym.quadratic_reciprocity' ha₁ hb',
-      nat.cast_pow, jacobi_sym.pow_left, jacobi_sym.pow_left,
-      (show ((2 : ℕ) : ℤ) = 2, by refl), jacobi_sym.at_two hb, jacobi_sym.at_two hb'],
+  rw [nat.cast_mul, mul_left, mul_left,
+      quadratic_reciprocity' ha₁ hb, quadratic_reciprocity' ha₁ hb',
+      nat.cast_pow, pow_left, pow_left,
+      (show ((2 : ℕ) : ℤ) = 2, by refl), at_two hb, at_two hb'],
   congr' 1, swap, congr' 1,
   { simp_rw [qr_sign],
     rw [χ₄_nat_mod_four, χ₄_nat_mod_four (b % (4 * a)), mod_mod_of_dvd b (dvd_mul_right 4 a) ] },
-  { rw [jacobi_sym.mod_left ↑(b % _), jacobi_sym.mod_left b, int.coe_nat_mod,
+  { rw [mod_left ↑(b % _), mod_left b, int.coe_nat_mod,
         int.mod_mod_of_dvd b],
     simp only [ha₂, nat.cast_mul, ← mul_assoc],
     exact dvd_mul_left a' _, },
@@ -374,13 +385,15 @@ begin
 end
 
 /-- The Jacobi symbol `J(a | b)` depends only on `b` mod `4*a`. -/
-lemma jacobi_sym.mod_right (a : ℤ) {b : ℕ} (hb : odd b) : J(a | b) = J(a | b % (4 * a.nat_abs)) :=
+lemma mod_right (a : ℤ) {b : ℕ} (hb : odd b) : J(a | b) = J(a | b % (4 * a.nat_abs)) :=
 begin
   cases int.nat_abs_eq a with ha ha; nth_rewrite 1 [ha]; nth_rewrite 0 [ha],
-  { exact jacobi_sym.mod_right' a.nat_abs hb, },
+  { exact mod_right' a.nat_abs hb, },
   { have hb' : odd (b % (4 * a.nat_abs)) := hb.mod_even (even.mul_right (by norm_num) _),
-    rw [jacobi_sym.neg _ hb, jacobi_sym.neg _ hb', jacobi_sym.mod_right' _ hb, χ₄_nat_mod_four,
+    rw [jacobi_sym.neg _ hb, jacobi_sym.neg _ hb', mod_right' _ hb, χ₄_nat_mod_four,
         χ₄_nat_mod_four (b % (4 * _)), mod_mod_of_dvd b (dvd_mul_right 4 _)], }
 end
+
+end jacobi_sym
 
 end jacobi

--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -95,7 +95,7 @@ by simp only [jacobi_sym, factors_one, list.prod_nil, list.pmap]
 
 /-- The Legendre symbol `legendre_sym p a` with an integer `a` and a prime number `p`
 is the same as the Jacobi symbol `J(a | p)`. -/
-lemma _root_.legendre_sym.to_jacobi_sym {p : ℕ} [fp : fact p.prime] {a : ℤ} :
+lemma _root_.legendre_sym.to_jacobi_sym (p : ℕ) [fp : fact p.prime] (a : ℤ) :
   legendre_sym p a = J(a | p) :=
 by simp only [jacobi_sym, factors_prime fp.1, list.prod_cons, list.prod_nil, mul_one, list.pmap]
 

--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -60,8 +60,8 @@ section jacobi
 /-!
 ### Definition of the Jacobi symbol
 
-We define the Jacobi symbol $\Bigl\frac{a}{b}\Bigr$ for integers `a` and natural numbers `b` as the
-product of the Legendre symbols $\Bigl\frac{a}{p}\Bigr$, where `p` runs through the prime divisors
+We define the Jacobi symbol $\Bigl(\frac{a}{b}\Bigr)$ for integers `a` and natural numbers `b` as the
+product of the Legendre symbols $(\Bigl\frac{a}{p}\Bigr)$, where `p` runs through the prime divisors
 (with multiplicity) of `b`, as provided by `b.factors`. This agrees with the Jacobi symbol
 when `b` is odd and gives less meaningful values when it is not (e.g., the symbol is `1`
 when `b = 0`). This is called `jacobi_sym a b`.

--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -70,8 +70,7 @@ We define localized notation (locale `number_theory_symbols`) `J(a | b)` for the
 symbol `jacobi_sym a b`. (Unfortunately, there is no subscript "J" in unicode.)
 -/
 
-namespace zmod
-open nat
+open nat zmod
 
 /-- The Jacobi symbol of `a` and `b` -/
 -- Since we need the fact that the factors are prime, we use `list.pmap`.
@@ -203,7 +202,7 @@ lemma jacobi_sym_mod_left' {a₁ a₂ : ℤ} {b : ℕ} (h : a₁ % b = a₂ % b)
 by rw [jacobi_sym_mod_left, h, ← jacobi_sym_mod_left]
 
 /-- If `J(a | b)` is `-1`, then `a` is not a square modulo `b`. -/
-lemma nonsquare_of_jacobi_sym_eq_neg_one {a : ℤ} {b : ℕ} (h : J(a | b) = -1) :
+lemma zmod.nonsquare_of_jacobi_sym_eq_neg_one {a : ℤ} {b : ℕ} (h : J(a | b) = -1) :
   ¬ is_square (a : zmod b) :=
 λ ⟨r, ha⟩, begin
   rw [← r.coe_val_min_abs, ← int.cast_mul, int_coe_eq_int_coe_iff', ← sq] at ha,
@@ -213,14 +212,14 @@ lemma nonsquare_of_jacobi_sym_eq_neg_one {a : ℤ} {b : ℕ} (h : J(a | b) = -1)
 end
 
 /-- If `p` is prime, then `J(a | p)` is `-1` iff `a` is not a square modulo `p`. -/
-lemma nonsquare_iff_jacobi_sym_eq_neg_one {a : ℤ} {p : ℕ} [fact p.prime] :
+lemma zmod.nonsquare_iff_jacobi_sym_eq_neg_one {a : ℤ} {p : ℕ} [fact p.prime] :
   J(a | p) = -1 ↔ ¬ is_square (a : zmod p) :=
 by { rw [← legendre_sym.to_jacobi_sym], exact legendre_sym_eq_neg_one_iff p }
 
 /-- If `p` is prime and `J(a | p) = 1`, then `a` is q square mod `p`. -/
-lemma is_square_of_jacobi_sym_eq_one {a : ℤ} {p : ℕ} [fact p.prime] (h : J(a | p) = 1) :
+lemma zmod.is_square_of_jacobi_sym_eq_one {a : ℤ} {p : ℕ} [fact p.prime] (h : J(a | p) = 1) :
   is_square (a : zmod p) :=
-not_not.mp $ mt nonsquare_iff_jacobi_sym_eq_neg_one.mpr $
+not_not.mp $ mt zmod.nonsquare_iff_jacobi_sym_eq_neg_one.mpr $
   λ hf, one_ne_zero $ neg_eq_self_iff.mp $ hf.symm.trans h
 
 /-!
@@ -314,7 +313,7 @@ begin
   refine jacobi_sym_value p (rhs p) (λ q pq hq, _) ha,
   have hqo := pq.eq_two_or_odd'.resolve_left hq,
   rw [rhs_apply, nat.cast_id, ← @legendre_sym.to_jacobi_sym p ⟨pp⟩, qr_sign_symm hqo hpo,
-      qr_sign_neg_one_pow hpo hqo, @quadratic_reciprocity' p q ⟨pp⟩ ⟨pq⟩ hp hq],
+      qr_sign_neg_one_pow hpo hqo, @legendre_sym_quadratic_reciprocity' p q ⟨pp⟩ ⟨pq⟩ hp hq],
 end
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol -/
@@ -379,7 +378,5 @@ begin
     rw [jacobi_sym_neg _ hb, jacobi_sym_neg _ hb', jacobi_sym_mod_right' _ hb, χ₄_nat_mod_four,
         χ₄_nat_mod_four (b % (4 * _)), mod_mod_of_dvd b (dvd_mul_right 4 _)], }
 end
-
-end zmod
 
 end jacobi

--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -24,28 +24,28 @@ this implies in particular that `jacobi_sym a 0 = 1` for all `a`.
 
 We prove the main properties of the Jacobi symbol, including the following.
 
-* Multiplicativity in both arguments (`jacobi_sym_mul_left`, `jacobi_sym_mul_right`)
+* Multiplicativity in both arguments (`jacobi_sym.mul_left`, `jacobi_sym.mul_right`)
 
 * The value of the symbol is `1` or `-1` when the arguments are coprime
-  (`jacobi_sym_eq_one_or_neg_one`)
+  (`jacobi_sym.eq_one_or_neg_one`)
 
 * The symbol vanishes if and only if `b ≠ 0` and the arguments are not coprime
-  (`jacobi_sym_eq_zero_iff`)
+  (`jacobi_sym.eq_zero_iff`)
 
 * If the symbol has the value `-1`, then `a : zmod b` is not a square
   (`nonsquare_of_jacobi_sym_eq_neg_one`); the converse holds when `b = p` is a prime
   (`nonsquare_iff_jacobi_sym_eq_neg_one`); in particular, in this case `a` is a
   square mod `p` when the symbol has the value `1` (`is_square_of_jacobi_sym_eq_one`).
 
-* Quadratic reciprocity (`jacobi_sym_quadratic_reciprocity`,
-  `jacobi_sym_quadratic_reciprocity_one_mod_four`,
-  `jacobi_sym_quadratic_reciprocity_three_mod_four`)
+* Quadratic reciprocity (`jacobi_sym.quadratic_reciprocity`,
+  `jacobi_sym.quadratic_reciprocity_one_mod_four`,
+  `jacobi_sym.quadratic_reciprocity_three_mod_four`)
 
-* The supplementary laws for `a = -1`, `a = 2`, `a = -2` (`jacobi_sym_neg_one`, `jacobi_sym_two`,
-  `jacobi_sym_neg_two`)
+* The supplementary laws for `a = -1`, `a = 2`, `a = -2` (`jacobi_sym.at_neg_one`,
+  `jacobi_sym.at_two`, `jacobi_sym.at_neg_two`)
 
-* The symbol depends on `a` only via its residue class mod `b` (`jacobi_sym_mod_left`)
-  and on `b` only via its residue class mod `4*a` (`jacobi_sym_mod_right`)
+* The symbol depends on `a` only via its residue class mod `b` (`jacobi_sym.mod_left`)
+  and on `b` only via its residue class mod `4*a` (`jacobi_sym.mod_right`)
 
 ## Notations
 
@@ -85,11 +85,11 @@ localized "notation `J(` a ` | ` b `)` := jacobi_sym a b" in number_theory_symbo
 -/
 
 /-- The symbol `J(a | 0)` has the value `1`. -/
-@[simp] lemma jacobi_sym_zero_right (a : ℤ) : J(a | 0) = 1 :=
+@[simp] lemma jacobi_sym.zero_right (a : ℤ) : J(a | 0) = 1 :=
 by simp only [jacobi_sym, factors_zero, list.prod_nil, list.pmap]
 
 /-- The symbol `J(a | 1)` has the value `1`. -/
-@[simp] lemma jacobi_sym_one_right (a : ℤ) : J(a | 1) = 1 :=
+@[simp] lemma jacobi_sym.one_right (a : ℤ) : J(a | 1) = 1 :=
 by simp only [jacobi_sym, factors_one, list.prod_nil, list.pmap]
 
 /-- The Legendre symbol `legendre_sym p a` with an integer `a` and a prime number `p`
@@ -99,7 +99,7 @@ lemma legendre_sym.to_jacobi_sym {p : ℕ} [fp : fact p.prime] {a : ℤ} :
 by simp only [jacobi_sym, factors_prime fp.1, list.prod_cons, list.prod_nil, mul_one, list.pmap]
 
 /-- The Jacobi symbol is multiplicative in its second argument. -/
-lemma jacobi_sym_mul_right' (a : ℤ) {b₁ b₂ : ℕ} (hb₁ : b₁ ≠ 0) (hb₂ : b₂ ≠ 0) :
+lemma jacobi_sym.mul_right' (a : ℤ) {b₁ b₂ : ℕ} (hb₁ : b₁ ≠ 0) (hb₂ : b₂ ≠ 0) :
   J(a | b₁ * b₂) = J(a | b₁) * J(a | b₂) :=
 begin
   rw [jacobi_sym, ((perm_factors_mul hb₁ hb₂).pmap _).prod_eq, list.pmap_append, list.prod_append],
@@ -107,12 +107,12 @@ begin
 end
 
 /-- The Jacobi symbol is multiplicative in its second argument. -/
-lemma jacobi_sym_mul_right (a : ℤ) (b₁ b₂ : ℕ) [ne_zero b₁] [ne_zero b₂] :
+lemma jacobi_sym.mul_right (a : ℤ) (b₁ b₂ : ℕ) [ne_zero b₁] [ne_zero b₂] :
   J(a | b₁ * b₂) = J(a | b₁) * J(a | b₂) :=
-jacobi_sym_mul_right' a (ne_zero.ne b₁) (ne_zero.ne b₂)
+jacobi_sym.mul_right' a (ne_zero.ne b₁) (ne_zero.ne b₂)
 
 /-- The Jacobi symbol takes only the values `0`, `1` and `-1`. -/
-lemma jacobi_sym_trichotomy (a : ℤ) (b : ℕ) : J(a | b) = 0 ∨ J(a | b) = 1 ∨ J(a | b) = -1 :=
+lemma jacobi_sym.trichotomy (a : ℤ) (b : ℕ) : J(a | b) = 0 ∨ J(a | b) = 1 ∨ J(a | b) = -1 :=
 ((@sign_type.cast_hom ℤ _ _).to_monoid_hom.mrange.copy {0, 1, -1} $
   by {rw set.pair_comm, exact (sign_type.range_eq sign_type.cast_hom).symm}).list_prod_mem
 begin
@@ -123,16 +123,16 @@ begin
 end
 
 /-- The symbol `J(1 | b)` has the value `1`. -/
-@[simp] lemma jacobi_sym_one_left (b : ℕ) : J(1 | b) = 1 :=
+@[simp] lemma jacobi_sym.one_left (b : ℕ) : J(1 | b) = 1 :=
 list.prod_eq_one (λ z hz,
                   let ⟨p, hp, he⟩ := list.mem_pmap.1 hz in by rw [← he, legendre_sym.at_one])
 
 /-- The Jacobi symbol is multiplicative in its first argument. -/
-lemma jacobi_sym_mul_left (a₁ a₂ : ℤ) (b : ℕ) : J(a₁ * a₂ | b) = J(a₁ | b) * J(a₂ | b) :=
+lemma jacobi_sym.mul_left (a₁ a₂ : ℤ) (b : ℕ) : J(a₁ * a₂ | b) = J(a₁ | b) * J(a₂ | b) :=
 by { simp_rw [jacobi_sym, list.pmap_eq_map_attach, legendre_sym.mul], exact list.prod_map_mul }
 
 /-- The symbol `J(a | b)` vanishes iff `a` and `b` are not coprime (assuming `b ≠ 0`). -/
-lemma jacobi_sym_eq_zero_iff_not_coprime {a : ℤ} {b : ℕ} [ne_zero b] :
+lemma jacobi_sym.eq_zero_iff_not_coprime {a : ℤ} {b : ℕ} [ne_zero b] :
   J(a | b) = 0 ↔ a.gcd b ≠ 1 :=
 list.prod_eq_zero_iff.trans begin
   rw [list.mem_pmap, int.gcd_eq_nat_abs, ne, prime.not_coprime_iff_dvd],
@@ -141,57 +141,58 @@ list.prod_eq_zero_iff.trans begin
 end
 
 /-- The symbol `J(a | b)` is nonzero when `a` and `b` are coprime. -/
-lemma jacobi_sym_ne_zero {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a | b) ≠ 0 :=
+protected
+lemma jacobi_sym.ne_zero {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a | b) ≠ 0 :=
 begin
   casesI eq_zero_or_ne_zero b with hb,
-  { rw [hb, jacobi_sym_zero_right],
+  { rw [hb, jacobi_sym.zero_right],
     exact one_ne_zero },
-  { contrapose! h, exact jacobi_sym_eq_zero_iff_not_coprime.1 h },
+  { contrapose! h, exact jacobi_sym.eq_zero_iff_not_coprime.1 h },
 end
 
 /-- The symbol `J(a | b)` vanishes if and only if `b ≠ 0` and `a` and `b` are not coprime. -/
-lemma jacobi_sym_eq_zero_iff {a : ℤ} {b : ℕ} : J(a | b) = 0 ↔ b ≠ 0 ∧ a.gcd b ≠ 1 :=
+lemma jacobi_sym.eq_zero_iff {a : ℤ} {b : ℕ} : J(a | b) = 0 ↔ b ≠ 0 ∧ a.gcd b ≠ 1 :=
 ⟨λ h, begin
   casesI eq_or_ne b 0 with hb hb,
-  { rw [hb, jacobi_sym_zero_right] at h, cases h },
-  exact ⟨hb, mt jacobi_sym_ne_zero $ not_not.2 h⟩,
-end, λ ⟨hb, h⟩, by { rw ← ne_zero_iff at hb, exactI jacobi_sym_eq_zero_iff_not_coprime.2 h }⟩
+  { rw [hb, jacobi_sym.zero_right] at h, cases h },
+  exact ⟨hb, mt jacobi_sym.ne_zero $ not_not.2 h⟩,
+end, λ ⟨hb, h⟩, by { rw ← ne_zero_iff at hb, exactI jacobi_sym.eq_zero_iff_not_coprime.2 h }⟩
 
 /-- The symbol `J(0 | b)` vanishes when `b > 1`. -/
-lemma jacobi_sym_zero_left {b : ℕ} (hb : 1 < b) : J(0 | b) = 0 :=
-(@jacobi_sym_eq_zero_iff_not_coprime 0 b ⟨ne_zero_of_lt hb⟩).mpr $
+lemma jacobi_sym.zero_left {b : ℕ} (hb : 1 < b) : J(0 | b) = 0 :=
+(@jacobi_sym.eq_zero_iff_not_coprime 0 b ⟨ne_zero_of_lt hb⟩).mpr $
   by { rw [int.gcd_zero_left, int.nat_abs_of_nat], exact hb.ne' }
 
 /-- The symbol `J(a | b)` takes the value `1` or `-1` if `a` and `b` are coprime. -/
-lemma jacobi_sym_eq_one_or_neg_one {a : ℤ} {b : ℕ} (h : a.gcd b = 1) :
+lemma jacobi_sym.eq_one_or_neg_one {a : ℤ} {b : ℕ} (h : a.gcd b = 1) :
   J(a | b) = 1 ∨ J(a | b) = -1 :=
-(jacobi_sym_trichotomy a b).resolve_left $ jacobi_sym_ne_zero h
+(jacobi_sym.trichotomy a b).resolve_left $ jacobi_sym.ne_zero h
 
 /-- We have that `J(a^e | b) = J(a | b)^e`. -/
-lemma jacobi_sym_pow_left (a : ℤ) (e b : ℕ) : J(a ^ e | b) = J(a | b) ^ e :=
-nat.rec_on e (by rw [pow_zero, pow_zero, jacobi_sym_one_left]) $
-  λ _ ih, by rw [pow_succ, pow_succ, jacobi_sym_mul_left, ih]
+lemma jacobi_sym.pow_left (a : ℤ) (e b : ℕ) : J(a ^ e | b) = J(a | b) ^ e :=
+nat.rec_on e (by rw [pow_zero, pow_zero, jacobi_sym.one_left]) $
+  λ _ ih, by rw [pow_succ, pow_succ, jacobi_sym.mul_left, ih]
 
 /-- We have that `J(a | b^e) = J(a | b)^e`. -/
-lemma jacobi_sym_pow_right (a : ℤ) (b e : ℕ) : J(a | b ^ e) = J(a | b) ^ e :=
+lemma jacobi_sym.pow_right (a : ℤ) (b e : ℕ) : J(a | b ^ e) = J(a | b) ^ e :=
 begin
   induction e with e ih,
-  { rw [pow_zero, pow_zero, jacobi_sym_one_right], },
+  { rw [pow_zero, pow_zero, jacobi_sym.one_right], },
   { casesI eq_zero_or_ne_zero b with hb,
-    { rw [hb, zero_pow (succ_pos e), jacobi_sym_zero_right, one_pow], },
-    { rw [pow_succ, pow_succ, jacobi_sym_mul_right, ih], } }
+    { rw [hb, zero_pow (succ_pos e), jacobi_sym.zero_right, one_pow], },
+    { rw [pow_succ, pow_succ, jacobi_sym.mul_right, ih], } }
 end
 
 /-- The square of `J(a | b)` is `1` when `a` and `b` are coprime. -/
-lemma jacobi_sym_sq_one {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a | b) ^ 2 = 1 :=
-by cases jacobi_sym_eq_one_or_neg_one h with h₁ h₁; rw h₁; refl
+lemma jacobi_sym.sq_one {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a | b) ^ 2 = 1 :=
+by cases jacobi_sym.eq_one_or_neg_one h with h₁ h₁; rw h₁; refl
 
 /-- The symbol `J(a^2 | b)` is `1` when `a` and `b` are coprime. -/
-lemma jacobi_sym_sq_one' {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a ^ 2 | b) = 1 :=
-by rw [jacobi_sym_pow_left, jacobi_sym_sq_one h]
+lemma jacobi_sym.sq_one' {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a ^ 2 | b) = 1 :=
+by rw [jacobi_sym.pow_left, jacobi_sym.sq_one h]
 
 /-- The symbol `J(a | b)` depends only on `a` mod `b`. -/
-lemma jacobi_sym_mod_left (a : ℤ) (b : ℕ) : J(a | b) = J(a % b | b) :=
+lemma jacobi_sym.mod_left (a : ℤ) (b : ℕ) : J(a | b) = J(a % b | b) :=
 congr_arg list.prod $ list.pmap_congr _ begin
   rintro p hp _ _,
   conv_rhs { rw [legendre_sym.mod, int.mod_mod_of_dvd _
@@ -199,8 +200,8 @@ congr_arg list.prod $ list.pmap_congr _ begin
 end
 
 /-- The symbol `J(a | b)` depends only on `a` mod `b`. -/
-lemma jacobi_sym_mod_left' {a₁ a₂ : ℤ} {b : ℕ} (h : a₁ % b = a₂ % b) : J(a₁ | b) = J(a₂ | b) :=
-by rw [jacobi_sym_mod_left, h, ← jacobi_sym_mod_left]
+lemma jacobi_sym.mod_left' {a₁ a₂ : ℤ} {b : ℕ} (h : a₁ % b = a₂ % b) : J(a₁ | b) = J(a₂ | b) :=
+by rw [jacobi_sym.mod_left, h, ← jacobi_sym.mod_left]
 
 /-- If `J(a | b)` is `-1`, then `a` is not a square modulo `b`. -/
 lemma zmod.nonsquare_of_jacobi_sym_eq_neg_one {a : ℤ} {b : ℕ} (h : J(a | b) = -1) :
@@ -208,7 +209,7 @@ lemma zmod.nonsquare_of_jacobi_sym_eq_neg_one {a : ℤ} {b : ℕ} (h : J(a | b) 
 λ ⟨r, ha⟩, begin
   rw [← r.coe_val_min_abs, ← int.cast_mul, int_coe_eq_int_coe_iff', ← sq] at ha,
   apply (by norm_num : ¬ (0 : ℤ) ≤ -1),
-  rw [← h, jacobi_sym_mod_left, ha, ← jacobi_sym_mod_left, jacobi_sym_pow_left],
+  rw [← h, jacobi_sym.mod_left, ha, ← jacobi_sym.mod_left, jacobi_sym.pow_left],
   apply sq_nonneg,
 end
 
@@ -229,7 +230,7 @@ not_not.mp $ mt zmod.nonsquare_iff_jacobi_sym_eq_neg_one.mpr $
 
 /-- If `χ` is a multiplicative function such that `J(a | p) = χ p` for all odd primes `p`,
 then `J(a | b)` equals `χ b` for all odd natural numbers `b`. -/
-lemma jacobi_sym_value (a : ℤ) {R : Type*} [comm_semiring R] (χ : R →* ℤ)
+lemma jacobi_sym.value_at (a : ℤ) {R : Type*} [comm_semiring R] (χ : R →* ℤ)
   (hp : ∀ (p : ℕ) (pp : p.prime) (h2 : p ≠ 2), @legendre_sym p ⟨pp⟩ a = χ p) {b : ℕ} (hb : odd b) :
   J(a | b) = χ b :=
 begin
@@ -240,20 +241,21 @@ begin
 end
 
 /-- If `b` is odd, then `J(-1 | b)` is given by `χ₄ b`. -/
-lemma jacobi_sym_neg_one {b : ℕ} (hb : odd b) : J(-1 | b) = χ₄ b :=
-jacobi_sym_value (-1) χ₄ (λ p pp, @legendre_sym.at_neg_one p ⟨pp⟩) hb
+lemma jacobi_sym.at_neg_one {b : ℕ} (hb : odd b) : J(-1 | b) = χ₄ b :=
+jacobi_sym.value_at (-1) χ₄ (λ p pp, @legendre_sym.at_neg_one p ⟨pp⟩) hb
 
 /-- If `b` is odd, then `J(-a | b) = χ₄ b * J(a | b)`. -/
-lemma jacobi_sym_neg (a : ℤ) {b : ℕ} (hb : odd b) : J(-a | b) = χ₄ b * J(a | b) :=
-by rw [neg_eq_neg_one_mul, jacobi_sym_mul_left, jacobi_sym_neg_one hb]
+protected
+lemma jacobi_sym.neg (a : ℤ) {b : ℕ} (hb : odd b) : J(-a | b) = χ₄ b * J(a | b) :=
+by rw [neg_eq_neg_one_mul, jacobi_sym.mul_left, jacobi_sym.at_neg_one hb]
 
 /-- If `b` is odd, then `J(2 | b)` is given by `χ₈ b`. -/
-lemma jacobi_sym_two {b : ℕ} (hb : odd b) : J(2 | b) = χ₈ b :=
-jacobi_sym_value 2 χ₈ (λ p pp, @legendre_sym.at_two p ⟨pp⟩) hb
+lemma jacobi_sym.at_two {b : ℕ} (hb : odd b) : J(2 | b) = χ₈ b :=
+jacobi_sym.value_at 2 χ₈ (λ p pp, @legendre_sym.at_two p ⟨pp⟩) hb
 
 /-- If `b` is odd, then `J(-2 | b)` is given by `χ₈' b`. -/
-lemma jacobi_sym_neg_two {b : ℕ} (hb : odd b) : J(-2 | b) = χ₈' b :=
-jacobi_sym_value (-2) χ₈' (λ p pp, @legendre_sym.at_neg_two p ⟨pp⟩) hb
+lemma jacobi_sym.at_neg_two {b : ℕ} (hb : odd b) : J(-2 | b) = χ₈' b :=
+jacobi_sym.value_at (-2) χ₈' (λ p pp, @legendre_sym.at_neg_two p ⟨pp⟩) hb
 
 
 /-!
@@ -264,89 +266,90 @@ jacobi_sym_value (-2) χ₈' (λ p pp, @legendre_sym.at_neg_two p ⟨pp⟩) hb
 def qr_sign (m n : ℕ) : ℤ := J(χ₄ m | n)
 
 /-- We can express `qr_sign m n` as a power of `-1` when `m` and `n` are odd. -/
-lemma qr_sign_neg_one_pow {m n : ℕ} (hm : odd m) (hn : odd n) :
+lemma qr_sign.neg_one_pow {m n : ℕ} (hm : odd m) (hn : odd n) :
   qr_sign m n = (-1) ^ ((m / 2) * (n / 2)) :=
 begin
   rw [qr_sign, pow_mul, ← χ₄_eq_neg_one_pow (odd_iff.mp hm)],
   cases odd_mod_four_iff.mp (odd_iff.mp hm) with h h,
-  { rw [χ₄_nat_one_mod_four h, jacobi_sym_one_left, one_pow], },
-  { rw [χ₄_nat_three_mod_four h, ← χ₄_eq_neg_one_pow (odd_iff.mp hn), jacobi_sym_neg_one hn], }
+  { rw [χ₄_nat_one_mod_four h, jacobi_sym.one_left, one_pow], },
+  { rw [χ₄_nat_three_mod_four h, ← χ₄_eq_neg_one_pow (odd_iff.mp hn), jacobi_sym.at_neg_one hn], }
 end
 
 /-- When `m` and `n` are odd, then the square of `qr_sign m n` is `1`. -/
-lemma qr_sign_sq_eq_one {m n : ℕ} (hm : odd m) (hn : odd n) : (qr_sign m n) ^ 2 = 1 :=
-by rw [qr_sign_neg_one_pow hm hn, ← pow_mul, mul_comm, pow_mul, neg_one_sq, one_pow]
+lemma qr_sign.sq_eq_one {m n : ℕ} (hm : odd m) (hn : odd n) : (qr_sign m n) ^ 2 = 1 :=
+by rw [qr_sign.neg_one_pow hm hn, ← pow_mul, mul_comm, pow_mul, neg_one_sq, one_pow]
 
 /-- `qr_sign` is multiplicative in the first argument. -/
-lemma qr_sign_mul_left (m₁ m₂ n : ℕ) : qr_sign (m₁ * m₂) n = qr_sign m₁ n * qr_sign m₂ n :=
-by simp_rw [qr_sign, nat.cast_mul, map_mul, jacobi_sym_mul_left]
+lemma qr_sign.mul_left (m₁ m₂ n : ℕ) : qr_sign (m₁ * m₂) n = qr_sign m₁ n * qr_sign m₂ n :=
+by simp_rw [qr_sign, nat.cast_mul, map_mul, jacobi_sym.mul_left]
 
 /-- `qr_sign` is multiplicative in the second argument. -/
-lemma qr_sign_mul_right (m n₁ n₂ : ℕ) [ne_zero n₁] [ne_zero n₂] :
+lemma qr_sign.mul_right (m n₁ n₂ : ℕ) [ne_zero n₁] [ne_zero n₂] :
   qr_sign m (n₁ * n₂) = qr_sign m n₁ * qr_sign m n₂ :=
-jacobi_sym_mul_right (χ₄ m) n₁ n₂
+jacobi_sym.mul_right (χ₄ m) n₁ n₂
 
 /-- `qr_sign` is symmetric when both arguments are odd. -/
-lemma qr_sign_symm {m n : ℕ} (hm : odd m) (hn : odd n) : qr_sign m n = qr_sign n m :=
-by rw [qr_sign_neg_one_pow hm hn, qr_sign_neg_one_pow hn hm, mul_comm (m / 2)]
+protected
+lemma qr_sign.symm {m n : ℕ} (hm : odd m) (hn : odd n) : qr_sign m n = qr_sign n m :=
+by rw [qr_sign.neg_one_pow hm hn, qr_sign.neg_one_pow hn hm, mul_comm (m / 2)]
 
 /-- We can move `qr_sign m n` from one side of an equality to the other when `m` and `n` are odd. -/
-lemma qr_sign_eq_iff_eq {m n : ℕ} (hm : odd m) (hn : odd n) (x y : ℤ) :
+lemma qr_sign.eq_iff_eq {m n : ℕ} (hm : odd m) (hn : odd n) (x y : ℤ) :
   qr_sign m n * x = y ↔ x = qr_sign m n * y :=
 by refine ⟨λ h', let h := h'.symm in _, λ h, _⟩;
-   rw [h, ← mul_assoc, ← pow_two, qr_sign_sq_eq_one hm hn, one_mul]
+   rw [h, ← mul_assoc, ← pow_two, qr_sign.sq_eq_one hm hn, one_mul]
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol, version with `qr_sign` -/
-lemma jacobi_sym_quadratic_reciprocity' {a b : ℕ} (ha : odd a) (hb : odd b) :
+lemma jacobi_sym.quadratic_reciprocity' {a b : ℕ} (ha : odd a) (hb : odd b) :
   J(a | b) = qr_sign b a * J(b | a) :=
 begin
   -- define the right hand side for fixed `a` as a `ℕ →* ℤ`
   let rhs : ℕ → ℕ →* ℤ := λ a,
   { to_fun := λ x, qr_sign x a * J(x | a),
-    map_one' := by { convert ← mul_one _, symmetry, all_goals { apply jacobi_sym_one_left } },
-    map_mul' := λ x y, by rw [qr_sign_mul_left, nat.cast_mul, jacobi_sym_mul_left,
+    map_one' := by { convert ← mul_one _, symmetry, all_goals { apply jacobi_sym.one_left } },
+    map_mul' := λ x y, by rw [qr_sign.mul_left, nat.cast_mul, jacobi_sym.mul_left,
                               mul_mul_mul_comm] },
   have rhs_apply : ∀ (a b : ℕ), rhs a b = qr_sign b a * J(b | a) := λ a b, rfl,
-  refine jacobi_sym_value a (rhs a) (λ p pp hp, eq.symm _) hb,
+  refine jacobi_sym.value_at a (rhs a) (λ p pp hp, eq.symm _) hb,
   have hpo := pp.eq_two_or_odd'.resolve_left hp,
   rw [@legendre_sym.to_jacobi_sym p ⟨pp⟩, rhs_apply, nat.cast_id,
-      qr_sign_eq_iff_eq hpo ha, qr_sign_symm hpo ha],
-  refine jacobi_sym_value p (rhs p) (λ q pq hq, _) ha,
+      qr_sign.eq_iff_eq hpo ha, qr_sign.symm hpo ha],
+  refine jacobi_sym.value_at p (rhs p) (λ q pq hq, _) ha,
   have hqo := pq.eq_two_or_odd'.resolve_left hq,
-  rw [rhs_apply, nat.cast_id, ← @legendre_sym.to_jacobi_sym p ⟨pp⟩, qr_sign_symm hqo hpo,
-      qr_sign_neg_one_pow hpo hqo, @legendre_sym.quadratic_reciprocity' p q ⟨pp⟩ ⟨pq⟩ hp hq],
+  rw [rhs_apply, nat.cast_id, ← @legendre_sym.to_jacobi_sym p ⟨pp⟩, qr_sign.symm hqo hpo,
+      qr_sign.neg_one_pow hpo hqo, @legendre_sym.quadratic_reciprocity' p q ⟨pp⟩ ⟨pq⟩ hp hq],
 end
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol -/
-lemma jacobi_sym_quadratic_reciprocity {a b : ℕ} (ha : odd a) (hb : odd b) :
+lemma jacobi_sym.quadratic_reciprocity {a b : ℕ} (ha : odd a) (hb : odd b) :
   J(a | b) = (-1) ^ ((a / 2) * (b / 2)) * J(b | a) :=
-by rw [← qr_sign_neg_one_pow ha hb, qr_sign_symm ha hb, jacobi_sym_quadratic_reciprocity' ha hb]
+by rw [← qr_sign.neg_one_pow ha hb, qr_sign.symm ha hb, jacobi_sym.quadratic_reciprocity' ha hb]
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol: if `a` and `b` are natural numbers
 with `a % 4 = 1` and `b` odd, then `J(a | b) = J(b | a)`. -/
-theorem jacobi_sym_quadratic_reciprocity_one_mod_four {a b : ℕ} (ha : a % 4 = 1) (hb : odd b) :
+theorem jacobi_sym.quadratic_reciprocity_one_mod_four {a b : ℕ} (ha : a % 4 = 1) (hb : odd b) :
   J(a | b) = J(b | a) :=
-by rw [jacobi_sym_quadratic_reciprocity (odd_iff.mpr (odd_of_mod_four_eq_one ha)) hb,
+by rw [jacobi_sym.quadratic_reciprocity (odd_iff.mpr (odd_of_mod_four_eq_one ha)) hb,
        pow_mul, neg_one_pow_div_two_of_one_mod_four ha, one_pow, one_mul]
 
 /-- The Law of Quadratic Reciprocity for the Jacobi symbol: if `a` and `b` are natural numbers
 with `a` odd and `b % 4 = 1`, then `J(a | b) = J(b | a)`. -/
-theorem jacobi_sym_quadratic_reciprocity_one_mod_four' {a b : ℕ} (ha : odd a) (hb : b % 4 = 1) :
+theorem jacobi_sym.quadratic_reciprocity_one_mod_four' {a b : ℕ} (ha : odd a) (hb : b % 4 = 1) :
   J(a | b) = J(b | a) :=
-(jacobi_sym_quadratic_reciprocity_one_mod_four hb ha).symm
+(jacobi_sym.quadratic_reciprocity_one_mod_four hb ha).symm
 
 /-- The Law of Quadratic Reciprocityfor the Jacobi symbol: if `a` and `b` are natural numbers
 both congruent to `3` mod `4`, then `J(a | b) = -J(b | a)`. -/
-theorem jacobi_sym_quadratic_reciprocity_three_mod_four
+theorem jacobi_sym.quadratic_reciprocity_three_mod_four
   {a b : ℕ} (ha : a % 4 = 3) (hb : b % 4 = 3) :
   J(a | b) = - J(b | a) :=
 let nop := @neg_one_pow_div_two_of_three_mod_four in begin
-  rw [jacobi_sym_quadratic_reciprocity, pow_mul, nop ha, nop hb, neg_one_mul];
+  rw [jacobi_sym.quadratic_reciprocity, pow_mul, nop ha, nop hb, neg_one_mul];
   rwa [odd_iff, odd_of_mod_four_eq_three],
 end
 
 /-- The Jacobi symbol `J(a | b)` depends only on `b` mod `4*a` (version for `a : ℕ`). -/
-lemma jacobi_sym_mod_right' (a : ℕ) {b : ℕ} (hb : odd b) : J(a | b) = J(a | b % (4 * a)) :=
+lemma jacobi_sym.mod_right' (a : ℕ) {b : ℕ} (hb : odd b) : J(a | b) = J(a | b % (4 * a)) :=
 begin
   rcases eq_or_ne a 0 with rfl | ha₀,
   { rw [mul_zero, mod_zero], },
@@ -354,14 +357,14 @@ begin
   rcases exists_eq_pow_mul_and_not_dvd ha₀ 2 (by norm_num) with ⟨e, a', ha₁', ha₂⟩,
   have ha₁ := odd_iff.mpr (two_dvd_ne_zero.mp ha₁'),
   nth_rewrite 1 [ha₂], nth_rewrite 0 [ha₂],
-  rw [nat.cast_mul, jacobi_sym_mul_left, jacobi_sym_mul_left,
-      jacobi_sym_quadratic_reciprocity' ha₁ hb, jacobi_sym_quadratic_reciprocity' ha₁ hb',
-      nat.cast_pow, jacobi_sym_pow_left, jacobi_sym_pow_left,
-      (show ((2 : ℕ) : ℤ) = 2, by refl), jacobi_sym_two hb, jacobi_sym_two hb'],
+  rw [nat.cast_mul, jacobi_sym.mul_left, jacobi_sym.mul_left,
+      jacobi_sym.quadratic_reciprocity' ha₁ hb, jacobi_sym.quadratic_reciprocity' ha₁ hb',
+      nat.cast_pow, jacobi_sym.pow_left, jacobi_sym.pow_left,
+      (show ((2 : ℕ) : ℤ) = 2, by refl), jacobi_sym.at_two hb, jacobi_sym.at_two hb'],
   congr' 1, swap, congr' 1,
   { simp_rw [qr_sign],
     rw [χ₄_nat_mod_four, χ₄_nat_mod_four (b % (4 * a)), mod_mod_of_dvd b (dvd_mul_right 4 a) ] },
-  { rw [jacobi_sym_mod_left ↑(b % _), jacobi_sym_mod_left b, int.coe_nat_mod,
+  { rw [jacobi_sym.mod_left ↑(b % _), jacobi_sym.mod_left b, int.coe_nat_mod,
         int.mod_mod_of_dvd b],
     simp only [ha₂, nat.cast_mul, ← mul_assoc],
     exact dvd_mul_left a' _, },
@@ -371,12 +374,12 @@ begin
 end
 
 /-- The Jacobi symbol `J(a | b)` depends only on `b` mod `4*a`. -/
-lemma jacobi_sym_mod_right (a : ℤ) {b : ℕ} (hb : odd b) : J(a | b) = J(a | b % (4 * a.nat_abs)) :=
+lemma jacobi_sym.mod_right (a : ℤ) {b : ℕ} (hb : odd b) : J(a | b) = J(a | b % (4 * a.nat_abs)) :=
 begin
   cases int.nat_abs_eq a with ha ha; nth_rewrite 1 [ha]; nth_rewrite 0 [ha],
-  { exact jacobi_sym_mod_right' a.nat_abs hb, },
+  { exact jacobi_sym.mod_right' a.nat_abs hb, },
   { have hb' : odd (b % (4 * a.nat_abs)) := hb.mod_even (even.mul_right (by norm_num) _),
-    rw [jacobi_sym_neg _ hb, jacobi_sym_neg _ hb', jacobi_sym_mod_right' _ hb, χ₄_nat_mod_four,
+    rw [jacobi_sym.neg _ hb, jacobi_sym.neg _ hb', jacobi_sym.mod_right' _ hb, χ₄_nat_mod_four,
         χ₄_nat_mod_four (b % (4 * _)), mod_mod_of_dvd b (dvd_mul_right 4 _)], }
 end
 

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -372,8 +372,7 @@ lemma exists_sq_eq_prime_iff_of_mod_four_eq_one (hp1 : p % 4 = 1) (hq1 : q ≠ 2
 begin
   cases eq_or_ne p q with h h,
   { substI p },
-  { rw [← eq_one_iff' p (prime_ne_zero p q h),
-        ← eq_one_iff' q (prime_ne_zero q p h.symm),
+  { rw [← eq_one_iff' p (prime_ne_zero p q h), ← eq_one_iff' q (prime_ne_zero q p h.symm),
         quadratic_reciprocity_one_mod_four hp1 hq1], }
 end
 

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -198,7 +198,7 @@ section values
 /-!
 ### The value of the Legendre symbol at `-1`
 
-See `jacobi_symbol_neg_one` for the corresponding statement for the Jacobi symbol.
+See `jacobi_sym_neg_one` for the corresponding statement for the Jacobi symbol.
 -/
 
 variables {p : ℕ} [fact p.prime]
@@ -236,7 +236,7 @@ end zmod
 /-!
 ### The value of the Legendre symbol at `2` and `-2`
 
-See `jacobi_symbol_two` and `jacobi_symbol_neg_two` for the corresponding statements
+See `jacobi_sym_two` and `jacobi_sym_neg_two` for the corresponding statements
 for the Jacobi symbol.
 -/
 

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -19,17 +19,17 @@ and (odd) natural numbers `b`, which extends the Legendre symbol.
 
 ## Main results
 
-We prove the law of quadratic reciprocity, see `legendre_sym_quadratic_reciprocity` and
-`legendre_sym_quadratic_reciprocity'`, as well as the
+We prove the law of quadratic reciprocity, see `legendre_sym.quadratic_reciprocity` and
+`legendre_sym.quadratic_reciprocity'`, as well as the
 interpretations in terms of existence of square roots depending on the congruence mod 4,
 `zmod.exists_sq_eq_prime_iff_of_mod_four_eq_one`, and
 `zmod.exists_sq_eq_prime_iff_of_mod_four_eq_three`.
 
 We also prove the supplementary laws that give conditions for when `-1` or `2`
 (or `-2`) is a square modulo a prime `p`:
-`legendre_sym_neg_one` and `zmod.exists_sq_eq_neg_one_iff` for `-1`,
-`legendre_sym_two` and `zmod.exists_sq_eq_two_iff` for `2`,
-`legendre_sym_neg_two` and `zmod.exists_sq_eq_neg_two_iff` for `-2`.
+`legendre_sym.at_neg_one` and `zmod.exists_sq_eq_neg_one_iff` for `-1`,
+`legendre_sym.at_two` and `zmod.exists_sq_eq_two_iff` for `2`,
+`legendre_sym.at_neg_two` and `zmod.exists_sq_eq_neg_two_iff` for `-2`.
 
 ## Implementation notes
 
@@ -112,7 +112,7 @@ that `legendre_sym p` is a multiplicative function `ℤ → ℤ`.
 def legendre_sym (a : ℤ) : ℤ := quadratic_char (zmod p) a
 
 /-- We have the congruence `legendre_sym p a ≡ a ^ (p / 2) mod p`. -/
-lemma legendre_sym_eq_pow (a : ℤ) : (legendre_sym p a : zmod p) = a ^ (p / 2) :=
+lemma legendre_sym.eq_pow (a : ℤ) : (legendre_sym p a : zmod p) = a ^ (p / 2) :=
 begin
   cases eq_or_ne (ring_char (zmod p)) 2 with hc hc,
   { by_cases ha : (a : zmod p) = 0,
@@ -129,65 +129,67 @@ begin
 end
 
 /-- If `p ∤ a`, then `legendre_sym p a` is `1` or `-1`. -/
-lemma legendre_sym_eq_one_or_neg_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
+lemma legendre_sym.eq_one_or_neg_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
   legendre_sym p a = 1 ∨ legendre_sym p a = -1 :=
 quadratic_char_dichotomy ha
 
-lemma legendre_sym_eq_neg_one_iff_not_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
+lemma legendre_sym.eq_neg_one_iff_not_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
   legendre_sym p a = -1 ↔ ¬ legendre_sym p a = 1 :=
 quadratic_char_eq_neg_one_iff_not_one ha
 
 /-- The Legendre symbol of `p` and `a` is zero iff `p ∣ a`. -/
-lemma legendre_sym_eq_zero_iff (a : ℤ) : legendre_sym p a = 0 ↔ (a : zmod p) = 0 :=
+lemma legendre_sym.eq_zero_iff (a : ℤ) : legendre_sym p a = 0 ↔ (a : zmod p) = 0 :=
 quadratic_char_eq_zero_iff
 
-@[simp] lemma legendre_sym_zero : legendre_sym p 0 = 0 :=
+@[simp] lemma legendre_sym.at_zero : legendre_sym p 0 = 0 :=
 by rw [legendre_sym, int.cast_zero, mul_char.map_zero]
 
-@[simp] lemma legendre_sym_one : legendre_sym p 1 = 1 :=
+@[simp] lemma legendre_sym.at_one : legendre_sym p 1 = 1 :=
 by rw [legendre_sym, int.cast_one, mul_char.map_one]
 
 /-- The Legendre symbol is multiplicative in `a` for `p` fixed. -/
-lemma legendre_sym_mul (a b : ℤ) : legendre_sym p (a * b) = legendre_sym p a * legendre_sym p b :=
+protected
+lemma legendre_sym.mul (a b : ℤ) : legendre_sym p (a * b) = legendre_sym p a * legendre_sym p b :=
 by simp only [legendre_sym, int.cast_mul, map_mul]
 
 /-- The Legendre symbol is a homomorphism of monoids with zero. -/
-@[simps] def legendre_sym_hom : ℤ →*₀ ℤ :=
+@[simps] def legendre_sym.hom : ℤ →*₀ ℤ :=
 { to_fun := legendre_sym p,
-  map_zero' := legendre_sym_zero p,
-  map_one' := legendre_sym_one p,
-  map_mul' := legendre_sym_mul p }
+  map_zero' := legendre_sym.at_zero p,
+  map_one' := legendre_sym.at_one p,
+  map_mul' := legendre_sym.mul p }
 
 /-- The square of the symbol is 1 if `p ∤ a`. -/
-theorem legendre_sym_sq_one {a : ℤ} (ha : (a : zmod p) ≠ 0) : (legendre_sym p a) ^ 2 = 1 :=
+theorem legendre_sym.sq_one {a : ℤ} (ha : (a : zmod p) ≠ 0) : (legendre_sym p a) ^ 2 = 1 :=
 quadratic_char_sq_one ha
 
 /-- The Legendre symbol of `a^2` at `p` is 1 if `p ∤ a`. -/
-theorem legendre_sym_sq_one' {a : ℤ} (ha : (a : zmod p) ≠ 0) : legendre_sym p (a ^ 2) = 1 :=
+theorem legendre_sym.sq_one' {a : ℤ} (ha : (a : zmod p) ≠ 0) : legendre_sym p (a ^ 2) = 1 :=
 by exact_mod_cast quadratic_char_sq_one' ha
 
 /-- The Legendre symbol depends only on `a` mod `p`. -/
-theorem legendre_sym_mod (a : ℤ) : legendre_sym p a = legendre_sym p (a % p) :=
+protected
+theorem legendre_sym.mod (a : ℤ) : legendre_sym p a = legendre_sym p (a % p) :=
 by simp only [legendre_sym, int_cast_mod]
 
 /-- When `p ∤ a`, then `legendre_sym p a = 1` iff `a` is a square mod `p`. -/
-lemma legendre_sym_eq_one_iff {a : ℤ} (ha0 : (a : zmod p) ≠ 0) :
+lemma legendre_sym.eq_one_iff {a : ℤ} (ha0 : (a : zmod p) ≠ 0) :
   legendre_sym p a = 1 ↔ is_square (a : zmod p) :=
 quadratic_char_one_iff_is_square ha0
 
-lemma legendre_sym_eq_one_iff' {a : ℕ} (ha0 : (a : zmod p) ≠ 0) :
+lemma legendre_sym.eq_one_iff' {a : ℕ} (ha0 : (a : zmod p) ≠ 0) :
   legendre_sym p a = 1 ↔ is_square (a : zmod p) :=
-by {rw legendre_sym_eq_one_iff, norm_cast, exact_mod_cast ha0}
+by {rw legendre_sym.eq_one_iff, norm_cast, exact_mod_cast ha0}
 
 /-- `legendre_sym p a = -1` iff `a` is a nonsquare mod `p`. -/
-lemma legendre_sym_eq_neg_one_iff {a : ℤ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
+lemma legendre_sym.eq_neg_one_iff {a : ℤ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
 quadratic_char_neg_one_iff_not_is_square
 
-lemma legendre_sym_eq_neg_one_iff' {a : ℕ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
-by {rw legendre_sym_eq_neg_one_iff, norm_cast}
+lemma legendre_sym.eq_neg_one_iff' {a : ℕ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
+by {rw legendre_sym.eq_neg_one_iff, norm_cast}
 
 /-- The number of square roots of `a` modulo `p` is determined by the Legendre symbol. -/
-lemma legendre_sym_card_sqrts (hp : p ≠ 2) (a : ℤ) :
+lemma legendre_sym.card_sqrts (hp : p ≠ 2) (a : ℤ) :
   ↑{x : zmod p | x^2 = a}.to_finset.card = legendre_sym p a + 1 :=
 quadratic_char_card_sqrts ((ring_char_zmod_n p).substr hp) a
 
@@ -198,7 +200,7 @@ section values
 /-!
 ### The value of the Legendre symbol at `-1`
 
-See `jacobi_sym_neg_one` for the corresponding statement for the Jacobi symbol.
+See `jacobi_sym.at_neg_one` for the corresponding statement for the Jacobi symbol.
 -/
 
 variables {p : ℕ} [fact p.prime]
@@ -206,7 +208,7 @@ variables {p : ℕ} [fact p.prime]
 open zmod
 
 /-- `legendre_sym p (-1)` is given by `χ₄ p`. -/
-lemma legendre_sym_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=
+lemma legendre_sym.at_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=
 by simp only [legendre_sym, card p, quadratic_char_neg_one ((ring_char_zmod_n p).substr hp),
               int.cast_neg, int.cast_one]
 
@@ -236,7 +238,7 @@ end zmod
 /-!
 ### The value of the Legendre symbol at `2` and `-2`
 
-See `jacobi_sym_two` and `jacobi_sym_neg_two` for the corresponding statements
+See `jacobi_sym.at_two` and `jacobi_sym.at_neg_two` for the corresponding statements
 for the Jacobi symbol.
 -/
 
@@ -244,7 +246,7 @@ variables (hp : p ≠ 2)
 include hp
 
 /-- `legendre_sym p 2` is given by `χ₈ p`. -/
-lemma legendre_sym_two : legendre_sym p 2 = χ₈ p :=
+lemma legendre_sym.at_two : legendre_sym p 2 = χ₈ p :=
 by simp only [legendre_sym, card p, quadratic_char_two ((ring_char_zmod_n p).substr hp),
               int.cast_bit0, int.cast_one]
 
@@ -261,7 +263,7 @@ begin
 end
 
 /-- `legendre_sym p (-2)` is given by `χ₈' p`. -/
-lemma legendre_sym_neg_two : legendre_sym p (-2) = χ₈' p :=
+lemma legendre_sym.at_neg_two : legendre_sym p (-2) = χ₈' p :=
 by simp only [legendre_sym, card p, quadratic_char_neg_two ((ring_char_zmod_n p).substr hp),
               int.cast_bit0, int.cast_one, int.cast_neg]
 
@@ -284,7 +286,7 @@ section reciprocity
 /-!
 ### The Law of Quadratic Reciprocity
 
-See `jacobi_sym_quadratic_reciprocity` and variants for a version of Quadratic Reciprocity
+See `jacobi_sym.quadratic_reciprocity` and variants for a version of Quadratic Reciprocity
 for the Jacobi symbol.
 -/
 
@@ -294,7 +296,7 @@ open zmod
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are distinct odd primes, then
 `(q / p) * (p / q) = (-1)^((p-1)(q-1)/4)`. -/
-theorem legendre_sym_quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
+theorem legendre_sym.quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
   legendre_sym q p * legendre_sym p q = (-1) ^ ((p / 2) * (q / 2)) :=
 begin
   have hp₁ := (prime.eq_two_or_odd $ fact.out p.prime).resolve_left hp,
@@ -312,31 +314,31 @@ end
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are odd primes, then
 `(q / p) = (-1)^((p-1)(q-1)/4) * (p / q)`. -/
-theorem legendre_sym_quadratic_reciprocity' (hp : p ≠ 2) (hq : q ≠ 2) :
+theorem legendre_sym.quadratic_reciprocity' (hp : p ≠ 2) (hq : q ≠ 2) :
   legendre_sym q p = (-1) ^ ((p / 2) * (q / 2)) * legendre_sym p q :=
 begin
   cases eq_or_ne p q with h h,
   { substI p,
-    rw [(legendre_sym_eq_zero_iff q q).mpr (by exact_mod_cast nat_cast_self q), mul_zero] },
-  { have qr := congr_arg (* legendre_sym p q) (legendre_sym_quadratic_reciprocity hp hq h),
+    rw [(legendre_sym.eq_zero_iff q q).mpr (by exact_mod_cast nat_cast_self q), mul_zero] },
+  { have qr := congr_arg (* legendre_sym p q) (legendre_sym.quadratic_reciprocity hp hq h),
     have : ((q : ℤ) : zmod p) ≠ 0 := by exact_mod_cast prime_ne_zero p q h,
-    simpa only [mul_assoc, ← pow_two, legendre_sym_sq_one p this, mul_one] using qr }
+    simpa only [mul_assoc, ← pow_two, legendre_sym.sq_one p this, mul_one] using qr }
 end
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are odd primes and `p % 4 = 1`,
 then `(q / p) = (p / q)`. -/
-theorem legendre_sym_quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
+theorem legendre_sym.quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
   legendre_sym q p = legendre_sym p q :=
-by rw [legendre_sym_quadratic_reciprocity' (prime.mod_two_eq_one_iff_ne_two.mp
+by rw [legendre_sym.quadratic_reciprocity' (prime.mod_two_eq_one_iff_ne_two.mp
                                              (odd_of_mod_four_eq_one hp)) hq,
        pow_mul, neg_one_pow_div_two_of_one_mod_four hp, one_pow, one_mul]
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are primes that are both congruent
 to `3` mod `4`, then `(q / p) = -(p / q)`. -/
-theorem legendre_sym_quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
+theorem legendre_sym.quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
   legendre_sym q p = -legendre_sym p q :=
 let nop := @neg_one_pow_div_two_of_three_mod_four in begin
-  rw [legendre_sym_quadratic_reciprocity', pow_mul, nop hp, nop hq, neg_one_mul];
+  rw [legendre_sym.quadratic_reciprocity', pow_mul, nop hp, nop hq, neg_one_mul];
   rwa [← prime.mod_two_eq_one_iff_ne_two, odd_of_mod_four_eq_three],
 end
 
@@ -347,9 +349,9 @@ lemma zmod.exists_sq_eq_prime_iff_of_mod_four_eq_one (hp1 : p % 4 = 1) (hq1 : q 
 begin
   cases eq_or_ne p q with h h,
   { substI p },
-  { rw [← legendre_sym_eq_one_iff' p (prime_ne_zero p q h),
-        ← legendre_sym_eq_one_iff' q (prime_ne_zero q p h.symm),
-        legendre_sym_quadratic_reciprocity_one_mod_four hp1 hq1], }
+  { rw [← legendre_sym.eq_one_iff' p (prime_ne_zero p q h),
+        ← legendre_sym.eq_one_iff' q (prime_ne_zero q p h.symm),
+        legendre_sym.quadratic_reciprocity_one_mod_four hp1 hq1], }
 end
 
 /-- If `p` and `q` are distinct primes that are both congruent to `3` mod `4`, then `q` is
@@ -357,7 +359,7 @@ a square mod `p` iff `p` is a nonsquare mod `q`. -/
 lemma zmod.exists_sq_eq_prime_iff_of_mod_four_eq_three (hp3 : p % 4 = 3) (hq3 : q % 4 = 3)
   (hpq : p ≠ q) :
   is_square (q : zmod p) ↔ ¬ is_square (p : zmod q) :=
-by rw [← legendre_sym_eq_one_iff' p (prime_ne_zero p q hpq), ← legendre_sym_eq_neg_one_iff' q,
-       legendre_sym_quadratic_reciprocity_three_mod_four hp3 hq3, neg_inj]
+by rw [← legendre_sym.eq_one_iff' p (prime_ne_zero p q hpq), ← legendre_sym.eq_neg_one_iff' q,
+       legendre_sym.quadratic_reciprocity_three_mod_four hp3 hq3, neg_inj]
 
 end reciprocity

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -111,8 +111,10 @@ that `legendre_sym p` is a multiplicative function `ℤ → ℤ`.
 -/
 def legendre_sym (a : ℤ) : ℤ := quadratic_char (zmod p) a
 
+namespace legendre_sym
+
 /-- We have the congruence `legendre_sym p a ≡ a ^ (p / 2) mod p`. -/
-lemma legendre_sym.eq_pow (a : ℤ) : (legendre_sym p a : zmod p) = a ^ (p / 2) :=
+lemma eq_pow (a : ℤ) : (legendre_sym p a : zmod p) = a ^ (p / 2) :=
 begin
   cases eq_or_ne (ring_char (zmod p)) 2 with hc hc,
   { by_cases ha : (a : zmod p) = 0,
@@ -129,69 +131,71 @@ begin
 end
 
 /-- If `p ∤ a`, then `legendre_sym p a` is `1` or `-1`. -/
-lemma legendre_sym.eq_one_or_neg_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
+lemma eq_one_or_neg_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
   legendre_sym p a = 1 ∨ legendre_sym p a = -1 :=
 quadratic_char_dichotomy ha
 
-lemma legendre_sym.eq_neg_one_iff_not_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
+lemma eq_neg_one_iff_not_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
   legendre_sym p a = -1 ↔ ¬ legendre_sym p a = 1 :=
 quadratic_char_eq_neg_one_iff_not_one ha
 
 /-- The Legendre symbol of `p` and `a` is zero iff `p ∣ a`. -/
-lemma legendre_sym.eq_zero_iff (a : ℤ) : legendre_sym p a = 0 ↔ (a : zmod p) = 0 :=
+lemma eq_zero_iff (a : ℤ) : legendre_sym p a = 0 ↔ (a : zmod p) = 0 :=
 quadratic_char_eq_zero_iff
 
-@[simp] lemma legendre_sym.at_zero : legendre_sym p 0 = 0 :=
+@[simp] lemma at_zero : legendre_sym p 0 = 0 :=
 by rw [legendre_sym, int.cast_zero, mul_char.map_zero]
 
-@[simp] lemma legendre_sym.at_one : legendre_sym p 1 = 1 :=
+@[simp] lemma at_one : legendre_sym p 1 = 1 :=
 by rw [legendre_sym, int.cast_one, mul_char.map_one]
 
 /-- The Legendre symbol is multiplicative in `a` for `p` fixed. -/
 protected
-lemma legendre_sym.mul (a b : ℤ) : legendre_sym p (a * b) = legendre_sym p a * legendre_sym p b :=
+lemma mul (a b : ℤ) : legendre_sym p (a * b) = legendre_sym p a * legendre_sym p b :=
 by simp only [legendre_sym, int.cast_mul, map_mul]
 
 /-- The Legendre symbol is a homomorphism of monoids with zero. -/
-@[simps] def legendre_sym.hom : ℤ →*₀ ℤ :=
+@[simps] def hom : ℤ →*₀ ℤ :=
 { to_fun := legendre_sym p,
-  map_zero' := legendre_sym.at_zero p,
-  map_one' := legendre_sym.at_one p,
+  map_zero' := at_zero p,
+  map_one' := at_one p,
   map_mul' := legendre_sym.mul p }
 
 /-- The square of the symbol is 1 if `p ∤ a`. -/
-theorem legendre_sym.sq_one {a : ℤ} (ha : (a : zmod p) ≠ 0) : (legendre_sym p a) ^ 2 = 1 :=
+theorem sq_one {a : ℤ} (ha : (a : zmod p) ≠ 0) : (legendre_sym p a) ^ 2 = 1 :=
 quadratic_char_sq_one ha
 
 /-- The Legendre symbol of `a^2` at `p` is 1 if `p ∤ a`. -/
-theorem legendre_sym.sq_one' {a : ℤ} (ha : (a : zmod p) ≠ 0) : legendre_sym p (a ^ 2) = 1 :=
+theorem sq_one' {a : ℤ} (ha : (a : zmod p) ≠ 0) : legendre_sym p (a ^ 2) = 1 :=
 by exact_mod_cast quadratic_char_sq_one' ha
 
 /-- The Legendre symbol depends only on `a` mod `p`. -/
 protected
-theorem legendre_sym.mod (a : ℤ) : legendre_sym p a = legendre_sym p (a % p) :=
+theorem mod (a : ℤ) : legendre_sym p a = legendre_sym p (a % p) :=
 by simp only [legendre_sym, int_cast_mod]
 
 /-- When `p ∤ a`, then `legendre_sym p a = 1` iff `a` is a square mod `p`. -/
-lemma legendre_sym.eq_one_iff {a : ℤ} (ha0 : (a : zmod p) ≠ 0) :
+lemma eq_one_iff {a : ℤ} (ha0 : (a : zmod p) ≠ 0) :
   legendre_sym p a = 1 ↔ is_square (a : zmod p) :=
 quadratic_char_one_iff_is_square ha0
 
-lemma legendre_sym.eq_one_iff' {a : ℕ} (ha0 : (a : zmod p) ≠ 0) :
+lemma eq_one_iff' {a : ℕ} (ha0 : (a : zmod p) ≠ 0) :
   legendre_sym p a = 1 ↔ is_square (a : zmod p) :=
-by {rw legendre_sym.eq_one_iff, norm_cast, exact_mod_cast ha0}
+by {rw eq_one_iff, norm_cast, exact_mod_cast ha0}
 
 /-- `legendre_sym p a = -1` iff `a` is a nonsquare mod `p`. -/
-lemma legendre_sym.eq_neg_one_iff {a : ℤ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
+lemma eq_neg_one_iff {a : ℤ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
 quadratic_char_neg_one_iff_not_is_square
 
-lemma legendre_sym.eq_neg_one_iff' {a : ℕ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
-by {rw legendre_sym.eq_neg_one_iff, norm_cast}
+lemma eq_neg_one_iff' {a : ℕ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
+by {rw eq_neg_one_iff, norm_cast}
 
 /-- The number of square roots of `a` modulo `p` is determined by the Legendre symbol. -/
-lemma legendre_sym.card_sqrts (hp : p ≠ 2) (a : ℤ) :
+lemma card_sqrts (hp : p ≠ 2) (a : ℤ) :
   ↑{x : zmod p | x^2 = a}.to_finset.card = legendre_sym p a + 1 :=
 quadratic_char_card_sqrts ((ring_char_zmod_n p).substr hp) a
+
+end legendre_sym
 
 end legendre
 
@@ -242,16 +246,30 @@ See `jacobi_sym.at_two` and `jacobi_sym.at_neg_two` for the corresponding statem
 for the Jacobi symbol.
 -/
 
+namespace legendre_sym
+
 variables (hp : p ≠ 2)
 include hp
 
 /-- `legendre_sym p 2` is given by `χ₈ p`. -/
-lemma legendre_sym.at_two : legendre_sym p 2 = χ₈ p :=
+lemma at_two : legendre_sym p 2 = χ₈ p :=
 by simp only [legendre_sym, card p, quadratic_char_two ((ring_char_zmod_n p).substr hp),
               int.cast_bit0, int.cast_one]
 
+/-- `legendre_sym p (-2)` is given by `χ₈' p`. -/
+lemma at_neg_two : legendre_sym p (-2) = χ₈' p :=
+by simp only [legendre_sym, card p, quadratic_char_neg_two ((ring_char_zmod_n p).substr hp),
+              int.cast_bit0, int.cast_one, int.cast_neg]
+
+end legendre_sym
+
+namespace zmod
+
+variables (hp : p ≠ 2)
+include hp
+
 /-- `2` is a square modulo an odd prime `p` iff `p` is congruent to `1` or `7` mod `8`. -/
-lemma zmod.exists_sq_eq_two_iff : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
+lemma exists_sq_eq_two_iff : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
 begin
   rw [finite_field.is_square_two_iff, card p],
   have h₁ := prime.mod_two_eq_one_iff_ne_two.mpr hp,
@@ -262,13 +280,8 @@ begin
   dec_trivial!,
 end
 
-/-- `legendre_sym p (-2)` is given by `χ₈' p`. -/
-lemma legendre_sym.at_neg_two : legendre_sym p (-2) = χ₈' p :=
-by simp only [legendre_sym, card p, quadratic_char_neg_two ((ring_char_zmod_n p).substr hp),
-              int.cast_bit0, int.cast_one, int.cast_neg]
-
 /-- `-2` is a square modulo an odd prime `p` iff `p` is congruent to `1` or `3` mod `8`. -/
-lemma zmod.exists_sq_eq_neg_two_iff : is_square (-2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 3 :=
+lemma exists_sq_eq_neg_two_iff : is_square (-2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 3 :=
 begin
   rw [finite_field.is_square_neg_two_iff, card p],
   have h₁ := prime.mod_two_eq_one_iff_ne_two.mpr hp,
@@ -278,6 +291,8 @@ begin
   generalize hm : p % 8 = m, unfreezingI {clear_dependent p},
   dec_trivial!,
 end
+
+end zmod
 
 end values
 
@@ -292,11 +307,13 @@ for the Jacobi symbol.
 
 variables {p q : ℕ} [fact p.prime] [fact q.prime]
 
+namespace legendre_sym
+
 open zmod
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are distinct odd primes, then
 `(q / p) * (p / q) = (-1)^((p-1)(q-1)/4)`. -/
-theorem legendre_sym.quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
+theorem quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
   legendre_sym q p * legendre_sym p q = (-1) ^ ((p / 2) * (q / 2)) :=
 begin
   have hp₁ := (prime.eq_two_or_odd $ fact.out p.prime).resolve_left hp,
@@ -314,52 +331,60 @@ end
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are odd primes, then
 `(q / p) = (-1)^((p-1)(q-1)/4) * (p / q)`. -/
-theorem legendre_sym.quadratic_reciprocity' (hp : p ≠ 2) (hq : q ≠ 2) :
+theorem quadratic_reciprocity' (hp : p ≠ 2) (hq : q ≠ 2) :
   legendre_sym q p = (-1) ^ ((p / 2) * (q / 2)) * legendre_sym p q :=
 begin
   cases eq_or_ne p q with h h,
   { substI p,
-    rw [(legendre_sym.eq_zero_iff q q).mpr (by exact_mod_cast nat_cast_self q), mul_zero] },
-  { have qr := congr_arg (* legendre_sym p q) (legendre_sym.quadratic_reciprocity hp hq h),
+    rw [(eq_zero_iff q q).mpr (by exact_mod_cast nat_cast_self q), mul_zero] },
+  { have qr := congr_arg (* legendre_sym p q) (quadratic_reciprocity hp hq h),
     have : ((q : ℤ) : zmod p) ≠ 0 := by exact_mod_cast prime_ne_zero p q h,
-    simpa only [mul_assoc, ← pow_two, legendre_sym.sq_one p this, mul_one] using qr }
+    simpa only [mul_assoc, ← pow_two, sq_one p this, mul_one] using qr }
 end
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are odd primes and `p % 4 = 1`,
 then `(q / p) = (p / q)`. -/
-theorem legendre_sym.quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
+theorem quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
   legendre_sym q p = legendre_sym p q :=
-by rw [legendre_sym.quadratic_reciprocity' (prime.mod_two_eq_one_iff_ne_two.mp
+by rw [quadratic_reciprocity' (prime.mod_two_eq_one_iff_ne_two.mp
                                              (odd_of_mod_four_eq_one hp)) hq,
        pow_mul, neg_one_pow_div_two_of_one_mod_four hp, one_pow, one_mul]
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are primes that are both congruent
 to `3` mod `4`, then `(q / p) = -(p / q)`. -/
-theorem legendre_sym.quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
+theorem quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
   legendre_sym q p = -legendre_sym p q :=
 let nop := @neg_one_pow_div_two_of_three_mod_four in begin
-  rw [legendre_sym.quadratic_reciprocity', pow_mul, nop hp, nop hq, neg_one_mul];
+  rw [quadratic_reciprocity', pow_mul, nop hp, nop hq, neg_one_mul];
   rwa [← prime.mod_two_eq_one_iff_ne_two, odd_of_mod_four_eq_three],
 end
 
+end legendre_sym
+
+namespace zmod
+
+open legendre_sym
+
 /-- If `p` and `q` are odd primes and `p % 4 = 1`, then `q` is a square mod `p` iff
 `p` is a square mod `q`. -/
-lemma zmod.exists_sq_eq_prime_iff_of_mod_four_eq_one (hp1 : p % 4 = 1) (hq1 : q ≠ 2) :
+lemma exists_sq_eq_prime_iff_of_mod_four_eq_one (hp1 : p % 4 = 1) (hq1 : q ≠ 2) :
   is_square (q : zmod p) ↔ is_square (p : zmod q) :=
 begin
   cases eq_or_ne p q with h h,
   { substI p },
-  { rw [← legendre_sym.eq_one_iff' p (prime_ne_zero p q h),
-        ← legendre_sym.eq_one_iff' q (prime_ne_zero q p h.symm),
-        legendre_sym.quadratic_reciprocity_one_mod_four hp1 hq1], }
+  { rw [← eq_one_iff' p (prime_ne_zero p q h),
+        ← eq_one_iff' q (prime_ne_zero q p h.symm),
+        quadratic_reciprocity_one_mod_four hp1 hq1], }
 end
 
 /-- If `p` and `q` are distinct primes that are both congruent to `3` mod `4`, then `q` is
 a square mod `p` iff `p` is a nonsquare mod `q`. -/
-lemma zmod.exists_sq_eq_prime_iff_of_mod_four_eq_three (hp3 : p % 4 = 3) (hq3 : q % 4 = 3)
+lemma exists_sq_eq_prime_iff_of_mod_four_eq_three (hp3 : p % 4 = 3) (hq3 : q % 4 = 3)
   (hpq : p ≠ q) :
   is_square (q : zmod p) ↔ ¬ is_square (p : zmod q) :=
-by rw [← legendre_sym.eq_one_iff' p (prime_ne_zero p q hpq), ← legendre_sym.eq_neg_one_iff' q,
-       legendre_sym.quadratic_reciprocity_three_mod_four hp3 hq3, neg_inj]
+by rw [← eq_one_iff' p (prime_ne_zero p q hpq), ← eq_neg_one_iff' q,
+       quadratic_reciprocity_three_mod_four hp3 hq3, neg_inj]
+
+end zmod
 
 end reciprocity

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -10,7 +10,7 @@ import number_theory.legendre_symbol.quadratic_char
 
 This file contains results about quadratic residues modulo a prime number.
 
-We define the Legendre symbol `(a / p)` as `legendre_sym p a`.
+We define the Legendre symbol $\Bigl(\frac{a}{p}\Bigr)$ as `legendre_sym p a`.
 Note the order of arguments! The advantage of this form is that then `legendre_sym p`
 is a multiplicative map.
 

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -10,23 +10,23 @@ import number_theory.legendre_symbol.quadratic_char
 
 This file contains results about quadratic residues modulo a prime number.
 
-We define the Legendre symbol `(a / p)` as `zmod.legendre_sym p a`.
-Note the order of arguments! The advantage of this form is that then `zmod.legendre_sym p`
+We define the Legendre symbol `(a / p)` as `legendre_sym p a`.
+Note the order of arguments! The advantage of this form is that then `legendre_sym p`
 is a multiplicative map.
 
 ## Main results
 
-We prove the law of quadratic reciprocity, see `zmod.quadratic_reciprocity` and
-`zmod.quadratic_reciprocity'`, as well as the
+We prove the law of quadratic reciprocity, see `legendre_sym_quadratic_reciprocity` and
+`legendre_sym_quadratic_reciprocity'`, as well as the
 interpretations in terms of existence of square roots depending on the congruence mod 4,
 `zmod.exists_sq_eq_prime_iff_of_mod_four_eq_one`, and
 `zmod.exists_sq_eq_prime_iff_of_mod_four_eq_three`.
 
 We also prove the supplementary laws that give conditions for when `-1` or `2`
 (or `-2`) is a square modulo a prime `p`:
-`zmod.legende_sym_neg_one` and `zmod.exists_sq_eq_neg_one_iff` for `-1`,
-`zmod.legendre_sym_two` and `zmod.exists_sq_eq_two_iff` for `2`,
-`zmod.legendre_sym_neg_two` and `zmod.exists_sq_eq_neg_two_iff` for `-2`.
+`legendre_sym_neg_one` and `zmod.exists_sq_eq_neg_one_iff` for `-1`,
+`legendre_sym_two` and `zmod.exists_sq_eq_two_iff` for `2`,
+`legendre_sym_neg_two` and `zmod.exists_sq_eq_neg_two_iff` for `-2`.
 
 ## Implementation notes
 
@@ -41,9 +41,9 @@ quadratic residue, quadratic nonresidue, Legendre symbol, quadratic reciprocity
 
 open nat
 
-namespace zmod
-
 section euler
+
+namespace zmod
 
 variables (p : ℕ) [fact p.prime]
 
@@ -82,6 +82,8 @@ begin
   exact pow_card_sub_one_eq_one ha
 end
 
+end zmod
+
 end euler
 
 section legendre
@@ -89,6 +91,8 @@ section legendre
 /-!
 ### Definition of the Legendre symbol and basic properties
 -/
+
+open zmod
 
 variables (p : ℕ) [fact p.prime]
 
@@ -194,10 +198,14 @@ section values
 
 variables {p : ℕ} [fact p.prime]
 
+open zmod
+
 /-- `legendre_sym p (-1)` is given by `χ₄ p`. -/
 lemma legendre_sym_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=
 by simp only [legendre_sym, card p, quadratic_char_neg_one ((ring_char_zmod_n p).substr hp),
               int.cast_neg, int.cast_one]
+
+namespace zmod
 
 /-- `-1` is a square in `zmod p` iff `p` is not congruent to `3` mod `4`. -/
 lemma exists_sq_eq_neg_one_iff : is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
@@ -218,6 +226,8 @@ lemma mod_four_ne_three_of_sq_eq_neg_sq {x y : zmod p} (hx : x ≠ 0) (hxy : x ^
   p % 4 ≠ 3 :=
 mod_four_ne_three_of_sq_eq_neg_sq' hx (eq_neg_iff_eq_neg.1 hxy)
 
+end zmod
+
 /-!
 ### The value of the Legendre symbol at `2` and `-2`
 -/
@@ -231,7 +241,7 @@ by simp only [legendre_sym, card p, quadratic_char_two ((ring_char_zmod_n p).sub
               int.cast_bit0, int.cast_one]
 
 /-- `2` is a square modulo an odd prime `p` iff `p` is congruent to `1` or `7` mod `8`. -/
-lemma exists_sq_eq_two_iff : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
+lemma zmod.exists_sq_eq_two_iff : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
 begin
   rw [finite_field.is_square_two_iff, card p],
   have h₁ := prime.mod_two_eq_one_iff_ne_two.mpr hp,
@@ -248,7 +258,7 @@ by simp only [legendre_sym, card p, quadratic_char_neg_two ((ring_char_zmod_n p)
               int.cast_bit0, int.cast_one, int.cast_neg]
 
 /-- `-2` is a square modulo an odd prime `p` iff `p` is congruent to `1` or `3` mod `8`. -/
-lemma exists_sq_eq_neg_two_iff : is_square (-2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 3 :=
+lemma zmod.exists_sq_eq_neg_two_iff : is_square (-2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 3 :=
 begin
   rw [finite_field.is_square_neg_two_iff, card p],
   have h₁ := prime.mod_two_eq_one_iff_ne_two.mpr hp,
@@ -269,9 +279,11 @@ section reciprocity
 
 variables {p q : ℕ} [fact p.prime] [fact q.prime]
 
+open zmod
+
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are distinct odd primes, then
 `(q / p) * (p / q) = (-1)^((p-1)(q-1)/4)`. -/
-theorem quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
+theorem legendre_sym_quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
   legendre_sym q p * legendre_sym p q = (-1) ^ ((p / 2) * (q / 2)) :=
 begin
   have hp₁ := (prime.eq_two_or_odd $ fact.out p.prime).resolve_left hp,
@@ -289,53 +301,52 @@ end
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are odd primes, then
 `(q / p) = (-1)^((p-1)(q-1)/4) * (p / q)`. -/
-theorem quadratic_reciprocity' (hp : p ≠ 2) (hq : q ≠ 2) :
+theorem legendre_sym_quadratic_reciprocity' (hp : p ≠ 2) (hq : q ≠ 2) :
   legendre_sym q p = (-1) ^ ((p / 2) * (q / 2)) * legendre_sym p q :=
 begin
   cases eq_or_ne p q with h h,
   { substI p,
     rw [(legendre_sym_eq_zero_iff q q).mpr (by exact_mod_cast nat_cast_self q), mul_zero] },
-  { have qr := congr_arg (* legendre_sym p q) (quadratic_reciprocity hp hq h),
+  { have qr := congr_arg (* legendre_sym p q) (legendre_sym_quadratic_reciprocity hp hq h),
     have : ((q : ℤ) : zmod p) ≠ 0 := by exact_mod_cast prime_ne_zero p q h,
     simpa only [mul_assoc, ← pow_two, legendre_sym_sq_one p this, mul_one] using qr }
 end
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are odd primes and `p % 4 = 1`,
 then `(q / p) = (p / q)`. -/
-theorem quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
+theorem legendre_sym_quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
   legendre_sym q p = legendre_sym p q :=
-by rw [quadratic_reciprocity' (prime.mod_two_eq_one_iff_ne_two.mp (odd_of_mod_four_eq_one hp)) hq,
+by rw [legendre_sym_quadratic_reciprocity' (prime.mod_two_eq_one_iff_ne_two.mp
+                                             (odd_of_mod_four_eq_one hp)) hq,
        pow_mul, neg_one_pow_div_two_of_one_mod_four hp, one_pow, one_mul]
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are primes that are both congruent
 to `3` mod `4`, then `(q / p) = -(p / q)`. -/
-theorem quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
+theorem legendre_sym_quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
   legendre_sym q p = -legendre_sym p q :=
 let nop := @neg_one_pow_div_two_of_three_mod_four in begin
-  rw [quadratic_reciprocity', pow_mul, nop hp, nop hq, neg_one_mul];
+  rw [legendre_sym_quadratic_reciprocity', pow_mul, nop hp, nop hq, neg_one_mul];
   rwa [← prime.mod_two_eq_one_iff_ne_two, odd_of_mod_four_eq_three],
 end
 
 /-- If `p` and `q` are odd primes and `p % 4 = 1`, then `q` is a square mod `p` iff
 `p` is a square mod `q`. -/
-lemma exists_sq_eq_prime_iff_of_mod_four_eq_one (hp1 : p % 4 = 1) (hq1 : q ≠ 2) :
+lemma zmod.exists_sq_eq_prime_iff_of_mod_four_eq_one (hp1 : p % 4 = 1) (hq1 : q ≠ 2) :
   is_square (q : zmod p) ↔ is_square (p : zmod q) :=
 begin
   cases eq_or_ne p q with h h,
   { substI p },
   { rw [← legendre_sym_eq_one_iff' p (prime_ne_zero p q h),
         ← legendre_sym_eq_one_iff' q (prime_ne_zero q p h.symm),
-        quadratic_reciprocity_one_mod_four hp1 hq1], }
+        legendre_sym_quadratic_reciprocity_one_mod_four hp1 hq1], }
 end
 
 /-- If `p` and `q` are distinct primes that are both congruent to `3` mod `4`, then `q` is
 a square mod `p` iff `p` is a nonsquare mod `q`. -/
-lemma exists_sq_eq_prime_iff_of_mod_four_eq_three (hp3 : p % 4 = 3) (hq3 : q % 4 = 3)
+lemma zmod.exists_sq_eq_prime_iff_of_mod_four_eq_three (hp3 : p % 4 = 3) (hq3 : q % 4 = 3)
   (hpq : p ≠ q) :
   is_square (q : zmod p) ↔ ¬ is_square (p : zmod q) :=
 by rw [← legendre_sym_eq_one_iff' p (prime_ne_zero p q hpq), ← legendre_sym_eq_neg_one_iff' q,
-       quadratic_reciprocity_three_mod_four hp3 hq3, neg_inj]
+       legendre_sym_quadratic_reciprocity_three_mod_four hp3 hq3, neg_inj]
 
 end reciprocity
-
-end zmod

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -14,6 +14,9 @@ We define the Legendre symbol `(a / p)` as `legendre_sym p a`.
 Note the order of arguments! The advantage of this form is that then `legendre_sym p`
 is a multiplicative map.
 
+The Legendre symbol is used to define the Jacobi symbol, `jacobi_sym a b`, for integers `a`
+and (odd) natural numbers `b`, which extends the Legendre symbol.
+
 ## Main results
 
 We prove the law of quadratic reciprocity, see `legendre_sym_quadratic_reciprocity` and
@@ -194,6 +197,8 @@ section values
 
 /-!
 ### The value of the Legendre symbol at `-1`
+
+See `jacobi_symbol_neg_one` for the corresponding statement for the Jacobi symbol.
 -/
 
 variables {p : ℕ} [fact p.prime]
@@ -230,6 +235,9 @@ end zmod
 
 /-!
 ### The value of the Legendre symbol at `2` and `-2`
+
+See `jacobi_symbol_two` and `jacobi_symbol_neg_two` for the corresponding statements
+for the Jacobi symbol.
 -/
 
 variables (hp : p ≠ 2)
@@ -275,6 +283,9 @@ section reciprocity
 
 /-!
 ### The Law of Quadratic Reciprocity
+
+See `jacobi_sym_quadratic_reciprocity` and variants for a version of Quadratic Reciprocity
+for the Jacobi symbol.
 -/
 
 variables {p q : ℕ} [fact p.prime] [fact q.prime]


### PR DESCRIPTION
This PR moves `legendre_sym` and `jacobi_sym` (and `qr_sign`) to the root namespace. It also moves definitions and lemmas named `legendre_sym_...` to the `legendre_sym` namespace and analogous for `jacobi_sym_...` and `qr_sign_...`. We change names like `jacobi_sym_two` to `jacobi_sym.at_two`.

This mostly affects the files `number_theory.legendre_symbol.quadratic_reciprocity` and `number_theory.legendre_symbol.jacobi_symbol`. Note that names like `exists_sq_eq_neg_one_iff` have been left in `zmod`. We prefix `quadratic_reciprocity*` by `legendre_sym` to disambiguate with the versions for the Jacobi symbol. (The links in `docs/100.yaml` and `docs/overview.yaml` are updated accordingly.)

We also move the results in `number_theory.legendre_symbol.gauss_eisenstein_lemmas` from the `legendre_symbol` namespace to the `zmod` namespace.

See this [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Jacobi.20symbol/near/297792676) and the comments at [#16395](https://github.com/leanprover-community/mathlib/pull/16395) for discussion.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
