### PR TITLE
[Merged by Bors] - feat(data/fintype/basic): Existence of a bijection with specified behaviour on a subset

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1425,10 +1425,10 @@ begin
     tauto }
 end
 
-/-- There exists a bijection between two types of the same finite cardinality, which extends a given
-bijection on a given set. -/
-lemma finset.exists_equiv_extend_of_card_eq' [fintype α] {t : finset β}
-  (hαt : fintype.card α = t.card) {s : set α} {f : α → β} (hfst : f '' s ⊆ t)
+/-- Any injection from a set `s` in a fintype `α` to a finset `t` of the same cardinality as `α`
+can be extended to a bijection between `α` and `t`. -/
+lemma set.maps_to.exists_equiv_extend_of_card_eq [fintype α] {t : finset β}
+  (hαt : fintype.card α = t.card) {s : set α} {f : α → β} (hfst : s.maps_to f t)
   (hfs : set.inj_on f s) :
   ∃ g : α ≃ t, ∀ i ∈ s, (g i : β) = f i :=
 begin

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1393,36 +1393,27 @@ by rw [←e.equiv_of_fintype_self_embedding_to_embedding, univ_map_equiv_to_embe
 /-- Any injection from a finset `s` in a fintype `α` to a finset `t` of the same cardinality as `α`
 can be extended to a bijection between `α` and `t`. -/
 lemma finset.exists_equiv_extend_of_card_eq [fintype α] {t : finset β}
-  (hαt : fintype.card α = t.card) {s : finset α} :
-  ∀ {f : α → β} (hfst : s.image f ⊆ t) (hfs : set.inj_on f s),
-    ∃ g : α ≃ t, ∀ i ∈ s, (g i : β) = f i :=
+  (hαt : fintype.card α = t.card) {s : finset α} {f : α → β} (hfst : s.image f ⊆ t)
+  (hfs : set.inj_on f s) :
+  ∃ g : α ≃ t, ∀ i ∈ s, (g i : β) = f i :=
 begin
   classical,
-  induction s using finset.induction with a s has H,
-  { intros f hfst hfs,
-    obtain ⟨e⟩ : nonempty (α ≃ ↥t) := by rwa [← fintype.card_eq, fintype.card_coe],
+  induction s using finset.induction with a s has H generalizing f,
+  { obtain ⟨e⟩ : nonempty (α ≃ ↥t) := by rwa [← fintype.card_eq, fintype.card_coe],
     use e,
     simp },
-  intros f hfst hfs,
   have hfst' : finset.image f s ⊆ t := (finset.image_mono _ (s.subset_insert a)).trans hfst,
   have hfs' : set.inj_on f s := hfs.mono (s.subset_insert a),
   obtain ⟨g', hg'⟩ := H hfst' hfs',
-  have hfat : f a ∈ t := hfst (finset.mem_image_of_mem _ (s.mem_insert_self a)),
+  have hfat : f a ∈ t := hfst (mem_image_of_mem _ (s.mem_insert_self a)),
   use g'.trans (equiv.swap (⟨f a, hfat⟩ : t) (g' a)),
-  intros i hi,
-  obtain rfl | his : i = a ∨ i ∈ s := by simpa using hi,
+  simp_rw mem_insert,
+  rintro i (rfl | hi),
   { simp },
-  simp only [equiv.coe_trans, comp_app],
-  rw equiv.swap_apply_of_ne_of_ne,
-  { rw hg' i his },
-  { intros h,
-    apply has,
-    have h' : f i = f a := by simpa only [subtype.ext_iff, hg' i his, subtype.coe_mk] using h,
-    rw ← hfs (finset.mem_coe.mpr hi) (s.mem_insert_self a) h',
-    exact his },
-  { apply g'.injective.ne,
-    apply ne_of_apply_ne (λ p, p ∈ s),
-    tauto }
+  rw [equiv.trans_apply, equiv.swap_apply_of_ne_of_ne, hg' _ hi],
+  { exact ne_of_apply_ne subtype.val (ne_of_eq_of_ne (hg' _ hi) $
+    hfs.ne (subset_insert _ _ hi) (mem_insert_self _ _) $ ne_of_mem_of_not_mem hi has) },
+  { exact g'.injective.ne (ne_of_mem_of_not_mem hi has) },
 end
 
 /-- Any injection from a set `s` in a fintype `α` to a finset `t` of the same cardinality as `α`

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1390,24 +1390,23 @@ lemma finset.univ_map_embedding {α : Type*} [fintype α] (e : α ↪ α) :
   univ.map e = univ :=
 by rw [←e.equiv_of_fintype_self_embedding_to_embedding, univ_map_equiv_to_embedding]
 
-/-- There exists a bijection between two types of the same finite cardinality, which extends a given
-bijection on a given finset. -/
-lemma finset.exists_equiv_extend_of_card_eq [fintype α] [decidable_eq β] {t : finset β}
+/-- Any injection from a finset `s` in a fintype `α` to a finset `t` of the same cardinality as `α`
+can be extended to a bijection between `α` and `t`. -/
+lemma finset.exists_equiv_extend_of_card_eq [fintype α] {t : finset β}
   (hαt : fintype.card α = t.card) {s : finset α} :
   ∀ {f : α → β} (hfst : s.image f ⊆ t) (hfs : set.inj_on f s),
     ∃ g : α ≃ t, ∀ i ∈ s, (g i : β) = f i :=
 begin
   classical,
-  apply @finset.induction α
-    (λ s, ∀ f (hfst : s.image f ⊆ t) (hfs : set.inj_on f s), ∃ g : α ≃ t, ∀ i ∈ s, (g i : β) = f i),
+  induction s using finset.induction with a s has H,
   { intros f hfst hfs,
-    have : nonempty (α ≃ ↥t) := by rwa [← fintype.card_eq, fintype.card_coe],
-    use this.some,
-    simp }, clear s,
-  intros a s has H f hfst hfs,
+    obtain ⟨e⟩ : nonempty (α ≃ ↥t) := by rwa [← fintype.card_eq, fintype.card_coe],
+    use e,
+    simp },
+  intros f hfst hfs,
   have hfst' : finset.image f s ⊆ t := (finset.image_mono _ (s.subset_insert a)).trans hfst,
   have hfs' : set.inj_on f s := hfs.mono (s.subset_insert a),
-  obtain ⟨g', hg'⟩ := H f hfst' hfs',
+  obtain ⟨g', hg'⟩ := H hfst' hfs',
   have hfat : f a ∈ t := hfst (finset.mem_image_of_mem _ (s.mem_insert_self a)),
   use g'.trans (equiv.swap (⟨f a, hfat⟩ : t) (g' a)),
   intros i hi,
@@ -1422,8 +1421,8 @@ begin
     rw ← hfs (finset.mem_coe.mpr hi) (s.mem_insert_self a) h',
     exact his },
   { apply g'.injective.ne,
-    rintros rfl,
-    contradiction }
+    apply ne_of_apply_ne (λ p, p ∈ s),
+    tauto }
 end
 
 /-- There exists a bijection between two types of the same finite cardinality, which extends a given

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -413,6 +413,11 @@ theorem inj_on.eq_iff {x y} (h : inj_on f s) (hx : x ∈ s) (hy : y ∈ s) :
   f x = f y ↔ x = y :=
 ⟨h hx hy, λ h, h ▸ rfl⟩
 
+lemma inj_on.ne_iff {x y} (h : inj_on f s) (hx : x ∈ s) (hy : y ∈ s) : f x ≠ f y ↔ x ≠ y :=
+(h.eq_iff hx hy).not
+
+alias inj_on.ne_iff ↔ _ inj_on.ne
+
 theorem inj_on.congr (h₁ : inj_on f₁ s) (h : eq_on f₁ f₂ s) :
   inj_on f₂ s :=
 λ x hx y hy, h hx ▸ h hy ▸ h₁ hx hy


### PR DESCRIPTION
Given a function `f : α → β` which is injective on a set `s` in `α`, and a set `t` in `β` which has the same finite cardinality as the type `α` and which contains the image `f '' s`, extend/modify to a bijection between `α` and `t` which agrees on `s` with the original `f`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Formalized as part of the Sphere Eversion project.  Golfing would be welcome, or suggestions for a more ergonomic reformulation; see #16478 for the use case.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
