### PR TITLE
[Merged by Bors] - feat(algebra/field/opposite): Missing instances

### DIFF
--- a/src/algebra/field/opposite.lean
+++ b/src/algebra/field/opposite.lean
@@ -7,12 +7,10 @@ import algebra.field.basic
 import algebra.ring.opposite
 
 /-!
-# Field structure on the multiplicative opposite
+# Field structure on the multiplicative/additive opposite
 -/
 
 variables (α : Type*)
-
-namespace mul_opposite
 
 instance [division_semiring α] : division_semiring αᵐᵒᵖ :=
 { .. mul_opposite.group_with_zero α, .. mul_opposite.semiring α }
@@ -26,4 +24,14 @@ instance [semifield α] : semifield αᵐᵒᵖ :=
 instance [field α] : field αᵐᵒᵖ :=
 { .. mul_opposite.division_ring α, .. mul_opposite.comm_ring α }
 
-end mul_opposite
+instance [division_semiring α] : division_semiring αᵃᵒᵖ :=
+{ ..add_opposite.group_with_zero α, ..add_opposite.semiring α }
+
+instance [division_ring α] : division_ring αᵃᵒᵖ :=
+{ ..add_opposite.group_with_zero α, ..add_opposite.ring α }
+
+instance [semifield α] : semifield αᵃᵒᵖ :=
+{ ..add_opposite.division_semiring α, ..add_opposite.comm_semiring α }
+
+instance [field α] : field αᵃᵒᵖ :=
+{ ..add_opposite.division_ring α, ..add_opposite.comm_ring α }

--- a/src/algebra/field/opposite.lean
+++ b/src/algebra/field/opposite.lean
@@ -14,8 +14,14 @@ variables (α : Type*)
 
 namespace mul_opposite
 
+instance [division_semiring α] : division_semiring αᵐᵒᵖ :=
+{ .. mul_opposite.group_with_zero α, .. mul_opposite.semiring α }
+
 instance [division_ring α] : division_ring αᵐᵒᵖ :=
 { .. mul_opposite.group_with_zero α, .. mul_opposite.ring α }
+
+instance [semifield α] : semifield αᵐᵒᵖ :=
+{ .. mul_opposite.division_semiring α, .. mul_opposite.comm_semiring α }
 
 instance [field α] : field αᵐᵒᵖ :=
 { .. mul_opposite.division_ring α, .. mul_opposite.comm_ring α }


### PR DESCRIPTION
A few missing field-like instances for `mul_opposite` and `add_opposite`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
