### PR TITLE
[Merged by Bors] - feat(topology/algebra/group): discrete subgroup acts properly discontinuously

### DIFF
--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -1299,6 +1299,38 @@ lemma subset_set_smul_iff : A ⊆ a • B ↔ a⁻¹ • A ⊆ B :=
 iff.symm $ (image_subset_iff).trans $ iff.symm $ iff_of_eq $ congr_arg _ $
   image_equiv_eq_preimage_symm _ $ mul_action.to_perm _
 
+@[to_additive]
+lemma smul_inter_ne_empty_iff {s t : set α} {x : α} :
+  x • s ∩ t ≠ ∅ ↔ ∃ a b, (a ∈ t ∧ b ∈ s) ∧ a * b⁻¹ = x :=
+begin
+  rw ne_empty_iff_nonempty,
+  split,
+  { rintros ⟨a, h, ha⟩,
+    obtain ⟨b, hb, rfl⟩ := mem_smul_set.mp h,
+    exact ⟨x • b, b, ⟨ha, hb⟩, by simp⟩, },
+  { rintros ⟨a, b, ⟨ha, hb⟩, rfl⟩,
+    exact ⟨a, mem_inter (mem_smul_set.mpr ⟨b, hb, by simp⟩) ha⟩, },
+end
+
+@[to_additive]
+lemma smul_inter_ne_empty_iff' {s t : set α} {x : α} :
+  x • s ∩ t ≠ ∅ ↔ ∃ a b, (a ∈ t ∧ b ∈ s) ∧ a / b = x :=
+by simp_rw [smul_inter_ne_empty_iff, div_eq_mul_inv]
+
+@[to_additive]
+lemma op_smul_inter_ne_empty_iff {s t : set α} {x : αᵐᵒᵖ} :
+  x • s ∩ t ≠ ∅ ↔ ∃ a b, (a ∈ s ∧ b ∈ t) ∧ a⁻¹ * b = mul_opposite.unop x :=
+begin
+  rw ne_empty_iff_nonempty,
+  split,
+  { rintros ⟨a, h, ha⟩,
+    obtain ⟨b, hb, rfl⟩ := mem_smul_set.mp h,
+    exact ⟨b, x • b, ⟨hb, ha⟩, by simp⟩, },
+  { rintros ⟨a, b, ⟨ha, hb⟩, H⟩,
+    have : mul_opposite.op (a⁻¹ * b) = x := congr_arg mul_opposite.op H,
+    exact ⟨b, mem_inter (mem_smul_set.mpr ⟨a, ha, by simp [← this]⟩) hb⟩, },
+end
+
 end group
 
 section group_with_zero

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -1032,10 +1032,12 @@ begin
   exact topological_group.t1_space (G ⧸ S) ((quotient_map_quotient_mk.is_closed_preimage).mp hS),
 end
 
-/-- A discrete subgroup of a topological group `G` acts on `G` properly discontinuously on the left.
--/
-@[to_additive "A discrete subgroup of an additive topological group `G` acts on `G` properly
-discontinuously on the left."]
+/-- A subgroup `S` of a topological group `G` acts on `G` properly discontinuously on the left, if
+it is discrete in the sense that `S ∩ K` is finite for all compact `K`. (See also
+`discrete_topology`.) -/
+@[to_additive "A subgroup `S` of an additive topological group `G` acts on `G` properly
+discontinuously on the left, if it is discrete in the sense that `S ∩ K` is finite for all compact
+`K`. (See also `discrete_topology`."]
 lemma subgroup.properly_discontinuous_smul_of_tendsto_cofinite
   (S : subgroup G) (hS : tendsto S.subtype cofinite (cocompact G)) :
   properly_discontinuous_smul S G :=
@@ -1050,13 +1052,15 @@ lemma subgroup.properly_discontinuous_smul_of_tendsto_cofinite
 
 local attribute [semireducible] mul_opposite
 
-/-- A discrete subgroup of a topological group `G` acts on `G` properly discontinuously on the
-right.
+/-- A subgroup `S` of a topological group `G` acts on `G` properly discontinuously on the right, if
+it is discrete in the sense that `S ∩ K` is finite for all compact `K`. (See also
+`discrete_topology`.)
 
 If `G` is Hausdorff, this can be combined with `t2_space_of_properly_discontinuous_smul_of_t2_space`
 to show that the quotient group `G ⧸ S` is Hausdorff. -/
-@[to_additive "A discrete subgroup of an additive topological group `G` acts on `G` properly
-discontinuously on the right.
+@[to_additive "A subgroup `S` of an additive topological group `G` acts on `G` properly
+discontinuously on the right, if it is discrete in the sense that `S ∩ K` is finite for all compact
+`K`. (See also `discrete_topology`.)
 
 If `G` is Hausdorff, this can be combined with `t2_space_of_properly_discontinuous_vadd_of_t2_space`
 to show that the quotient group `G ⧸ S` is Hausdorff."]

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot
 import group_theory.group_action.conj_act
 import group_theory.group_action.quotient
 import order.filter.pointwise
-import tactic.congrm
 import topology.algebra.monoid
 import topology.compact_open
 import topology.sets.compacts

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -1043,18 +1043,10 @@ lemma subgroup.properly_discontinuous_smul_of_tendsto_cofinite
 { finite_disjoint_inter_image := begin
     intros K L hK hL,
     have H : set.finite _ := hS ((hL.prod hK).image continuous_div').compl_mem_cocompact,
+    rw [preimage_compl, compl_compl] at H,
     convert H,
     ext x,
-    obtain ⟨x, hx⟩ := x,
-    dsimp,
-    simp_rw [set.ext_iff, prod.exists],
-    calc ¬(∀ l, (∃ k, k ∈ K ∧ x * k = l) ∧ l ∈ L ↔ false)
-        ↔ ¬¬∃ l k, (l ∈ L ∧ k ∈ K) ∧ x * k = l : by tidy
-    ... ↔ ¬¬∃ l k, (l ∈ L ∧ k ∈ K) ∧ l / k = x :
-            begin
-              congrm ¬¬∃ l k, _ ∧ _,
-              rw [div_eq_iff_eq_mul, @comm G (=)],
-            end
+    simpa only [image_smul, mem_image, prod.exists] using set.smul_inter_ne_empty_iff',
   end }
 
 local attribute [semireducible] mul_opposite
@@ -1077,18 +1069,10 @@ lemma subgroup.properly_discontinuous_smul_opposite_of_tendsto_cofinite
     have : continuous (λ p : G × G, (p.1⁻¹, p.2)) := continuous_inv.prod_map continuous_id,
     have H : set.finite _ :=
       hS ((hK.prod hL).image (continuous_mul.comp this)).compl_mem_cocompact,
-    convert H using 1,
+    rw [preimage_compl, compl_compl] at H,
+    convert H,
     ext x,
-    obtain ⟨x, hx⟩ := x,
-    dsimp,
-    simp_rw [set.ext_iff, prod.exists],
-    calc (¬∀ (l : G), (∃ (k : G), k ∈ K ∧ k * x = l) ∧ l ∈ L ↔ false)
-        ↔ ¬¬∃ (k l : G), (k ∈ K ∧ l ∈ L) ∧ k * x = l : by tidy
-    ... ↔ ¬¬∃ (k l : G), (k ∈ K ∧ l ∈ L) ∧ k⁻¹ * l = x :
-            begin
-              congrm ¬¬∃ (k l : G), (k ∈ K ∧ l ∈ L) ∧ _,
-              rw [inv_mul_eq_iff_eq_mul, @comm G (=)]
-            end
+    simpa only [image_smul, mem_image, prod.exists] using set.op_smul_inter_ne_empty_iff,
   end }
 
 end

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot
 import group_theory.group_action.conj_act
 import group_theory.group_action.quotient
 import order.filter.pointwise
+import tactic.congrm
 import topology.algebra.monoid
 import topology.compact_open
 import topology.sets.compacts
@@ -1031,6 +1032,64 @@ begin
   rw ← quotient_group.ker_mk S at hS,
   exact topological_group.t1_space (G ⧸ S) ((quotient_map_quotient_mk.is_closed_preimage).mp hS),
 end
+
+/-- A discrete subgroup of a topological group `G` acts on `G` properly discontinuously on the left.
+-/
+@[to_additive "A discrete subgroup of an additive topological group `G` acts on `G` properly
+discontinuously on the left."]
+lemma subgroup.properly_discontinuous_smul_of_tendsto_cofinite
+  (S : subgroup G) (hS : tendsto S.subtype cofinite (cocompact G)) :
+  properly_discontinuous_smul S G :=
+{ finite_disjoint_inter_image := begin
+    intros K L hK hL,
+    have H : set.finite _ := hS ((hL.prod hK).image continuous_div').compl_mem_cocompact,
+    convert H,
+    ext x,
+    obtain ⟨x, hx⟩ := x,
+    dsimp,
+    simp_rw [set.ext_iff, prod.exists],
+    calc ¬(∀ l, (∃ k, k ∈ K ∧ x * k = l) ∧ l ∈ L ↔ false)
+        ↔ ¬¬∃ l k, (l ∈ L ∧ k ∈ K) ∧ x * k = l : by tidy
+    ... ↔ ¬¬∃ l k, (l ∈ L ∧ k ∈ K) ∧ l / k = x :
+            begin
+              congrm ¬¬∃ l k, _ ∧ _,
+              rw [div_eq_iff_eq_mul, @comm G (=)],
+            end
+  end }
+
+local attribute [semireducible] mul_opposite
+
+/-- A discrete subgroup of a topological group `G` acts on `G` properly discontinuously on the
+right.
+
+If `G` is Hausdorff, this can be combined with `t2_space_of_properly_discontinuous_smul_of_t2_space`
+to show that the quotient group `G ⧸ S` is Hausdorff. -/
+@[to_additive "A discrete subgroup of an additive topological group `G` acts on `G` properly
+discontinuously on the right.
+
+If `G` is Hausdorff, this can be combined with `t2_space_of_properly_discontinuous_vadd_of_t2_space`
+to show that the quotient group `G ⧸ S` is Hausdorff."]
+lemma subgroup.properly_discontinuous_smul_opposite_of_tendsto_cofinite
+  (S : subgroup G) (hS : tendsto S.subtype cofinite (cocompact G)) :
+  properly_discontinuous_smul S.opposite G :=
+{ finite_disjoint_inter_image := begin
+    intros K L hK hL,
+    have : continuous (λ p : G × G, (p.1⁻¹, p.2)) := continuous_inv.prod_map continuous_id,
+    have H : set.finite _ :=
+      hS ((hK.prod hL).image (continuous_mul.comp this)).compl_mem_cocompact,
+    convert H using 1,
+    ext x,
+    obtain ⟨x, hx⟩ := x,
+    dsimp,
+    simp_rw [set.ext_iff, prod.exists],
+    calc (¬∀ (l : G), (∃ (k : G), k ∈ K ∧ k * x = l) ∧ l ∈ L ↔ false)
+        ↔ ¬¬∃ (k l : G), (k ∈ K ∧ l ∈ L) ∧ k * x = l : by tidy
+    ... ↔ ¬¬∃ (k l : G), (k ∈ K ∧ l ∈ L) ∧ k⁻¹ * l = x :
+            begin
+              congrm ¬¬∃ (k l : G), (k ∈ K ∧ l ∈ L) ∧ _,
+              rw [inv_mul_eq_iff_eq_mul, @comm G (=)]
+            end
+  end }
 
 end
 


### PR DESCRIPTION
A discrete subgroup of a topological group acts properly discontinuously on the left and on the right.  Here discrete means finite intersection with any compact subset.

Co-authored-by: Alex Kontorovich <58564076+AlexKontorovich@users.noreply.github.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
