### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/affine_isometry): `subtypeₐᵢ`

### DIFF
--- a/src/analysis/normed_space/affine_isometry.lean
+++ b/src/analysis/normed_space/affine_isometry.lean
@@ -197,9 +197,31 @@ instance : monoid (P →ᵃⁱ[𝕜] P) :=
 
 end affine_isometry
 
--- remark: by analogy with the `linear_isometry` file from which this is adapted, there should
--- follow here a section defining an "inclusion" affine isometry from `p : affine_subspace 𝕜 P`
--- into `P`; we omit this for now
+namespace affine_subspace
+
+include V
+
+/-- `affine_subspace.subtype` as an `affine_isometry`. -/
+def subtypeₐᵢ (s : affine_subspace 𝕜 P) [nonempty s] : s →ᵃⁱ[𝕜] P :=
+{ norm_map := s.direction.subtypeₗᵢ.norm_map,
+  .. s.subtype }
+
+lemma subtypeₐᵢ_linear (s : affine_subspace 𝕜 P) [nonempty s] :
+  s.subtypeₐᵢ.linear = s.direction.subtype :=
+rfl
+
+@[simp] lemma subtypeₐᵢ_linear_isometry (s : affine_subspace 𝕜 P) [nonempty s] :
+  s.subtypeₐᵢ.linear_isometry = s.direction.subtypeₗᵢ :=
+rfl
+
+@[simp] lemma coe_subtypeₐᵢ (s : affine_subspace 𝕜 P) [nonempty s] : ⇑s.subtypeₐᵢ = s.subtype :=
+rfl
+
+@[simp] lemma subtypeₐᵢ_to_affine_map (s : affine_subspace 𝕜 P) [nonempty s] :
+  s.subtypeₐᵢ.to_affine_map = s.subtype :=
+rfl
+
+end affine_subspace
 
 variables (𝕜 P P₂)
 include V V₂


### PR DESCRIPTION
Now that we have `affine_subspace.subtype`, add the corresponding definition as a bundled affine isometry (so resolving a comment about that being missing).

The name uses subscript `ₐᵢ` rather than superscript `ᵃⁱ` as in the notation for `affine_isometry` because Lean does not accept the superscript in identifiers.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
