### PR TITLE
refactor(*): use `map_smul` for `alg_equiv` instead of `commutes`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -811,9 +811,9 @@ by rw [algebra.smul_def, mul_one, eq_rat_cast]
 set_option old_structure_cmd true
 /-- An equivalence of algebras is an equivalence of rings commuting with the actions of scalars. -/
 structure alg_equiv (R : Type u) (A : Type v) (B : Type w)
-  [comm_semiring R] [semiring A] [semiring B] [algebra R A] [algebra R B]
+  [has_add A] [has_mul A] [has_add B] [has_mul B] [has_smul R A] [has_smul R B]
   extends A ≃ B, A ≃* B, A ≃+ B, A ≃+* B :=
-(commutes' : ∀ r : R, to_fun (algebra_map R A r) = algebra_map R B r)
+(map_smul' : ∀ (r : R) (a : A), to_fun (r • a) = r • to_fun a)
 
 attribute [nolint doc_blame] alg_equiv.to_ring_equiv
 attribute [nolint doc_blame] alg_equiv.to_equiv
@@ -825,9 +825,9 @@ notation A ` ≃ₐ[`:50 R `] ` A' := alg_equiv R A A'
 /-- `alg_equiv_class F R A B` states that `F` is a type of algebra structure preserving
   equivalences. You should extend this class when you extend `alg_equiv`. -/
 class alg_equiv_class (F : Type*) (R A B : out_param Type*)
-  [comm_semiring R] [semiring A] [semiring B] [algebra R A] [algebra R B]
+  [has_add A] [has_mul A] [has_add B] [has_mul B] [has_smul R A] [has_smul R B]
   extends ring_equiv_class F A B :=
-(commutes : ∀ (f : F) (r : R), f (algebra_map R A r) = algebra_map R B r)
+(map_smul : ∀ (f : F) (r : R) (a : A), f (r • a) = r • f a)
 
 -- `R` becomes a metavariable but that's fine because it's an `out_param`
 attribute [nolint dangerous_instance] alg_equiv_class.to_ring_equiv_class
@@ -842,15 +842,17 @@ instance to_alg_hom_class (F R A B : Type*)
   coe_injective' := fun_like.coe_injective,
   map_zero := map_zero,
   map_one := map_one,
+  commutes := λ f r, by simp only [algebra.algebra_map_eq_smul_one, map_smul, map_one],
   .. h }
 
 @[priority 100]
 instance to_linear_equiv_class (F R A B : Type*)
   [comm_semiring R] [semiring A] [semiring B] [algebra R A] [algebra R B]
   [h : alg_equiv_class F R A B] : linear_equiv_class F R A B :=
-{ map_smulₛₗ := λ f, map_smulₛₗ f,
+{ map_smulₛₗ := λ f, map_smul f,
   ..h }
 
+#exit
 end alg_equiv_class
 
 namespace alg_equiv
@@ -859,9 +861,14 @@ variables {R : Type u} {A₁ : Type v} {A₂ : Type w} {A₃ : Type u₁}
 
 section semiring
 
+variables [has_add A₁] [has_mul A₁] [has_add A₂] [has_mul A₂] [has_add A₃] [has_mul A₃]
+variables [has_smul R A₁] [has_smul R A₂] [has_smul R A₃]
+variables (e : A₁ ≃ₐ[R] A₂)
+/-
 variables [comm_semiring R] [semiring A₁] [semiring A₂] [semiring A₃]
 variables [algebra R A₁] [algebra R A₂] [algebra R A₃]
 variables (e : A₁ ≃ₐ[R] A₂)
+-/
 
 instance : alg_equiv_class (A₁ ≃ₐ[R] A₂) R A₁ A₂ :=
 { coe := to_fun,
@@ -869,7 +876,7 @@ instance : alg_equiv_class (A₁ ≃ₐ[R] A₂) R A₁ A₂ :=
   coe_injective' := λ f g h₁ h₂, by { cases f, cases g, congr' },
   map_add := map_add',
   map_mul := map_mul',
-  commutes := commutes',
+  map_smul := map_smul',
   left_inv := left_inv,
   right_inv := right_inv }
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -834,7 +834,7 @@ attribute [nolint dangerous_instance] alg_equiv_class.to_ring_equiv_class
 
 namespace alg_equiv_class
 
-@[priority 100] -- See note [lower_instance_priority]
+@[priority 50] -- See note [lower_instance_priority]
 instance to_smul_hom_class (F : Type*) (R A B : out_param Type*)
   [has_add A] [has_mul A] [has_add B] [has_mul B] [has_smul R A] [has_smul R B]
   [h : alg_equiv_class F R A B] : smul_hom_class F R A B :=

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1143,6 +1143,15 @@ variables [comm_semiring R] [semiring A₁] [semiring A₂] [semiring A₃]
 variables [algebra R A₁] [algebra R A₂] [algebra R A₃]
 variables (e : A₁ ≃ₐ[R] A₂)
 
+/-- This lemma exists solely for convenience. In particular, it may be the case that one wants to
+upgrade a `ring_equiv` to an `alg_equiv` by providing a `commutes'` field instead of the `map_smul'`
+field. In that case, one can simply apply this lemma. -/
+lemma map_smul_of_map_mul_of_commutes {f : A₁ → A₂} (map_mul' : ∀ x y, f (x * y) = f x * f y)
+  (commutes' : ∀ r : R, f (algebra_map R A₁ r) = algebra_map R A₂ r) :
+  ∀ (r : R) (a : A₁), f (r • a) = r • f a :=
+λ r a, by simpa only [algebra.algebra_map_eq_smul_one, algebra.smul_mul_assoc, one_mul] using
+  (commutes' r ▸ map_mul' _ _ : f (algebra_map R A₁ r * a) = algebra_map R A₂ r * f a)
+
 /-- Interpret an algebra equivalence as an algebra homomorphism.
 
 This definition is included for symmetry with the other `to_*_hom` projections.

--- a/src/algebra/algebra/subalgebra/basic.lean
+++ b/src/algebra/algebra/subalgebra/basic.lean
@@ -493,6 +493,7 @@ def of_left_inverse
   right_inv := λ x, subtype.ext $
     let ⟨x', hx'⟩ := f.mem_range.mp x.prop in
     show f (g x) = x, by rw [←hx', h x'],
+  map_smul' := map_smul f.range_restrict,
   ..f.range_restrict }
 
 @[simp] lemma of_left_inverse_apply

--- a/src/algebra/algebra/subalgebra/basic.lean
+++ b/src/algebra/algebra/subalgebra/basic.lean
@@ -521,7 +521,7 @@ of_injective f f.to_ring_hom.injective
 `subalgebra_map` is the induced equivalence between `S` and `S.map e` -/
 @[simps] def subalgebra_map (e : A ≃ₐ[R] B) (S : subalgebra R A) :
   S ≃ₐ[R] (S.map e.to_alg_hom) :=
-{ commutes' := λ r, by { ext, simp },
+{ map_smul' := λ r a, by { ext, simpa },
   ..e.to_ring_equiv.subsemiring_map S.to_subsemiring }
 
 end alg_equiv
@@ -771,7 +771,7 @@ def equiv_of_eq (S T : subalgebra R A) (h : S = T) : S ≃ₐ[R] T :=
 { to_fun := λ x, ⟨x, h ▸ x.2⟩,
   inv_fun := λ x, ⟨x, h.symm ▸ x.2⟩,
   map_mul' := λ _ _, rfl,
-  commutes' := λ _, rfl,
+  map_smul' := λ _ _, rfl,
   .. linear_equiv.of_eq _ _ (congr_arg to_submodule h) }
 
 @[simp] lemma equiv_of_eq_symm (S T : subalgebra R A) (h : S = T) :

--- a/src/algebra/algebra/tower.lean
+++ b/src/algebra/algebra/tower.lean
@@ -184,8 +184,9 @@ namespace alg_equiv
 
 /-- R ⟶ S induces S-Alg ⥤ R-Alg -/
 def restrict_scalars (f : A ≃ₐ[S] B) : A ≃ₐ[R] B :=
-{ commutes' := λ r, by { rw [algebra_map_apply R S A, algebra_map_apply R S B],
-    exact f.commutes (algebra_map R S r) },
+{ map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul f)
+    (λ r, by { rw [algebra_map_apply R S A, algebra_map_apply R S B],
+      exact f.commutes (algebra_map R S r) }),
   .. (f : A ≃+* B) }
 
 lemma restrict_scalars_apply (f : A ≃ₐ[S] B) (x : A) : f.restrict_scalars R x = f x := rfl

--- a/src/algebra/category/Algebra/basic.lean
+++ b/src/algebra/category/Algebra/basic.lean
@@ -161,6 +161,6 @@ instance Algebra.forget_reflects_isos : reflects_isomorphisms (forget (Algebra.{
   begin
     resetI,
     let i := as_iso ((forget (Algebra.{u} R)).map f),
-    let e : X ≃ₐ[R] Y := { ..f, ..i.to_equiv },
+    let e : X ≃ₐ[R] Y := { map_smul' := map_smul f, ..f, ..i.to_equiv },
     exact ⟨(is_iso.of_iso e.to_Algebra_iso).1⟩,
   end }

--- a/src/algebra/category/Algebra/basic.lean
+++ b/src/algebra/category/Algebra/basic.lean
@@ -140,7 +140,7 @@ def to_alg_equiv {X Y : Algebra R} (i : X ≅ Y) : X ≃ₐ[R] Y :=
   right_inv := by tidy,
   map_add'  := by tidy,
   map_mul'  := by tidy,
-  commutes' := by tidy, }.
+  map_smul' := by tidy, }.
 
 end category_theory.iso
 

--- a/src/algebra/hom/non_unital_alg.lean
+++ b/src/algebra/hom/non_unital_alg.lean
@@ -29,8 +29,6 @@ functions on a non-compact topological space. A proper map between a pair of suc
 (contravariantly) induces a morphism between their algebras of compactly-supported functions which
 will be a `non_unital_alg_hom`.
 
-TODO: add `non_unital_alg_equiv` when needed.
-
 ## Main definitions
 
   * `non_unital_alg_hom`

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -1548,12 +1548,15 @@ variables [comm_semiring R] (k G)
 `multiplicative`. -/
 def add_monoid_algebra.to_multiplicative_alg_equiv [semiring k] [algebra R k] [add_monoid G] :
   add_monoid_algebra k G ≃ₐ[R] monoid_algebra k (multiplicative G) :=
-{ commutes' := λ r, by simp [add_monoid_algebra.to_multiplicative],
+{ map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes
+    (map_mul $ add_monoid_algebra.to_multiplicative k G)
+    (λ r, by simp [add_monoid_algebra.to_multiplicative]),
   ..add_monoid_algebra.to_multiplicative k G }
 
 /-- The algebra equivalence between `monoid_algebra` and `add_monoid_algebra` in terms of
 `additive`. -/
 def monoid_algebra.to_additive_alg_equiv [semiring k] [algebra R k] [monoid G] :
   monoid_algebra k G ≃ₐ[R] add_monoid_algebra k (additive G) :=
-{ commutes' := λ r, by simp [monoid_algebra.to_additive],
+{ map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul $ monoid_algebra.to_additive k G)
+    (λ r, by simp [monoid_algebra.to_additive]),
   ..monoid_algebra.to_additive k G }

--- a/src/algebra/monoid_algebra/to_direct_sum.lean
+++ b/src/algebra/monoid_algebra/to_direct_sum.lean
@@ -191,7 +191,7 @@ def add_monoid_algebra_alg_equiv_direct_sum
   [Π m : A, decidable (m ≠ 0)] :
   add_monoid_algebra A ι ≃ₐ[R] ⨁ i : ι, A :=
 { to_fun := add_monoid_algebra.to_direct_sum, inv_fun := direct_sum.to_add_monoid_algebra,
-  commutes' := λ r, add_monoid_algebra.to_direct_sum_single _ _,
+  map_smul' := finsupp.to_dfinsupp_smul,
   ..(add_monoid_algebra_ring_equiv_direct_sum : add_monoid_algebra A ι ≃+* ⨁ i : ι, A) }
 
 end equivs

--- a/src/algebra/quaternion.lean
+++ b/src/algebra/quaternion.lean
@@ -331,7 +331,7 @@ def conj_ae : ℍ[R, c₁, c₂] ≃ₐ[R] (ℍ[R, c₁, c₂]ᵐᵒᵖ) :=
 { to_fun := op ∘ conj,
   inv_fun := conj ∘ unop,
   map_mul' := λ x y, by simp,
-  commutes' := λ r, by simp,
+  map_smul' := λ r a, by simp,
   .. conj.to_add_equiv.trans op_add_equiv }
 
 @[simp] lemma coe_conj_ae : ⇑(conj_ae : ℍ[R, c₁, c₂] ≃ₐ[R] _) = op ∘ conj := rfl

--- a/src/algebra/star/free.lean
+++ b/src/algebra/star/free.lean
@@ -56,7 +56,7 @@ by simp [star, has_star.star]
 
 /-- `star` as an `alg_equiv` -/
 def star_hom : free_algebra R X ≃ₐ[R] (free_algebra R X)ᵐᵒᵖ :=
-{ commutes' := λ r, by simp [star_algebra_map],
+{ map_smul' := λ r a, by simp [has_star.star],
   ..star_ring_equiv }
 
 end free_algebra

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -231,7 +231,7 @@ def conj_ae : ℂ ≃ₐ[ℝ] ℂ :=
 { inv_fun := conj,
   left_inv := star_star,
   right_inv := star_star,
-  commutes' := conj_of_real,
+  map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul _) conj_of_real,
   .. conj }
 
 @[simp] lemma conj_ae_coe : ⇑conj_ae = conj := rfl

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -1088,7 +1088,7 @@ coefficients. This is `matrix.map` as a `alg_equiv`. -/
 def map_matrix (f : α ≃ₐ[R] β) : matrix m m α ≃ₐ[R] matrix m m β :=
 { to_fun := λ M, M.map f,
   inv_fun := λ M, M.map f.symm,
-  .. f.to_alg_hom.map_matrix,
+  .. f.to_linear_map.map_matrix,
   .. f.to_ring_equiv.map_matrix }
 
 @[simp] lemma map_matrix_refl :
@@ -1452,8 +1452,7 @@ variables (R m α)
 def transpose_alg_equiv [comm_semiring R] [comm_semiring α] [fintype m] [decidable_eq m]
   [algebra R α] : matrix m m α ≃ₐ[R] (matrix m m α)ᵐᵒᵖ :=
 { to_fun := λ M, mul_opposite.op (Mᵀ),
-  commutes' := λ r, by simp only [algebra_map_eq_diagonal, diagonal_transpose,
-                                  mul_opposite.algebra_map_apply],
+  map_smul' := by simp [transpose_smul],
   ..(transpose_add_equiv m m α).trans mul_opposite.op_add_equiv,
   ..transpose_ring_equiv m α }
 

--- a/src/data/mv_polynomial/equiv.lean
+++ b/src/data/mv_polynomial/equiv.lean
@@ -85,7 +85,8 @@ def punit_alg_equiv : mv_polynomial punit R ≃ₐ[R] R[X] :=
         eval₂_mul, eval₂_C, eval₂_pow, eval₂_X]),
   map_mul'  := λ _ _, eval₂_mul _ _,
   map_add'  := λ _ _, eval₂_add _ _,
-  commutes' := λ _, eval₂_C _ _ _}
+  map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (λ _ _, eval₂_mul _ _)
+    (λ _, eval₂_C _ _ _) }
 
 section map
 variables {R} (σ)
@@ -120,6 +121,7 @@ variables [algebra R A₁] [algebra R A₂] [algebra R A₃]
 def map_alg_equiv (e : A₁ ≃ₐ[R] A₂) :
   mv_polynomial σ A₁ ≃ₐ[R] mv_polynomial σ A₂ :=
 { to_fun := map (e : A₁ →+* A₂),
+  map_smul' := map_smul (map_alg_hom (e : A₁ →ₐ[R] A₂) : mv_polynomial σ A₁ →ₐ[R] _),
   ..map_alg_hom (e : A₁ →ₐ[R] A₂),
   ..map_equiv σ (e : A₁ ≃+* A₂) }
 
@@ -243,7 +245,8 @@ with coefficents in multivariable polynomials in the other type.
 -/
 def sum_alg_equiv : mv_polynomial (S₁ ⊕ S₂) R ≃ₐ[R]
   mv_polynomial S₁ (mv_polynomial S₂ R) :=
-{ commutes' := begin
+{ map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul $ sum_ring_equiv R S₁ S₂)
+  begin
     intro r,
     have A : algebra_map R (mv_polynomial S₁ (mv_polynomial S₂ R)) r = (C (C r) : _), by refl,
     have B : algebra_map R (mv_polynomial (S₁ ⊕ S₂) R) r = C r, by refl,

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -133,6 +133,7 @@ def rename_equiv (f : σ ≃ τ) : mv_polynomial σ R ≃ₐ[R] mv_polynomial τ
   inv_fun := rename f.symm,
   left_inv := λ p, by rw [rename_rename, f.symm_comp_self, rename_id],
   right_inv := λ p, by rw [rename_rename, f.self_comp_symm, rename_id],
+  map_smul' := map_smul (rename f),
   ..rename f}
 
 @[simp] lemma rename_equiv_refl :

--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -82,11 +82,8 @@ variable (R)
 implementation detail, but it can be useful to transfer results from `finsupp` to polynomials. -/
 @[simps]
 def to_finsupp_iso_alg : R[X] ≃ₐ[R] add_monoid_algebra R ℕ :=
-{ commutes' := λ r,
-  begin
-    dsimp,
-    exact to_finsupp_algebra_map _,
-  end,
+{ map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul $ to_finsupp_iso R)
+    (λ r, by { dsimp, exact to_finsupp_algebra_map _, }),
   ..to_finsupp_iso R }
 
 variable {R}

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -923,7 +923,7 @@ lemma alg_hom_mk_adjoin_splits' (hS : adjoin F S = ⊤)
 begin
   cases alg_hom_mk_adjoin_splits hK with ϕ,
   rw hS at ϕ,
-  exact ⟨ϕ.comp top_equiv.symm.to_alg_hom⟩,
+  exact ⟨ϕ.comp $ alg_equiv.to_alg_hom top_equiv.symm⟩,
 end
 
 end alg_hom_mk_adjoin_splits

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -101,7 +101,7 @@ begin
     right_inv := λ _, rfl,
     map_mul' := λ _ _, rfl,
     map_add' := λ _ _, rfl,
-    commutes' := λ _, rfl },
+    map_smul' := λ _ _, rfl },
   have H : is_integral F α := is_galois.integral F α,
   have h_sep : (minpoly F α).separable := is_galois.separable F α,
   have h_splits : (minpoly F α).splits (algebra_map F E) := is_galois.splits F α,
@@ -191,7 +191,10 @@ lemma le_iff_le : K ≤ fixed_field H ↔ H ≤ fixing_subgroup K :=
 
 /-- The fixing_subgroup of `K : intermediate_field F E` is isomorphic to `E ≃ₐ[K] E` -/
 def fixing_subgroup_equiv : fixing_subgroup K ≃* (E ≃ₐ[K] E) :=
-{ to_fun := λ ϕ, { commutes' := ϕ.mem, ..alg_equiv.to_ring_equiv ↑ϕ },
+{ to_fun := λ ϕ,
+  { map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (by simpa only [ring_equiv.to_fun_eq_coe]
+      using map_mul _) ϕ.mem,
+    ..alg_equiv.to_ring_equiv ↑ϕ },
   inv_fun := λ ϕ, ⟨ϕ.restrict_scalars _, ϕ.commutes⟩,
   left_inv := λ _, by { ext, refl },
   right_inv := λ _, by { ext, refl },
@@ -379,9 +382,10 @@ begin
   suffices : P (intermediate_field.adjoin F ↑s),
   { rw adjoin_root at this,
     apply of_card_aut_eq_finrank,
-    rw ← eq.trans this (linear_equiv.finrank_eq intermediate_field.top_equiv.to_linear_equiv),
+    rw ← eq.trans this (linear_equiv.finrank_eq $
+      alg_equiv.to_linear_equiv intermediate_field.top_equiv),
     exact fintype.card_congr ((alg_equiv_equiv_alg_hom F E).to_equiv.trans
-      (intermediate_field.top_equiv.symm.arrow_congr alg_equiv.refl)) },
+      ((@intermediate_field.top_equiv F _ E _ _).symm.arrow_congr alg_equiv.refl)) },
   apply intermediate_field.induction_on_adjoin_finset s P,
   { have key := intermediate_field.card_alg_hom_adjoin_integral F
       (show is_integral F (0 : E), by exact is_integral_zero),

--- a/src/field_theory/normal.lean
+++ b/src/field_theory/normal.lean
@@ -376,7 +376,8 @@ begin
     map_one' := alg_equiv.ext (λ _, rfl),
     map_mul' := λ _ _, alg_equiv.ext (λ _, rfl) },
   refine solvable_of_ker_le_range f (alg_equiv.restrict_normal_hom K₁)
-    (λ ϕ hϕ, ⟨{commutes' := λ x, _, .. ϕ}, alg_equiv.ext (λ _, rfl)⟩),
+    (λ ϕ hϕ, ⟨{map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul ϕ) (λ x, _), .. ϕ},
+      alg_equiv.ext (λ _, rfl)⟩),
   exact (eq.trans (ϕ.restrict_normal_commutes K₁ x).symm (congr_arg _ (alg_equiv.ext_iff.mp hϕ x))),
 end
 

--- a/src/linear_algebra/charpoly/basic.lean
+++ b/src/linear_algebra/charpoly/basic.lean
@@ -61,7 +61,8 @@ to the linear map itself, is zero.
 See `matrix.aeval_self_charpoly` for the equivalent statement about matrices. -/
 lemma aeval_self_charpoly : aeval f f.charpoly = 0 :=
 begin
-  apply (linear_equiv.map_eq_zero_iff (alg_equiv_matrix _).to_linear_equiv).1,
+  apply (linear_equiv.map_eq_zero_iff
+    (alg_equiv_matrix (module.free.choose_basis R M)).to_linear_equiv).1,
   rw [alg_equiv.to_linear_equiv_apply, ← alg_equiv.coe_alg_hom,
     ← polynomial.aeval_alg_hom_apply _ _ _, charpoly_def],
   exact aeval_self_charpoly _,

--- a/src/linear_algebra/clifford_algebra/conjugation.lean
+++ b/src/linear_algebra/clifford_algebra/conjugation.lean
@@ -165,7 +165,8 @@ section involute
 lemma submodule_map_involute_eq_comap (p : submodule R (clifford_algebra Q)) :
   p.map (involute : clifford_algebra Q →ₐ[R] clifford_algebra Q).to_linear_map
     = p.comap (involute : clifford_algebra Q →ₐ[R] clifford_algebra Q).to_linear_map :=
-(submodule.map_equiv_eq_comap_symm involute_equiv.to_linear_equiv _)
+(submodule.map_equiv_eq_comap_symm
+  (involute_equiv : clifford_algebra Q ≃ₐ[R] clifford_algebra Q).to_linear_equiv _)
 
 @[simp] lemma ι_range_map_involute :
   (ι Q).range.map (involute : clifford_algebra Q →ₐ[R] clifford_algebra Q).to_linear_map

--- a/src/linear_algebra/free_algebra.lean
+++ b/src/linear_algebra/free_algebra.lean
@@ -22,8 +22,8 @@ mapping `[x₁, x₂, ..., xₙ]` to the "monomial" `1 • x₁ * x₂ * ⋯ * x
 @[simps]
 noncomputable def basis_free_monoid (R : Type u) (X : Type v) [comm_ring R] :
   basis (free_monoid X) R (free_algebra R X) :=
-finsupp.basis_single_one.map
-  (equiv_monoid_algebra_free_monoid.symm.to_linear_equiv : _ ≃ₗ[R] free_algebra R X)
+finsupp.basis_single_one.map (equiv_monoid_algebra_free_monoid :
+  free_algebra R X ≃ₐ[R] monoid_algebra R (free_monoid X)).symm.to_linear_equiv
 
 -- TODO: generalize to `X : Type v`
 lemma dim_eq {K : Type u} {X : Type (max u v)} [field K] :

--- a/src/linear_algebra/matrix/reindex.lean
+++ b/src/linear_algebra/matrix/reindex.lean
@@ -108,7 +108,7 @@ a matrix's rows and columns with equivalent types, `matrix.reindex`, is an equiv
 def reindex_alg_equiv (e : m ≃ n) : matrix m m R ≃ₐ[R] matrix n n R :=
 { to_fun    := reindex e e,
   map_mul'  := λ a b, (reindex_linear_equiv_mul R R e e e a b).symm,
-  commutes' := λ r, by simp [algebra_map, algebra.to_ring_hom, submatrix_smul],
+  map_smul' := by simp [submatrix_smul],
   ..(reindex_linear_equiv R R e e) }
 
 @[simp] lemma reindex_alg_equiv_apply (e : m ≃ n) (M : matrix m m R) :

--- a/src/linear_algebra/matrix/to_lin.lean
+++ b/src/linear_algebra/matrix/to_lin.lean
@@ -289,7 +289,6 @@ def matrix.to_lin'_of_inv [fintype m] [decidable_eq m]
 /-- Linear maps `(n → R) →ₗ[R] (n → R)` are algebra equivalent to `matrix n n R`. -/
 def linear_map.to_matrix_alg_equiv' : ((n → R) →ₗ[R] (n → R)) ≃ₐ[R] matrix n n R :=
 alg_equiv.of_linear_equiv linear_map.to_matrix' linear_map.to_matrix'_mul
-  linear_map.to_matrix'_algebra_map
 
 /-- A `matrix n n R` is algebra equivalent to a linear map `(n → R) →ₗ[R] (n → R)`. -/
 def matrix.to_lin_alg_equiv' : matrix n n R ≃ₐ[R] ((n → R) →ₗ[R] (n → R)) :=
@@ -522,7 +521,6 @@ equivalence between linear maps `M₁ →ₗ M₁` and square matrices over `R` 
 def linear_map.to_matrix_alg_equiv :
   (M₁ →ₗ[R] M₁) ≃ₐ[R] matrix n n R :=
 alg_equiv.of_linear_equiv (linear_map.to_matrix v₁ v₁) (linear_map.to_matrix_mul v₁)
-  (linear_map.to_matrix_algebra_map v₁)
 
 /-- Given a basis of a module `M₁` over a commutative ring `R`, we get an algebra
 equivalence between square matrices over `R` indexed by the basis and linear maps `M₁ →ₗ M₁`. -/
@@ -759,8 +757,7 @@ is compatible with the algebra structures. -/
 def alg_equiv_matrix' [fintype n] : module.End R (n → R) ≃ₐ[R] matrix n n R :=
 { map_mul'  := linear_map.to_matrix'_comp,
   map_add'  := linear_map.to_matrix'.map_add,
-  commutes' := λ r, by { change (r • (linear_map.id : module.End R _)).to_matrix' = r • 1,
-                         rw ←linear_map.to_matrix'_id, refl, apply_instance },
+  map_smul' := linear_map.to_matrix'.map_smul,
   ..linear_map.to_matrix' }
 
 /-- A linear equivalence of two modules induces an equivalence of algebras of their
@@ -769,8 +766,7 @@ def linear_equiv.alg_conj (e : M₁ ≃ₗ[R] M₂) :
   module.End R M₁ ≃ₐ[R] module.End R M₂ :=
 { map_mul'  := λ f g, by apply e.arrow_congr_comp,
   map_add'  := e.conj.map_add,
-  commutes' := λ r, by { change e.conj (r • linear_map.id) = r • linear_map.id,
-                         rw [linear_equiv.map_smul, linear_equiv.conj_id], },
+  map_smul' := e.conj.map_smul,
   ..e.conj }
 
 /-- A basis of a module induces an equivalence of algebras from the endomorphisms of the module to

--- a/src/logic/equiv/transfer_instance.lean
+++ b/src/logic/equiv/transfer_instance.lean
@@ -395,7 +395,8 @@ def alg_equiv (e : α ≃ β) [semiring β] [algebra R β] :
 begin
   introsI,
   exact
-  { commutes' := λ r, by { apply e.symm.injective, simp, refl, },
+  { map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul $ equiv.ring_equiv e)
+      (λ r, by { apply e.symm.injective, simp, refl, }),
     ..equiv.ring_equiv e }
 end
 

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -500,6 +500,7 @@ def equiv' (h₁ : aeval (root g) (minpoly R pb.gen) = 0) (h₂ : aeval pb.gen g
     obtain ⟨f, hf, rfl⟩ := pb.exists_eq_aeval x,
     rw [pb.lift_aeval, aeval_eq, lift_hom_mk]
   end,
+  map_smul' := map_smul (adjoin_root.lift_hom g pb.gen h₂),
   .. adjoin_root.lift_hom g pb.gen h₂ }
 
 @[simp] lemma equiv'_to_alg_hom

--- a/src/ring_theory/etale.lean
+++ b/src/ring_theory/etale.lean
@@ -118,7 +118,9 @@ begin
   { introsI B _ I hI _, exact formally_smooth.comp_surjective I hI },
   { introsI B _ I J hIJ h₁ h₂ _ g,
     let : ((B ⧸ I) ⧸ J.map (ideal.quotient.mk I)) ≃ₐ[R] B ⧸ J :=
-      { commutes' := λ x, rfl,
+      { map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes
+          (map_mul $ (double_quot.quot_quot_equiv_quot_sup I J).trans
+          (ideal.quot_equiv_of_eq (sup_eq_right.mpr hIJ))) (λ x, rfl),
         ..((double_quot.quot_quot_equiv_quot_sup I J).trans
           (ideal.quot_equiv_of_eq (sup_eq_right.mpr hIJ))) },
     obtain ⟨g', e⟩ := h₂ (this.symm.to_alg_hom.comp g),

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -377,7 +377,8 @@ lemma iff_quotient_mv_polynomial' : finite_presentation R A ↔ ∃ (ι : Type u
 begin
   split,
   { rintro ⟨n, f, hfs, hfk⟩,
-    set ulift_var := mv_polynomial.rename_equiv R equiv.ulift,
+    set ulift_var : mv_polynomial (ulift (fin n)) _ ≃ₐ[R] _ :=
+      mv_polynomial.rename_equiv R equiv.ulift,
     refine ⟨ulift (fin n), infer_instance, f.comp ulift_var.to_alg_hom,
       hfs.comp ulift_var.surjective,
       ideal.fg_ker_comp _ _ _ hfk ulift_var.surjective⟩,
@@ -405,12 +406,14 @@ begin
   let g := (mv_polynomial.map_alg_hom f).comp (mv_polynomial.sum_alg_equiv R ι ι').to_alg_hom,
   casesI nonempty_fintype (ι ⊕ ι'),
   refine ⟨ι ⊕ ι', by apply_instance, g,
-    (mv_polynomial.map_surjective f.to_ring_hom hf_surj).comp (alg_equiv.surjective _),
-    ideal.fg_ker_comp _ _ _ _ (alg_equiv.surjective _)⟩,
+    (mv_polynomial.map_surjective f.to_ring_hom hf_surj).comp (alg_equiv.surjective _), _⟩,
+  apply ideal.fg_ker_comp,
   { convert submodule.fg_bot,
-    exact ring_hom.ker_coe_equiv (mv_polynomial.sum_alg_equiv R ι ι').to_ring_equiv },
+    rw ←ring_hom.injective_iff_ker_eq_bot,
+    simpa only using (mv_polynomial.sum_alg_equiv R ι ι').injective, },
   { rw [alg_hom.to_ring_hom_eq_coe, mv_polynomial.map_alg_hom_coe_ring_hom, mv_polynomial.ker_map],
-    exact hf_ker.map mv_polynomial.C, }
+    exact hf_ker.map mv_polynomial.C, },
+  exact (alg_equiv.surjective _),
 end
 
 /-- If `A` is an `R`-algebra and `S` is an `A`-algebra, both finitely presented, then `S` is

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -714,7 +714,9 @@ ideals in `P` and in `P'` -/
 noncomputable def canonical_equiv :
   fractional_ideal S P ≃+* fractional_ideal S P' :=
 map_equiv
-  { commutes' := λ r, ring_equiv_of_ring_equiv_eq _ _,
+  { map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes
+      (λ x y, by simp only [ring_equiv.to_fun_eq_coe, mul_hom_class.map_mul])
+      (λ r, ring_equiv_of_ring_equiv_eq _ _),
     ..ring_equiv_of_ring_equiv P P' (ring_equiv.refl R)
       (show S.map _ = S, by rw [ring_equiv.to_monoid_hom_refl, submonoid.map_id]) }
 

--- a/src/ring_theory/graded_algebra/basic.lean
+++ b/src/ring_theory/graded_algebra/basic.lean
@@ -199,7 +199,7 @@ an algebra to a direct sum of components. -/
 def decompose_alg_equiv : A ≃ₐ[R] ⨁ i, 𝒜 i := alg_equiv.symm
 { map_mul' := (coe_alg_hom 𝒜).map_mul,
   map_add' := (coe_alg_hom 𝒜).map_add,
-  commutes' := (coe_alg_hom 𝒜).commutes,
+  map_smul' := map_smul (coe_alg_hom 𝒜),
   ..(decompose_add_equiv 𝒜).symm }
 
 end direct_sum

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -1118,20 +1118,9 @@ variables (R) [comm_semiring R] {A : Type*} [semiring A] [algebra R A]
 
 /-- The `R`-algebra `hahn_series ℕ A` is isomorphic to `power_series A`. -/
 @[simps] def to_power_series_alg : (hahn_series ℕ A) ≃ₐ[R] power_series A :=
-{ map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul (@to_power_series A _)) $ λ r,
-  begin
-    ext n,
-    simp only [algebra_map_apply, power_series.algebra_map_apply, ring_equiv.to_fun_eq_coe, C_apply,
-      coeff_to_power_series],
-    cases n,
-    { simp only [power_series.coeff_zero_eq_constant_coeff, single_coeff_same],
-      refl },
-    { simp only [n.succ_ne_zero, ne.def, not_false_iff, single_coeff_of_ne],
-      rw [power_series.coeff_C, if_neg n.succ_ne_zero] }
-  end,
+{ map_smul' := λ r a, rfl,
   .. to_power_series }
 
-set_option pp.all true
 variables (Γ) (R) [ordered_semiring Γ] [nontrivial Γ]
 /-- Casting a power series as a Hahn series with coefficients from an `ordered_semiring`
   is an algebra homomorphism. -/
@@ -1140,13 +1129,7 @@ begin
   let bar := (@to_power_series_alg R _ A _ _).symm.to_alg_hom,
   let foo := (hahn_series.emb_domain_alg_hom (nat.cast_add_monoid_hom Γ) nat.strict_mono_cast.injective
   (λ (_ : ℕ) _, nat.cast_le) : hahn_series ℕ A →ₐ[R] hahn_series Γ A),
-  refine alg_hom.comp _ bar,
-  refine hahn_series.emb_domain_alg_hom (nat.cast_add_monoid_hom Γ) _ _,
-  exact nat.strict_mono_cast.injective,
-  intros g g',
-  simp only [@nat.coe_cast_add_monoid_hom Γ _],
-  have := @nat.cast_le Γ _inst_4 _inst_5 g g',
-  --exact this
+  refine alg_hom.comp foo bar,
 end
 #exit
 /-

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -1118,7 +1118,8 @@ variables (R) [comm_semiring R] {A : Type*} [semiring A] [algebra R A]
 
 /-- The `R`-algebra `hahn_series ℕ A` is isomorphic to `power_series A`. -/
 @[simps] def to_power_series_alg : (hahn_series ℕ A) ≃ₐ[R] power_series A :=
-{ commutes' := λ r, begin
+{ map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul (@to_power_series A _)) $ λ r,
+  begin
     ext n,
     simp only [algebra_map_apply, power_series.algebra_map_apply, ring_equiv.to_fun_eq_coe, C_apply,
       coeff_to_power_series],
@@ -1130,13 +1131,29 @@ variables (R) [comm_semiring R] {A : Type*} [semiring A] [algebra R A]
   end,
   .. to_power_series }
 
+set_option pp.all true
 variables (Γ) (R) [ordered_semiring Γ] [nontrivial Γ]
 /-- Casting a power series as a Hahn series with coefficients from an `ordered_semiring`
   is an algebra homomorphism. -/
 @[simps] def of_power_series_alg : (power_series A) →ₐ[R] hahn_series Γ A :=
+begin
+  let bar := (@to_power_series_alg R _ A _ _).symm.to_alg_hom,
+  let foo := (hahn_series.emb_domain_alg_hom (nat.cast_add_monoid_hom Γ) nat.strict_mono_cast.injective
+  (λ (_ : ℕ) _, nat.cast_le) : hahn_series ℕ A →ₐ[R] hahn_series Γ A),
+  refine alg_hom.comp _ bar,
+  refine hahn_series.emb_domain_alg_hom (nat.cast_add_monoid_hom Γ) _ _,
+  exact nat.strict_mono_cast.injective,
+  intros g g',
+  simp only [@nat.coe_cast_add_monoid_hom Γ _],
+  have := @nat.cast_le Γ _inst_4 _inst_5 g g',
+  --exact this
+end
+#exit
+/-
 (hahn_series.emb_domain_alg_hom (nat.cast_add_monoid_hom Γ) nat.strict_mono_cast.injective
   (λ _ _, nat.cast_le)).comp
-  (alg_equiv.to_alg_hom (to_power_series_alg R).symm)
+  (alg_equiv.to_alg_hom (@to_power_series_alg R _ A _ _).symm)
+  -/
 
 instance power_series_algebra {S : Type*} [comm_semiring S] [algebra S (power_series R)] :
   algebra S (hahn_series Γ R) :=

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -1124,19 +1124,15 @@ variables (R) [comm_semiring R] {A : Type*} [semiring A] [algebra R A]
 variables (Γ) (R) [ordered_semiring Γ] [nontrivial Γ]
 /-- Casting a power series as a Hahn series with coefficients from an `ordered_semiring`
   is an algebra homomorphism. -/
-@[simps] def of_power_series_alg : (power_series A) →ₐ[R] hahn_series Γ A :=
-begin
-  let bar := (@to_power_series_alg R _ A _ _).symm.to_alg_hom,
-  let foo := (hahn_series.emb_domain_alg_hom (nat.cast_add_monoid_hom Γ) nat.strict_mono_cast.injective
-  (λ (_ : ℕ) _, nat.cast_le) : hahn_series ℕ A →ₐ[R] hahn_series Γ A),
-  refine alg_hom.comp foo bar,
-end
-#exit
-/-
+def of_power_series_alg : (power_series A) →ₐ[R] hahn_series Γ A :=
 (hahn_series.emb_domain_alg_hom (nat.cast_add_monoid_hom Γ) nat.strict_mono_cast.injective
   (λ _ _, nat.cast_le)).comp
-  (alg_equiv.to_alg_hom (@to_power_series_alg R _ A _ _).symm)
-  -/
+  (alg_equiv.to_alg_hom (to_power_series_alg R).symm)
+
+lemma hahn_series.of_power_series_alg_apply_coeff (f : power_series A) (x : Γ) :
+  (hahn_series.of_power_series_alg Γ R f).coeff x =
+  dite (∃ (a : ℕ), ¬power_series.coeff A a f = 0 ∧ ↑a = x)
+  (λ h, (power_series.coeff A (classical.some h)) f) (λ _, 0) := rfl
 
 instance power_series_algebra {S : Type*} [comm_semiring S] [algebra S (power_series R)] :
   algebra S (hahn_series Γ R) :=

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1869,7 +1869,8 @@ ring_hom.ker_lift_injective f
 def quotient_ker_alg_equiv_of_right_inverse
   {f : A →ₐ[R₁] B} {g : B → A} (hf : function.right_inverse g f) :
   (A ⧸ f.to_ring_hom.ker) ≃ₐ[R₁] B :=
-{ ..ring_hom.quotient_ker_equiv_of_right_inverse (λ x, show f.to_ring_hom (g x) = x, from hf x),
+{ map_smul' := map_smul (ker_lift_alg f),
+  ..ring_hom.quotient_ker_equiv_of_right_inverse (λ x, show f.to_ring_hom (g x) = x, from hf x),
   ..ker_lift_alg f}
 
 @[simp]
@@ -1979,7 +1980,7 @@ where`J = f(I)`. -/
 def quotient_equiv_alg (I : ideal A) (J : ideal B) (f : A ≃ₐ[R₁] B)
   (hIJ : J = I.map (f : A →+* B)) :
   (A ⧸ I) ≃ₐ[R₁] B ⧸ J :=
-{ commutes' := λ r, by simp,
+{ map_smul' := map_smul (J.quotient_mapₐ (f : A →ₐ[R₁] B) (_ : I ≤ ideal.comap _ J)),
   ..quotient_equiv I J (f : A ≃+* B) hIJ }
 
 @[priority 100]

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -650,7 +650,7 @@ begin
   rw ring_hom.comp_assoc at this,
   convert this,
   refine ring_hom.ext (λ x, _),
-  exact ((rename_equiv R e).commutes' x).symm,
+  exact ((rename_equiv R e).commutes x).symm,
 end
 
 end mv_polynomial

--- a/src/ring_theory/localization/basic.lean
+++ b/src/ring_theory/localization/basic.lean
@@ -609,7 +609,8 @@ variables (M S Q)
 there is an isomorphism of localizations `S ≃ₐ[R] Q`. -/
 @[simps]
 noncomputable def alg_equiv : S ≃ₐ[R] Q :=
-{ commutes' := ring_equiv_of_ring_equiv_eq _,
+{ map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes
+    (map_mul $ ring_equiv_of_ring_equiv S Q (ring_equiv.refl R) _) (ring_equiv_of_ring_equiv_eq _),
   .. ring_equiv_of_ring_equiv S Q (ring_equiv.refl R) M.map_id }
 
 end
@@ -658,7 +659,8 @@ lemma is_localization_iff_of_ring_equiv (h : S ≃+* P) :
     @@is_localization _ M P _ (h.to_ring_hom.comp $ algebra_map R S).to_algebra :=
 begin
   letI := (h.to_ring_hom.comp $ algebra_map R S).to_algebra,
-  exact is_localization_iff_of_alg_equiv M { commutes' := λ _, rfl, ..h },
+  exact is_localization_iff_of_alg_equiv M
+  { map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul h) (λ _, rfl), ..h },
 end
 
 variable (S)

--- a/src/ring_theory/matrix_algebra.lean
+++ b/src/ring_theory/matrix_algebra.lean
@@ -138,7 +138,10 @@ variables [fintype n] [decidable_eq n]
 The `R`-algebra isomorphism `matrix n n A ≃ₐ[R] (A ⊗[R] matrix n n R)`.
 -/
 def matrix_equiv_tensor : matrix n n A ≃ₐ[R] (A ⊗[R] matrix n n R) :=
-alg_equiv.symm { ..(matrix_equiv_tensor.to_fun_alg_hom R A n), ..(matrix_equiv_tensor.equiv R A n) }
+alg_equiv.symm
+{ map_smul' := map_smul (matrix_equiv_tensor.to_fun_alg_hom R A n),
+  ..(matrix_equiv_tensor.to_fun_alg_hom R A n),
+  ..(matrix_equiv_tensor.equiv R A n) }
 
 open matrix_equiv_tensor
 

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -1171,7 +1171,8 @@ def quotient_equiv_quotient_mv_polynomial (I : ideal R) :
         eval₂_X],
       simp only [hp] }
   end,
-  commutes' := λ r, eval₂_hom_C _ _ (ideal.quotient.mk I r) }
+  map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes (map_mul _)
+    (λ r, eval₂_hom_C _ _ (ideal.quotient.mk I r)) }
 
 end mv_polynomial
 

--- a/src/ring_theory/polynomial_algebra.lean
+++ b/src/ring_theory/polynomial_algebra.lean
@@ -198,7 +198,9 @@ The `R`-algebra isomorphism `polynomial A ≃ₐ[R] (A ⊗[R] R[X])`.
 -/
 def poly_equiv_tensor : A[X] ≃ₐ[R] (A ⊗[R] R[X]) :=
 alg_equiv.symm
-{ ..(poly_equiv_tensor.to_fun_alg_hom R A), ..(poly_equiv_tensor.equiv R A) }
+{ map_smul' := map_smul (poly_equiv_tensor.to_fun_alg_hom R A),
+  ..(poly_equiv_tensor.to_fun_alg_hom R A),
+  ..(poly_equiv_tensor.equiv R A) }
 
 @[simp]
 lemma poly_equiv_tensor_apply (p : A[X]) :

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -573,8 +573,7 @@ def alg_equiv_of_linear_equiv_triple_tensor_product
     f ((a₁ * a₂) ⊗ₜ (b₁ * b₂) ⊗ₜ (c₁ * c₂)) = f (a₁ ⊗ₜ b₁ ⊗ₜ c₁) * f (a₂ ⊗ₜ b₂ ⊗ₜ c₂))
   (w₂ : ∀ r, f (((algebra_map R A) r ⊗ₜ[R] (1 : B)) ⊗ₜ[R] (1 : C)) = (algebra_map R D) r) :
   (A ⊗[R] B) ⊗[R] C ≃ₐ[R] D :=
-{ to_fun := f,
-  map_mul' := λ x y,
+have w₃ : ∀ x y, f (x * y) = f x * f y := λ x y,
   begin
     apply tensor_product.induction_on x,
     { simp only [map_zero, zero_mul] },
@@ -599,7 +598,9 @@ def alg_equiv_of_linear_equiv_triple_tensor_product
     { intros x₁ x₂ h₁ h₂,
       simp only [tmul_mul_tmul, map_add, mul_add, add_mul, h₁, h₂], }
   end,
-  commutes' := λ r, by simp [w₂],
+{ to_fun := f,
+  map_mul' := w₃,
+  map_smul' := alg_equiv.map_smul_of_map_mul_of_commutes w₃ (λ r, by simp [w₂]),
   .. f }
 
 @[simp]


### PR DESCRIPTION
This refactors `alg_equiv` to take a `map_smul` field instead of a `commutes` field. This makes it possible to unify non-unital algebra equivalences (which don't currently exist in mathlib) and algebra equivalences under one definition, much like the current `ring_equiv`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
