### PR TITLE
[Merged by Bors] - refactor (equiv.perm.basic): base of_subtype on extend_domain

### DIFF
--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -275,7 +275,6 @@ lemma of_subtype_apply_of_mem {p : α → Prop} [decidable_pred p]
   of_subtype f x = f ⟨x, hx⟩ := extend_domain_apply_subtype f _ hx
 -- dif_pos hx
 
-
 @[simp] lemma of_subtype_apply_coe {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) (x : subtype p)  :
   of_subtype f x = f x :=

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -242,7 +242,6 @@ lemma of_subtype_subtype_perm {f : perm α} {p : α → Prop} [decidable_pred p]
   (h₁ : ∀ x, p x ↔ p (f x)) (h₂ : ∀ x, f x ≠ x → p x) :
   of_subtype (subtype_perm f h₁) = f :=
 equiv.ext $ λ x, begin
-  -- rw [of_subtype, subtype_perm],
   by_cases hx : p x,
   { exact (subtype_perm f h₁).extend_domain_apply_subtype _ hx, },
   { rw [of_subtype, monoid_hom.coe_mk, equiv.perm.extend_domain_apply_not_subtype],

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -236,7 +236,6 @@ equiv.ext $ λ ⟨_, _⟩, rfl
 def of_subtype {p : α → Prop} [decidable_pred p] : perm (subtype p) →* perm α :=
 { to_fun := λ f, extend_domain f (equiv.refl (subtype p)),
   map_one' := equiv.perm.extend_domain_one _,
-  /- begin ext, dsimp, split_ifs; refl, end -/
   map_mul' := λ f g, (equiv.perm.extend_domain_mul _ f g).symm, }
 
 lemma of_subtype_subtype_perm {f : perm α} {p : α → Prop} [decidable_pred p]

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -262,7 +262,7 @@ subtype.cases_on x $ λ _, of_subtype_apply_of_mem f
 
 lemma of_subtype_apply_of_not_mem {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) {x : α} (hx : ¬ p x) :
-  of_subtype f x = x := extend_domain_apply_not_subtype f _ hx
+  of_subtype f x = x := extend_domain_apply_not_subtype f (equiv.refl (subtype p)) hx
 
 lemma mem_iff_of_subtype_apply_mem {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) (x : α) :

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -234,39 +234,47 @@ equiv.ext $ λ ⟨_, _⟩, rfl
 /-- The inclusion map of permutations on a subtype of `α` into permutations of `α`,
   fixing the other points. -/
 def of_subtype {p : α → Prop} [decidable_pred p] : perm (subtype p) →* perm α :=
-{ to_fun := λ f,
-  ⟨λ x, if h : p x then f ⟨x, h⟩ else x, λ x, if h : p x then f⁻¹ ⟨x, h⟩ else x,
+{ to_fun := λ f, extend_domain f (equiv.refl (subtype p))
+  /- ⟨λ x, if h : p x then f ⟨x, h⟩ else x, λ x, if h : p x then f⁻¹ ⟨x, h⟩ else x,
   λ x, have h : ∀ h : p x, p (f ⟨x, h⟩), from λ h, (f ⟨x, h⟩).2,
     by { simp only [], split_ifs at *;
          simp only [perm.inv_apply_self, subtype.coe_eta, subtype.coe_mk, not_true, *] at * },
   λ x, have h : ∀ h : p x, p (f⁻¹ ⟨x, h⟩), from λ h, (f⁻¹ ⟨x, h⟩).2,
     by { simp only [], split_ifs at *;
-         simp only [perm.apply_inv_self, subtype.coe_eta, subtype.coe_mk, not_true, *] at * }⟩,
-  map_one' := begin ext, dsimp, split_ifs; refl, end,
-  map_mul' := λ f g, equiv.ext $ λ x, begin
+         simp only [perm.apply_inv_self, subtype.coe_eta, subtype.coe_mk, not_true, *] at * }⟩ -/,
+  map_one' := equiv.perm.extend_domain_one _,
+  /- begin ext, dsimp, split_ifs; refl, end -/
+  map_mul' := λ f g, (equiv.perm.extend_domain_mul _ f g).symm,
+  /- λ f g, equiv.ext $ λ x, begin
   by_cases h : p x,
   { have h₁ : p (f (g ⟨x, h⟩)), from (f (g ⟨x, h⟩)).2,
     have h₂ : p (g ⟨x, h⟩), from (g ⟨x, h⟩).2,
     simp only [h, h₂, coe_fn_mk, perm.mul_apply, dif_pos, subtype.coe_eta] },
   { simp only [h, coe_fn_mk, perm.mul_apply, dif_neg, not_false_iff] }
-end }
+end -/ }
 
 lemma of_subtype_subtype_perm {f : perm α} {p : α → Prop} [decidable_pred p]
   (h₁ : ∀ x, p x ↔ p (f x)) (h₂ : ∀ x, f x ≠ x → p x) :
   of_subtype (subtype_perm f h₁) = f :=
 equiv.ext $ λ x, begin
-  rw [of_subtype, subtype_perm],
+  -- rw [of_subtype, subtype_perm],
   by_cases hx : p x,
-  { simp only [hx, coe_fn_mk, dif_pos, monoid_hom.coe_mk, subtype.coe_mk]},
-  { haveI := classical.prop_decidable,
-    simp only [hx, not_not.mp (mt (h₂ x) hx), coe_fn_mk, dif_neg, not_false_iff,
-      monoid_hom.coe_mk] }
+  { exact (subtype_perm f h₁).extend_domain_apply_subtype _ hx,
+    -- simp only [hx, coe_fn_mk, dif_pos, monoid_hom.coe_mk, subtype.coe_mk]
+    },
+  { -- haveI := classical.prop_decidable,
+    rw [of_subtype, monoid_hom.coe_mk, equiv.perm.extend_domain_apply_not_subtype],
+    { exact not_not.mp (λ h, hx (h₂ x (ne.symm h))),  },
+    { exact hx, },
+/-     simp only [hx, not_not.mp (mt (h₂ x) hx), coe_fn_mk, dif_neg, not_false_iff,
+      monoid_hom.coe_mk] -/ }
 end
 
 lemma of_subtype_apply_of_mem {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) {x : α} (hx : p x) :
-  of_subtype f x = f ⟨x, hx⟩ :=
-dif_pos hx
+  of_subtype f x = f ⟨x, hx⟩ := extend_domain_apply_subtype f _ hx
+-- dif_pos hx
+
 
 @[simp] lemma of_subtype_apply_coe {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) (x : subtype p)  :
@@ -275,20 +283,25 @@ subtype.cases_on x $ λ _, of_subtype_apply_of_mem f
 
 lemma of_subtype_apply_of_not_mem {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) {x : α} (hx : ¬ p x) :
-  of_subtype f x = x :=
-dif_neg hx
+  of_subtype f x = x := extend_domain_apply_not_subtype f _ hx
+-- dif_neg hx
 
 lemma mem_iff_of_subtype_apply_mem {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) (x : α) :
   p x ↔ p ((of_subtype f : α → α) x) :=
-if h : p x then by simpa only [of_subtype, h, coe_fn_mk, dif_pos, true_iff, monoid_hom.coe_mk]
-  using (f ⟨x, h⟩).2
+if h : p x then
+by
+  simpa only [h, true_iff, monoid_hom.coe_mk, of_subtype_apply_of_mem f h] using (f ⟨x, h⟩).2
+/- simpa only [of_subtype, h, coe_fn_mk, dif_pos, true_iff, monoid_hom.coe_mk]
+  using (f ⟨x, h⟩).2 -/
 else by simp [h, of_subtype_apply_of_not_mem f h]
 
 @[simp] lemma subtype_perm_of_subtype {p : α → Prop} [decidable_pred p] (f : perm (subtype p)) :
   subtype_perm (of_subtype f) (mem_iff_of_subtype_apply_mem f) = f :=
-equiv.ext $ λ ⟨x, hx⟩, by { dsimp [subtype_perm, of_subtype],
-  simp only [show p x, from hx, dif_pos, subtype.coe_eta] }
+equiv.ext $ λ ⟨x, hx⟩,
+    subtype.coe_injective (of_subtype_apply_of_mem f hx)
+  /- by { dsimp [subtype_perm, of_subtype],
+  simp only [show p x, from hx, dif_pos, subtype.coe_eta] } -/
 
 @[simp] lemma default_perm {n : Type*} : (default : perm n) = 1 := rfl
 

--- a/src/group_theory/perm/basic.lean
+++ b/src/group_theory/perm/basic.lean
@@ -234,24 +234,10 @@ equiv.ext $ λ ⟨_, _⟩, rfl
 /-- The inclusion map of permutations on a subtype of `α` into permutations of `α`,
   fixing the other points. -/
 def of_subtype {p : α → Prop} [decidable_pred p] : perm (subtype p) →* perm α :=
-{ to_fun := λ f, extend_domain f (equiv.refl (subtype p))
-  /- ⟨λ x, if h : p x then f ⟨x, h⟩ else x, λ x, if h : p x then f⁻¹ ⟨x, h⟩ else x,
-  λ x, have h : ∀ h : p x, p (f ⟨x, h⟩), from λ h, (f ⟨x, h⟩).2,
-    by { simp only [], split_ifs at *;
-         simp only [perm.inv_apply_self, subtype.coe_eta, subtype.coe_mk, not_true, *] at * },
-  λ x, have h : ∀ h : p x, p (f⁻¹ ⟨x, h⟩), from λ h, (f⁻¹ ⟨x, h⟩).2,
-    by { simp only [], split_ifs at *;
-         simp only [perm.apply_inv_self, subtype.coe_eta, subtype.coe_mk, not_true, *] at * }⟩ -/,
+{ to_fun := λ f, extend_domain f (equiv.refl (subtype p)),
   map_one' := equiv.perm.extend_domain_one _,
   /- begin ext, dsimp, split_ifs; refl, end -/
-  map_mul' := λ f g, (equiv.perm.extend_domain_mul _ f g).symm,
-  /- λ f g, equiv.ext $ λ x, begin
-  by_cases h : p x,
-  { have h₁ : p (f (g ⟨x, h⟩)), from (f (g ⟨x, h⟩)).2,
-    have h₂ : p (g ⟨x, h⟩), from (g ⟨x, h⟩).2,
-    simp only [h, h₂, coe_fn_mk, perm.mul_apply, dif_pos, subtype.coe_eta] },
-  { simp only [h, coe_fn_mk, perm.mul_apply, dif_neg, not_false_iff] }
-end -/ }
+  map_mul' := λ f g, (equiv.perm.extend_domain_mul _ f g).symm, }
 
 lemma of_subtype_subtype_perm {f : perm α} {p : α → Prop} [decidable_pred p]
   (h₁ : ∀ x, p x ↔ p (f x)) (h₂ : ∀ x, f x ≠ x → p x) :
@@ -259,21 +245,15 @@ lemma of_subtype_subtype_perm {f : perm α} {p : α → Prop} [decidable_pred p]
 equiv.ext $ λ x, begin
   -- rw [of_subtype, subtype_perm],
   by_cases hx : p x,
-  { exact (subtype_perm f h₁).extend_domain_apply_subtype _ hx,
-    -- simp only [hx, coe_fn_mk, dif_pos, monoid_hom.coe_mk, subtype.coe_mk]
-    },
-  { -- haveI := classical.prop_decidable,
-    rw [of_subtype, monoid_hom.coe_mk, equiv.perm.extend_domain_apply_not_subtype],
+  { exact (subtype_perm f h₁).extend_domain_apply_subtype _ hx, },
+  { rw [of_subtype, monoid_hom.coe_mk, equiv.perm.extend_domain_apply_not_subtype],
     { exact not_not.mp (λ h, hx (h₂ x (ne.symm h))),  },
-    { exact hx, },
-/-     simp only [hx, not_not.mp (mt (h₂ x) hx), coe_fn_mk, dif_neg, not_false_iff,
-      monoid_hom.coe_mk] -/ }
+    { exact hx, }, }
 end
 
 lemma of_subtype_apply_of_mem {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) {x : α} (hx : p x) :
   of_subtype f x = f ⟨x, hx⟩ := extend_domain_apply_subtype f _ hx
--- dif_pos hx
 
 @[simp] lemma of_subtype_apply_coe {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) (x : subtype p)  :
@@ -283,24 +263,18 @@ subtype.cases_on x $ λ _, of_subtype_apply_of_mem f
 lemma of_subtype_apply_of_not_mem {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) {x : α} (hx : ¬ p x) :
   of_subtype f x = x := extend_domain_apply_not_subtype f _ hx
--- dif_neg hx
 
 lemma mem_iff_of_subtype_apply_mem {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) (x : α) :
   p x ↔ p ((of_subtype f : α → α) x) :=
 if h : p x then
-by
-  simpa only [h, true_iff, monoid_hom.coe_mk, of_subtype_apply_of_mem f h] using (f ⟨x, h⟩).2
-/- simpa only [of_subtype, h, coe_fn_mk, dif_pos, true_iff, monoid_hom.coe_mk]
-  using (f ⟨x, h⟩).2 -/
+by simpa only [h, true_iff, monoid_hom.coe_mk, of_subtype_apply_of_mem f h] using (f ⟨x, h⟩).2
 else by simp [h, of_subtype_apply_of_not_mem f h]
 
 @[simp] lemma subtype_perm_of_subtype {p : α → Prop} [decidable_pred p] (f : perm (subtype p)) :
   subtype_perm (of_subtype f) (mem_iff_of_subtype_apply_mem f) = f :=
 equiv.ext $ λ ⟨x, hx⟩,
     subtype.coe_injective (of_subtype_apply_of_mem f hx)
-  /- by { dsimp [subtype_perm, of_subtype],
-  simp only [show p x, from hx, dif_pos, subtype.coe_eta] } -/
 
 @[simp] lemma default_perm {n : Type*} : (default : perm n) = 1 := rfl
 

--- a/src/group_theory/perm/cycle/basic.lean
+++ b/src/group_theory/perm/cycle/basic.lean
@@ -579,7 +579,13 @@ def cycle_of [fintype α] (f : perm α) (x : α) : perm α :=
 of_subtype (@subtype_perm _ f (same_cycle f x) (λ _, same_cycle_apply.symm))
 
 lemma cycle_of_apply [fintype α] (f : perm α) (x y : α) :
-  cycle_of f x y = if same_cycle f x y then f y else y := rfl
+  cycle_of f x y = if same_cycle f x y then f y else y :=
+begin
+  dsimp only [cycle_of],
+  split_ifs,
+  { apply of_subtype_apply_of_mem, exact h, },
+  { apply of_subtype_apply_of_not_mem, exact h },
+end
 
 lemma cycle_of_inv [fintype α] (f : perm α) (x : α) :
   (cycle_of f x)⁻¹ = cycle_of f⁻¹ x :=
@@ -602,10 +608,16 @@ end
   zpow_neg_succ_of_nat, ← inv_pow, cycle_of_pow_apply_self]
 
 lemma same_cycle.cycle_of_apply [fintype α] {f : perm α} {x y : α} (h : same_cycle f x y) :
-  cycle_of f x y = f y := dif_pos h
+  cycle_of f x y = f y :=
+begin
+  apply of_subtype_apply_of_mem, exact h,
+end
 
 lemma cycle_of_apply_of_not_same_cycle [fintype α] {f : perm α} {x y : α} (h : ¬same_cycle f x y) :
-  cycle_of f x y = y := dif_neg h
+  cycle_of f x y = y :=
+begin
+  apply of_subtype_apply_of_not_mem, exact h,
+end
 
 lemma same_cycle.cycle_of_eq [fintype α] {f : perm α} {x y : α} (h : same_cycle f x y) :
   cycle_of f x = cycle_of f y :=

--- a/src/group_theory/perm/cycle/type.lean
+++ b/src/group_theory/perm/cycle/type.lean
@@ -303,6 +303,9 @@ begin
     rw [hd.cycle_type, ← extend_domain_mul, (hd.extend_domain f).cycle_type, hσ, hτ] }
 end
 
+lemma cycle_type_of_subtype {p : α → Prop} [decidable_pred p] {g : perm (subtype p)}:
+  cycle_type (g.of_subtype) = cycle_type g := cycle_type_extend_domain (equiv.refl (subtype p))
+
 lemma mem_cycle_type_iff {n : ℕ} {σ : perm α} :
   n ∈ cycle_type σ ↔ ∃ c τ : perm α, σ = c * τ ∧ disjoint c τ ∧ is_cycle c ∧ c.support.card = n :=
 begin

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -564,11 +564,6 @@ have hl'₂ : (l.1.map of_subtype).prod = f,
 by { conv { congr, rw ← l.2.1, skip, rw ← hl'₂ },
   rw [sign_prod_list_swap l.2.2, sign_prod_list_swap hl', list.length_map] }
 
-/- @[simp] lemma sign_of_subtype {p : α → Prop} [decidable_pred p]
-  (f : perm (subtype p)) : sign (of_subtype f) = sign f :=
-have ∀ x, of_subtype f x ≠ x → p x, from λ x, not_imp_comm.1 (of_subtype_apply_of_not_mem f),
-by conv {to_rhs, rw [← subtype_perm_of_subtype f, sign_subtype_perm _ _ this]} -/
-
 lemma sign_eq_sign_of_equiv [decidable_eq β] [fintype β] (f : perm α) (g : perm β)
   (e : α ≃ β) (h : ∀ x, e (f x) = g (e x)) : sign f = sign g :=
 have hg : g = (e.symm.trans f).trans e, from equiv.ext $ by simp [h],

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -564,10 +564,10 @@ have hl'₂ : (l.1.map of_subtype).prod = f,
 by { conv { congr, rw ← l.2.1, skip, rw ← hl'₂ },
   rw [sign_prod_list_swap l.2.2, sign_prod_list_swap hl', list.length_map] }
 
-@[simp] lemma sign_of_subtype {p : α → Prop} [decidable_pred p]
+/- @[simp] lemma sign_of_subtype {p : α → Prop} [decidable_pred p]
   (f : perm (subtype p)) : sign (of_subtype f) = sign f :=
 have ∀ x, of_subtype f x ≠ x → p x, from λ x, not_imp_comm.1 (of_subtype_apply_of_not_mem f),
-by conv {to_rhs, rw [← subtype_perm_of_subtype f, sign_subtype_perm _ _ this]}
+by conv {to_rhs, rw [← subtype_perm_of_subtype f, sign_subtype_perm _ _ this]} -/
 
 lemma sign_eq_sign_of_equiv [decidable_eq β] [fintype β] (f : perm α) (g : perm β)
   (e : α ≃ β) (h : ∀ x, e (f x) = g (e x)) : sign f = sign g :=
@@ -685,7 +685,11 @@ by simp [subtype_congr]
 @[simp] lemma sign_extend_domain (e : perm α)
   {p : β → Prop} [decidable_pred p] (f : α ≃ subtype p) :
   equiv.perm.sign (e.extend_domain f) = equiv.perm.sign e :=
-by simp [equiv.perm.extend_domain]
+by simp only [equiv.perm.extend_domain, sign_subtype_congr, sign_perm_congr, sign_refl, mul_one]
+
+@[simp] lemma sign_of_subtype {p : α → Prop} [decidable_pred p]
+  (f : equiv.perm (subtype p)) : equiv.perm.sign (f.of_subtype) = equiv.perm.sign f :=
+sign_extend_domain f (equiv.refl (subtype p))
 
 end congr
 

--- a/src/group_theory/perm/support.lean
+++ b/src/group_theory/perm/support.lean
@@ -172,7 +172,7 @@ variable [decidable_eq α]
 /-- `f.is_swap` indicates that the permutation `f` is a transposition of two elements. -/
 def is_swap (f : perm α) : Prop := ∃ x y, x ≠ y ∧ f = swap x y
 
-lemma of_subtype_swap_eq {p : α → Prop} [decidable_pred p]
+@[simp] lemma of_subtype_swap_eq {p : α → Prop} [decidable_pred p]
   (x y : subtype p) : -- (hxy : x ≠ y) :
   (equiv.swap x y).of_subtype = equiv.swap ↑x ↑y :=
 equiv.ext $ λ z, begin

--- a/src/group_theory/perm/support.lean
+++ b/src/group_theory/perm/support.lean
@@ -173,7 +173,7 @@ variable [decidable_eq α]
 def is_swap (f : perm α) : Prop := ∃ x y, x ≠ y ∧ f = swap x y
 
 @[simp] lemma of_subtype_swap_eq {p : α → Prop} [decidable_pred p]
-  (x y : subtype p) : -- (hxy : x ≠ y) :
+  (x y : subtype p) :
   (equiv.swap x y).of_subtype = equiv.swap ↑x ↑y :=
 equiv.ext $ λ z, begin
   by_cases hz : p z,

--- a/src/group_theory/perm/support.lean
+++ b/src/group_theory/perm/support.lean
@@ -187,10 +187,6 @@ let ⟨⟨x, hx⟩, ⟨y, hy⟩, hxy⟩ := h in
         simp only [h_1, ne.def, not_false_iff],
         simp only [h_2, ne.def, not_false_iff], },
       { rw of_subtype_apply_of_not_mem, exact h_z, }, },
-    /- rw [hxy.2, of_subtype],
-    simp only [swap_apply_def, coe_fn_mk, swap_inv, subtype.mk_eq_mk, monoid_hom.coe_mk],
-    split_ifs;
-       rw subtype.coe_mk <|> cc, -/
   end⟩
 
 lemma ne_and_ne_of_swap_mul_apply_ne_self {f : perm α} {x y : α}

--- a/src/group_theory/perm/support.lean
+++ b/src/group_theory/perm/support.lean
@@ -172,22 +172,42 @@ variable [decidable_eq α]
 /-- `f.is_swap` indicates that the permutation `f` is a transposition of two elements. -/
 def is_swap (f : perm α) : Prop := ∃ x y, x ≠ y ∧ f = swap x y
 
+lemma of_subtype_swap_eq {p : α → Prop} [decidable_pred p]
+  (x y : subtype p) : -- (hxy : x ≠ y) :
+  (equiv.swap x y).of_subtype = equiv.swap ↑x ↑y :=
+equiv.ext $ λ z, begin
+  by_cases hz : p z,
+  { rw [swap_apply_def, of_subtype_apply_of_mem _ hz],
+    split_ifs with hzx hzy,
+    { simp_rw [hzx, subtype.coe_eta, swap_apply_left], },
+    { simp_rw [hzy, subtype.coe_eta, swap_apply_right], },
+    { rw swap_apply_of_ne_of_ne, refl,
+      intro h, apply hzx, rw ← h, refl,
+      intro h, apply hzy, rw ← h, refl, } },
+  { rw [of_subtype_apply_of_not_mem _ hz, swap_apply_of_ne_of_ne],
+    intro h, apply hz, rw h, exact subtype.prop x,
+    intro h, apply hz, rw h, exact subtype.prop y, }
+/- -- Initial proof, I don't know which one is better?
+    rw [swap_apply_def],
+    split_ifs with hzx hzy,
+    { rw [hzx, of_subtype_apply_of_mem, subtype.coe_eta, swap_apply_left],
+      exact subtype.prop x,  },
+    { rw [hzy, of_subtype_apply_of_mem, subtype.coe_eta, swap_apply_right],
+      exact subtype.prop y, },
+    { by_cases hz : p z,
+      { rw [of_subtype_apply_of_mem _ hz],
+        rw swap_apply_of_ne_of_ne, refl,
+        intro h, apply hzx, rw ← h, refl,
+        intro h, apply hzy, rw ← h, refl, },
+      { rw of_subtype_apply_of_not_mem, exact hz, }, }
+ -/
+end
+
 lemma is_swap.of_subtype_is_swap {p : α → Prop} [decidable_pred p]
   {f : perm (subtype p)} (h : f.is_swap) : (of_subtype f).is_swap :=
 let ⟨⟨x, hx⟩, ⟨y, hy⟩, hxy⟩ := h in
 ⟨x, y, by { simp only [ne.def] at hxy, exact hxy.1 },
-  equiv.ext $ λ z, begin
-    rw [hxy.2, swap_apply_def],
-    split_ifs,
-    { rw [h_1, of_subtype_apply_of_mem, swap_apply_left], refl, },
-    { rw [h_2, of_subtype_apply_of_mem, swap_apply_right], refl, },
-    { by_cases h_z : p z,
-      { rw [of_subtype_apply_of_mem _ h_z],
-        rw swap_apply_of_ne_of_ne, refl,
-        simp only [h_1, ne.def, not_false_iff],
-        simp only [h_2, ne.def, not_false_iff], },
-      { rw of_subtype_apply_of_not_mem, exact h_z, }, },
-  end⟩
+  by { simp only [hxy.2, of_subtype_swap_eq], refl, }⟩
 
 lemma ne_and_ne_of_swap_mul_apply_ne_self {f : perm α} {x y : α}
   (hy : (swap x (f x) * f) y ≠ y) : f y ≠ y ∧ y ≠ x :=

--- a/src/group_theory/perm/support.lean
+++ b/src/group_theory/perm/support.lean
@@ -177,10 +177,20 @@ lemma is_swap.of_subtype_is_swap {p : α → Prop} [decidable_pred p]
 let ⟨⟨x, hx⟩, ⟨y, hy⟩, hxy⟩ := h in
 ⟨x, y, by { simp only [ne.def] at hxy, exact hxy.1 },
   equiv.ext $ λ z, begin
-    rw [hxy.2, of_subtype],
+    rw [hxy.2, swap_apply_def],
+    split_ifs,
+    { rw [h_1, of_subtype_apply_of_mem, swap_apply_left], refl, },
+    { rw [h_2, of_subtype_apply_of_mem, swap_apply_right], refl, },
+    { by_cases h_z : p z,
+      { rw [of_subtype_apply_of_mem _ h_z],
+        rw swap_apply_of_ne_of_ne, refl,
+        simp only [h_1, ne.def, not_false_iff],
+        simp only [h_2, ne.def, not_false_iff], },
+      { rw of_subtype_apply_of_not_mem, exact h_z, }, },
+    /- rw [hxy.2, of_subtype],
     simp only [swap_apply_def, coe_fn_mk, swap_inv, subtype.mk_eq_mk, monoid_hom.coe_mk],
     split_ifs;
-    rw subtype.coe_mk <|> cc,
+       rw subtype.coe_mk <|> cc, -/
   end⟩
 
 lemma ne_and_ne_of_swap_mul_apply_ne_self {f : perm α} {x y : α}

--- a/src/group_theory/perm/support.lean
+++ b/src/group_theory/perm/support.lean
@@ -187,20 +187,6 @@ equiv.ext $ λ z, begin
   { rw [of_subtype_apply_of_not_mem _ hz, swap_apply_of_ne_of_ne],
     intro h, apply hz, rw h, exact subtype.prop x,
     intro h, apply hz, rw h, exact subtype.prop y, }
-/- -- Initial proof, I don't know which one is better?
-    rw [swap_apply_def],
-    split_ifs with hzx hzy,
-    { rw [hzx, of_subtype_apply_of_mem, subtype.coe_eta, swap_apply_left],
-      exact subtype.prop x,  },
-    { rw [hzy, of_subtype_apply_of_mem, subtype.coe_eta, swap_apply_right],
-      exact subtype.prop y, },
-    { by_cases hz : p z,
-      { rw [of_subtype_apply_of_mem _ hz],
-        rw swap_apply_of_ne_of_ne, refl,
-        intro h, apply hzx, rw ← h, refl,
-        intro h, apply hzy, rw ← h, refl, },
-      { rw of_subtype_apply_of_not_mem, exact hz, }, }
- -/
 end
 
 lemma is_swap.of_subtype_is_swap {p : α → Prop} [decidable_pred p]


### PR DESCRIPTION
There were two distinct ways to extend a permutation from a subtype to the ambient type.
As suggested by Johann Commelin in 
https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/permutations.20.3A.20of_subtype.20vs.20extend_domain/near/298180355
this PR unifies them by basing .of_subtype on the more general .extend_domain.

Some proofs have been redone, some other simplified.
For symmetry, I also added cycle_type_of_subtype (it just calls cycle_type_extend_domain.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
