### PR TITLE
[Merged by Bors] - feat(algebra/order/hom/monoid): add `monotone_iff_map_nonneg/pos` + golf

### DIFF
--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -316,7 +316,7 @@ section real
 variables {R S : Type*} [ordered_ring R] [linear_ordered_ring S]
 
 lemma ring_hom_monotone (hR : ∀ r : R, 0 ≤ r → ∃ s : R, s^2 = r) (f : R →+* S) : monotone f :=
-monotone_iff_map_nonneg.2 $ λ r h, by { obtain ⟨s, rfl⟩ := hR r h, rw map_pow, apply sq_nonneg }
+(monotone_iff_map_nonneg f).2 $ λ r h, by { obtain ⟨s, rfl⟩ := hR r h, rw map_pow, apply sq_nonneg }
 
 /-- There exists no nontrivial ring homomorphism `ℝ →+* ℝ`. -/
 instance real.ring_hom.unique : unique (ℝ →+* ℝ) :=

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -316,16 +316,7 @@ section real
 variables {R S : Type*} [ordered_ring R] [linear_ordered_ring S]
 
 lemma ring_hom_monotone (hR : ∀ r : R, 0 ≤ r → ∃ s : R, s^2 = r) (f : R →+* S) : monotone f :=
-begin
-  intros a b hab,
-  apply le_of_sub_nonneg,
-  obtain ⟨s, hs⟩ := hR (b - a) (sub_nonneg.mpr hab),
-  calc
-    f b - f a = f (b - a) : (ring_hom.map_sub _ _ _).symm
-          ... = f(s^2)    : by rw ←hs
-          ... = f(s)^2    : ring_hom.map_pow _ _ _
-          ... ≥ 0         : sq_nonneg _
-end
+monotone_iff_map_nonneg.2 $ λ r h, by { obtain ⟨s, rfl⟩ := hR r h, rw map_pow, apply sq_nonneg }
 
 /-- There exists no nontrivial ring homomorphism `ℝ →+* ℝ`. -/
 instance real.ring_hom.unique : unique (ℝ →+* ℝ) :=

--- a/src/algebra/order/hom/monoid.lean
+++ b/src/algebra/order/hom/monoid.lean
@@ -172,10 +172,9 @@ lemma map_nonpos (ha : a ≤ 0) : f a ≤ 0 := by { rw ←map_zero f, exact orde
 end ordered_add_comm_monoid
 
 section ordered_add_comm_group
-variables [ordered_add_comm_group α]
 
-section
-variables [ordered_add_comm_monoid β] [add_monoid_hom_class F α β] (f : F)
+variables [ordered_add_comm_group α]
+  [ordered_add_comm_monoid β] [add_monoid_hom_class F α β] (f : F)
 
 lemma monotone_iff_map_nonneg : monotone (f : α → β) ↔ ∀ a, 0 ≤ a → 0 ≤ f a :=
 ⟨λ h a, by { rw ←map_zero f, apply h }, λ h a b hl,
@@ -188,10 +187,7 @@ antitone_comp_of_dual_iff.symm.trans $ antitone_iff_map_nonpos _
 lemma antitone_iff_map_nonneg : antitone (f : α → β) ↔ ∀ a ≤ 0, 0 ≤ f a :=
 monotone_comp_of_dual_iff.symm.trans $ monotone_iff_map_nonneg _
 
-end
-
-section
-variables [ordered_cancel_add_comm_monoid β] [add_monoid_hom_class F α β] (f : F)
+variable [covariant_class β β (+) (<)]
 
 lemma strict_mono_iff_map_pos : strict_mono (f : α → β) ↔ ∀ a, 0 < a → 0 < f a :=
 ⟨λ h a, by { rw ←map_zero f, apply h }, λ h a b hl,
@@ -203,8 +199,6 @@ lemma strict_mono_iff_map_neg : strict_mono (f : α → β) ↔ ∀ a < 0, f a <
 strict_anti_comp_of_dual_iff.symm.trans $ strict_anti_iff_map_neg _
 lemma strict_anti_iff_map_pos : strict_anti (f : α → β) ↔ ∀ a < 0, 0 < f a :=
 strict_mono_comp_of_dual_iff.symm.trans $ strict_mono_iff_map_pos _
-
-end
 
 end ordered_add_comm_group
 

--- a/src/algebra/order/hom/monoid.lean
+++ b/src/algebra/order/hom/monoid.lean
@@ -171,6 +171,20 @@ lemma map_nonpos (ha : a ≤ 0) : f a ≤ 0 := by { rw ←map_zero f, exact orde
 
 end ordered_add_comm_monoid
 
+section ordered_add_comm_group
+variables [ordered_add_comm_group α] [ordered_add_comm_monoid β] [add_monoid_hom_class F α β]
+  {f : F}
+
+lemma monotone_iff_map_nonneg : monotone (f : α → β) ↔ ∀ a, 0 ≤ a → 0 ≤ f a :=
+⟨λ h a, by { rw ←map_zero f, apply h }, λ h a b hl,
+  by { rw [←sub_add_cancel b a, map_add f], exact le_add_of_nonneg_left (h _ $ sub_nonneg.2 hl) }⟩
+
+lemma monotone_iff_map_nonpos : monotone (f : α → β) ↔ ∀ a ≤ 0, f a ≤ 0 :=
+⟨λ h a, by { rw ←map_zero f, apply h }, λ h a b hl,
+  by { rw [←sub_add_cancel a b, map_add f], exact add_le_of_nonpos_left (h _ $ sub_nonpos.2 hl) }⟩
+
+end ordered_add_comm_group
+
 namespace order_monoid_hom
 section preorder
 variables [preorder α] [preorder β] [preorder γ] [preorder δ] [mul_one_class α]

--- a/src/algebra/order/hom/monoid.lean
+++ b/src/algebra/order/hom/monoid.lean
@@ -182,11 +182,11 @@ lemma monotone_iff_map_nonneg : monotone (f : α → β) ↔ ∀ a, 0 ≤ a → 
   by { rw [←sub_add_cancel b a, map_add f], exact le_add_of_nonneg_left (h _ $ sub_nonneg.2 hl) }⟩
 
 lemma antitone_iff_map_nonpos : antitone (f : α → β) ↔ ∀ a, 0 ≤ a → f a ≤ 0 :=
-by { rw ←monotone_to_dual_comp_iff, apply monotone_iff_map_nonneg }
-lemma antitone_iff_map_nonneg : antitone (f : α → β) ↔ ∀ a ≤ 0, 0 ≤ f a :=
-by { rw ←monotone_comp_of_dual_iff, apply monotone_iff_map_nonneg }
+monotone_to_dual_comp_iff.symm.trans $ monotone_iff_map_nonneg _
 lemma monotone_iff_map_nonpos : monotone (f : α → β) ↔ ∀ a ≤ 0, f a ≤ 0 :=
-by { rw ←antitone_comp_of_dual_iff, apply antitone_iff_map_nonpos }
+antitone_comp_of_dual_iff.symm.trans $ antitone_iff_map_nonpos _
+lemma antitone_iff_map_nonneg : antitone (f : α → β) ↔ ∀ a ≤ 0, 0 ≤ f a :=
+monotone_comp_of_dual_iff.symm.trans $ monotone_iff_map_nonneg _
 
 end
 
@@ -198,11 +198,11 @@ lemma strict_mono_iff_map_pos : strict_mono (f : α → β) ↔ ∀ a, 0 < a →
   by { rw [←sub_add_cancel b a, map_add f], exact lt_add_of_pos_left _ (h _ $ sub_pos.2 hl) }⟩
 
 lemma strict_anti_iff_map_neg : strict_anti (f : α → β) ↔ ∀ a, 0 < a → f a < 0 :=
-by { rw ←strict_mono_to_dual_comp_iff, apply strict_mono_iff_map_pos }
-lemma strict_anti_iff_map_pos : strict_anti (f : α → β) ↔ ∀ a < 0, 0 < f a :=
-by { rw ←strict_mono_comp_of_dual_iff, apply strict_mono_iff_map_pos }
+strict_mono_to_dual_comp_iff.symm.trans $ strict_mono_iff_map_pos _
 lemma strict_mono_iff_map_neg : strict_mono (f : α → β) ↔ ∀ a < 0, f a < 0 :=
-by { rw ←strict_anti_comp_of_dual_iff, apply strict_anti_iff_map_neg }
+strict_anti_comp_of_dual_iff.symm.trans $ strict_anti_iff_map_neg _
+lemma strict_anti_iff_map_pos : strict_anti (f : α → β) ↔ ∀ a < 0, 0 < f a :=
+strict_mono_comp_of_dual_iff.symm.trans $ strict_mono_iff_map_pos _
 
 end
 

--- a/src/algebra/order/hom/monoid.lean
+++ b/src/algebra/order/hom/monoid.lean
@@ -172,16 +172,39 @@ lemma map_nonpos (ha : a ≤ 0) : f a ≤ 0 := by { rw ←map_zero f, exact orde
 end ordered_add_comm_monoid
 
 section ordered_add_comm_group
-variables [ordered_add_comm_group α] [ordered_add_comm_monoid β] [add_monoid_hom_class F α β]
-  {f : F}
+variables [ordered_add_comm_group α]
+
+section
+variables [ordered_add_comm_monoid β] [add_monoid_hom_class F α β] (f : F)
 
 lemma monotone_iff_map_nonneg : monotone (f : α → β) ↔ ∀ a, 0 ≤ a → 0 ≤ f a :=
 ⟨λ h a, by { rw ←map_zero f, apply h }, λ h a b hl,
   by { rw [←sub_add_cancel b a, map_add f], exact le_add_of_nonneg_left (h _ $ sub_nonneg.2 hl) }⟩
 
+lemma antitone_iff_map_nonpos : antitone (f : α → β) ↔ ∀ a, 0 ≤ a → f a ≤ 0 :=
+by { rw ←monotone_to_dual_comp_iff, apply monotone_iff_map_nonneg }
+lemma antitone_iff_map_nonneg : antitone (f : α → β) ↔ ∀ a ≤ 0, 0 ≤ f a :=
+by { rw ←monotone_comp_of_dual_iff, apply monotone_iff_map_nonneg }
 lemma monotone_iff_map_nonpos : monotone (f : α → β) ↔ ∀ a ≤ 0, f a ≤ 0 :=
+by { rw ←antitone_comp_of_dual_iff, apply antitone_iff_map_nonpos }
+
+end
+
+section
+variables [ordered_cancel_add_comm_monoid β] [add_monoid_hom_class F α β] (f : F)
+
+lemma strict_mono_iff_map_pos : strict_mono (f : α → β) ↔ ∀ a, 0 < a → 0 < f a :=
 ⟨λ h a, by { rw ←map_zero f, apply h }, λ h a b hl,
-  by { rw [←sub_add_cancel a b, map_add f], exact add_le_of_nonpos_left (h _ $ sub_nonpos.2 hl) }⟩
+  by { rw [←sub_add_cancel b a, map_add f], exact lt_add_of_pos_left _ (h _ $ sub_pos.2 hl) }⟩
+
+lemma strict_anti_iff_map_neg : strict_anti (f : α → β) ↔ ∀ a, 0 < a → f a < 0 :=
+by { rw ←strict_mono_to_dual_comp_iff, apply strict_mono_iff_map_pos }
+lemma strict_anti_iff_map_pos : strict_anti (f : α → β) ↔ ∀ a < 0, 0 < f a :=
+by { rw ←strict_mono_comp_of_dual_iff, apply strict_mono_iff_map_pos }
+lemma strict_mono_iff_map_neg : strict_mono (f : α → β) ↔ ∀ a < 0, f a < 0 :=
+by { rw ←strict_anti_comp_of_dual_iff, apply strict_anti_iff_map_neg }
+
+end
 
 end ordered_add_comm_group
 


### PR DESCRIPTION
If the source is an ordered add_group, a monoid hom is monotone if and only if it sends nonnegative elements to a nonnegative elements. This connects the notion of [positive linear functional](https://en.wikipedia.org/wiki/Positive_linear_functional) to monotonicity.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Amenable.20Groups/near/300076886)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
