### PR TITLE
[Merged by Bors] - feat(tactic/push_neg): option for an alternate normal form of `¬ (P ∧ Q)`

### DIFF
--- a/src/tactic/push_neg.lean
+++ b/src/tactic/push_neg.lean
@@ -10,6 +10,10 @@ import logic.basic
 
 open tactic expr
 
+/- Enable the option `trace.push_neg.use_distrib` in order to have `¬ (p ∧ q)` normalized to
+`¬ p ∨ ¬ q`, rather than the default `p → ¬ q`. -/
+declare_trace push_neg.use_distrib
+
 namespace push_neg
 section
 
@@ -21,6 +25,7 @@ variable  (s : α → Prop)
 local attribute [instance, priority 10] classical.prop_decidable
 theorem not_not_eq : (¬ ¬ p) = p := propext not_not
 theorem not_and_eq : (¬ (p ∧ q)) = (p → ¬ q) := propext not_and
+theorem not_and_distrib_eq : (¬ (p ∧ q)) = (¬ p ∨ ¬ q) := propext not_and_distrib
 theorem not_or_eq : (¬ (p ∨ q)) = (¬ p ∧ ¬ q) := propext not_or_distrib
 theorem not_forall_eq : (¬ ∀ x, s x) = (∃ x, ¬ s x) := propext not_forall
 theorem not_exists_eq : (¬ ∃ x, s x) = (∀ x, ¬ s x) := propext not_exists
@@ -48,8 +53,13 @@ do e ← whnf_reducible e,
       match ne with
       | `(¬ %%a)      := do pr ← mk_app ``not_not_eq [a],
                             return (some (a, pr))
-      | `(%%a ∧ %%b)  := do pr ← mk_app ``not_and_eq [a, b],
-                            return (some (`((%%a : Prop) → ¬ %%b), pr))
+      | `(%%a ∧ %%b)  := do distrib ← get_bool_option `trace.push_neg.use_distrib ff,
+                            if distrib then do
+                              pr ← mk_app ``not_and_distrib_eq [a, b],
+                              return (some (`(¬ (%%a : Prop) ∨ ¬ %%b), pr))
+                            else do
+                              pr ← mk_app ``not_and_eq [a, b],
+                              return (some (`((%%a : Prop) → ¬ %%b), pr))
       | `(%%a ∨ %%b)  := do pr ← mk_app ``not_or_eq [a, b],
                             return (some (`(¬ %%a ∧ ¬ %%b), pr))
       | `(%%a ≤ %%b)  := do e ← to_expr ``(%%b < %%a),

--- a/test/push_neg.lean
+++ b/test/push_neg.lean
@@ -89,3 +89,23 @@ begin
       guard (ht = h1t) ),
   exact hf
 end
+
+/-! Test the option `trace.push_neg.use_distrib` for changing the normal form of `¬(P ∧ Q)`. -/
+
+section
+
+example (a b : ℤ) (h : ¬ (∃ x, (a < x ∧ x < b))) : ∀ x, a < x → b ≤ x :=
+begin
+  push_neg at h,
+  exact h,
+end
+
+set_option trace.push_neg.use_distrib true
+
+example (a b : ℤ) (h : ¬ (∃ x, (a < x ∧ x < b))) : ∀ x, x ≤ a ∨ b ≤ x :=
+begin
+  push_neg at h,
+  exact h,
+end
+
+end


### PR DESCRIPTION
Backport a feature of the [mathlib4 version](https://github.com/leanprover-community/mathlib4/pull/344) of `push_neg`: an option to make `¬ (P ∧ Q)` be normalized to `¬ P ∨ ¬ Q`, rather than `P → ¬ Q`.  That was actually the original behaviour, but it was changed in  #3362.

I have implemented this as a global option `trace.push_neg.use_distrib` (using the [tracing option hack](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/custom.20options)) rather than as a piece of configuration information which is passed when using the tactic, because I imagine this feature will mostly be used in teaching (that was both my motivation and also @PatrickMassot's when he wrote the original version), where it is convenient to "set it and forget it".  This is also how it is implemented in the mathlib4 version (cc @dupuisf @j-loreaux).

Zulip:
https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/alternative.20normal.20form.20for.20push_neg

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
