### PR TITLE
[Merged by Bors] - feat(order/well_founded, data/fin/tuple/*, ...): add `well_founded.induction_bot`, `tuple.bubble_sort_induction`

### DIFF
--- a/src/data/fin/tuple/bubble_sort_induction.lean
+++ b/src/data/fin/tuple/bubble_sort_induction.lean
@@ -39,7 +39,7 @@ begin
     (@finite.preorder.well_founded_lt (equiv.perm (fin n)) _ _)
     (equiv.refl _) (sort f) P (λ σ, f ∘ σ) (λ σ hσ hfσ, _) hf,
   obtain ⟨i, j, hij₁, hij₂⟩ := antitone_pair_of_not_sorted' hσ,
-  exact ⟨σ * equiv.swap i j, lex_desc hij₁ hij₂, h σ i j hij₁ hij₂ hfσ⟩,
+  exact ⟨σ * equiv.swap i j, pi.lex_desc hij₁ hij₂, h σ i j hij₁ hij₂ hfσ⟩,
 end
 
 /-- *Bubble sort induction*: Prove that the sorted version of `f` has some property `P`

--- a/src/data/fin/tuple/bubble_sort_induction.lean
+++ b/src/data/fin/tuple/bubble_sort_induction.lean
@@ -43,9 +43,7 @@ begin
   { intro σ, simp only [POf, φ', function.comp_app], congr' 1, },
   rw [hf₁],
   refine @well_founded.induction_bot Of _
-    (@set.finite.well_founded_on _ (<) _ _ (set.finite_range φ)) (φ' 1) _ POf _ (λ g hg₁ hg₂, _),
-  { simp only [POf, φ', φ, function.comp_app],
-    rwa [set.coe_cod_restrict_apply, of_lex_to_lex, equiv.perm.coe_one, function.comp.right_id], },
+    (@set.finite.well_founded_on _ (<) _ _ (set.finite_range φ)) (φ' 1) _ POf (λ g hg₁ hg₂, _) _,
   { obtain ⟨σ, hσ⟩ := set.mem_range.mp (subtype.mem g),
     have hg₁' : (g : lex (fin n → α)) ≠ φ (sort f),
     { rw [← hφ],
@@ -62,7 +60,9 @@ begin
       simp only [inv_image, φ', ←hσ, φ, set.coe_cod_restrict_apply, equiv.perm.coe_mul], },
     { simp only [← hf₁, equiv.perm.coe_mul],
       rw [← function.comp.assoc],
-      exact h σ i j hij₁ hij₂ ((hf₁ σ).mpr hσ'), } }
+      exact h σ i j hij₁ hij₂ ((hf₁ σ).mpr hσ'), } },
+  { simp only [POf, φ', φ, function.comp_app],
+    rwa [set.coe_cod_restrict_apply, of_lex_to_lex, equiv.perm.coe_one, function.comp.right_id] }
 end
 
 /-- *Bubble sort induction*: Prove that the sorted version of `f` has some property `P`

--- a/src/data/fin/tuple/bubble_sort_induction.lean
+++ b/src/data/fin/tuple/bubble_sort_induction.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2022 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import data.fin.tuple.sort
+import order.well_founded_set
+
+/-!
+# "Bubble sort" induction
+
+We implement the following induction principle `tuple.bubble_sort_induction`
+on tuples with values in a linear order `α`.
+
+Let `f : fin n  → α` and let `P` be a predicate on `fin n → α`. Then we can show that
+`f ∘ sort f` satisfies `P` if `f` satisfies `P`, and whenever some `g : fin n → α`
+satisfies `P` and `g i > g j` for some `i < j`, then `g ∘ swap i j` also satisfies `P`.
+
+We deduce it from a stronger variant `tuple.bubble_sort_induction'`, which
+requires the assumption only for `g` that are permutations of `f`.
+
+The latter is proved by well-founded induction with respect to the lexicographic ordering
+on the finite set of all permutations of `f`.
+-/
+
+namespace tuple
+
+/-- *Bubble sort induction*: Prove that the sorted version of `f` has some property `P`
+if `f` satsifies `P` and `P` is preserved on permutations of `f` when swapping two
+antitone values. -/
+lemma bubble_sort_induction' {n : ℕ} {α : Type*} [linear_order α] {f : fin n → α}
+  {P : (fin n → α) → Prop} (hf : P f)
+  (h : ∀ (σ : equiv.perm (fin n)) (i j : fin n),
+              i < j → (f ∘ σ) j < (f ∘ σ) i → P (f ∘ σ) → P (f ∘ σ ∘ equiv.swap i j)) :
+  P (f ∘ sort f) :=
+begin
+  let φ : equiv.perm (fin n) → lex (fin n → α) := λ σ, to_lex (f ∘ σ),
+  let Of := set.range φ,
+  let φ' := set.cod_restrict φ Of set.mem_range_self,
+  have hφ : ∀ σ, (φ' σ : lex (fin n → α)) = φ σ := set.coe_cod_restrict_apply φ Of _,
+  let POf : Of → Prop := λ g, P (of_lex (g : lex (fin n → α))),
+  have hf₁ : ∀ σ : equiv.perm (fin n),  P (f ∘ σ) ↔ POf (φ' σ),
+  { intro σ, simp only [POf, φ', function.comp_app], congr' 1, },
+  rw [hf₁],
+  refine @well_founded.induction_bot Of _
+    (@set.finite.well_founded_on _ (<) _ _ (set.finite_range φ)) (φ' 1) _ POf _ (λ g hg₁ hg₂, _),
+  { simp only [POf, φ', φ, function.comp_app],
+    rwa [set.coe_cod_restrict_apply, of_lex_to_lex, equiv.perm.coe_one, function.comp.right_id], },
+  { obtain ⟨σ, hσ⟩ := set.mem_range.mp (subtype.mem g),
+    have hg₁' : (g : lex (fin n → α)) ≠ φ (sort f),
+    { rw [← hφ],
+      by_contra' hf,
+      exact hg₁ (subtype.coe_injective hf), },
+    rw [← hσ, ne.def, to_lex_inj, ← ne.def] at hg₁',
+    obtain ⟨i, j, hij₁, hij₂⟩ := antitone_pair_of_not_sorted' hg₁',
+    have hσ': POf (φ' σ),
+    { convert hg₂,
+      apply_fun (coe : Of → lex (fin n → α)) using subtype.coe_injective,
+      rwa hφ, },
+    refine ⟨φ' (σ * (equiv.swap i j)), _, _⟩,
+    { convert lex_desc hij₁ hij₂,
+      simp only [inv_image, φ', ←hσ, φ, set.coe_cod_restrict_apply, equiv.perm.coe_mul], },
+    { simp only [← hf₁, equiv.perm.coe_mul],
+      rw [← function.comp.assoc],
+      exact h σ i j hij₁ hij₂ ((hf₁ σ).mpr hσ'), } }
+end
+
+/-- *Bubble sort induction*: Prove that the sorted version of `f` has some property `P`
+if `f` satsifies `P` and `P` is preserved when swapping two antitone values. -/
+lemma bubble_sort_induction {n : ℕ} {α : Type*} [linear_order α] {f : fin n → α}
+  {P : (fin n → α) → Prop} (hf : P f)
+  (h : ∀ (g : fin n → α) (i j : fin n), i < j → g j < g i → P g → P (g ∘ equiv.swap i j)) :
+  P (f ∘ sort f) :=
+bubble_sort_induction' hf (λ σ, h _)
+
+end tuple

--- a/src/data/fin/tuple/bubble_sort_induction.lean
+++ b/src/data/fin/tuple/bubble_sort_induction.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
 import data.fin.tuple.sort
-import order.well_founded_set
+import order.well_founded
 
 /-!
 # "Bubble sort" induction

--- a/src/data/fin/tuple/bubble_sort_induction.lean
+++ b/src/data/fin/tuple/bubble_sort_induction.lean
@@ -12,7 +12,7 @@ import order.well_founded_set
 We implement the following induction principle `tuple.bubble_sort_induction`
 on tuples with values in a linear order `α`.
 
-Let `f : fin n  → α` and let `P` be a predicate on `fin n → α`. Then we can show that
+Let `f : fin n → α` and let `P` be a predicate on `fin n → α`. Then we can show that
 `f ∘ sort f` satisfies `P` if `f` satisfies `P`, and whenever some `g : fin n → α`
 satisfies `P` and `g i > g j` for some `i < j`, then `g ∘ swap i j` also satisfies `P`.
 

--- a/src/data/fin/tuple/bubble_sort_induction.lean
+++ b/src/data/fin/tuple/bubble_sort_induction.lean
@@ -19,8 +19,8 @@ satisfies `P` and `g i > g j` for some `i < j`, then `g ∘ swap i j` also satis
 We deduce it from a stronger variant `tuple.bubble_sort_induction'`, which
 requires the assumption only for `g` that are permutations of `f`.
 
-The latter is proved by well-founded induction with respect to the lexicographic ordering
-on the finite set of all permutations of `f`.
+The latter is proved by well-founded induction via `well_founded.induction_bot'`
+with respect to the lexicographic ordering on the finite set of all permutations of `f`.
 -/
 
 namespace tuple

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -117,6 +117,35 @@ of_fn_injective $ eq_of_perm_of_sorted
 
 variables [linear_order α] {f : fin n → α} {σ : equiv.perm (fin n)}
 
+lemma graph_equiv₁_apply (i : fin n) : (graph_equiv₁ f i).val = to_lex (f i, i) := rfl
+
+/-- If `f` is monotone, then the map that sends `i` to `(f i, i)` is an order isomorphism. -/
+def order_iso_of_monotone (hf : monotone f) : fin n ≃o graph f :=
+{ to_equiv := graph_equiv₁ f,
+  map_rel_iff' :=
+  begin
+    intros a b,
+    simp_rw [←subtype.coe_le_coe, ←subtype.val_eq_coe, graph_equiv₁_apply, prod.lex.le_iff],
+    refine ⟨λ h, h.elim (λ h', _) (λ h', h'.2),
+            λ h, (hf h).lt_or_eq.elim or.inl (λ h', or.inr ⟨h', h⟩)⟩,
+    by_contra' hh,
+    exact not_le_of_lt h' (hf hh.le),
+  end }
+
+lemma order_iso_of_monotone_eq (hf : monotone f) : order_iso_of_monotone hf = graph_equiv₂ f :=
+(eq_iff_true_of_subsingleton _ _).mpr trivial
+
+/-- The permutation that sorts `f` is the identity if and only if `f` is monotone. -/
+lemma sort_eq_refl_iff_monotone : sort f = equiv.refl _ ↔ monotone f :=
+begin
+  refine ⟨λ h, _, λ h, _⟩,
+  { have := monotone_sort f,
+    rwa [h, equiv.coe_refl, function.comp.right_id] at this, },
+  { simp only [sort],
+    change (graph_equiv₂ f).to_equiv.trans (order_iso_of_monotone h).to_equiv.symm = _,
+    simp only [order_iso_of_monotone_eq h, equiv.self_trans_symm], }
+end
+
 /-- A permutation of a tuple `f` is `f` sorted if and only if it is monotone. -/
 lemma comp_sort_eq_comp_iff_monotone :
   f ∘ σ = f ∘ sort f ↔ monotone (f ∘ σ) :=

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -101,12 +101,8 @@ variables {n : ℕ} {α : Type*}
 smaller than the original tuple. -/
 lemma lex_desc [preorder α] {f : fin n → α} {i j : fin n} (h₁ : i < j) (h₂ : f j < f i) :
   to_lex (f ∘ equiv.swap i j) < to_lex f :=
-begin
-  simp only [(<), pi.lex, pi.to_lex_apply, function.comp_app],
-  refine ⟨i, λ k (hik : k < i), _, _⟩,
-  { rw [equiv.swap_apply_of_ne_of_ne hik.ne (hik.trans h₁).ne], },
-  { simpa only [equiv.swap_apply_left], }
-end
+⟨i, λ k hik, congr_arg f (equiv.swap_apply_of_ne_of_ne hik.ne (hik.trans h₁).ne),
+  by simpa only [pi.to_lex_apply, function.comp_app, equiv.swap_apply_left] using h₂⟩
 
 /-- If two permutations of a tuple `f` are both monotone, then they are equal. -/
 lemma unique_monotone [partial_order α] {f : fin n → α} {σ τ : equiv.perm (fin n)}

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -112,12 +112,6 @@ of_fn_injective $ eq_of_perm_of_sorted
 
 variables [linear_order α] {f : fin n → α} {σ : equiv.perm (fin n)}
 
-lemma graph_equiv₁_apply (i : fin n) : ↑(graph_equiv₁ f i) = to_lex (f i, i) := rfl
-
-lemma graph_equiv₂_apply' (i : fin n) : graph_equiv₂ f i =
-  ⟨to_lex (f (sort f i), sort f i), finset.mem_image_of_mem _ $ finset.mem_univ _⟩ :=
-((graph_equiv₁ f).apply_symm_apply _).symm
-
 /- maybe add some docstring -/
 lemma eq_sort_iff' : σ = sort f ↔ strict_mono (σ.trans $ graph_equiv₁ f) :=
 begin

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -132,20 +132,18 @@ end
 lemma graph_equiv₂_apply' (i : fin n) :
   graph_equiv₂ f i = ⟨to_lex (f (sort f i), sort f i),
                       (@graph_equiv₂_apply _ _ _ f i) ▸ (graph_equiv₂ f i).prop⟩ :=
-begin
-  simp [subtype.ext_iff, ← subtype.val_eq_coe, graph_equiv₂_apply],
-end
+by simp [subtype.ext_iff, ← subtype.val_eq_coe, graph_equiv₂_apply]
 
-/-- A permutation `σ` is `sort f` if and only if `f ∘ σ` is monotone and whenever `i < j`
+/-- A permutation `σ` equals `sort f` if and only if `f ∘ σ` is monotone and whenever `i < j`
 and `f (σ i) = f (σ j)`, then `σ i < σ j`. -/
 lemma eq_sort_iff : σ = sort f ↔ monotone (f ∘ σ) ∧ ∀ i j, i < j → f (σ i) = f (σ j) → σ i < σ j :=
 begin
-  refine ⟨λ h, ⟨_, λ i j hij hfij, _⟩, λ h₁, _⟩,
-  { have :=  monotone_sort f, rwa ← h at this, },
-  { rw [h] at hfij ⊢,
-    have := (order_iso.lt_iff_lt (graph_equiv₂ f)).mpr hij,
+  refine ⟨λ h, ⟨@eq.substr _ (λ (τ : equiv.perm (fin n)), monotone (f ∘ τ)) _ _ h (monotone_sort f),
+                λ i j hij hfij, _⟩, λ h₁, _⟩,
+  { have := (order_iso.lt_iff_lt (graph_equiv₂ f)).mpr hij,
     rw [graph_equiv₂_apply', graph_equiv₂_apply' j, subtype.mk_lt_mk, prod.lex.lt_iff] at this,
     simp only at this,
+    rw [h] at hfij ⊢,
     exact this.elim (λ h₁, false.elim $ hfij.not_lt h₁) (λ h₁, h₁.2), },
   { obtain ⟨hf, h₂⟩ := h₁,
     let oi : fin n ≃o graph f :=
@@ -164,20 +162,17 @@ begin
           exact this.lt_or_eq.elim or.inl (λ he, or.inr ⟨he, h.lt_or_eq.elim
              (λ hl, (h₂ a b hl he).le) (λ he', (congr_arg σ he').le)⟩), }
       end },
-    have := subsingleton.elim (graph_equiv₂ f) oi,
     ext,
-    simp only [sort, this, equiv.coe_trans, function.comp_app, equiv.symm_apply_apply], }
+    simp only [sort, subsingleton.elim (graph_equiv₂ f) oi, equiv.coe_trans, function.comp_app,
+               equiv.symm_apply_apply], }
 end
 
 /-- The permutation that sorts `f` is the identity if and only if `f` is monotone. -/
 lemma sort_eq_refl_iff_monotone : sort f = equiv.refl _ ↔ monotone f :=
 begin
-  refine ⟨λ h, _, λ h, _⟩,
-  { have := monotone_sort f,
-    rwa [h, equiv.coe_refl, function.comp.right_id] at this, },
-  { refine (eq_sort_iff.mpr ⟨_, λ i j hij hfij, _⟩).symm,
-    { simpa only, },
-    { simpa only [equiv.coe_refl, id.def], } }
+  rw [eq_comm, eq_sort_iff, equiv.coe_refl, function.comp.right_id],
+  simp only [id.def, and_iff_left_iff_imp],
+  exact λ _ _ _ hij _, hij,
 end
 
 /-- A permutation of a tuple `f` is `f` sorted if and only if it is monotone. -/

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -112,7 +112,8 @@ of_fn_injective $ eq_of_perm_of_sorted
 
 variables [linear_order α] {f : fin n → α} {σ : equiv.perm (fin n)}
 
-/- maybe add some docstring -/
+/-- A permutation `σ` equals `sort f` if and only if the map `i ↦ (f (σ i), σ i)` is
+strictly monotone (w.r.t. the lexicographic ordering on the target). -/
 lemma eq_sort_iff' : σ = sort f ↔ strict_mono (σ.trans $ graph_equiv₁ f) :=
 begin
   split; intro h,

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -72,6 +72,10 @@ finset.order_iso_of_fin _ (by simp)
 def sort (f : fin n → α) : equiv.perm (fin n) :=
 (graph_equiv₂ f).to_equiv.trans (graph_equiv₁ f).symm
 
+lemma graph_equiv₂_apply (f : fin n → α) (i : fin n) :
+  graph_equiv₂ f i = graph_equiv₁ f (sort f i) :=
+((graph_equiv₁ f).apply_symm_apply _).symm
+
 lemma self_comp_sort (f : fin n → α) : f ∘ sort f = graph.proj ∘ graph_equiv₂ f :=
 show graph.proj ∘ ((graph_equiv₁ f) ∘ (graph_equiv₁ f).symm) ∘ (graph_equiv₂ f).to_equiv = _,
   by simp
@@ -104,10 +108,6 @@ of_fn_injective $ eq_of_perm_of_sorted
   ((σ.of_fn_comp_perm f).trans (τ.of_fn_comp_perm f).symm) hfσ.of_fn_sorted hfτ.of_fn_sorted
 
 variables [linear_order α] {f : fin n → α} {σ : equiv.perm (fin n)}
-
-lemma graph_equiv₂_apply (i : fin n) : graph_equiv₂ f i =
-  ⟨to_lex (f (sort f i), sort f i), finset.mem_image_of_mem _ $ finset.mem_univ _⟩ :=
-((graph_equiv₁ f).apply_symm_apply _).symm
 
 /-- A permutation `σ` equals `sort f` if and only if the map `i ↦ (f (σ i), σ i)` is
 strictly monotone (w.r.t. the lexicographic ordering on the target). -/

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -112,6 +112,10 @@ of_fn_injective $ eq_of_perm_of_sorted
 
 variables [linear_order α] {f : fin n → α} {σ : equiv.perm (fin n)}
 
+lemma graph_equiv₂_apply (i : fin n) : graph_equiv₂ f i =
+  ⟨to_lex (f (sort f i), sort f i), finset.mem_image_of_mem _ $ finset.mem_univ _⟩ :=
+((graph_equiv₁ f).apply_symm_apply _).symm
+
 /-- A permutation `σ` equals `sort f` if and only if the map `i ↦ (f (σ i), σ i)` is
 strictly monotone (w.r.t. the lexicographic ordering on the target). -/
 lemma eq_sort_iff' : σ = sort f ↔ strict_mono (σ.trans $ graph_equiv₁ f) :=

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -97,13 +97,6 @@ open list
 
 variables {n : ℕ} {α : Type*}
 
-/-- If we swap two strictly decreasing entries in a tuple, then the result is lexicographically
-smaller than the original tuple. -/
-lemma lex_desc [preorder α] {f : fin n → α} {i j : fin n} (h₁ : i < j) (h₂ : f j < f i) :
-  to_lex (f ∘ equiv.swap i j) < to_lex f :=
-⟨i, λ k hik, congr_arg f (equiv.swap_apply_of_ne_of_ne hik.ne (hik.trans h₁).ne),
-  by simpa only [pi.to_lex_apply, function.comp_app, equiv.swap_apply_left] using h₂⟩
-
 /-- If two permutations of a tuple `f` are both monotone, then they are equal. -/
 lemma unique_monotone [partial_order α] {f : fin n → α} {σ τ : equiv.perm (fin n)}
   (hfσ : monotone (f ∘ σ)) (hfτ : monotone (f ∘ τ)) : f ∘ σ = f ∘ τ :=

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -147,8 +147,7 @@ begin
 end
 
 /-- A permutation of a tuple `f` is `f` sorted if and only if it is monotone. -/
-lemma comp_sort_eq_comp_iff_monotone :
-  f ∘ σ = f ∘ sort f ↔ monotone (f ∘ σ) :=
+lemma comp_sort_eq_comp_iff_monotone : f ∘ σ = f ∘ sort f ↔ monotone (f ∘ σ) :=
 ⟨λ h, h.symm ▸ monotone_sort f, λ h, unique_monotone h (monotone_sort f)⟩
 
 /-- The sorted versions of a tuple `f` and of any permutation of `f` agree. -/

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -98,6 +98,8 @@ open list
 
 variables {n : ℕ} {α : Type*}
 
+/-- If we swap two strictly decreasing entries in a tuple, then the result is lexicographically
+smaller than the original tuple. -/
 lemma lex_desc [preorder α] {f : fin n → α} {i j : fin n} (h₁ : i < j) (h₂ : f j < f i) :
   to_lex (f ∘ equiv.swap i j) < to_lex f :=
 begin
@@ -107,13 +109,15 @@ begin
   { simpa only [equiv.swap_apply_left], }
 end
 
-lemma unique_monotone [partial_order α] {f : fin n → α}
-  {σ : equiv.perm (fin n)} (hf : monotone f) (hfσ : monotone (f ∘ σ)) : f ∘ σ = f :=
+/-- If a tuple `f` and a permutation of `f` are both monotone, then they are equal. -/
+lemma unique_monotone [partial_order α] {f : fin n → α} {σ : equiv.perm (fin n)} (hf : monotone f)
+  (hfσ : monotone (f ∘ σ)) : f ∘ σ = f :=
 of_fn_injective $ eq_of_perm_of_sorted (σ.of_fn_comp_perm f) hfσ.of_fn_sorted hf.of_fn_sorted
 
 variables [linear_order α] {f : fin n → α}
 
-lemma unique_sort' {σ : equiv.perm (fin n)} (h : monotone (f ∘ σ)) : f ∘ σ = f ∘ (sort f) :=
+/-- If a permutation of a tuple `f` is monotone, then it is equal to `f ∘ sort f`. -/
+lemma unique_sort' {σ : equiv.perm (fin n)} (h : monotone (f ∘ σ)) : f ∘ σ = f ∘ sort f :=
 begin
   let σ' := (sort f)⁻¹ * σ,
   have h' : f ∘ σ = (f ∘ sort f) ∘ σ',
@@ -123,7 +127,8 @@ begin
   rwa [← h'],
 end
 
-lemma unique_sort (h : monotone f) : f = f ∘ (sort f) :=
+/-- If a tuple `f` is monotone, then it equals `f ∘ sort f`. -/
+lemma unique_sort (h : monotone f) : f = f ∘ sort f :=
 begin
   have hf : f = f ∘ (1 : equiv.perm (fin n)),
   { simp only [equiv.perm.coe_one, function.comp.right_id], },
@@ -136,16 +141,16 @@ lemma unique_sort'' {σ : equiv.perm (fin n)} (hf : monotone f) (hfσ : monotone
   f ∘ σ = f :=
 (unique_sort' hfσ).trans (unique_sort hf).symm
 
-lemma sort_absorb {σ : equiv.perm (fin n)} : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ (sort f) :=
+lemma sort_absorb {σ : equiv.perm (fin n)} : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin
   let τ := σ⁻¹ * (sort f),
-  have h' : (f ∘ σ) ∘ τ = f ∘ (sort f),
+  have h' : (f ∘ σ) ∘ τ = f ∘ sort f,
   { ext, simp only [equiv.perm.coe_mul, function.comp_app, equiv.perm.apply_inv_self] },
   have hm : monotone ((f ∘ σ) ∘ τ) := by { rw [h'], exact monotone_sort _, },
   exact (unique_sort' hm).symm.trans h',
 end
 
-lemma antitone_pair_of_not_sorted' {σ : equiv.perm (fin n)} (h : f ∘ σ ≠ f ∘ (sort f)) :
+lemma antitone_pair_of_not_sorted' {σ : equiv.perm (fin n)} (h : f ∘ σ ≠ f ∘ sort f) :
   ∃ i j, i < j ∧ (f ∘ σ) j < (f ∘ σ) i :=
 begin
   by_contra' hf,
@@ -157,7 +162,7 @@ begin
   exact h (unique_sort' hm),
 end
 
-lemma antitone_pair_of_not_sorted (h : f ≠ f ∘ (sort f)) : ∃ i j, i < j ∧ f j < f i :=
+lemma antitone_pair_of_not_sorted (h : f ≠ f ∘ sort f) : ∃ i j, i < j ∧ f j < f i :=
 begin
   have hf : f = f ∘ (1 : equiv.perm (fin n)),
   { simp only [equiv.perm.coe_one, function.comp.right_id], },

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -159,10 +159,8 @@ end
 entries. -/
 lemma antitone_pair_of_not_sorted (h : f ≠ f ∘ sort f) : ∃ i j, i < j ∧ f j < f i :=
 begin
-  have := mt eq_comp_sort_iff_monotone.mpr h.symm.elim,
-  simp only [monotone, not_forall, not_le, exists_prop] at this,
-  obtain ⟨i, j, hij, h⟩ := this,
-  exact ⟨i, j, lt_of_le_of_ne hij (λ hf, ne_of_lt h $ congr_arg f hf.symm), h⟩,
+  by_contra' hf,
+  exact mt monotone_iff_forall_lt.mpr (mt eq_comp_sort_iff_monotone.mpr h.symm.elim) hf,
 end
 
 end tuple

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -122,15 +122,6 @@ lemma comp_sort_eq_comp_iff_monotone {σ : equiv.perm (fin n)} :
   f ∘ σ = f ∘ sort f ↔ monotone (f ∘ σ) :=
 ⟨λ h, h.symm ▸ monotone_sort f, λ h, unique_monotone h (monotone_sort f)⟩
 
-/-- If a permutation of a tuple `f` is monotone, then it is equal to `f ∘ sort f`. -/
-lemma sort_unique {σ : equiv.perm (fin n)} (h : monotone (f ∘ σ)) : f ∘ σ = f ∘ sort f :=
-begin
-  have h' : f ∘ σ = (f ∘ sort f) ∘ coe_fn ((sort f)⁻¹ * σ) :=
-  by rw [function.comp.assoc _ (sort f), ← equiv.perm.coe_mul, ← mul_assoc, mul_inv_self, one_mul],
-  rw [h'],
-  exact unique_monotone (monotone_sort f) (h' ▸ h),
-end
-
 /-- The sorted versions of a tuple `f` and any permutation of it agree. -/
 lemma sort_absorb {σ : equiv.perm (fin n)} : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -122,7 +122,7 @@ lemma comp_sort_eq_comp_iff_monotone {σ : equiv.perm (fin n)} :
   f ∘ σ = f ∘ sort f ↔ monotone (f ∘ σ) :=
 ⟨λ h, h.symm ▸ monotone_sort f, λ h, unique_monotone h (monotone_sort f)⟩
 
-/-- The sorted versions of a tuple `f` and any permutation of it agree. -/
+/-- The sorted versions of a tuple `f` and of any permutation of it agree. -/
 lemma comp_perm_comp_sort_eq_comp_sort {σ : equiv.perm (fin n)} :
   (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -116,8 +116,12 @@ of_fn_injective $ eq_of_perm_of_sorted (σ.of_fn_comp_perm f) hfσ.of_fn_sorted 
 
 variables [linear_order α] {f : fin n → α}
 
+/-- A tuple `f` equals its sorted version if and only if it is monotone. -/
+lemma eq_comp_sort_iff_monotone : f ∘ sort f = f ↔ monotone f :=
+⟨λ h, h ▸ monotone_sort f, λ h, unique_monotone h $ monotone_sort f⟩
+
 /-- If a permutation of a tuple `f` is monotone, then it is equal to `f ∘ sort f`. -/
-lemma unique_sort' {σ : equiv.perm (fin n)} (h : monotone (f ∘ σ)) : f ∘ σ = f ∘ sort f :=
+lemma sort_unique {σ : equiv.perm (fin n)} (h : monotone (f ∘ σ)) : f ∘ σ = f ∘ sort f :=
 begin
   let σ' := (sort f)⁻¹ * σ,
   have h' : f ∘ σ = (f ∘ sort f) ∘ σ',
@@ -127,16 +131,6 @@ begin
   rwa [← h'],
 end
 
-/-- If a tuple `f` is monotone, then it equals `f ∘ sort f`. -/
-lemma unique_sort (h : monotone f) : f = f ∘ sort f :=
-begin
-  have hf : f = f ∘ (1 : equiv.perm (fin n)),
-  { simp only [equiv.perm.coe_one, function.comp.right_id], },
-  conv_lhs {rw hf},
-  rw hf at h,
-  exact unique_sort' h,
-end
-
 /-- The sorted versions of a tuple `f` and any permutation of it agree. -/
 lemma sort_absorb {σ : equiv.perm (fin n)} : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin
@@ -144,7 +138,7 @@ begin
   have h' : (f ∘ σ) ∘ τ = f ∘ sort f,
   { ext, simp only [equiv.perm.coe_mul, function.comp_app, equiv.perm.apply_inv_self] },
   have hm : monotone ((f ∘ σ) ∘ τ) := by { rw [h'], exact monotone_sort _, },
-  exact (unique_sort' hm).symm.trans h',
+  exact (sort_unique hm).symm.trans h',
 end
 
 /-- If a permutation `f ∘ σ` of the tuple `f` is not the same as `f ∘ sort f`, then `f ∘ σ`
@@ -158,7 +152,7 @@ begin
     cases eq_or_lt_of_le hij with heq hlt,
     { rw [heq], },
     { exact hf i j hlt, } },
-  exact h (unique_sort' hm),
+  exact h (sort_unique hm),
 end
 
 /-- If the tuple `f` is not the same as `f ∘ sort f`, then it has a pair of strictly decreasing

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -147,12 +147,7 @@ lemma antitone_pair_of_not_sorted' {σ : equiv.perm (fin n)} (h : f ∘ σ ≠ f
   ∃ i j, i < j ∧ (f ∘ σ) j < (f ∘ σ) i :=
 begin
   by_contra' hf,
-  have hm : monotone (f ∘ σ),
-  { intros i j hij,
-    cases eq_or_lt_of_le hij with heq hlt,
-    { rw [heq], },
-    { exact hf i j hlt, } },
-  exact h (sort_unique hm),
+  exact h (sort_unique $ monotone_iff_forall_lt.mpr hf),
 end
 
 /-- If the tuple `f` is not the same as `f ∘ sort f`, then it has a pair of strictly decreasing
@@ -160,7 +155,7 @@ entries. -/
 lemma antitone_pair_of_not_sorted (h : f ≠ f ∘ sort f) : ∃ i j, i < j ∧ f j < f i :=
 begin
   by_contra' hf,
-  exact mt monotone_iff_forall_lt.mpr (mt eq_comp_sort_iff_monotone.mpr h.symm.elim) hf,
+  exact h.symm (eq_comp_sort_iff_monotone.mpr $ monotone_iff_forall_lt.mpr hf),
 end
 
 end tuple

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -134,11 +134,10 @@ end
 /-- The sorted versions of a tuple `f` and any permutation of it agree. -/
 lemma sort_absorb {σ : equiv.perm (fin n)} : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin
-  let τ := σ⁻¹ * (sort f),
-  have h' : (f ∘ σ) ∘ τ = f ∘ sort f,
-  { ext, simp only [equiv.perm.coe_mul, function.comp_app, equiv.perm.apply_inv_self] },
-  have hm : monotone ((f ∘ σ) ∘ τ) := by { rw [h'], exact monotone_sort _, },
-  exact (sort_unique hm).symm.trans h',
+  rw [function.comp.assoc, ← equiv.perm.coe_mul],
+  refine sort_unique _,
+  rw [equiv.perm.coe_mul, ← function.comp.assoc],
+  exact monotone_sort _,
 end
 
 /-- If a permutation `f ∘ σ` of the tuple `f` is not the same as `f ∘ sort f`, then `f ∘ σ`

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -123,7 +123,8 @@ lemma comp_sort_eq_comp_iff_monotone {σ : equiv.perm (fin n)} :
 ⟨λ h, h.symm ▸ monotone_sort f, λ h, unique_monotone h (monotone_sort f)⟩
 
 /-- The sorted versions of a tuple `f` and any permutation of it agree. -/
-lemma sort_absorb {σ : equiv.perm (fin n)} : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
+lemma comp_perm_comp_sort_eq_comp_sort {σ : equiv.perm (fin n)} :
+  (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin
   rw [function.comp.assoc, ← equiv.perm.coe_mul],
   exact unique_monotone (monotone_sort (f ∘ σ)) (monotone_sort f),

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -92,38 +92,9 @@ end
 
 end tuple
 
-lemma list.perm.map_congr {α β} {l₁ l₂ : list α} (h : l₁ ~ l₂) (f : α → β) : l₁.map f ~ l₂.map f :=
-begin
-  induction h,
-  { simp },
-  { simpa },
-  { simpa using list.perm.swap _ _ _ },
-  case list.perm.trans : _ _ _ _ _ h₁₂ h₂₃
-  { exact h₁₂.trans h₂₃ },
-end
-
 open list
 
 variables {n : ℕ} {α : Type*}
-
-lemma equiv.perm.of_fn_comp_perm (f : fin n → α) (σ : equiv.perm (fin n)) :
-  of_fn (f ∘ σ) ~ of_fn f :=
-begin
-  rw [of_fn_eq_map, of_fn_eq_map, ←map_map],
-  apply perm.map_congr,
-  rw [perm_ext ((nodup_fin_range n).map σ.injective) $ nodup_fin_range n],
-  simpa only [mem_map, mem_fin_range, true_and, iff_true] using σ.surjective
-end
-
-lemma monotone.of_fn_sorted [preorder α] {f : fin n → α} (h : monotone f) :
-  (of_fn f).sorted (≤) :=
-begin
-  rw [sorted, pairwise_iff_nth_le],
-  intros i j hj hij,
-  rw [nth_le_of_fn', nth_le_of_fn'],
-  apply h,
-  exact hij.le
-end
 
 namespace tuple
 

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -159,10 +159,10 @@ end
 entries. -/
 lemma antitone_pair_of_not_sorted (h : f ≠ f ∘ sort f) : ∃ i j, i < j ∧ f j < f i :=
 begin
-  have hf : f = f ∘ (1 : equiv.perm (fin n)),
-  { simp only [equiv.perm.coe_one, function.comp.right_id], },
-  rw [hf], nth_rewrite 0 hf at h,
-  exact antitone_pair_of_not_sorted' h,
+  have := mt eq_comp_sort_iff_monotone.mpr h.symm.elim,
+  simp only [monotone, not_forall, not_le, exists_prop] at this,
+  obtain ⟨i, j, hij, h⟩ := this,
+  exact ⟨i, j, lt_of_le_of_ne hij (λ hf, ne_of_lt h $ congr_arg f hf.symm), h⟩,
 end
 
 end tuple

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -117,9 +117,10 @@ of_fn_injective $ eq_of_perm_of_sorted
 
 variables [linear_order α] {f : fin n → α}
 
-/-- A tuple `f` equals its sorted version if and only if it is monotone. -/
-lemma eq_comp_sort_iff_monotone : f ∘ sort f = f ↔ monotone f :=
-⟨λ h, h ▸ monotone_sort f, λ h, unique_monotone h $ monotone_sort f⟩
+/-- A permutation of a tuple `f` is `f` sorted if and only if it is monotone. -/
+lemma comp_sort_eq_comp_iff_monotone {σ : equiv.perm (fin n)} :
+  f ∘ σ = f ∘ sort f ↔ monotone (f ∘ σ) :=
+⟨λ h, h.symm ▸ monotone_sort f, λ h, unique_monotone h (monotone_sort f)⟩
 
 /-- If a permutation of a tuple `f` is monotone, then it is equal to `f ∘ sort f`. -/
 lemma sort_unique {σ : equiv.perm (fin n)} (h : monotone (f ∘ σ)) : f ∘ σ = f ∘ sort f :=

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -137,10 +137,6 @@ begin
   exact unique_sort' h,
 end
 
-lemma unique_sort'' {σ : equiv.perm (fin n)} (hf : monotone f) (hfσ : monotone (f ∘ σ)) :
-  f ∘ σ = f :=
-(unique_sort' hfσ).trans (unique_sort hf).symm
-
 lemma sort_absorb {σ : equiv.perm (fin n)} : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin
   let τ := σ⁻¹ * (sort f),

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -137,6 +137,7 @@ begin
   exact unique_sort' h,
 end
 
+/-- The sorted versions of a tuple `f` and any permutation of it agree. -/
 lemma sort_absorb {σ : equiv.perm (fin n)} : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin
   let τ := σ⁻¹ * (sort f),
@@ -146,6 +147,8 @@ begin
   exact (unique_sort' hm).symm.trans h',
 end
 
+/-- If a permutation `f ∘ σ` of the tuple `f` is not the same as `f ∘ sort f`, then `f ∘ σ`
+has a pair of strictly decreasing entries. -/
 lemma antitone_pair_of_not_sorted' {σ : equiv.perm (fin n)} (h : f ∘ σ ≠ f ∘ sort f) :
   ∃ i j, i < j ∧ (f ∘ σ) j < (f ∘ σ) i :=
 begin
@@ -158,6 +161,8 @@ begin
   exact h (unique_sort' hm),
 end
 
+/-- If the tuple `f` is not the same as `f ∘ sort f`, then it has a pair of strictly decreasing
+entries. -/
 lemma antitone_pair_of_not_sorted (h : f ≠ f ∘ sort f) : ∃ i j, i < j ∧ f j < f i :=
 begin
   have hf : f = f ∘ (1 : equiv.perm (fin n)),

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -115,16 +115,15 @@ lemma unique_monotone [partial_order α] {f : fin n → α} {σ τ : equiv.perm 
 of_fn_injective $ eq_of_perm_of_sorted
   ((σ.of_fn_comp_perm f).trans (τ.of_fn_comp_perm f).symm) hfσ.of_fn_sorted hfτ.of_fn_sorted
 
-variables [linear_order α] {f : fin n → α}
+variables [linear_order α] {f : fin n → α} {σ : equiv.perm (fin n)}
 
 /-- A permutation of a tuple `f` is `f` sorted if and only if it is monotone. -/
-lemma comp_sort_eq_comp_iff_monotone {σ : equiv.perm (fin n)} :
+lemma comp_sort_eq_comp_iff_monotone :
   f ∘ σ = f ∘ sort f ↔ monotone (f ∘ σ) :=
 ⟨λ h, h.symm ▸ monotone_sort f, λ h, unique_monotone h (monotone_sort f)⟩
 
 /-- The sorted versions of a tuple `f` and of any permutation of it agree. -/
-lemma comp_perm_comp_sort_eq_comp_sort {σ : equiv.perm (fin n)} :
-  (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
+lemma comp_perm_comp_sort_eq_comp_sort : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin
   rw [function.comp.assoc, ← equiv.perm.coe_mul],
   exact unique_monotone (monotone_sort (f ∘ σ)) (monotone_sort f),
@@ -132,7 +131,7 @@ end
 
 /-- If a permutation `f ∘ σ` of the tuple `f` is not the same as `f ∘ sort f`, then `f ∘ σ`
 has a pair of strictly decreasing entries. -/
-lemma antitone_pair_of_not_sorted' {σ : equiv.perm (fin n)} (h : f ∘ σ ≠ f ∘ sort f) :
+lemma antitone_pair_of_not_sorted' (h : f ∘ σ ≠ f ∘ sort f) :
   ∃ i j, i < j ∧ (f ∘ σ) j < (f ∘ σ) i :=
 by { contrapose! h, exact comp_sort_eq_comp_iff_monotone.mpr (monotone_iff_forall_lt.mpr h) }
 

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -123,12 +123,10 @@ lemma eq_comp_sort_iff_monotone : f ∘ sort f = f ↔ monotone f :=
 /-- If a permutation of a tuple `f` is monotone, then it is equal to `f ∘ sort f`. -/
 lemma sort_unique {σ : equiv.perm (fin n)} (h : monotone (f ∘ σ)) : f ∘ σ = f ∘ sort f :=
 begin
-  let σ' := (sort f)⁻¹ * σ,
-  have h' : f ∘ σ = (f ∘ sort f) ∘ σ',
-  { ext, simp only [function.comp_app, equiv.perm.coe_mul, equiv.perm.apply_inv_self], },
+  have h' : f ∘ σ = (f ∘ sort f) ∘ coe_fn ((sort f)⁻¹ * σ) :=
+  by rw [function.comp.assoc _ (sort f), ← equiv.perm.coe_mul, ← mul_assoc, mul_inv_self, one_mul],
   rw [h'],
-  refine unique_monotone (monotone_sort f) _,
-  rwa [← h'],
+  exact unique_monotone (monotone_sort f) (h' ▸ h),
 end
 
 /-- The sorted versions of a tuple `f` and any permutation of it agree. -/

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -103,7 +103,7 @@ smaller than the original tuple. -/
 lemma lex_desc [preorder α] {f : fin n → α} {i j : fin n} (h₁ : i < j) (h₂ : f j < f i) :
   to_lex (f ∘ equiv.swap i j) < to_lex f :=
 begin
-  simp [has_lt.lt, pi.lex],
+  simp only [has_lt.lt, pi.lex, pi.to_lex_apply, function.comp_app],
   refine ⟨i, λ k (hik : k < i), _, _⟩,
   { rw [equiv.swap_apply_of_ne_of_ne (ne_of_lt hik) (ne_of_lt $ hik.trans h₁)], },
   { simpa only [equiv.swap_apply_left], }

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -109,10 +109,11 @@ begin
   { simpa only [equiv.swap_apply_left], }
 end
 
-/-- If a tuple `f` and a permutation of `f` are both monotone, then they are equal. -/
-lemma unique_monotone [partial_order α] {f : fin n → α} {σ : equiv.perm (fin n)} (hf : monotone f)
-  (hfσ : monotone (f ∘ σ)) : f ∘ σ = f :=
-of_fn_injective $ eq_of_perm_of_sorted (σ.of_fn_comp_perm f) hfσ.of_fn_sorted hf.of_fn_sorted
+/-- If two permutations of a tuple `f` are both monotone, then they are equal. -/
+lemma unique_monotone [partial_order α] {f : fin n → α} {σ τ : equiv.perm (fin n)}
+  (hfσ : monotone (f ∘ σ)) (hfτ : monotone (f ∘ τ)) : f ∘ σ = f ∘ τ :=
+of_fn_injective $ eq_of_perm_of_sorted
+  ((σ.of_fn_comp_perm f).trans (τ.of_fn_comp_perm f).symm) hfσ.of_fn_sorted hfτ.of_fn_sorted
 
 variables [linear_order α] {f : fin n → α}
 

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -103,9 +103,9 @@ smaller than the original tuple. -/
 lemma lex_desc [preorder α] {f : fin n → α} {i j : fin n} (h₁ : i < j) (h₂ : f j < f i) :
   to_lex (f ∘ equiv.swap i j) < to_lex f :=
 begin
-  simp only [has_lt.lt, pi.lex, pi.to_lex_apply, function.comp_app],
+  simp only [(<), pi.lex, pi.to_lex_apply, function.comp_app],
   refine ⟨i, λ k (hik : k < i), _, _⟩,
-  { rw [equiv.swap_apply_of_ne_of_ne (ne_of_lt hik) (ne_of_lt $ hik.trans h₁)], },
+  { rw [equiv.swap_apply_of_ne_of_ne hik.ne (hik.trans h₁).ne], },
   { simpa only [equiv.swap_apply_left], }
 end
 

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -92,11 +92,11 @@ end
 
 end tuple
 
+namespace tuple
+
 open list
 
 variables {n : ℕ} {α : Type*}
-
-namespace tuple
 
 lemma lex_desc [preorder α] {f : fin n → α} {i j : fin n} (h₁ : i < j) (h₂ : f j < f i) :
   to_lex (f ∘ equiv.swap i j) < to_lex f :=

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -135,26 +135,18 @@ end
 lemma sort_absorb {σ : equiv.perm (fin n)} : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin
   rw [function.comp.assoc, ← equiv.perm.coe_mul],
-  refine sort_unique _,
-  rw [equiv.perm.coe_mul, ← function.comp.assoc],
-  exact monotone_sort _,
+  exact unique_monotone (monotone_sort (f ∘ σ)) (monotone_sort f),
 end
 
 /-- If a permutation `f ∘ σ` of the tuple `f` is not the same as `f ∘ sort f`, then `f ∘ σ`
 has a pair of strictly decreasing entries. -/
 lemma antitone_pair_of_not_sorted' {σ : equiv.perm (fin n)} (h : f ∘ σ ≠ f ∘ sort f) :
   ∃ i j, i < j ∧ (f ∘ σ) j < (f ∘ σ) i :=
-begin
-  by_contra' hf,
-  exact h (sort_unique $ monotone_iff_forall_lt.mpr hf),
-end
+by { contrapose! h, exact comp_sort_eq_comp_iff_monotone.mpr (monotone_iff_forall_lt.mpr h) }
 
 /-- If the tuple `f` is not the same as `f ∘ sort f`, then it has a pair of strictly decreasing
 entries. -/
 lemma antitone_pair_of_not_sorted (h : f ≠ f ∘ sort f) : ∃ i j, i < j ∧ f j < f i :=
-begin
-  by_contra' hf,
-  exact h.symm (eq_comp_sort_iff_monotone.mpr $ monotone_iff_forall_lt.mpr hf),
-end
+antitone_pair_of_not_sorted' (id h : f ∘ equiv.refl _ ≠ _)
 
 end tuple

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -122,7 +122,7 @@ lemma comp_sort_eq_comp_iff_monotone :
   f ∘ σ = f ∘ sort f ↔ monotone (f ∘ σ) :=
 ⟨λ h, h.symm ▸ monotone_sort f, λ h, unique_monotone h (monotone_sort f)⟩
 
-/-- The sorted versions of a tuple `f` and of any permutation of it agree. -/
+/-- The sorted versions of a tuple `f` and of any permutation of `f` agree. -/
 lemma comp_perm_comp_sort_eq_comp_sort : (f ∘ σ) ∘ (sort (f ∘ σ)) = f ∘ sort f :=
 begin
   rw [function.comp.assoc, ← equiv.perm.coe_mul],
@@ -135,7 +135,7 @@ lemma antitone_pair_of_not_sorted' (h : f ∘ σ ≠ f ∘ sort f) :
   ∃ i j, i < j ∧ (f ∘ σ) j < (f ∘ σ) i :=
 by { contrapose! h, exact comp_sort_eq_comp_iff_monotone.mpr (monotone_iff_forall_lt.mpr h) }
 
-/-- If the tuple `f` is not the same as `f ∘ sort f`, then it has a pair of strictly decreasing
+/-- If the tuple `f` is not the same as `f ∘ sort f`, then `f` has a pair of strictly decreasing
 entries. -/
 lemma antitone_pair_of_not_sorted (h : f ≠ f ∘ sort f) : ∃ i j, i < j ∧ f j < f i :=
 antitone_pair_of_not_sorted' (id h : f ∘ equiv.refl _ ≠ _)

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -531,6 +531,16 @@ theorem perm_append_right_iff {l₁ l₂ : list α} (l) : l₁++l ~ l₂++l ↔ 
 ⟨λ p, (perm_append_left_iff _).1 $ perm_append_comm.trans $ p.trans perm_append_comm,
  perm.append_right _⟩
 
+lemma perm.map_congr {α β} {l₁ l₂ : list α} (h : l₁ ~ l₂) (f : α → β) : l₁.map f ~ l₂.map f :=
+begin
+  induction h,
+  { exact perm.refl _, },
+  { simpa only [map, perm_cons]},
+  { exact perm.swap _ _ _ },
+  case perm.trans : _ _ _ _ _ h₁₂ h₂₃
+  { exact h₁₂.trans h₂₃ },
+end
+
 theorem perm_option_to_list {o₁ o₂ : option α} : o₁.to_list ~ o₂.to_list ↔ o₁ = o₂ :=
 begin
   refine ⟨λ p, _, λ e, e ▸ perm.refl _⟩,

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -1404,6 +1404,12 @@ end
 -- TODO: `nodup s.permutations ↔ nodup s`
 -- TODO: `count s s.permutations = (zip_with count s s.tails).prod`
 
+end permutations
+
+end list
+
+open list
+
 /-- The list obtained from a permutation of a tuple `f` is permutation equivalent to
 the list obtained from `f`. -/
 lemma equiv.perm.of_fn_comp_perm {n : ℕ} {α : Type uu} (σ : equiv.perm (fin n)) (f : fin n → α) :
@@ -1414,7 +1420,3 @@ begin
   rw [perm_ext ((nodup_fin_range n).map σ.injective) $ nodup_fin_range n],
   simpa only [mem_map, mem_fin_range, true_and, iff_true] using σ.surjective
 end
-
-end permutations
-
-end list

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -1402,7 +1402,7 @@ end
 -- TODO: `nodup s.permutations ↔ nodup s`
 -- TODO: `count s s.permutations = (zip_with count s s.tails).prod`
 
-lemma equiv.perm.of_fn_comp_perm {n : ℕ} {α : Type uu} (f : fin n → α) (σ : equiv.perm (fin n)) :
+lemma equiv.perm.of_fn_comp_perm {n : ℕ} {α : Type uu} (σ : equiv.perm (fin n)) (f : fin n → α) :
   of_fn (f ∘ σ) ~ of_fn f :=
 begin
   rw [of_fn_eq_map, of_fn_eq_map, ←map_map],

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -1402,7 +1402,7 @@ end
 -- TODO: `nodup s.permutations ↔ nodup s`
 -- TODO: `count s s.permutations = (zip_with count s s.tails).prod`
 
-lemma equiv.perm.of_fn_comp_perm {n : ℕ} (f : fin n → α) (σ : equiv.perm (fin n)) :
+lemma equiv.perm.of_fn_comp_perm {n : ℕ} {α : Type uu} (f : fin n → α) (σ : equiv.perm (fin n)) :
   of_fn (f ∘ σ) ~ of_fn f :=
 begin
   rw [of_fn_eq_map, of_fn_eq_map, ←map_map],

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -1402,6 +1402,15 @@ end
 -- TODO: `nodup s.permutations ↔ nodup s`
 -- TODO: `count s s.permutations = (zip_with count s s.tails).prod`
 
+lemma equiv.perm.of_fn_comp_perm {n : ℕ} (f : fin n → α) (σ : equiv.perm (fin n)) :
+  of_fn (f ∘ σ) ~ of_fn f :=
+begin
+  rw [of_fn_eq_map, of_fn_eq_map, ←map_map],
+  apply perm.map_congr,
+  rw [perm_ext ((nodup_fin_range n).map σ.injective) $ nodup_fin_range n],
+  simpa only [mem_map, mem_fin_range, true_and, iff_true] using σ.surjective
+end
+
 end permutations
 
 end list

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -1402,6 +1402,8 @@ end
 -- TODO: `nodup s.permutations ↔ nodup s`
 -- TODO: `count s s.permutations = (zip_with count s s.tails).prod`
 
+/-- The list obtained from a permutation of a tuple `f` is permutation equivalent to
+the list obtained from `f`. -/
 lemma equiv.perm.of_fn_comp_perm {n : ℕ} {α : Type uu} (σ : equiv.perm (fin n)) (f : fin n → α) :
   of_fn (f ∘ σ) ~ of_fn f :=
 begin

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -1411,5 +1411,5 @@ lemma equiv.perm.of_fn_comp_perm {n : ℕ} {α : Type uu} (σ : equiv.perm (fin 
   of_fn (f ∘ σ) ~ of_fn f :=
 begin
   rw [of_fn_eq_map, of_fn_eq_map, ←map_map],
-  exact perm.map f (equiv.perm.map_fin_range_perm σ),
+  exact σ.map_fin_range_perm.map f,
 end

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -531,18 +531,6 @@ theorem perm_append_right_iff {l₁ l₂ : list α} (l) : l₁++l ~ l₂++l ↔ 
 ⟨λ p, (perm_append_left_iff _).1 $ perm_append_comm.trans $ p.trans perm_append_comm,
  perm.append_right _⟩
 
-/-- Mapping a function `f` over two permutation equivalent lists results in permutation
-equivalent lists. -/
-lemma perm.map_congr {α β} {l₁ l₂ : list α} (h : l₁ ~ l₂) (f : α → β) : l₁.map f ~ l₂.map f :=
-begin
-  induction h,
-  { exact perm.refl _, },
-  { simpa only [map, perm_cons]},
-  { exact perm.swap _ _ _ },
-  case perm.trans : _ _ _ _ _ h₁₂ h₂₃
-  { exact h₁₂.trans h₂₃ },
-end
-
 theorem perm_option_to_list {o₁ o₂ : option α} : o₁.to_list ~ o₂.to_list ↔ o₁ = o₂ :=
 begin
   refine ⟨λ p, _, λ e, e ▸ perm.refl _⟩,

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -531,6 +531,8 @@ theorem perm_append_right_iff {l₁ l₂ : list α} (l) : l₁++l ~ l₂++l ↔ 
 ⟨λ p, (perm_append_left_iff _).1 $ perm_append_comm.trans $ p.trans perm_append_comm,
  perm.append_right _⟩
 
+/-- Mapping a function `f` over two permutation equivalent lists results in permutation
+equivalent lists. -/
 lemma perm.map_congr {α β} {l₁ l₂ : list α} (h : l₁ ~ l₂) (f : α → β) : l₁.map f ~ l₂.map f :=
 begin
   induction h,

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -1398,13 +1398,18 @@ end list
 
 open list
 
+lemma equiv.perm.map_fin_range_perm {n : ℕ} (σ : equiv.perm (fin n)) :
+  map σ (fin_range n) ~ fin_range n :=
+begin
+  rw [perm_ext ((nodup_fin_range n).map σ.injective) $ nodup_fin_range n],
+  simpa only [mem_map, mem_fin_range, true_and, iff_true] using σ.surjective
+end
+
 /-- The list obtained from a permutation of a tuple `f` is permutation equivalent to
 the list obtained from `f`. -/
 lemma equiv.perm.of_fn_comp_perm {n : ℕ} {α : Type uu} (σ : equiv.perm (fin n)) (f : fin n → α) :
   of_fn (f ∘ σ) ~ of_fn f :=
 begin
   rw [of_fn_eq_map, of_fn_eq_map, ←map_map],
-  apply perm.map_congr,
-  rw [perm_ext ((nodup_fin_range n).map σ.injective) $ nodup_fin_range n],
-  simpa only [mem_map, mem_fin_range, true_and, iff_true] using σ.surjective
+  exact perm.map f (equiv.perm.map_fin_range_perm σ),
 end

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -104,6 +104,7 @@ end
 
 end sorted
 
+/-- The list obtained from a monotone tuple is sorted. -/
 lemma monotone.of_fn_sorted {n : ℕ} {α : Type uu} [preorder α] {f : fin n → α} (h : monotone f) :
   (of_fn f).sorted (≤) :=
 begin

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -104,16 +104,19 @@ end
 
 end sorted
 
+/-- A tuple is monotone if and only if the list obtained from it is sorted. -/
+lemma monotone_iff_of_fn_sorted {n : ℕ} {α : Type uu} [preorder α] {f : fin n → α} :
+  monotone f ↔ (of_fn f).sorted (≤) :=
+begin
+  simp_rw [sorted, pairwise_iff_nth_le, length_of_fn, nth_le_of_fn', monotone_iff_forall_lt],
+  refine ⟨λ h i j hj hij, h _, λ h ⟨i, _⟩ ⟨j, hj⟩ hij, h i j hj hij⟩,
+  exact hij,
+end
+
 /-- The list obtained from a monotone tuple is sorted. -/
 lemma monotone.of_fn_sorted {n : ℕ} {α : Type uu} [preorder α] {f : fin n → α} (h : monotone f) :
   (of_fn f).sorted (≤) :=
-begin
-  rw [sorted, pairwise_iff_nth_le],
-  intros i j hj hij,
-  rw [nth_le_of_fn', nth_le_of_fn'],
-  apply h,
-  exact hij.le
-end
+monotone_iff_of_fn_sorted.1 h
 
 section sort
 variables {α : Type uu} (r : α → α → Prop) [decidable_rel r]

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -104,6 +104,16 @@ end
 
 end sorted
 
+lemma monotone.of_fn_sorted {n : ℕ} {α : Type uu} [preorder α] {f : fin n → α} (h : monotone f) :
+  (of_fn f).sorted (≤) :=
+begin
+  rw [sorted, pairwise_iff_nth_le],
+  intros i j hj hij,
+  rw [nth_le_of_fn', nth_le_of_fn'],
+  apply h,
+  exact hij.le
+end
+
 section sort
 variables {α : Type uu} (r : α → α → Prop) [decidable_rel r]
 local infix ` ≼ ` : 50 := r

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -109,8 +109,7 @@ lemma monotone_iff_of_fn_sorted {n : ℕ} {α : Type uu} [preorder α] {f : fin 
   monotone f ↔ (of_fn f).sorted (≤) :=
 begin
   simp_rw [sorted, pairwise_iff_nth_le, length_of_fn, nth_le_of_fn', monotone_iff_forall_lt],
-  refine ⟨λ h i j hj hij, h _, λ h ⟨i, _⟩ ⟨j, hj⟩ hij, h i j hj hij⟩,
-  exact hij,
+  exact ⟨λ h i j hj hij, h $ fin.mk_lt_mk.mpr hij, λ h ⟨i, _⟩ ⟨j, hj⟩ hij, h i j hj hij⟩,
 end
 
 /-- The list obtained from a monotone tuple is sorted. -/

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -104,18 +104,22 @@ end
 
 end sorted
 
+section monotone
+
+variables {n : ℕ} {α : Type uu} [preorder α] {f : fin n → α}
+
 /-- A tuple is monotone if and only if the list obtained from it is sorted. -/
-lemma monotone_iff_of_fn_sorted {n : ℕ} {α : Type uu} [preorder α] {f : fin n → α} :
-  monotone f ↔ (of_fn f).sorted (≤) :=
+lemma monotone_iff_of_fn_sorted : monotone f ↔ (of_fn f).sorted (≤) :=
 begin
   simp_rw [sorted, pairwise_iff_nth_le, length_of_fn, nth_le_of_fn', monotone_iff_forall_lt],
   exact ⟨λ h i j hj hij, h $ fin.mk_lt_mk.mpr hij, λ h ⟨i, _⟩ ⟨j, hj⟩ hij, h i j hj hij⟩,
 end
 
 /-- The list obtained from a monotone tuple is sorted. -/
-lemma monotone.of_fn_sorted {n : ℕ} {α : Type uu} [preorder α] {f : fin n → α} (h : monotone f) :
-  (of_fn f).sorted (≤) :=
+lemma monotone.of_fn_sorted (h : monotone f) : (of_fn f).sorted (≤) :=
 monotone_iff_of_fn_sorted.1 h
+
+end monotone
 
 section sort
 variables {α : Type uu} (r : α → α → Prop) [decidable_rel r]

--- a/src/data/pi/lex.lean
+++ b/src/data/pi/lex.lean
@@ -125,8 +125,8 @@ instance lex.ordered_comm_group [linear_order ι] [∀ a, ordered_comm_group (β
   ..pi.lex.partial_order,
   ..pi.comm_group }
 
-/-- If we swap two strictly decreasing entries in a tuple, then the result is lexicographically
-smaller than the original tuple. -/
+/-- If we swap two strictly decreasing values in a function, then the result is lexicographically
+smaller than the original function. -/
 lemma lex_desc {α} [preorder ι] [decidable_eq ι] [preorder α] {f : ι → α} {i j : ι}
   (h₁ : i < j) (h₂ : f j < f i) :
   to_lex (f ∘ equiv.swap i j) < to_lex f :=

--- a/src/data/pi/lex.lean
+++ b/src/data/pi/lex.lean
@@ -125,4 +125,12 @@ instance lex.ordered_comm_group [linear_order ι] [∀ a, ordered_comm_group (β
   ..pi.lex.partial_order,
   ..pi.comm_group }
 
+/-- If we swap two strictly decreasing entries in a tuple, then the result is lexicographically
+smaller than the original tuple. -/
+lemma lex_desc {α} [preorder ι] [decidable_eq ι] [preorder α] {f : ι → α} {i j : ι}
+  (h₁ : i < j) (h₂ : f j < f i) :
+  to_lex (f ∘ equiv.swap i j) < to_lex f :=
+⟨i, λ k hik, congr_arg f (equiv.swap_apply_of_ne_of_ne hik.ne (hik.trans h₁).ne),
+  by simpa only [pi.to_lex_apply, function.comp_app, equiv.swap_apply_left] using h₂⟩
+
 end pi

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -215,6 +215,17 @@ end function
 
 section induction
 
+lemma acc.induction_bot {α} {r : α → α → Prop} {a bot : α} (hwf : acc r a)
+  {C : α → Prop} (ha : C a) (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C bot :=
+begin
+  revert ha,
+  refine hwf.rec_on (λ x ac ih', _),
+  intro hC,
+  rcases eq_or_ne x bot with (rfl | hbot),
+  { exact hC, },
+  { obtain ⟨y, hy₁, hy₂⟩ := ih x hbot hC, exact ih' y hy₁ hy₂, },
+end
+
 /-- Let `r` be a well-founded relation on `α` and let `bot : α`.
 This induction principle that shows that `P bot` holds, given that some `a : α` satisfies `P`
 and for each `b` that satisfies `P`, there is `c` satisfying `P` such that `r c b` holds.
@@ -222,13 +233,6 @@ The naming is inspired by the fact that when `r` is transitive, it follows that 
 the smallest element w.r.t. `r` that satisfies `P`. -/
 lemma well_founded.induction_bot {α} {r : α → α → Prop} (hwf : well_founded r) {a bot : α}
   {C : α → Prop} (ha : C a) (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C bot :=
-begin
-  revert ha,
-  refine well_founded.induction hwf a (λ x ih', _),
-  intro hC,
-  rcases eq_or_ne x bot with (rfl | hbot),
-  { exact hC, },
-  { obtain ⟨y, hy₁, hy₂⟩ := ih x hbot hC, exact ih' y hy₁ hy₂, },
-end
+(hwf.apply a).induction_bot ha ih
 
 end induction

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -259,6 +259,6 @@ The naming is inspired by the fact that when `r` is transitive, it follows that 
 the smallest element w.r.t. `r` that satisfies `C`. -/
 lemma well_founded.induction_bot {α} {r : α → α → Prop} (hwf : well_founded r) {a bot : α}
   {C : α → Prop} (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C a → C bot :=
-(hwf.apply a).induction_bot ih
+hwf.induction_bot' ih
 
 end induction

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -14,7 +14,8 @@ implies `P x`. Well-founded relations can be used for induction and recursion, i
 construction of fixed points in the space of dependent functions `Π x : α , β x`.
 
 The predicate `well_founded` is defined in the core library. In this file we prove some extra lemmas
-and provide a few new definitions: `well_founded.min`, `well_founded.sup`, and `well_founded.succ`.
+and provide a few new definitions: `well_founded.min`, `well_founded.sup`, and `well_founded.succ`,
+and an induction principle `well_founded.induction_bot`.
 -/
 
 variables {α : Type*}
@@ -211,3 +212,23 @@ not_lt.mp $ not_lt_argmin_on f h s ha hs
 end linear_order
 
 end function
+
+section induction
+
+/-- Let `r` be a well-founded relation on `α` and let `bot : α`.
+This induction principle that shows that `P bot` holds, given that some `a : α` satisfies `P`
+and for each `b` that satisfies `P`, there is `c` satisfying `P` such that `r c b` holds.
+The naming is inspired by the fact that when `r` is transitive, it follows that `bot` is
+the smallest element w.r.t. `r` that satisfies `P`. -/
+lemma well_founded.induction_bot {α} (r : α → α → Prop) (hwf : well_founded r) {a bot : α}
+  {C : α → Prop} (ha : C a) (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C bot :=
+begin
+  revert ha,
+  refine well_founded.induction hwf a (λ x ih', _),
+  intro hC,
+  rcases eq_or_ne x bot with (rfl | hbot),
+  { exact hC, },
+  { obtain ⟨y, hy₁, hy₂⟩ := ih x hbot hC, exact ih' y hy₁ hy₂, },
+end
+
+end induction

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -220,7 +220,7 @@ This induction principle that shows that `P bot` holds, given that some `a : α`
 and for each `b` that satisfies `P`, there is `c` satisfying `P` such that `r c b` holds.
 The naming is inspired by the fact that when `r` is transitive, it follows that `bot` is
 the smallest element w.r.t. `r` that satisfies `P`. -/
-lemma well_founded.induction_bot {α} (r : α → α → Prop) (hwf : well_founded r) {a bot : α}
+lemma well_founded.induction_bot {α} {r : α → α → Prop} (hwf : well_founded r) {a bot : α}
   {C : α → Prop} (ha : C a) (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C bot :=
 begin
   revert ha,

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -235,6 +235,19 @@ lemma acc.induction_bot {α} {r : α → α → Prop} {a bot : α} (ha : acc r a
   {C : α → Prop} (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C a → C bot :=
 ha.induction_bot' ih
 
+/-- Let `r` be a well-founded relation on `α`, let `f : α → β` be a function,
+and let `C : β → Prop` be a property that elements of `β` can have.
+This induction principle that shows that `C (f bot)` holds, given that
+* some `a : α` satisfies `C`, and
+* for each `b : α` such that `f b ≠ f bot` and `C (f b)` holds, there is `c : α`
+  satisfying `r c b` and `C (f c)`.
+
+The naming is inspired by the fact that when `r` is transitive, it follows that `bot` is
+the smallest element w.r.t. `r` suc that `C ( bot)` holds. -/
+lemma well_founded.induction_bot' {α β} {r : α → α → Prop} (hwf : well_founded r) {a bot : α}
+  {C : β → Prop} {f : α → β} (ih : ∀ b, f b ≠ f bot → C (f b) → ∃ c, r c b ∧ C (f c)) :
+  C (f a) → C (f bot) := (hwf.apply a).induction_bot' ih
+
 /-- Let `r` be a well-founded relation on `α`, let `bot : α`, and let `C : α → Prop`
 be some property that elements of `α` can have.
 This induction principle that shows that `C bot` holds, given that

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -246,7 +246,8 @@ The naming is inspired by the fact that when `r` is transitive, it follows that 
 the smallest element w.r.t. `r` suc that `C ( bot)` holds. -/
 lemma well_founded.induction_bot' {α β} {r : α → α → Prop} (hwf : well_founded r) {a bot : α}
   {C : β → Prop} {f : α → β} (ih : ∀ b, f b ≠ f bot → C (f b) → ∃ c, r c b ∧ C (f c)) :
-  C (f a) → C (f bot) := (hwf.apply a).induction_bot' ih
+  C (f a) → C (f bot) :=
+(hwf.apply a).induction_bot' ih
 
 /-- Let `r` be a well-founded relation on `α`, let `bot : α`, and let `C : α → Prop`
 be some property that elements of `α` can have.

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -215,11 +215,10 @@ end function
 
 section induction
 
-/-- Let `r` be a relation on `α`, let `f : α → β` be a function, and let `C : β → Prop`
-be a property that elements of `β` can have.
-This induction principle that shows that `C (f bot)` holds, given that
-* some `a : α` that is accessible by `r` satisfies `C (f a)`, and
-* for each `b : α` such that `f b ≠ f bot` and `C (f b)` holds, there is `c : α`
+/-- Let `r` be a relation on `α`, let `f : α → β` be a function, let `C : β → Prop`, and
+let `bot : α`. This induction principle shows that `C (f bot)` holds, given that
+* some `a` that is accessible by `r` satisfies `C (f a)`, and
+* for each `b` such that `f b ≠ f bot` and `C (f b)` holds, there is `c`
   satisfying `r c b` and `C (f c)`. -/
 lemma acc.induction_bot' {α β} {r : α → α → Prop} {a bot : α} (ha : acc r a) {C : β → Prop}
   {f : α → β} (ih : ∀ b, f b ≠ f bot → C (f b) → ∃ c, r c b ∧ C (f c)) : C (f a) → C (f bot) :=
@@ -227,33 +226,29 @@ lemma acc.induction_bot' {α β} {r : α → α → Prop} {a bot : α} (ha : acc
   (eq_or_ne (f x) (f bot)).elim (λ h, h ▸ hC)
     (λ h, let ⟨y, hy₁, hy₂⟩ := ih x h hC in ih' y hy₁ hy₂)
 
-/-- Let `r` be a relation on `α` and let `C : α → Prop` be a property that elements of `α`
-can have. This induction principle that shows that `C bot` holds, given that
-* some `a : α` that is accessible by `r` satisfies `C a`, and
-* for each `b ≠ bot` such that `C b` holds, there is `c : α` satisfying `r c b` and `C c`. -/
+/-- Let `r` be a relation on `α`, let `C : α → Prop` and let `bot : α`.
+This induction principle shows that `C bot` holds, given that
+* some `a` that is accessible by `r` satisfies `C a`, and
+* for each `b ≠ bot` such that `C b` holds, there is `c` satisfying `r c b` and `C c`. -/
 lemma acc.induction_bot {α} {r : α → α → Prop} {a bot : α} (ha : acc r a)
   {C : α → Prop} (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C a → C bot :=
 ha.induction_bot' ih
 
 /-- Let `r` be a well-founded relation on `α`, let `f : α → β` be a function,
-and let `C : β → Prop` be a property that elements of `β` can have.
-This induction principle that shows that `C (f bot)` holds, given that
-* some `a : α` satisfies `C`, and
-* for each `b : α` such that `f b ≠ f bot` and `C (f b)` holds, there is `c : α`
-  satisfying `r c b` and `C (f c)`.
-
-The naming is inspired by the fact that when `r` is transitive, it follows that `bot` is
-the smallest element w.r.t. `r` suc that `C ( bot)` holds. -/
+let `C : β → Prop`, and  let `bot : α`.
+This induction principle shows that `C (f bot)` holds, given that
+* some `a` satisfies `C (f a)`, and
+* for each `b` such that `f b ≠ f bot` and `C (f b)` holds, there is `c`
+  satisfying `r c b` and `C (f c)`. -/
 lemma well_founded.induction_bot' {α β} {r : α → α → Prop} (hwf : well_founded r) {a bot : α}
   {C : β → Prop} {f : α → β} (ih : ∀ b, f b ≠ f bot → C (f b) → ∃ c, r c b ∧ C (f c)) :
   C (f a) → C (f bot) :=
 (hwf.apply a).induction_bot' ih
 
-/-- Let `r` be a well-founded relation on `α`, let `bot : α`, and let `C : α → Prop`
-be some property that elements of `α` can have.
-This induction principle that shows that `C bot` holds, given that
-* some `a : α` satisfies `C`, and
-* for each `b : α` that satisfies `P`, there is `c` satisfying `P` such that `r c b` holds.
+/-- Let `r` be a well-founded relation on `α`, let `C : α → Prop`, and let `bot : α`.
+This induction principle shows that `C bot` holds, given that
+* some `a` satisfies `C a`, and
+* for each `b` that satisfies `C b`, there is `c` satisfying `r c b` and `C c`.
 
 The naming is inspired by the fact that when `r` is transitive, it follows that `bot` is
 the smallest element w.r.t. `r` that satisfies `C`. -/

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -216,15 +216,10 @@ end function
 section induction
 
 lemma acc.induction_bot {α} {r : α → α → Prop} {a bot : α} (hwf : acc r a)
-  {C : α → Prop} (ha : C a) (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C bot :=
-begin
-  revert ha,
-  refine hwf.rec_on (λ x ac ih', _),
-  intro hC,
-  rcases eq_or_ne x bot with (rfl | hbot),
-  { exact hC, },
-  { obtain ⟨y, hy₁, hy₂⟩ := ih x hbot hC, exact ih' y hy₁ hy₂, },
-end
+  {C : α → Prop} (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C a → C bot :=
+@acc.rec_on _ _ (λ x, C x → C bot) _ hwf $
+  λ x ac ih' hC, or.elim (eq_or_ne x bot) (λ h, h ▸ hC)
+                         (λ h, let ⟨y, hy₁, hy₂⟩ := ih x h hC in ih' y hy₁ hy₂)
 
 /-- Let `r` be a well-founded relation on `α` and let `bot : α`.
 This induction principle that shows that `P bot` holds, given that some `a : α` satisfies `P`
@@ -232,7 +227,7 @@ and for each `b` that satisfies `P`, there is `c` satisfying `P` such that `r c 
 The naming is inspired by the fact that when `r` is transitive, it follows that `bot` is
 the smallest element w.r.t. `r` that satisfies `P`. -/
 lemma well_founded.induction_bot {α} {r : α → α → Prop} (hwf : well_founded r) {a bot : α}
-  {C : α → Prop} (ha : C a) (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C bot :=
-(hwf.apply a).induction_bot ha ih
+  {C : α → Prop} (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C a → C bot :=
+(hwf.apply a).induction_bot ih
 
 end induction

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -215,17 +215,34 @@ end function
 
 section induction
 
-lemma acc.induction_bot {α} {r : α → α → Prop} {a bot : α} (hwf : acc r a)
-  {C : α → Prop} (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C a → C bot :=
-@acc.rec_on _ _ (λ x, C x → C bot) _ hwf $
-  λ x ac ih' hC, or.elim (eq_or_ne x bot) (λ h, h ▸ hC)
-                         (λ h, let ⟨y, hy₁, hy₂⟩ := ih x h hC in ih' y hy₁ hy₂)
+/-- Let `r` be a relation on `α`, let `f : α → β` be a function, and let `C : β → Prop`
+be a property that elements of `β` can have.
+This induction principle that shows that `C (f bot)` holds, given that
+* some `a : α` that is accessible by `r` satisfies `C (f a)`, and
+* for each `b : α` such that `f b ≠ f bot` and `C (f b)` holds, there is `c : α`
+  satisfying `r c b` and `C (f c)`. -/
+lemma acc.induction_bot' {α β} {r : α → α → Prop} {a bot : α} (ha : acc r a) {C : β → Prop}
+  {f : α → β} (ih : ∀ b, f b ≠ f bot → C (f b) → ∃ c, r c b ∧ C (f c)) : C (f a) → C (f bot) :=
+@acc.rec_on _ _ (λ x, C (f x) → C (f bot)) _ ha $ λ x ac ih' hC,
+  (eq_or_ne (f x) (f bot)).elim (λ h, h ▸ hC)
+    (λ h, let ⟨y, hy₁, hy₂⟩ := ih x h hC in ih' y hy₁ hy₂)
 
-/-- Let `r` be a well-founded relation on `α` and let `bot : α`.
-This induction principle that shows that `P bot` holds, given that some `a : α` satisfies `P`
-and for each `b` that satisfies `P`, there is `c` satisfying `P` such that `r c b` holds.
+/-- Let `r` be a relation on `α` and let `C : α → Prop` be a property that elements of `α`
+can have. This induction principle that shows that `C bot` holds, given that
+* some `a : α` that is accessible by `r` satisfies `C a`, and
+* for each `b ≠ bot` such that `C b` holds, there is `c : α` satisfying `r c b` and `C c`. -/
+lemma acc.induction_bot {α} {r : α → α → Prop} {a bot : α} (ha : acc r a)
+  {C : α → Prop} (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C a → C bot :=
+ha.induction_bot' ih
+
+/-- Let `r` be a well-founded relation on `α`, let `bot : α`, and let `C : α → Prop`
+be some property that elements of `α` can have.
+This induction principle that shows that `C bot` holds, given that
+* some `a : α` satisfies `C`, and
+* for each `b : α` that satisfies `P`, there is `c` satisfying `P` such that `r c b` holds.
+
 The naming is inspired by the fact that when `r` is transitive, it follows that `bot` is
-the smallest element w.r.t. `r` that satisfies `P`. -/
+the smallest element w.r.t. `r` that satisfies `C`. -/
 lemma well_founded.induction_bot {α} {r : α → α → Prop} (hwf : well_founded r) {a bot : α}
   {C : α → Prop} (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C a → C bot :=
 (hwf.apply a).induction_bot ih


### PR DESCRIPTION
The main purpose of this PR is to add the following induction principle fir tuples.
```lean
lemma tuple.bubble_sort_induction {n : ℕ} {α : Type*} [linear_order α] {f : fin n → α}
  {P : (fin n → α) → Prop} (hf : P f)
  (h : ∀ (g : fin n → α) (i j : fin n), i < j → g j < g i → P g → P (g ∘ equiv.swap i j)) :
  P (f ∘ sort f)
```
This is in a new file `data/fin/tuple/bubble_sort_induction`.

The additional API lemmas needed for it are mostly added to `data/fin/tuple/sort` (and some in `data/list/perm` and `data/list/sort`).
One of these lemmas is the following induction principle for well-founded relations.
```lean
lemma well_founded.induction_bot {α} {r : α → α → Prop} (hwf : well_founded r) {a bot : α}
  {C : α → Prop} (ha : C a) (ih : ∀ b, b ≠ bot → C b → ∃ c, r c b ∧ C c) : C bot
```

See the discussion on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/.22sort.22.20a.20function/near/299289703).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
