### PR TITLE
[Merged by Bors] - feat(data/set/intervals/ord_connected): lemmas about `order_dual` etc

### DIFF
--- a/src/data/set/intervals/unordered_interval.lean
+++ b/src/data/set/intervals/unordered_interval.lean
@@ -27,6 +27,7 @@ make the notation available.
 
 universe u
 open_locale pointwise
+open order_dual (to_dual of_dual)
 
 namespace set
 
@@ -38,6 +39,8 @@ variables {α : Type u} [linear_order α] {a a₁ a₂ b b₁ b₂ c x : α}
 def interval (a b : α) := Icc (min a b) (max a b)
 
 localized "notation (name := set.interval) `[`a `, ` b `]` := set.interval a b" in interval
+
+@[simp] lemma dual_interval (a b : α) : [to_dual a, to_dual b] = of_dual ⁻¹' [a, b] := dual_Icc
 
 @[simp] lemma interval_of_le (h : a ≤ b) : [a, b] = Icc a b :=
 by rw [interval, min_eq_left h, max_eq_right h]


### PR DESCRIPTION
* add `dual_interval`;
* add `ord_connected_preimage` for an `order_hom_class`, use it to golf `ord_connected_image`;
* add `dual_ord_connected_iff` and `dual_ord_connected`;
* one implication from `ord_connected_iff_interval_subset_left` doesn't need `(hx : x ∈ s)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
