### PR TITLE
[Merged by Bors] - feat(topology/separation): connected sets in a t1 space are infinite

### DIFF
--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -809,9 +809,9 @@ theorem is_clopen_iff [preconnected_space α] {s : set α} : is_clopen s ↔ s =
   h3 h2,
 by rintro (rfl | rfl); [exact is_clopen_empty, exact is_clopen_univ]⟩
 
-lemma eq_univ_of_nonempty_clopen [preconnected_space α] {s : set α}
-  (h : s.nonempty) (h' : is_clopen s) : s = univ :=
-by { rw is_clopen_iff at h', exact h'.resolve_left h.ne_empty }
+lemma is_clopen.eq_univ [preconnected_space α] {s : set α} (h' : is_clopen s) (h : s.nonempty) :
+  s = univ :=
+(is_clopen_iff.mp h').resolve_left h.ne_empty
 
 lemma frontier_eq_empty_iff [preconnected_space α] {s : set α} :
   frontier s = ∅ ↔ s = ∅ ∨ s = univ :=

--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -980,7 +980,7 @@ begin
   { introI hX,
     rw path_connected_space_iff_eq,
     use (classical.arbitrary X),
-    refine eq_univ_of_nonempty_clopen (by simp) ⟨_, _⟩,
+    refine is_clopen.eq_univ ⟨_, _⟩ (by simp),
     { rw is_open_iff_mem_nhds,
       intros y y_in,
       rcases (path_connected_basis y).ex_mem with ⟨U, ⟨U_in, hU⟩⟩,

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -673,8 +673,7 @@ begin
   exact @preconnected_space.trivial_of_discrete _ _ (subtype.preconnected_space h.2) _
 end
 
-@[priority 5]
-instance connected_space.infinite [connected_space α] [nontrivial α] [t1_space α] : infinite α :=
+lemma connected_space.infinite [connected_space α] [nontrivial α] [t1_space α] : infinite α :=
 infinite_univ_iff.mp $ is_connected_univ.infinite_of_nontrivial nontrivial_univ
 
 lemma singleton_mem_nhds_within_of_mem_discrete {s : set α} [discrete_topology s]

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -659,10 +659,9 @@ lemma preconnected_space.trivial_of_discrete [preconnected_space α] [discrete_t
 begin
   rw ←not_nontrivial_iff_subsingleton,
   rintro ⟨x, y, hxy⟩,
-  obtain h | h := is_clopen_iff.mp (is_clopen_discrete ({y} : set α)),
-  { exact (singleton_nonempty y).ne_empty h },
-  { rw [ne.def, ←mem_singleton_iff, h] at hxy,
-    exact hxy (mem_univ x) }
+  rw [ne.def, ←mem_singleton_iff,
+      eq_univ_of_nonempty_clopen (singleton_nonempty y) (is_clopen_discrete _)] at hxy,
+  exact hxy (mem_univ x)
 end
 
 lemma is_preconnected.infinite_of_nontrivial [t1_space α] {s : set α} (h : is_preconnected s)

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -665,16 +665,16 @@ begin
     exact hxy (mem_univ x) }
 end
 
-lemma is_connected.infinite_of_nontrivial [t1_space α] {s : set α} (h : is_connected s)
+lemma is_preconnected.infinite_of_nontrivial [t1_space α] {s : set α} (h : is_preconnected s)
   (hs : s.nontrivial) : s.infinite :=
 begin
   refine mt (λ hf, (subsingleton_coe s).mp _) (not_subsingleton_iff.mpr hs),
   haveI := @discrete_of_t1_of_finite s _ _ hf.to_subtype,
-  exact @preconnected_space.trivial_of_discrete _ _ (subtype.preconnected_space h.2) _
+  exact @preconnected_space.trivial_of_discrete _ _ (subtype.preconnected_space h) _
 end
 
 lemma connected_space.infinite [connected_space α] [nontrivial α] [t1_space α] : infinite α :=
-infinite_univ_iff.mp $ is_connected_univ.infinite_of_nontrivial nontrivial_univ
+infinite_univ_iff.mp $ is_preconnected_univ.infinite_of_nontrivial nontrivial_univ
 
 lemma singleton_mem_nhds_within_of_mem_discrete {s : set α} [discrete_topology s]
   {x : α} (hx : x ∈ s) :

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -659,8 +659,7 @@ lemma preconnected_space.trivial_of_discrete [preconnected_space α] [discrete_t
 begin
   rw ←not_nontrivial_iff_subsingleton,
   rintro ⟨x, y, hxy⟩,
-  rw [ne.def, ←mem_singleton_iff,
-      eq_univ_of_nonempty_clopen (singleton_nonempty y) (is_clopen_discrete _)] at hxy,
+  rw [ne.def, ←mem_singleton_iff, (is_clopen_discrete _).eq_univ $ singleton_nonempty y] at hxy,
   exact hxy (mem_univ x)
 end
 

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -654,6 +654,29 @@ begin
   exact (set.to_finite _).is_closed
 end
 
+lemma preconnected_space.trivial_of_discrete [preconnected_space α] [discrete_topology α] :
+  subsingleton α :=
+begin
+  rw ←not_nontrivial_iff_subsingleton,
+  rintro ⟨x, y, hxy⟩,
+  obtain h | h := is_clopen_iff.mp (is_clopen_discrete ({y} : set α)),
+  { exact (singleton_nonempty y).ne_empty h },
+  { rw [ne.def, ←mem_singleton_iff, h] at hxy,
+    exact hxy (mem_univ x) }
+end
+
+lemma is_connected.infinite_of_nontrivial [t1_space α] {s : set α} (h : is_connected s)
+  (hs : s.nontrivial) : s.infinite :=
+begin
+  refine mt (λ hf, (subsingleton_coe s).mp _) (not_subsingleton_iff.mpr hs),
+  haveI := @discrete_of_t1_of_finite s _ _ hf.to_subtype,
+  exact @preconnected_space.trivial_of_discrete _ _ (subtype.preconnected_space h.2) _
+end
+
+@[priority 5]
+instance connected_space.infinite [connected_space α] [nontrivial α] [t1_space α] : infinite α :=
+infinite_univ_iff.mp $ is_connected_univ.infinite_of_nontrivial nontrivial_univ
+
 lemma singleton_mem_nhds_within_of_mem_discrete {s : set α} [discrete_topology s]
   {x : α} (hx : x ∈ s) :
   {x} ∈ 𝓝[s] x :=


### PR DESCRIPTION
Also rename `eq_univ_of_nonempty_clopen` to `is_clopen.eq_univ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The result is trivial but I can't figure out the way to state it to fight Lean the least.
