### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/compare_exp): new file

### DIFF
--- a/src/analysis/asymptotics/asymptotic_equivalent.lean
+++ b/src/analysis/asymptotics/asymptotic_equivalent.lean
@@ -147,11 +147,14 @@ end
 lemma is_equivalent.tendsto_nhds_iff {c : β} (huv : u ~[l] v) :
   tendsto u l (𝓝 c) ↔ tendsto v l (𝓝 c) := ⟨huv.tendsto_nhds, huv.symm.tendsto_nhds⟩
 
-lemma is_equivalent.add_is_o (huv : u ~[l] v) (hwv : w =o[l] v) : (w + u) ~[l] v :=
-by simpa only [is_equivalent, pi.sub_apply, add_sub] using hwv.add huv
+lemma is_equivalent.add_is_o (huv : u ~[l] v) (hwv : w =o[l] v) : (u + w) ~[l] v :=
+by simpa only [is_equivalent, add_sub_right_comm] using huv.add hwv
+
+lemma is_equivalent.sub_is_o (huv : u ~[l] v) (hwv : w =o[l] v) : (u - w) ~[l] v :=
+by simpa only [sub_eq_add_neg] using huv.add_is_o hwv.neg_left
 
 lemma is_o.add_is_equivalent (hu : u =o[l] w) (hv : v ~[l] w) : (u + v) ~[l] w :=
-add_comm u v ▸ hv.add_is_o hu
+add_comm v u ▸ hv.add_is_o hu
 
 lemma is_o.is_equivalent (huv : (u - v) =o[l] v) : u ~[l] v := huv
 

--- a/src/analysis/special_functions/compare_exp.lean
+++ b/src/analysis/special_functions/compare_exp.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2022 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import analysis.special_functions.pow
+import analysis.asymptotics.specific_asymptotics
+
+/-!
+# Growth estimates on `x ^ y` for complex `x`, `y`
+
+Let `l` be a filter on `ℂ` such that `complex.re` tends to infinity along `l` and `complex.im z`
+grows at a subexponential rate compared to `complex.re z`. Then
+
+- `complex.is_o_log_abs_re_of_subexponential_im_re`: `real.log ∘ complex.abs` is `o`-small of
+  `complex.re` along `l`;
+
+- `complex.is_o_cpow_mul_exp`: $z^{a_1}e^{b_1 * z} = o\left(z^{a_1}e^{b_1 * z}\right)$ along `l`
+  for any complex `a₁`, `a₂` and real `b₁ < b₂`.
+
+We use these assumptions on `l` for two reasons. First, these are the assumptions that naturally
+appear in the proof. Second, in some applications (e.g., in Ilyashenko's proof of the individual
+finiteness theorem for limit cycles of polynomial ODEs with hyperbolic singularities only) natural
+stronger assumptions (e.g., `im z` is bounded from below and from above) are not available.
+
+-/
+
+open asymptotics filter function
+open_locale topological_space
+
+namespace complex
+
+/-- We say that `l : filter ℂ` is an *exponent comparison filter* if the real part tends to infinity
+along `l` and the imaginary part grows subexponentially compared to the real part. These properties
+guarantee that `(λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z))` for any complex
+`a₁`, `a₂` and real `b₁ < b₂`.
+
+In particular, the second property is automatically satisfied if the imaginary part is bounded along
+`l`. -/
+structure is_exp_cmp_filter (l : filter ℂ) : Prop :=
+(tendsto_re : tendsto re l at_top)
+(is_O_im_pow_re : ∀ n : ℕ, (λ z : ℂ, z.im ^ n) =O[l] (λ z, real.exp z.re))
+
+namespace is_exp_cmp_filter
+
+variables {l : filter ℂ}
+
+/-!
+### Alternative constructors
+-/
+
+lemma of_is_O_im_re_rpow (hre : tendsto re l at_top) (r : ℝ) (hr : im =O[l] (λ z, z.re ^ r)) :
+  is_exp_cmp_filter l :=
+⟨hre, λ n, is_o.is_O $
+  calc (λ z : ℂ, z.im ^ n) =O[l] (λ z, (z.re ^ r) ^ n) : hr.pow n
+  ... =ᶠ[l] (λ z, z.re ^ (r * n)) : (hre.eventually_ge_at_top 0).mono $
+    λ z hz, by simp only [real.rpow_mul hz r n, real.rpow_nat_cast]
+  ... =o[l] (λ z, real.exp z.re) : (is_o_rpow_exp_at_top _).comp_tendsto hre⟩
+
+lemma of_is_O_im_re_pow (hre : tendsto re l at_top) (n : ℕ) (hr : im =O[l] (λ z, z.re ^ n)) :
+  is_exp_cmp_filter l :=
+of_is_O_im_re_rpow hre n $ by simpa only [real.rpow_nat_cast]
+
+lemma of_bounded_under_abs_im (hre : tendsto re l at_top)
+  (him : is_bounded_under (≤) l (λ z, |z.im|)) :
+  is_exp_cmp_filter l :=
+of_is_O_im_re_pow hre 0 $
+  by simpa only [pow_zero] using @is_bounded_under.is_O_const ℂ ℝ ℝ _ _ _ l him 1 one_ne_zero
+
+lemma of_bounded_under_im (hre : tendsto re l at_top) (him_le : is_bounded_under (≤) l im)
+  (him_ge : is_bounded_under (≥) l im) :
+  is_exp_cmp_filter l :=
+of_bounded_under_abs_im hre $ is_bounded_under_le_abs.2 ⟨him_le, him_ge⟩
+
+/-!
+### Preliminary lemmas
+-/
+
+lemma eventually_ne (hl : is_exp_cmp_filter l) : ∀ᶠ w : ℂ in l, w ≠ 0 :=
+hl.tendsto_re.eventually_ne_at_top' _
+
+lemma tendsto_abs_re (hl : is_exp_cmp_filter l) : tendsto (λ z : ℂ, |z.re|) l at_top :=
+tendsto_abs_at_top_at_top.comp hl.tendsto_re
+
+lemma tendsto_abs (hl : is_exp_cmp_filter l) : tendsto abs l at_top :=
+tendsto_at_top_mono abs_re_le_abs hl.tendsto_abs_re
+
+lemma is_o_log_re_re (hl : is_exp_cmp_filter l) : (λ z, real.log z.re) =o[l] re :=
+real.is_o_log_id_at_top.comp_tendsto hl.tendsto_re
+
+lemma is_o_im_pow_exp_re (hl : is_exp_cmp_filter l) (n : ℕ) :
+  (λ z : ℂ, z.im ^ n) =o[l] (λ z, real.exp z.re) :=
+flip is_o.of_pow two_ne_zero $
+  calc (λ z : ℂ, (z.im ^ n) ^ 2) = (λ z, z.im ^ (2 * n)) : by simp only [pow_mul']
+  ... =O[l] (λ z, real.exp z.re) : hl.is_O_im_pow_re _
+  ... =     (λ z, (real.exp z.re) ^ 1) : by simp only [pow_one]
+  ... =o[l] (λ z, (real.exp z.re) ^ 2) : (is_o_pow_pow_at_top_of_lt one_lt_two).comp_tendsto $
+    real.tendsto_exp_at_top.comp hl.tendsto_re
+
+lemma abs_im_pow_eventually_le_exp_re (hl : is_exp_cmp_filter l) (n : ℕ) :
+  (λ z : ℂ, |z.im| ^ n) ≤ᶠ[l] (λ z, real.exp z.re) :=
+by simpa using (hl.is_o_im_pow_exp_re n).bound zero_lt_one
+
+/-- If `l : filter ℂ` is an "exponent comparison filter", then $\log |z| =o(ℜ z)$ along `l`.
+This is the main lemma in 
+-/
+lemma is_o_log_abs_re (hl : is_exp_cmp_filter l) : (λ z, real.log (abs z)) =o[l] re :=
+calc (λ z, real.log (abs z)) =O[l] (λ z, real.log (real.sqrt 2) + real.log (max z.re (|z.im|))) :
+  is_O.of_bound 1 $ (hl.tendsto_re.eventually_ge_at_top 1).mono $ λ z hz,
+    begin
+      have h2 : 0 < real.sqrt 2, by simp,
+      have hz' : 1 ≤ abs z, from hz.trans (re_le_abs z),
+      have hz₀ : 0 < abs z, from one_pos.trans_le hz',
+      have hm₀ : 0 < max z.re (|z.im|), from lt_max_iff.2 (or.inl $ one_pos.trans_le hz),
+      rw [one_mul, real.norm_eq_abs, _root_.abs_of_nonneg (real.log_nonneg hz')],
+      refine le_trans _ (le_abs_self _),
+      rw [← real.log_mul, real.log_le_log, ← _root_.abs_of_nonneg (le_trans zero_le_one hz)],
+      exacts [abs_le_sqrt_two_mul_max z, one_pos.trans_le hz', (mul_pos h2 hm₀), h2.ne', hm₀.ne']
+    end
+... =o[l] re : is_o.add (is_o_const_left.2 $ or.inr $ hl.tendsto_abs_re) $ is_o_iff_nat_mul_le.2 $
+  λ n, begin
+    filter_upwards [is_o_iff_nat_mul_le.1 hl.is_o_log_re_re n, hl.abs_im_pow_eventually_le_exp_re n,
+      hl.tendsto_re.eventually_gt_at_top 1] with z hre him h₁,
+    cases le_total (|z.im|) z.re with hle hle,
+    { rwa [max_eq_left hle] },
+    { have H : 1 < |z.im|, from h₁.trans_le hle,
+      rwa [max_eq_right hle, real.norm_eq_abs, real.norm_eq_abs, abs_of_pos (real.log_pos H),
+        ← real.log_pow, real.log_le_iff_le_exp (pow_pos (one_pos.trans H) _),
+        abs_of_pos (one_pos.trans h₁)] }
+  end
+
+/-!
+### Main results
+-/
+
+/-- If `l : filter ℂ` is an "exponent comparison filter", then for any complex `a` and any positive
+real `b`, we have `(λ z, z ^ a) =o[l] (λ z, exp (b * z))`. -/
+lemma is_o_cpow_exp (hl : is_exp_cmp_filter l) (a : ℂ) {b : ℝ} (hb : 0 < b) :
+  (λ z, z ^ a) =o[l] (λ z, exp (b * z)) :=
+calc (λ z, z ^ a) =Θ[l] λ z, abs z ^ re a : is_Theta_cpow_const_rpow $ λ _ _, hl.eventually_ne
+... =ᶠ[l] λ z, real.exp (re a * real.log (abs z)) : hl.eventually_ne.mono $
+  λ z hz, by simp only [real.rpow_def_of_pos (abs_pos.2 hz), mul_comm]
+... =o[l] λ z, exp (b * z) : is_o.of_norm_right $
+  begin
+    simp only [norm_eq_abs, abs_exp, of_real_mul_re, real.is_o_exp_comp_exp_comp],
+    refine (is_equivalent.refl.sub_is_o _).symm.tendsto_at_top (hl.tendsto_re.const_mul_at_top hb),
+    exact (hl.is_o_log_abs_re.const_mul_left _).const_mul_right hb.ne'
+  end
+
+/-- If `l : filter ℂ` is an "exponent comparison filter", then for any complex `a₁`, `a₂` and any
+real `b₁ < b₂`, we have `(λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z))`. -/
+lemma is_o_cpow_mul_exp {b₁ b₂ : ℝ} (hl : is_exp_cmp_filter l) (hb : b₁ < b₂) (a₁ a₂ : ℂ) :
+  (λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z)) :=
+calc (λ z, z ^ a₁ * exp (b₁ * z)) =ᶠ[l] (λ z, z ^ a₂ * exp (b₁ * z) * z ^ (a₁ - a₂)) :
+  hl.eventually_ne.mono $ λ z hz,
+    by { simp only, rw [mul_right_comm, ← cpow_add _ _ hz, add_sub_cancel'_right] }
+... =o[l] λ z, z ^ a₂ * exp (b₁ * z) * exp (↑(b₂ - b₁) * z) :
+  (is_O_refl (λ z, z ^ a₂ * exp (b₁ * z)) l).mul_is_o $ hl.is_o_cpow_exp _ (sub_pos.2 hb)
+... =ᶠ[l] λ z, z ^ a₂ * exp (b₂ * z) :
+  by simp only [of_real_sub, sub_mul, mul_assoc, ← exp_add, add_sub_cancel'_right]
+
+/-- If `l : filter ℂ` is an "exponent comparison filter", then for any complex `a` and any negative
+real `b`, we have `(λ z, exp (b * z)) =o[l] (λ z, z ^ a)`. -/
+lemma is_o_exp_cpow (hl : is_exp_cmp_filter l) (a : ℂ) {b : ℝ} (hb : b < 0) :
+  (λ z, exp (b * z)) =o[l] (λ z, z ^ a) :=
+by simpa using hl.is_o_cpow_mul_exp hb 0 a
+
+/-- If `l : filter ℂ` is an "exponent comparison filter", then for any complex `a₁`, `a₂` and any
+natural `b₁ < b₂`, we have `(λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z))`. -/
+lemma is_o_pow_mul_exp {b₁ b₂ : ℝ} (hl : is_exp_cmp_filter l) (hb : b₁ < b₂) (m n : ℕ) :
+  (λ z, z ^ m * exp (b₁ * z)) =o[l] (λ z, z ^ n * exp (b₂ * z)) :=
+by simpa only [cpow_nat_cast] using hl.is_o_cpow_mul_exp hb m n
+
+/-- If `l : filter ℂ` is an "exponent comparison filter", then for any complex `a₁`, `a₂` and any
+integer `b₁ < b₂`, we have `(λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z))`. -/
+lemma is_o_zpow_mul_exp {b₁ b₂ : ℝ} (hl : is_exp_cmp_filter l) (hb : b₁ < b₂) (m n : ℤ) :
+  (λ z, z ^ m * exp (b₁ * z)) =o[l] (λ z, z ^ n * exp (b₂ * z)) :=
+by simpa only [cpow_int_cast] using hl.is_o_cpow_mul_exp hb m n
+
+end is_exp_cmp_filter
+
+end complex

--- a/src/analysis/special_functions/compare_exp.lean
+++ b/src/analysis/special_functions/compare_exp.lean
@@ -30,10 +30,10 @@ open_locale topological_space
 
 namespace complex
 
-/-- We say that `l : filter ℂ` is an *exponent comparison filter* if the real part tends to infinity
-along `l` and the imaginary part grows subexponentially compared to the real part. These properties
-guarantee that `(λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z))` for any complex
-`a₁`, `a₂` and real `b₁ < b₂`.
+/-- We say that `l : filter ℂ` is an *exponential comparison filter* if the real part tends to
+infinity along `l` and the imaginary part grows subexponentially compared to the real part. These
+properties guarantee that `(λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z))` for any
+complex `a₁`, `a₂` and real `b₁ < b₂`.
 
 In particular, the second property is automatically satisfied if the imaginary part is bounded along
 `l`. -/
@@ -101,8 +101,8 @@ lemma abs_im_pow_eventually_le_exp_re (hl : is_exp_cmp_filter l) (n : ℕ) :
   (λ z : ℂ, |z.im| ^ n) ≤ᶠ[l] (λ z, real.exp z.re) :=
 by simpa using (hl.is_o_im_pow_exp_re n).bound zero_lt_one
 
-/-- If `l : filter ℂ` is an "exponent comparison filter", then $\log |z| =o(ℜ z)$ along `l`.
-This is the main lemma in 
+/-- If `l : filter ℂ` is an "exponential comparison filter", then $\log |z| =o(ℜ z)$ along `l`.
+This is the main lemma in the proof of `complex.is_exp_cmp_filter.is_o_cpow_exp` below.
 -/
 lemma is_o_log_abs_re (hl : is_exp_cmp_filter l) : (λ z, real.log (abs z)) =o[l] re :=
 calc (λ z, real.log (abs z)) =O[l] (λ z, real.log (real.sqrt 2) + real.log (max z.re (|z.im|))) :
@@ -133,8 +133,8 @@ calc (λ z, real.log (abs z)) =O[l] (λ z, real.log (real.sqrt 2) + real.log (ma
 ### Main results
 -/
 
-/-- If `l : filter ℂ` is an "exponent comparison filter", then for any complex `a` and any positive
-real `b`, we have `(λ z, z ^ a) =o[l] (λ z, exp (b * z))`. -/
+/-- If `l : filter ℂ` is an "exponential comparison filter", then for any complex `a` and any
+positive real `b`, we have `(λ z, z ^ a) =o[l] (λ z, exp (b * z))`. -/
 lemma is_o_cpow_exp (hl : is_exp_cmp_filter l) (a : ℂ) {b : ℝ} (hb : 0 < b) :
   (λ z, z ^ a) =o[l] (λ z, exp (b * z)) :=
 calc (λ z, z ^ a) =Θ[l] λ z, abs z ^ re a : is_Theta_cpow_const_rpow $ λ _ _, hl.eventually_ne
@@ -147,7 +147,7 @@ calc (λ z, z ^ a) =Θ[l] λ z, abs z ^ re a : is_Theta_cpow_const_rpow $ λ _ _
     exact (hl.is_o_log_abs_re.const_mul_left _).const_mul_right hb.ne'
   end
 
-/-- If `l : filter ℂ` is an "exponent comparison filter", then for any complex `a₁`, `a₂` and any
+/-- If `l : filter ℂ` is an "exponential comparison filter", then for any complex `a₁`, `a₂` and any
 real `b₁ < b₂`, we have `(λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z))`. -/
 lemma is_o_cpow_mul_exp {b₁ b₂ : ℝ} (hl : is_exp_cmp_filter l) (hb : b₁ < b₂) (a₁ a₂ : ℂ) :
   (λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z)) :=
@@ -159,19 +159,19 @@ calc (λ z, z ^ a₁ * exp (b₁ * z)) =ᶠ[l] (λ z, z ^ a₂ * exp (b₁ * z) 
 ... =ᶠ[l] λ z, z ^ a₂ * exp (b₂ * z) :
   by simp only [of_real_sub, sub_mul, mul_assoc, ← exp_add, add_sub_cancel'_right]
 
-/-- If `l : filter ℂ` is an "exponent comparison filter", then for any complex `a` and any negative
-real `b`, we have `(λ z, exp (b * z)) =o[l] (λ z, z ^ a)`. -/
+/-- If `l : filter ℂ` is an "exponential comparison filter", then for any complex `a` and any
+negative real `b`, we have `(λ z, exp (b * z)) =o[l] (λ z, z ^ a)`. -/
 lemma is_o_exp_cpow (hl : is_exp_cmp_filter l) (a : ℂ) {b : ℝ} (hb : b < 0) :
   (λ z, exp (b * z)) =o[l] (λ z, z ^ a) :=
 by simpa using hl.is_o_cpow_mul_exp hb 0 a
 
-/-- If `l : filter ℂ` is an "exponent comparison filter", then for any complex `a₁`, `a₂` and any
+/-- If `l : filter ℂ` is an "exponential comparison filter", then for any complex `a₁`, `a₂` and any
 natural `b₁ < b₂`, we have `(λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z))`. -/
 lemma is_o_pow_mul_exp {b₁ b₂ : ℝ} (hl : is_exp_cmp_filter l) (hb : b₁ < b₂) (m n : ℕ) :
   (λ z, z ^ m * exp (b₁ * z)) =o[l] (λ z, z ^ n * exp (b₂ * z)) :=
 by simpa only [cpow_nat_cast] using hl.is_o_cpow_mul_exp hb m n
 
-/-- If `l : filter ℂ` is an "exponent comparison filter", then for any complex `a₁`, `a₂` and any
+/-- If `l : filter ℂ` is an "exponential comparison filter", then for any complex `a₁`, `a₂` and any
 integer `b₁ < b₂`, we have `(λ z, z ^ a₁ * exp (b₁ * z)) =o[l] (λ z, z ^ a₂ * exp (b₂ * z))`. -/
 lemma is_o_zpow_mul_exp {b₁ b₂ : ℝ} (hl : is_exp_cmp_filter l) (hb : b₁ < b₂) (m n : ℤ) :
   (λ z, z ^ m * exp (b₁ * z)) =o[l] (λ z, z ^ n * exp (b₂ * z)) :=

--- a/src/analysis/special_functions/complex/arg.lean
+++ b/src/analysis/special_functions/complex/arg.lean
@@ -139,6 +139,8 @@ lemma arg_le_pi (x : ℂ) : arg x ≤ π :=
 lemma neg_pi_lt_arg (x : ℂ) : -π < arg x :=
 (arg_mem_Ioc x).1
 
+lemma abs_arg_le_pi (z : ℂ) : |arg z| ≤ π := abs_le.2 ⟨(neg_pi_lt_arg z).le, arg_le_pi z⟩
+
 @[simp] lemma arg_nonneg_iff {z : ℂ} : 0 ≤ arg z ↔ 0 ≤ z.im :=
 begin
   rcases eq_or_ne z 0 with (rfl|h₀), { simp },

--- a/src/analysis/special_functions/polynomials.lean
+++ b/src/analysis/special_functions/polynomials.lean
@@ -39,12 +39,10 @@ lemma is_equivalent_at_top_lead :
 begin
   by_cases h : P = 0,
   { simp [h] },
-  { conv_rhs
-    { funext,
-      rw [polynomial.eval_eq_sum_range, sum_range_succ] },
-    exact is_equivalent.refl.add_is_o (is_o.sum $ λ i hi, is_o.const_mul_left
+  { simp only [polynomial.eval_eq_sum_range, sum_range_succ],
+    exact is_o.add_is_equivalent (is_o.sum $ λ i hi, is_o.const_mul_left
       (is_o.const_mul_right (λ hz, h $ leading_coeff_eq_zero.mp hz) $
-        is_o_pow_pow_at_top_of_lt (mem_range.mp hi)) _) }
+        is_o_pow_pow_at_top_of_lt (mem_range.mp hi)) _) is_equivalent.refl }
 end
 
 lemma tendsto_at_top_of_leading_coeff_nonneg (hdeg : 0 < P.degree) (hnng : 0 ≤ P.leading_coeff) :

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -164,6 +164,10 @@ lemma tendsto.eventually_ne_at_top [preorder β] [no_max_order β] {f : α → �
   (hf : tendsto f l at_top) (c : β) : ∀ᶠ x in l, f x ≠ c :=
 hf.eventually (eventually_ne_at_top c)
 
+lemma tendsto.eventually_ne_at_top' [preorder β] [no_max_order β] {f : α → β} {l : filter α}
+  (hf : tendsto f l at_top) (c : α) : ∀ᶠ x in l, x ≠ c :=
+(hf.eventually_ne_at_top (f c)).mono $ λ x, ne_of_apply_ne f
+
 lemma eventually_lt_at_bot [preorder α] [no_min_order α] (a : α) :
   ∀ᶠ x in at_bot, x < a :=
 Iio_mem_at_bot a

--- a/src/order/liminf_limsup.lean
+++ b/src/order/liminf_limsup.lean
@@ -93,6 +93,9 @@ lemma is_bounded_under.mono_ge [preorder β] {l : filter α} {u v : α → β}
   (hu : is_bounded_under (≥) l u) (hv : u ≤ᶠ[l] v) : is_bounded_under (≥) l v :=
 @is_bounded_under.mono_le α βᵒᵈ _ _ _ _ hu hv
 
+lemma is_bounded_under_const [is_refl α r] {l : filter β} {a : α} : is_bounded_under r l (λ _, a) :=
+⟨a, eventually_map.2 $ eventually_of_forall $ λ _, refl _⟩
+
 lemma is_bounded.is_bounded_under {q : β → β → Prop} {u : α → β}
   (hf : ∀a₀ a₁, r a₀ a₁ → q (u a₀) (u a₁)) : f.is_bounded r → f.is_bounded_under q u
 | ⟨b, h⟩ := ⟨u b, show ∀ᶠ x in f, q (u x) (u b), from h.mono (λ x, hf x b)⟩


### PR DESCRIPTION
Prove `(λ z, z ^ a * exp (b * z)) =o[l] λ z, z ^ a' * exp (b' * z)` for an appropriate filter `l`, any complex `a`, `a'`, and real `b < b'`.

---

This is a new version of #14835. I added some unneeded lemmas to that branch, so I started a new one and cherry-picked "good" parts.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
