### PR TITLE
[Merged by Bors] - refactor(model_theory/*): Use `countable` in model theory

### DIFF
--- a/src/model_theory/basic.lean
+++ b/src/model_theory/basic.lean
@@ -128,11 +128,6 @@ rfl
 /-- The cardinality of a language is the cardinality of its type of symbols. -/
 def card : cardinal := # L.symbols
 
-/-- A language is countable when it has countably many symbols. -/
-@[protected] class countable : Prop := (card_le_aleph_0' : L.card ≤ ℵ₀)
-
-lemma card_le_aleph_0 [L.countable] : L.card ≤ ℵ₀ := countable.card_le_aleph_0'
-
 /-- A language is relational when it has no function symbols. -/
 class is_relational : Prop :=
 (empty_functions : ∀ n, is_empty (L.functions n))
@@ -140,12 +135,6 @@ class is_relational : Prop :=
 /-- A language is algebraic when it has no relation symbols. -/
 class is_algebraic : Prop :=
 (empty_relations : ∀ n, is_empty (L.relations n))
-
-/-- A language is countable when it has countably many symbols. -/
-class countable_functions : Prop := (card_functions_le_aleph_0' : # (Σ l, L.functions l) ≤ ℵ₀)
-
-lemma card_functions_le_aleph_0 [L.countable_functions] : #(Σ l, L.functions l) ≤ ℵ₀ :=
-countable_functions.card_functions_le_aleph_0'
 
 variables {L} {L' : language.{u' v'}}
 
@@ -198,28 +187,18 @@ instance subsingleton_mk₂_relations {c f₁ f₂ : Type u} {r₁ r₂ : Type v
 nat.cases_on n ⟨λ x, pempty.elim x⟩
   (λ n, nat.cases_on n h1 (λ n, nat.cases_on n h2 (λ n, ⟨λ x, pempty.elim x⟩)))
 
-lemma encodable.countable [_root_.countable L.symbols] : L.countable :=
-⟨cardinal.mk_le_aleph_0⟩
-
 @[simp] lemma empty_card : language.empty.card = 0 :=
 by simp [card_eq_card_functions_add_card_relations]
 
-instance countable_empty : language.empty.countable :=
-⟨by simp⟩
+instance is_empty_empty : is_empty language.empty.symbols :=
+begin
+  simp only [language.symbols, is_empty_sum, is_empty_sigma],
+  exact ⟨λ _, infer_instance, λ _, infer_instance⟩,
+end
 
-@[priority 100] instance countable.countable_functions [L.countable] : L.countable_functions :=
-⟨begin
-  refine lift_le_aleph_0.1 (trans _ L.card_le_aleph_0),
-  rw [card, symbols, mk_sum],
-  exact le_self_add
-end⟩
-
-lemma encodable.countable_functions [h : encodable (Σl, L.functions l)] : L.countable_functions :=
-⟨cardinal.mk_le_aleph_0⟩
-
-@[priority 100] instance is_relational.countable_functions [L.is_relational] :
-  L.countable_functions :=
-encodable.countable_functions
+instance countable.countable_functions [h : countable L.symbols] :
+  countable (Σl, L.functions l) :=
+@function.injective.countable _ _ h _ sum.inl_injective
 
 @[simp] lemma card_functions_sum (i : ℕ) :
   #((L.sum L').functions i) = (#(L.functions i)).lift + cardinal.lift.{u} (#(L'.functions i)) :=

--- a/src/model_theory/encoding.lean
+++ b/src/model_theory/encoding.lean
@@ -151,7 +151,6 @@ encodable.of_left_injection list_encode (λ l, (list_decode l).head'.join)
     simp only [option.join, head', list.map, option.some_bind, id.def],
   end)
 
-
 instance [h1 : countable α] [h2 : countable (Σl, L.functions l)] :
   countable (L.term α) :=
 begin

--- a/src/model_theory/encoding.lean
+++ b/src/model_theory/encoding.lean
@@ -151,13 +151,13 @@ encodable.of_left_injection list_encode (λ l, (list_decode l).head'.join)
     simp only [option.join, head', list.map, option.some_bind, id.def],
   end)
 
-lemma card_le_aleph_0 [h1 : countable α] [h2 : L.countable_functions] :
-  # (L.term α) ≤ ℵ₀ :=
+
+instance [h1 : countable α] [h2 : countable (Σl, L.functions l)] :
+  countable (L.term α) :=
 begin
-  refine (card_le.trans _),
-  rw [max_le_iff],
+  refine mk_le_aleph_0_iff.1 (card_le.trans (max_le_iff.2 _)),
   simp only [le_refl, mk_sum, add_le_aleph_0, lift_le_aleph_0, true_and],
-  exact ⟨mk_le_aleph_0, L.card_functions_le_aleph_0⟩,
+  exact ⟨cardinal.mk_le_aleph_0, cardinal.mk_le_aleph_0⟩,
 end
 
 instance small [small.{u} α] :

--- a/src/model_theory/finitely_generated.lean
+++ b/src/model_theory/finitely_generated.lean
@@ -156,7 +156,7 @@ begin
   exact hom.map_le_range h'
 end
 
-theorem cg_iff_countable [L.countable_functions] {s : L.substructure M} :
+theorem cg_iff_countable [countable (Σl, L.functions l)] {s : L.substructure M} :
   s.cg ↔ countable s :=
 begin
   refine ⟨_, λ h, ⟨s, h.to_set, s.closure_eq⟩⟩,
@@ -224,7 +224,7 @@ begin
   exact h.range f,
 end
 
-lemma cg_iff_countable [L.countable_functions] : cg L M ↔ countable M :=
+lemma cg_iff_countable [countable (Σl, L.functions l)] : cg L M ↔ countable M :=
 by rw [cg_def, cg_iff_countable, top_equiv.to_equiv.countable_iff]
 
 lemma fg.cg (h : fg L M) : cg L M :=

--- a/src/model_theory/fraisse.lean
+++ b/src/model_theory/fraisse.lean
@@ -147,21 +147,19 @@ lemma age.joint_embedding : joint_embedding (L.age M) :=
 /-- The age of a countable structure is essentially countable (has countably many isomorphism
 classes). -/
 lemma age.countable_quotient [h : countable M] :
-  (quotient.mk '' (L.age M)).countable :=
+  (quotient.mk '' L.age M).countable :=
 begin
-  refine (congr rfl (set.ext _)).mp ((countable_set_of_finite_subset
-    (countable_univ : (univ : set M).countable)).image
-    (λ s, ⟦⟨closure L s, infer_instance⟩⟧)),
-  rw forall_quotient_iff,
-  intro N,
-  simp only [subset_univ, and_true, mem_image, mem_set_of_eq, quotient.eq],
+  classical,
+  refine (congr_arg _ (set.ext $ forall_quotient_iff.2 $ λ N, _)).mp
+    (countable_range $ λ s : finset M, ⟦⟨closure L (s : set M), infer_instance⟩⟧),
+  simp only [mem_image, mem_range, mem_set_of_eq, quotient.eq],
   split,
-  { rintro ⟨s, hs1, hs2⟩,
-    use bundled.of ↥(closure L s),
-    exact ⟨⟨(fg_iff_Structure_fg _).1 (fg_closure hs1), ⟨subtype _⟩⟩, hs2⟩ },
+  { rintro ⟨s, hs⟩,
+    use bundled.of ↥(closure L (s : set M)),
+    exact ⟨⟨(fg_iff_Structure_fg _).1 (fg_closure s.finite_to_set), ⟨subtype _⟩⟩, hs⟩ },
   { rintro ⟨P, ⟨⟨s, hs⟩, ⟨PM⟩⟩, hP2⟩,
-    refine ⟨PM '' s, set.finite.image PM s.finite_to_set, setoid.trans _ hP2⟩,
-    rw [← embedding.coe_to_hom, closure_image PM.to_hom, hs, ← hom.range_eq_map],
+    refine ⟨s.image PM, setoid.trans _ hP2⟩,
+    rw [← embedding.coe_to_hom, finset.coe_image, closure_image PM.to_hom, hs, ← hom.range_eq_map],
     exact ⟨PM.equiv_range.symm⟩ }
 end
 

--- a/src/model_theory/fraisse.lean
+++ b/src/model_theory/fraisse.lean
@@ -146,10 +146,11 @@ lemma age.joint_embedding : joint_embedding (L.age M) :=
 
 /-- The age of a countable structure is essentially countable (has countably many isomorphism
 classes). -/
-lemma age.countable_quotient (h : (univ : set M).countable) :
+lemma age.countable_quotient [h : countable M] :
   (quotient.mk '' (L.age M)).countable :=
 begin
-  refine eq.mp (congr rfl (set.ext _)) ((countable_set_of_finite_subset h).image
+  refine (congr rfl (set.ext _)).mp ((countable_set_of_finite_subset
+    (countable_univ : (univ : set M).countable)).image
     (λ s, ⟦⟨closure L s, infer_instance⟩⟧)),
   rw forall_quotient_iff,
   intro N,
@@ -222,7 +223,7 @@ begin
 end
 
 theorem exists_countable_is_age_of_iff [countable (Σl, L.functions l)] :
-  (∃ (M : bundled.{w} L.Structure), (univ : set M).countable ∧ L.age M = K) ↔
+  (∃ (M : bundled.{w} L.Structure), countable M ∧ L.age M = K) ↔
     K.nonempty ∧
     (∀ (M N : bundled.{w} L.Structure), nonempty (M ≃[L] N) → (M ∈ K ↔ N ∈ K)) ∧
     (quotient.mk '' K).countable ∧
@@ -233,12 +234,11 @@ begin
   split,
   { rintros ⟨M, h1, h2, rfl⟩,
     resetI,
-    refine ⟨age.nonempty M, age.is_equiv_invariant L M, age.countable_quotient M h1, λ N hN, hN.1,
+    refine ⟨age.nonempty M, age.is_equiv_invariant L M, age.countable_quotient M, λ N hN, hN.1,
       age.hereditary M, age.joint_embedding M⟩, },
   { rintros ⟨Kn, eqinv, cq, hfg, hp, jep⟩,
     obtain ⟨M, hM, rfl⟩ := exists_cg_is_age_of Kn eqinv cq hfg hp jep,
-    haveI : countable M := Structure.cg_iff_countable.1 hM,
-    exact ⟨M, to_countable _, rfl⟩, }
+    exact ⟨M, Structure.cg_iff_countable.1 hM, rfl⟩ }
 end
 
 variables {K} (L) (M)
@@ -253,9 +253,9 @@ variables {L} (K)
 
 /-- A structure `M` is a Fraïssé limit for a class `K` if it is countably generated,
 ultrahomogeneous, and has age `K`. -/
-structure is_fraisse_limit [countable (Σl, L.functions l)] : Prop :=
+@[protect_proj] structure is_fraisse_limit [countable (Σl, L.functions l)]
+  [countable M] : Prop :=
 (ultrahomogeneous : is_ultrahomogeneous L M)
-(is_countable : (univ : set M).countable)
 (age : L.age M = K)
 
 variables {L} {M}
@@ -279,18 +279,18 @@ begin
     set.coe_inclusion, embedding.equiv_range_apply, hgn],
 end
 
-lemma is_ultrahomogeneous.age_is_fraisse (hc : (univ : set M).countable)
+lemma is_ultrahomogeneous.age_is_fraisse [countable M]
   (h : L.is_ultrahomogeneous M) :
   is_fraisse (L.age M) :=
-⟨age.nonempty M, λ _ hN, hN.1, age.is_equiv_invariant L M, age.countable_quotient M hc,
+⟨age.nonempty M, λ _ hN, hN.1, age.is_equiv_invariant L M, age.countable_quotient M,
   age.hereditary M, age.joint_embedding M, h.amalgamation_age⟩
 
 namespace is_fraisse_limit
 
 /-- If a class has a Fraïssé limit, it must be Fraïssé. -/
-theorem is_fraisse [_root_.countable (Σl, L.functions l)] (h : is_fraisse_limit K M) :
+theorem is_fraisse [countable (Σl, L.functions l)] [countable M] (h : is_fraisse_limit K M) :
   is_fraisse K :=
-(congr rfl h.age).mp (h.ultrahomogeneous.age_is_fraisse h.is_countable)
+(congr rfl h.age).mp h.ultrahomogeneous.age_is_fraisse
 
 end is_fraisse_limit
 

--- a/src/model_theory/fraisse.lean
+++ b/src/model_theory/fraisse.lean
@@ -221,7 +221,7 @@ begin
   { exact (hFP _ n).some }
 end
 
-theorem exists_countable_is_age_of_iff [L.countable_functions] :
+theorem exists_countable_is_age_of_iff [countable (Σl, L.functions l)] :
   (∃ (M : bundled.{w} L.Structure), (univ : set M).countable ∧ L.age M = K) ↔
     K.nonempty ∧
     (∀ (M N : bundled.{w} L.Structure), nonempty (M ≃[L] N) → (M ∈ K ↔ N ∈ K)) ∧
@@ -253,9 +253,9 @@ variables {L} (K)
 
 /-- A structure `M` is a Fraïssé limit for a class `K` if it is countably generated,
 ultrahomogeneous, and has age `K`. -/
-structure is_fraisse_limit [countable_functions L] : Prop :=
+structure is_fraisse_limit [countable (Σl, L.functions l)] : Prop :=
 (ultrahomogeneous : is_ultrahomogeneous L M)
-(countable : (univ : set M).countable)
+(is_countable : (univ : set M).countable)
 (age : L.age M = K)
 
 variables {L} {M}
@@ -288,8 +288,9 @@ lemma is_ultrahomogeneous.age_is_fraisse (hc : (univ : set M).countable)
 namespace is_fraisse_limit
 
 /-- If a class has a Fraïssé limit, it must be Fraïssé. -/
-theorem is_fraisse [countable_functions L] (h : is_fraisse_limit K M) : is_fraisse K :=
-(congr rfl h.age).mp (h.ultrahomogeneous.age_is_fraisse h.countable)
+theorem is_fraisse [_root_.countable (Σl, L.functions l)] (h : is_fraisse_limit K M) :
+  is_fraisse K :=
+(congr rfl h.age).mp (h.ultrahomogeneous.age_is_fraisse h.is_countable)
 
 end is_fraisse_limit
 

--- a/src/model_theory/substructures.lean
+++ b/src/model_theory/substructures.lean
@@ -272,13 +272,13 @@ end
 
 variable (L)
 
-lemma _root_.set.countable.substructure_closure
-  [L.countable_functions] (h : s.countable) :
-  countable (closure L s) :=
+instance _root_.set.countable.substructure_closure [countable (Σl, L.functions l)]
+  (h : s.countable) :
+  countable.{w + 1} (closure L s) :=
 begin
   haveI : countable s := h.to_subtype,
   rw [← mk_le_aleph_0_iff, ← lift_le_aleph_0],
-  exact lift_card_closure_le_card_term.trans term.card_le_aleph_0,
+  exact lift_card_closure_le_card_term.trans (mk_le_aleph_0_iff.2 term.countable),
 end
 
 variables {L} (S)

--- a/src/model_theory/substructures.lean
+++ b/src/model_theory/substructures.lean
@@ -272,7 +272,7 @@ end
 
 variable (L)
 
-instance _root_.set.countable.substructure_closure [countable (Σl, L.functions l)]
+lemma _root_.set.countable.substructure_closure [countable (Σl, L.functions l)]
   (h : s.countable) :
   countable.{w + 1} (closure L s) :=
 begin

--- a/src/model_theory/substructures.lean
+++ b/src/model_theory/substructures.lean
@@ -278,7 +278,7 @@ lemma _root_.set.countable.substructure_closure [countable (Σl, L.functions l)]
 begin
   haveI : countable s := h.to_subtype,
   rw [← mk_le_aleph_0_iff, ← lift_le_aleph_0],
-  exact lift_card_closure_le_card_term.trans (mk_le_aleph_0_iff.2 term.countable),
+  exact lift_card_closure_le_card_term.trans mk_le_aleph_0
 end
 
 variables {L} (S)


### PR DESCRIPTION
Uses `countable` instead of custom classes in the model theory library.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
