### PR TITLE
[Merged by Bors] - doc(number_theory/legendre_symbol/jacobi_symbol): remove now spurious reference to 'subscript J'

### DIFF
--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -67,7 +67,7 @@ Jacobi symbol when `b` is odd and gives less meaningful values when it is not (e
 is `1` when `b = 0`). This is called `jacobi_sym a b`.
 
 We define localized notation (locale `number_theory_symbols`) `J(a | b)` for the Jacobi
-symbol `jacobi_sym a b`. (Unfortunately, there is no subscript "J" in unicode.)
+symbol `jacobi_sym a b`.
 -/
 
 open nat zmod


### PR DESCRIPTION
This PR just fixes the docstring for the notation. The reference to "no subscript J in unicode" doesn't make sense anymore after the notation was changed to `J(a | b)`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
