### PR TITLE
feat(data/rat/floor): add norm_num support for `int.{floor,ceil,fract}`

### DIFF
--- a/src/data/rat/floor.lean
+++ b/src/data/rat/floor.lean
@@ -159,10 +159,9 @@ open tactic
   let z := int.floor q,
   let ze := `(z),
   t ← to_expr ``(%%e = %%ze),
-  ((), p) ← tactic.solve_aux t (do {
+  ((), p) ← tactic.solve_aux t (do
     tactic.mk_mapp `int.floor_eq_iff [some R, some inst_1, some inst_2] >>= tactic.rewrite_target,
-    tactic.interactive.norm_num [] (interactive.loc.ns [none])
-  }),
+    tactic.interactive.norm_num [] (interactive.loc.ns [none])),
   p ← instantiate_mvars p,
   pure (ze, p)
 | e@`(@int.ceil %%R %%inst_1 %%inst_2 %%x) := do
@@ -170,10 +169,9 @@ open tactic
   let z := int.ceil q,
   let ze := `(z),
   t ← to_expr ``(%%e = %%ze),
-  ((), p) ← tactic.solve_aux t (do {
+  ((), p) ← tactic.solve_aux t (do
     tactic.mk_mapp `int.ceil_eq_iff [some R, some inst_1, some inst_2] >>= tactic.rewrite_target,
-    `[norm_num]
-  }),
+    `[norm_num]),
   p ← instantiate_mvars p,
   pure (ze, p)
 | e@`(@int.fract %%R %%inst_1 %%inst_2 %%x) := do
@@ -184,20 +182,13 @@ open tactic
   let z := int.floor q,
   let ze := `(z),
   t ← to_expr ``(%%e = %%q'e),
-  ((), p) ← tactic.solve_aux t (do {
+  ((), p) ← tactic.solve_aux t (do
     `[rw int.fract_eq_iff; norm_num],
     tactic.refine ``(⟨%%ze, _⟩),
-    `[norm_num]
-  }),
+    `[norm_num]),
   p ← instantiate_mvars p,
   pure (q'e, p)
 | _ := failed
-
-variables (R :Type*) [linear_ordered_field R] [floor_ring R]
-
-example : int.floor (15 / 16 : R) + 1 = 1 := by norm_num
-example : int.ceil (15 / 16 : R) + 1 = 2 := by norm_num
-example : int.fract (17 / 16 : R) + 1 = 17 / 16 := by norm_num
 
 end norm_num
 end rat

--- a/src/data/rat/floor.lean
+++ b/src/data/rat/floor.lean
@@ -149,4 +149,55 @@ begin
   rwa [q_inv_eq, this.left, this.right, q_num_abs_eq_q_num, mul_comm] at q_inv_num_denom_ineq
 end
 
+namespace norm_num
+open tactic
+
+/-- A norm_num extension for `int.floor`, `int.ceil`, and `int.fract`. -/
+@[norm_num] meta def eval_floor_ceil : expr → tactic (expr × expr)
+| e@`(@int.floor %%R %%inst_1 %%inst_2 %%x) := do
+  q ← x.to_rat,
+  let z := int.floor q,
+  let ze := `(z),
+  t ← to_expr ``(%%e = %%ze),
+  ((), p) ← tactic.solve_aux t (do {
+    tactic.mk_mapp `int.floor_eq_iff [some R, some inst_1, some inst_2] >>= tactic.rewrite_target,
+    tactic.interactive.norm_num [] (interactive.loc.ns [none])
+  }),
+  p ← instantiate_mvars p,
+  pure (ze, p)
+| e@`(@int.ceil %%R %%inst_1 %%inst_2 %%x) := do
+  q ← x.to_rat,
+  let z := int.ceil q,
+  let ze := `(z),
+  t ← to_expr ``(%%e = %%ze),
+  ((), p) ← tactic.solve_aux t (do {
+    tactic.mk_mapp `int.ceil_eq_iff [some R, some inst_1, some inst_2] >>= tactic.rewrite_target,
+    `[norm_num]
+  }),
+  p ← instantiate_mvars p,
+  pure (ze, p)
+| e@`(@int.fract %%R %%inst_1 %%inst_2 %%x) := do
+  q ← x.to_rat,
+  ic ← mk_instance_cache R,
+  let q' := int.fract q,
+  (ic, q'e) ← ic.of_rat q',
+  let z := int.floor q,
+  let ze := `(z),
+  t ← to_expr ``(%%e = %%q'e),
+  ((), p) ← tactic.solve_aux t (do {
+    `[rw int.fract_eq_iff; norm_num],
+    tactic.refine ``(⟨%%ze, _⟩),
+    `[norm_num]
+  }),
+  p ← instantiate_mvars p,
+  pure (q'e, p)
+| _ := failed
+
+variables (R :Type*) [linear_ordered_field R] [floor_ring R]
+
+example : int.floor (15 / 16 : R) + 1 = 1 := by norm_num
+example : int.ceil (15 / 16 : R) + 1 = 2 := by norm_num
+example : int.fract (17 / 16 : R) + 1 = 17 / 16 := by norm_num
+
+end norm_num
 end rat

--- a/test/norm_num_ext.lean
+++ b/test/norm_num_ext.lean
@@ -7,6 +7,7 @@ import algebra.big_operators.norm_num
 import data.nat.squarefree
 import data.int.gcd
 import data.nat.fib
+import data.rat.floor
 import data.nat.prime
 import data.nat.sqrt_norm_num
 import analysis.special_functions.pow
@@ -301,3 +302,17 @@ example : ∏ i in {1, 4, 9, 16}, nat.sqrt i = 24 := by norm_num
 example : ∑ i : fin 2, ∑ j : fin 2, ![![0, 1], ![2, 3]] i j = 6 := by norm_num
 
 end big_operators
+
+section floor
+
+variables (R : Type*) [linear_ordered_field R] [floor_ring R]
+
+example : int.floor (15 / 16 : R) + 1 = 1 := by norm_num
+example : int.ceil (15 / 16 : R) + 1 = 2 := by norm_num
+example : int.fract (17 / 16 : R) + 1 = 17 / 16 := by norm_num
+
+example : int.floor (-15 / 16 : R) + 1 = 0 := by norm_num
+example : int.ceil (-15 / 16 : R) + 1 = 1 := by norm_num
+example : int.fract (-17 / 16 : R) - 1 = -1 / 16 := by norm_num
+
+end


### PR DESCRIPTION
This is super sloppy code, but is a working version to improve upon.

It's unfortunate that where in a proof it's often sufficient to do:
```lean
have : ⌊15 / 16⌋ = 0, { rw floor_eq_iff, norm_num},
norm_num [this]
```
the idiomatic norm_num handler is much more painful to write.

Closes #15992.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
