### PR TITLE
[Merged by Bors] - chore(category/endomorphism): remove unneeded ext attribute

### DIFF
--- a/src/category_theory/endomorphism.lean
+++ b/src/category_theory/endomorphism.lean
@@ -99,8 +99,6 @@ The order of arguments in multiplication agrees with
 -/
 def Aut (X : C) := X ≅ X
 
-attribute [ext Aut] iso.ext
-
 namespace Aut
 
 instance inhabited : inhabited (Aut X) := ⟨iso.refl X⟩


### PR DESCRIPTION
Removes an unnecessary `@[ext]` attribute that used an extended syntax which we are not planning to port to mathlib4.

Closes #16602.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
