### PR TITLE
[Merged by Bors] - chore(linear_algebra/matrix/adjugate): remove unnecessary fin_cases with

### DIFF
--- a/src/linear_algebra/matrix/adjugate.lean
+++ b/src/linear_algebra/matrix/adjugate.lean
@@ -346,7 +346,7 @@ lemma adjugate_fin_two (A : matrix (fin 2) (fin 2) α) :
 begin
   ext i j,
   rw [adjugate_apply, det_fin_two],
-  fin_cases i with [0, 1]; fin_cases j with [0, 1];
+  fin_cases i; fin_cases j;
   simp only [nat.one_ne_zero, one_mul, fin.one_eq_zero_iff, pi.single_eq_same, zero_mul,
     fin.zero_eq_one_iff, sub_zero, pi.single_eq_of_ne, ne.def, not_false_iff, update_row_self,
     update_row_ne, cons_val_zero, mul_zero, mul_one, zero_sub, cons_val_one, head_cons, of_apply],


### PR DESCRIPTION
This was the only use of `fin_cases ... with ...` in mathlib, and it wasn't even necessary. Removing it to avoid having to port unused tactic features.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
