### PR TITLE
[Merged by Bors] - feat(measure_theory/integral): finiteness of lower Lebesgue integral

### DIFF
--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -109,12 +109,7 @@ by simp only [has_finite_integral_iff_norm, edist_dist, dist_zero_right]
 
 lemma has_finite_integral_iff_of_real {f : α → ℝ} (h : 0 ≤ᵐ[μ] f) :
   has_finite_integral f μ ↔ ∫⁻ a, ennreal.of_real (f a) ∂μ < ∞ :=
-have lintegral_eq : ∫⁻ a, (ennreal.of_real ∥f a∥) ∂μ = ∫⁻ a, ennreal.of_real (f a) ∂μ :=
-begin
-  refine lintegral_congr_ae (h.mono $ λ a h, _),
-  rwa [real.norm_eq_abs, abs_of_nonneg]
-end,
-by rw [has_finite_integral_iff_norm, lintegral_eq]
+by rw [has_finite_integral_iff_norm, lintegral_norm_eq_of_ae_nonneg h]
 
 lemma has_finite_integral_iff_of_nnreal {f : α → ℝ≥0} :
   has_finite_integral (λ x, (f x : ℝ)) μ ↔ ∫⁻ a, f a ∂μ < ∞ :=

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -109,7 +109,7 @@ by simp only [has_finite_integral_iff_norm, edist_dist, dist_zero_right]
 
 lemma has_finite_integral_iff_of_real {f : α → ℝ} (h : 0 ≤ᵐ[μ] f) :
   has_finite_integral f μ ↔ ∫⁻ a, ennreal.of_real (f a) ∂μ < ∞ :=
-by rw [has_finite_integral_iff_norm, lintegral_norm_eq_of_ae_nonneg h]
+by rw [lintegral_nnnorm_eq_of_ae_nonneg h]
 
 lemma has_finite_integral_iff_of_nnreal {f : α → ℝ≥0} :
   has_finite_integral (λ x, (f x : ℝ)) μ ↔ ∫⁻ a, f a ∂μ < ∞ :=

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -109,7 +109,7 @@ by simp only [has_finite_integral_iff_norm, edist_dist, dist_zero_right]
 
 lemma has_finite_integral_iff_of_real {f : α → ℝ} (h : 0 ≤ᵐ[μ] f) :
   has_finite_integral f μ ↔ ∫⁻ a, ennreal.of_real (f a) ∂μ < ∞ :=
-by rw [lintegral_nnnorm_eq_of_ae_nonneg h]
+by rw [has_finite_integral, lintegral_nnnorm_eq_of_ae_nonneg h]
 
 lemma has_finite_integral_iff_of_nnreal {f : α → ℝ≥0} :
   has_finite_integral (λ x, (f x : ℝ)) μ ↔ ∫⁻ a, f a ∂μ < ∞ :=

--- a/src/measure_theory/integral/integrable_on.lean
+++ b/src/measure_theory/integral/integrable_on.lean
@@ -246,15 +246,6 @@ begin
   exact ((Lp.mem_ℒp _).restrict s).mem_ℒp_of_exponent_le hp,
 end
 
-lemma lintegral_to_real_le_lintegral_nnnorm (f : α → ℝ) :
-  ∫⁻ x, ennreal.of_real (f x) ∂μ ≤ ∫⁻ x, ∥f x∥₊ ∂μ :=
-begin
-  simp_rw ← of_real_norm_eq_coe_nnnorm,
-  refine lintegral_mono (λ x, ennreal.of_real_le_of_real _),
-  rw real.norm_eq_abs,
-  exact le_abs_self (f x),
-end
-
 lemma integrable.lintegral_lt_top {f : α → ℝ} (hf : integrable f μ) :
   ∫⁻ x, ennreal.of_real (f x) ∂μ < ∞ :=
 calc ∫⁻ x, ennreal.of_real (f x) ∂μ

--- a/src/measure_theory/integral/integrable_on.lean
+++ b/src/measure_theory/integral/integrable_on.lean
@@ -246,36 +246,20 @@ begin
   exact ((Lp.mem_ℒp _).restrict s).mem_ℒp_of_exponent_le hp,
 end
 
-lemma integrable_on.lintegral_lt_top_ae' {f : α → ℝ} {s : set α}
-  (hf : integrable_on f s μ) (h_nonneg : 0 ≤ᵐ[μ.restrict s] f) :
-  ∫⁻ x in s, ennreal.of_real (f x) ∂μ < ⊤ :=
+lemma lintegral_to_real_le_lintegral_to_real_norm (f : α → ℝ) :
+  ∫⁻ x, ennreal.of_real (f x) ∂μ ≤ ∫⁻ x, ennreal.of_real (∥f x∥) ∂μ :=
 begin
-  rw [←lintegral_norm_eq_of_ae_nonneg h_nonneg, ←has_finite_integral_iff_norm],
-  exact hf.2,
+  refine lintegral_mono (λ x, ennreal.of_real_le_of_real _),
+  rw real.norm_eq_abs,
+  exact le_abs_self (f x),
 end
 
-lemma integrable_on.lintegral_lt_top_ae {f : α → ℝ} {s : set α}
-  (hf : integrable_on f s μ) (hf' : ∀ᵐ x ∂μ, x ∈ s → 0 ≤ f x) :
-  ∫⁻ x in s, ennreal.of_real (f x) ∂μ < ⊤ :=
-begin
-  let g := hf.1.mk _,
-  have : ∫⁻ x in s, ennreal.of_real (f x) ∂μ = ∫⁻ x in s, ennreal.of_real (g x) ∂μ,
-  { apply lintegral_congr_ae,
-    filter_upwards [hf.1.ae_eq_mk] with x hx,
-    rw hx },
-  rw this,
-  apply integrable_on.lintegral_lt_top_ae' (hf.congr hf.1.ae_eq_mk),
-  apply (ae_restrict_iff (measurable_set_le measurable_zero (hf.1.measurable_mk))).2,
-  filter_upwards [hf', ae_imp_of_ae_restrict hf.1.ae_eq_mk] with x hx h'x,
-  assume xs,
-  rw ← h'x xs,
-  exact hx xs,
-end
-
-lemma integrable_on.lintegral_lt_top {f : α → ℝ} {s : set α}
-  (hf : integrable_on f s μ) (hf' : ∀ x : α, x ∈ s → 0 ≤ f x) :
-  ∫⁻ x in s, ennreal.of_real (f x) ∂μ < ⊤ :=
-integrable_on.lintegral_lt_top_ae hf (ae_of_all μ hf')
+lemma integrable_on.lintegral_lt_top {f : α → ℝ} {s : set α} (hf : integrable_on f s μ) :
+  ∫⁻ x in s, ennreal.of_real (f x) ∂μ < ∞ :=
+calc ∫⁻ x in s, ennreal.of_real (f x) ∂μ
+    ≤ ∫⁻ x in s, ennreal.of_real (∥f x∥) ∂μ : lintegral_to_real_le_lintegral_to_real_norm f
+... = ∫⁻ x in s, ↑∥f x∥₊ ∂μ : by simp_rw ← of_real_norm_eq_coe_nnnorm
+... < ∞ : hf.2
 
 /-- We say that a function `f` is *integrable at filter* `l` if it is integrable on some
 set `s ∈ l`. Equivalently, it is eventually integrable on `s` in `l.small_sets`. -/

--- a/src/measure_theory/integral/integrable_on.lean
+++ b/src/measure_theory/integral/integrable_on.lean
@@ -246,19 +246,19 @@ begin
   exact ((Lp.mem_ℒp _).restrict s).mem_ℒp_of_exponent_le hp,
 end
 
-lemma lintegral_to_real_le_lintegral_to_real_norm (f : α → ℝ) :
-  ∫⁻ x, ennreal.of_real (f x) ∂μ ≤ ∫⁻ x, ennreal.of_real (∥f x∥) ∂μ :=
+lemma lintegral_to_real_le_lintegral_nnnorm (f : α → ℝ) :
+  ∫⁻ x, ennreal.of_real (f x) ∂μ ≤ ∫⁻ x, ∥f x∥₊ ∂μ :=
 begin
+  simp_rw ← of_real_norm_eq_coe_nnnorm,
   refine lintegral_mono (λ x, ennreal.of_real_le_of_real _),
   rw real.norm_eq_abs,
   exact le_abs_self (f x),
 end
 
-lemma integrable_on.lintegral_lt_top {f : α → ℝ} {s : set α} (hf : integrable_on f s μ) :
+lemma integrable_on.lintegral_lt_top_ae' {f : α → ℝ} {s : set α} (hf : integrable_on f s μ) :
   ∫⁻ x in s, ennreal.of_real (f x) ∂μ < ∞ :=
 calc ∫⁻ x in s, ennreal.of_real (f x) ∂μ
-    ≤ ∫⁻ x in s, ennreal.of_real (∥f x∥) ∂μ : lintegral_to_real_le_lintegral_to_real_norm f
-... = ∫⁻ x in s, ↑∥f x∥₊ ∂μ : by simp_rw ← of_real_norm_eq_coe_nnnorm
+    ≤ ∫⁻ x in s, ↑∥f x∥₊ ∂μ : lintegral_to_real_le_lintegral_nnnorm f
 ... < ∞ : hf.2
 
 /-- We say that a function `f` is *integrable at filter* `l` if it is integrable on some

--- a/src/measure_theory/integral/integrable_on.lean
+++ b/src/measure_theory/integral/integrable_on.lean
@@ -255,11 +255,15 @@ begin
   exact le_abs_self (f x),
 end
 
-lemma integrable_on.lintegral_lt_top_ae' {f : α → ℝ} {s : set α} (hf : integrable_on f s μ) :
-  ∫⁻ x in s, ennreal.of_real (f x) ∂μ < ∞ :=
-calc ∫⁻ x in s, ennreal.of_real (f x) ∂μ
-    ≤ ∫⁻ x in s, ↑∥f x∥₊ ∂μ : lintegral_to_real_le_lintegral_nnnorm f
+lemma integrable.lintegral_lt_top {f : α → ℝ} (hf : integrable f μ) :
+  ∫⁻ x, ennreal.of_real (f x) ∂μ < ∞ :=
+calc ∫⁻ x, ennreal.of_real (f x) ∂μ
+    ≤ ∫⁻ x, ↑∥f x∥₊ ∂μ : lintegral_to_real_le_lintegral_nnnorm f
 ... < ∞ : hf.2
+
+lemma integrable_on.set_lintegral_lt_top {f : α → ℝ} {s : set α} (hf : integrable_on f s μ) :
+  ∫⁻ x in s, ennreal.of_real (f x) ∂μ < ∞ :=
+integrable.lintegral_lt_top hf
 
 /-- We say that a function `f` is *integrable at filter* `l` if it is integrable on some
 set `s ∈ l`. Equivalently, it is eventually integrable on `s` in `l.small_sets`. -/

--- a/src/measure_theory/integral/integrable_on.lean
+++ b/src/measure_theory/integral/integrable_on.lean
@@ -246,6 +246,37 @@ begin
   exact ((Lp.mem_ℒp _).restrict s).mem_ℒp_of_exponent_le hp,
 end
 
+lemma integrable_on.lintegral_lt_top_ae' {f : α → ℝ} {s : set α}
+  (hf : integrable_on f s μ) (h_nonneg : 0 ≤ᵐ[μ.restrict s] f) :
+  ∫⁻ x in s, ennreal.of_real (f x) ∂μ < ⊤ :=
+begin
+  rw [←lintegral_norm_eq_of_ae_nonneg h_nonneg, ←has_finite_integral_iff_norm],
+  exact hf.2,
+end
+
+lemma integrable_on.lintegral_lt_top_ae {f : α → ℝ} {s : set α}
+  (hf : integrable_on f s μ) (hf' : ∀ᵐ x ∂μ, x ∈ s → 0 ≤ f x) :
+  ∫⁻ x in s, ennreal.of_real (f x) ∂μ < ⊤ :=
+begin
+  let g := hf.1.mk _,
+  have : ∫⁻ x in s, ennreal.of_real (f x) ∂μ = ∫⁻ x in s, ennreal.of_real (g x) ∂μ,
+  { apply lintegral_congr_ae,
+    filter_upwards [hf.1.ae_eq_mk] with x hx,
+    rw hx },
+  rw this,
+  apply integrable_on.lintegral_lt_top_ae' (hf.congr hf.1.ae_eq_mk),
+  apply (ae_restrict_iff (measurable_set_le measurable_zero (hf.1.measurable_mk))).2,
+  filter_upwards [hf', ae_imp_of_ae_restrict hf.1.ae_eq_mk] with x hx h'x,
+  assume xs,
+  rw ← h'x xs,
+  exact hx xs,
+end
+
+lemma integrable_on.lintegral_lt_top {f : α → ℝ} {s : set α}
+  (hf : integrable_on f s μ) (hf' : ∀ x : α, x ∈ s → 0 ≤ f x) :
+  ∫⁻ x in s, ennreal.of_real (f x) ∂μ < ⊤ :=
+integrable_on.lintegral_lt_top_ae hf (ae_of_all μ hf')
+
 /-- We say that a function `f` is *integrable at filter* `l` if it is integrable on some
 set `s ∈ l`. Equivalently, it is eventually integrable on `s` in `l.small_sets`. -/
 def integrable_at_filter (f : α → E) (l : filter α) (μ : measure α . volume_tac) :=

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -1227,6 +1227,15 @@ lemma set_lintegral_congr_fun {f g : α → ℝ≥0∞} {s : set α} (hs : measu
   ∫⁻ x in s, f x ∂μ = ∫⁻ x in s, g x ∂μ :=
 by { rw lintegral_congr_ae, rw eventually_eq, rwa ae_restrict_iff' hs, }
 
+lemma lintegral_to_real_le_lintegral_nnnorm (f : α → ℝ) :
+  ∫⁻ x, ennreal.of_real (f x) ∂μ ≤ ∫⁻ x, ∥f x∥₊ ∂μ :=
+begin
+  simp_rw ← of_real_norm_eq_coe_nnnorm,
+  refine lintegral_mono (λ x, ennreal.of_real_le_of_real _),
+  rw real.norm_eq_abs,
+  exact le_abs_self (f x),
+end
+
 lemma lintegral_norm_eq_of_ae_nonneg {f : α → ℝ} (h_nonneg : 0 ≤ᵐ[μ] f) :
   ∫⁻ x, ennreal.of_real (∥f x∥) ∂μ = ∫⁻ x, ennreal.of_real (f x) ∂μ :=
 begin

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -1236,17 +1236,17 @@ begin
   exact le_abs_self (f x),
 end
 
-lemma lintegral_norm_eq_of_ae_nonneg {f : α → ℝ} (h_nonneg : 0 ≤ᵐ[μ] f) :
-  ∫⁻ x, ennreal.of_real (∥f x∥) ∂μ = ∫⁻ x, ennreal.of_real (f x) ∂μ :=
+lemma lintegral_nnnorm_eq_of_ae_nonneg {f : α → ℝ} (h_nonneg : 0 ≤ᵐ[μ] f) :
+  ∫⁻ x, ∥f x∥₊ ∂μ = ∫⁻ x, ennreal.of_real (f x) ∂μ :=
 begin
   apply lintegral_congr_ae,
   filter_upwards [h_nonneg] with x hx,
-  rw real.norm_of_nonneg hx,
+  rw [real.nnnorm_of_nonneg hx, ennreal.of_real_eq_coe_nnreal hx],
 end
 
-lemma lintegral_norm_eq_of_nonneg {f : α → ℝ} (h_nonneg : 0 ≤ f) :
-  ∫⁻ x, ennreal.of_real (∥f x∥) ∂μ = ∫⁻ x, ennreal.of_real (f x) ∂μ :=
-lintegral_norm_eq_of_ae_nonneg (filter.eventually_of_forall h_nonneg)
+lemma lintegral_nnnorm_eq_of_nonneg {f : α → ℝ} (h_nonneg : 0 ≤ f) :
+  ∫⁻ x, ∥f x∥₊ ∂μ = ∫⁻ x, ennreal.of_real (f x) ∂μ :=
+lintegral_nnnorm_eq_of_ae_nonneg (filter.eventually_of_forall h_nonneg)
 
 /-- Monotone convergence theorem -- sometimes called Beppo-Levi convergence.
 

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -1227,6 +1227,18 @@ lemma set_lintegral_congr_fun {f g : α → ℝ≥0∞} {s : set α} (hs : measu
   ∫⁻ x in s, f x ∂μ = ∫⁻ x in s, g x ∂μ :=
 by { rw lintegral_congr_ae, rw eventually_eq, rwa ae_restrict_iff' hs, }
 
+lemma lintegral_norm_eq_of_ae_nonneg {f : α → ℝ} (h_nonneg : 0 ≤ᵐ[μ] f) :
+  ∫⁻ x, ennreal.of_real (∥f x∥) ∂μ = ∫⁻ x, ennreal.of_real (f x) ∂μ :=
+begin
+  apply lintegral_congr_ae,
+  filter_upwards [h_nonneg] with x hx,
+  rw real.norm_of_nonneg hx,
+end
+
+lemma lintegral_norm_eq_of_nonneg {f : α → ℝ} (h_nonneg : 0 ≤ f) :
+  ∫⁻ x, ennreal.of_real (∥f x∥) ∂μ = ∫⁻ x, ennreal.of_real (f x) ∂μ :=
+lintegral_norm_eq_of_ae_nonneg (filter.eventually_of_forall h_nonneg)
+
 /-- Monotone convergence theorem -- sometimes called Beppo-Levi convergence.
 
 See `lintegral_supr_directed` for a more general form. -/


### PR DESCRIPTION
This PR proves that if a function is integrable and non-negative, then it's lower Lebesgue integral is finite.

Co-authored-by: Sébastien Gouëzel <sebastien.gouezel@univ-rennes1.fr>
Co-authored-by: Remy Degenne <remydegenne@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
