### PR TITLE
feat(tactic/positivity): Handle `a ≠ 0` goals

### DIFF
--- a/src/tactic/positivity.lean
+++ b/src/tactic/positivity.lean
@@ -100,6 +100,7 @@ namespace positivity
 
 /-- Inductive type recording whether the goal `positivity` is called on is nonnegativity, positivity
 or different from `0`. -/
+@[derive inhabited]
 inductive order_rel : Type
 | le  : order_rel -- `0 ≤ a`
 | lt  : order_rel -- `0 < a`

--- a/src/tactic/positivity.lean
+++ b/src/tactic/positivity.lean
@@ -189,9 +189,9 @@ namespace interactive
 setup_tactic_parser
 
 /-- Tactic solving goals of the form `0 ≤ x`, `0 < x` and `x ≠ 0`.  The tactic works recursively
-according to the syntax of the expression `x`, if the atoms composing the expression all have numeric
-lower bounds which can be proved positive/nonnegative by `norm_num`.  This tactic either closes the
-goal or fails.
+according to the syntax of the expression `x`, if the atoms composing the expression all have
+numeric lower bounds which can be proved positive/nonnegative by `norm_num`.  This tactic either
+closes the goal or fails.
 
 Examples:
 ```

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -107,3 +107,8 @@ example {a : ℤ} (ha : a > 0) : 0 ≤ a := by positivity
 example {a : ℤ} (ha : 0 < a) : a ≥ 0 := by positivity
 
 example {a : ℤ} (ha : a > 0) : a ≥ 0 := by positivity
+
+example {a : ℤ} (ha : 0 < a) : a ≠ 0 := by positivity
+example {a : ℤ} (ha : a > 0) : a ≠ 0 := by positivity
+example {a : ℤ} (ha : 0 < a) : 0 ≠ a := by positivity
+example {a : ℤ} (ha : a > 0) : 0 ≠ a := by positivity


### PR DESCRIPTION
Add some light postprocessing for `positivity` to prove goals of the form `0 ≠ a` and `a ≠ 0` when it can derive `0 < a`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
The motivation for this is that side goals of order lemmas are sometimes `a ≠ 0` because they hold for both `0 < a` and `a < 0`.

This is only a fraction of what can be done in this direction. If you're happy with this, I will then make `positivity` fully handle `a ≠ 0` hypotheses (rather than a simple postprocessing) by changing `strictness` to
```
meta inductive strictness : Type
| positive : expr → strictness
| nonnegative : expr → strictness
| nonzero : expr → strictness
```
This still works on a design level because there's a unique meaningful way of combining any two `≤`, `<`, `≠` results. In particular, there won't be any branching.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
