### PR TITLE
[Merged by Bors] - feat(topology/uniform_space/completion): add uniform_completion.complete_equiv_self

### DIFF
--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1446,6 +1446,9 @@ variables {f}
 lemma function.surjective.dense_range (hf : function.surjective f) : dense_range f :=
 λ x, by simp [hf.range_eq]
 
+lemma dense_range_id : dense_range (id : α → α) :=
+function.surjective.dense_range function.surjective_id
+
 lemma dense_range_iff_closure_range : dense_range f ↔ closure (range f) = univ :=
 dense_iff_closure_eq
 

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -241,11 +241,11 @@ lemma uniform_continuous_compare_equiv_symm : uniform_continuous (pkg.compare_eq
 pkg'.uniform_continuous_compare pkg
 
 /-- the completion of a complete space is uniform-equivalent to itself -/
-def abstract_completion.complete_equiv_self {α : Type*} [uniform_space α]
+def complete_equiv_self {α : Type*} [uniform_space α]
 [separated_space α] [complete_space α] (pkg : abstract_completion α) :
 pkg.space ≃ᵤ α :=
-abstract_completion.compare_equiv pkg (abstract_completion.mk α id
-  (by apply_instance) (by apply_instance) (by apply_instance) uniform_inducing_id dense_range_id)
+compare_equiv pkg (mk α id(by apply_instance) (by apply_instance) (by apply_instance)
+  uniform_inducing_id dense_range_id)
 
 end compare
 

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -68,7 +68,7 @@ variables {α : Type*} [uniform_space α] (pkg : abstract_completion α)
 local notation `hatα` := pkg.space
 local notation `ι` := pkg.coe
 
-/-- If `α` is complete, then it is an abstract completion of itself -/
+/-- If `α` is complete, then it is an abstract completion of itself. -/
 def of_complete [separated_space α] [complete_space α] : abstract_completion α :=
 mk α id (by apply_instance) (by apply_instance) (by apply_instance) uniform_inducing_id
   dense_range_id

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -223,8 +223,6 @@ begin
   refl
 end
 
-instance : uniform_space pkg.space := pkg.uniform_struct
-
 /-- The uniform bijection between two completions of the same uniform space. -/
 def compare_equiv : pkg.space ≃ᵤ pkg'.space :=
 { to_fun := pkg.compare pkg',
@@ -240,7 +238,7 @@ pkg.uniform_continuous_compare pkg'
 lemma uniform_continuous_compare_equiv_symm : uniform_continuous (pkg.compare_equiv pkg').symm :=
 pkg'.uniform_continuous_compare pkg
 
-/-- the completion of a complete space is uniform-equivalent to itself -/
+/-- The uniform bijection between a complete space and its abstract completion. -/
 def complete_equiv_self {α : Type*} [uniform_space α]
 [separated_space α] [complete_space α] (pkg : abstract_completion α) :
 pkg.space ≃ᵤ α :=

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -225,7 +225,7 @@ end
 
 instance : uniform_space pkg.space := pkg.uniform_struct
 
-/-- The bijection between two completions of the same uniform space. -/
+/-- The uniform bijection between two completions of the same uniform space. -/
 def compare_equiv : pkg.space ≃ᵤ pkg'.space :=
 { to_fun := pkg.compare pkg',
   inv_fun := pkg'.compare pkg,

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -240,6 +240,13 @@ pkg.uniform_continuous_compare pkg'
 lemma uniform_continuous_compare_equiv_symm : uniform_continuous (pkg.compare_equiv pkg').symm :=
 pkg'.uniform_continuous_compare pkg
 
+/-- the completion of a complete space is uniform-equivalent to itself -/
+def abstract_completion.complete_equiv_self {α : Type*} [uniform_space α]
+[separated_space α] [complete_space α] (pkg : abstract_completion α) :
+pkg.space ≃ᵤ α :=
+abstract_completion.compare_equiv pkg (abstract_completion.mk α id
+  (by apply_instance) (by apply_instance) (by apply_instance) uniform_inducing_id dense_range_id)
+
 end compare
 
 section prod

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -70,8 +70,7 @@ local notation `ι` := pkg.coe
 
 /-- If `α` is complete, then it is an abstract completion of itself. -/
 def of_complete [separated_space α] [complete_space α] : abstract_completion α :=
-mk α id (by apply_instance) (by apply_instance) (by apply_instance) uniform_inducing_id
-  dense_range_id
+mk α id infer_instance infer_instance infer_instance uniform_inducing_id dense_range_id
 
 lemma closure_range : closure (range ι) = univ :=
 pkg.dense.closure_range

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -68,6 +68,11 @@ variables {α : Type*} [uniform_space α] (pkg : abstract_completion α)
 local notation `hatα` := pkg.space
 local notation `ι` := pkg.coe
 
+/-- If `α` is complete, then it is an abstract completion of itself -/
+def eq_itself_of_complete [separated_space α] [complete_space α] : abstract_completion α :=
+(mk α id (by apply_instance) (by apply_instance) (by apply_instance) uniform_inducing_id
+  dense_range_id)
+
 lemma closure_range : closure (range ι) = univ :=
 pkg.dense.closure_range
 
@@ -238,13 +243,6 @@ pkg.uniform_continuous_compare pkg'
 lemma uniform_continuous_compare_equiv_symm : uniform_continuous (pkg.compare_equiv pkg').symm :=
 pkg'.uniform_continuous_compare pkg
 
-/-- The uniform bijection between a complete space and its abstract completion. -/
-def complete_equiv_self {α : Type*} [uniform_space α]
-[separated_space α] [complete_space α] (pkg : abstract_completion α) :
-pkg.space ≃ᵤ α :=
-compare_equiv pkg (mk α id(by apply_instance) (by apply_instance) (by apply_instance)
-  uniform_inducing_id dense_range_id)
-
 end compare
 
 section prod
@@ -262,8 +260,6 @@ protected def prod : abstract_completion (α × β) :=
   uniform_inducing := uniform_inducing.prod pkg.uniform_inducing pkg'.uniform_inducing,
   dense := pkg.dense.prod_map pkg'.dense }
 end prod
-
-
 
 section extension₂
 variables (pkg' : abstract_completion β)

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -69,9 +69,9 @@ local notation `hatα` := pkg.space
 local notation `ι` := pkg.coe
 
 /-- If `α` is complete, then it is an abstract completion of itself -/
-def eq_itself_of_complete [separated_space α] [complete_space α] : abstract_completion α :=
-(mk α id (by apply_instance) (by apply_instance) (by apply_instance) uniform_inducing_id
-  dense_range_id)
+def of_complete [separated_space α] [complete_space α] : abstract_completion α :=
+mk α id (by apply_instance) (by apply_instance) (by apply_instance) uniform_inducing_id
+  dense_range_id
 
 lemma closure_range : closure (range ι) = univ :=
 pkg.dense.closure_range

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
 import topology.uniform_space.uniform_embedding
+import topology.uniform_space.equiv
 
 /-!
 # Abstract theory of Hausdorff completions of uniform spaces
@@ -222,12 +223,16 @@ begin
   refl
 end
 
+instance : uniform_space pkg.space := pkg.uniform_struct
+
 /-- The bijection between two completions of the same uniform space. -/
-def compare_equiv : pkg.space ≃ pkg'.space :=
+def compare_equiv : pkg.space ≃ᵤ pkg'.space :=
 { to_fun := pkg.compare pkg',
   inv_fun := pkg'.compare pkg,
   left_inv := congr_fun (pkg'.inverse_compare pkg),
-  right_inv := congr_fun (pkg.inverse_compare pkg') }
+  right_inv := congr_fun (pkg.inverse_compare pkg'),
+  uniform_continuous_to_fun := uniform_continuous_compare _ _,
+  uniform_continuous_inv_fun := uniform_continuous_compare _ _, }
 
 lemma uniform_continuous_compare_equiv : uniform_continuous (pkg.compare_equiv pkg') :=
 pkg.uniform_continuous_compare pkg'

--- a/src/topology/uniform_space/compare_reals.lean
+++ b/src/topology/uniform_space/compare_reals.lean
@@ -103,7 +103,7 @@ instance bourbaki.uniform_space: uniform_space Bourbakiℝ := completion.uniform
 /-- Bourbaki reals packaged as a completion of Q using the general theory. -/
 def Bourbaki_pkg : abstract_completion Q := completion.cpkg
 
-/-- The uniform bijection between Bourbaki and Cauchy reals-/
+/-- The uniform bijection between Bourbaki and Cauchy reals. -/
 noncomputable def compare_equiv : Bourbakiℝ ≃ᵤ ℝ :=
 Bourbaki_pkg.compare_equiv rational_cau_seq_pkg
 

--- a/src/topology/uniform_space/compare_reals.lean
+++ b/src/topology/uniform_space/compare_reals.lean
@@ -103,7 +103,7 @@ instance bourbaki.uniform_space: uniform_space Bourbakiℝ := completion.uniform
 /-- Bourbaki reals packaged as a completion of Q using the general theory. -/
 def Bourbaki_pkg : abstract_completion Q := completion.cpkg
 
-/-- The equivalence between Bourbaki and Cauchy reals-/
+/-- The uniform bijection between Bourbaki and Cauchy reals-/
 noncomputable def compare_equiv : Bourbakiℝ ≃ᵤ ℝ :=
 Bourbaki_pkg.compare_equiv rational_cau_seq_pkg
 

--- a/src/topology/uniform_space/compare_reals.lean
+++ b/src/topology/uniform_space/compare_reals.lean
@@ -104,7 +104,7 @@ instance bourbaki.uniform_space: uniform_space Bourbakiℝ := completion.uniform
 def Bourbaki_pkg : abstract_completion Q := completion.cpkg
 
 /-- The equivalence between Bourbaki and Cauchy reals-/
-noncomputable def compare_equiv : Bourbakiℝ ≃ ℝ :=
+noncomputable def compare_equiv : Bourbakiℝ ≃ᵤ ℝ :=
 Bourbaki_pkg.compare_equiv rational_cau_seq_pkg
 
 lemma compare_uc : uniform_continuous (compare_equiv) :=

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -407,7 +407,7 @@ lemma dense_inducing_coe : dense_inducing (coe : α → completion α) :=
 { dense := dense_range_coe,
   ..(uniform_inducing_coe α).inducing }
 
-/-- the uniform completion of a complete space is uniform-equivalent to itself -/
+/-- The uniform bijection between a complete space and its uniform completion. -/
 def uniform_completion.complete_equiv_self [complete_space α] [separated_space α]:
 completion α ≃ᵤ α := abstract_completion.complete_equiv_self completion.cpkg
 

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -408,8 +408,7 @@ lemma dense_inducing_coe : dense_inducing (coe : α → completion α) :=
   ..(uniform_inducing_coe α).inducing }
 
 /-- the uniform completion of a complete space is uniform-equivalent to itself -/
-def uniform_completion.complete_equiv_self {α : Type*} [uniform_space α]
-[complete_space α] [separated_space α]:
+def uniform_completion.complete_equiv_self [complete_space α] [separated_space α]:
 completion α ≃ᵤ α :=
 abstract_completion.complete_equiv_self completion.cpkg
 

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -409,7 +409,8 @@ lemma dense_inducing_coe : dense_inducing (coe : α → completion α) :=
 
 /-- The uniform bijection between a complete space and its uniform completion. -/
 def uniform_completion.complete_equiv_self [complete_space α] [separated_space α]:
-completion α ≃ᵤ α := abstract_completion.complete_equiv_self completion.cpkg
+  completion α ≃ᵤ α :=
+abstract_completion.compare_equiv completion.cpkg abstract_completion.eq_itself_of_complete
 
 open topological_space
 

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -410,7 +410,7 @@ lemma dense_inducing_coe : dense_inducing (coe : α → completion α) :=
 /-- The uniform bijection between a complete space and its uniform completion. -/
 def uniform_completion.complete_equiv_self [complete_space α] [separated_space α]:
   completion α ≃ᵤ α :=
-abstract_completion.compare_equiv completion.cpkg abstract_completion.eq_itself_of_complete
+abstract_completion.compare_equiv completion.cpkg abstract_completion.of_complete
 
 open topological_space
 

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -407,6 +407,12 @@ lemma dense_inducing_coe : dense_inducing (coe : α → completion α) :=
 { dense := dense_range_coe,
   ..(uniform_inducing_coe α).inducing }
 
+/-- the uniform completion of a complete space is uniform-equivalent to itself -/
+def uniform_completion.complete_equiv_self {α : Type*} [uniform_space α]
+[complete_space α] [separated_space α]:
+completion α ≃ᵤ α :=
+abstract_completion.complete_equiv_self completion.cpkg
+
 open topological_space
 
 instance separable_space_completion [separable_space α] : separable_space (completion α) :=

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -409,8 +409,7 @@ lemma dense_inducing_coe : dense_inducing (coe : α → completion α) :=
 
 /-- the uniform completion of a complete space is uniform-equivalent to itself -/
 def uniform_completion.complete_equiv_self [complete_space α] [separated_space α]:
-completion α ≃ᵤ α :=
-abstract_completion.complete_equiv_self completion.cpkg
+completion α ≃ᵤ α := abstract_completion.complete_equiv_self completion.cpkg
 
 open topological_space
 


### PR DESCRIPTION
- Change ```abstract_completion.compare_equiv``` to uniform bijection.
- Define the ```abstract_completion α``` given by ```α``` when it is complete. 
- Use it to prove that there is a uniform bijection between a complete space and its ```uniform_completion```.
- Upgrade the bijection between ```Bourbaki reals``` and ```Cauchy reals``` to a uniform bijection. 
- Add a new function ```function.dense_range_id``` (needed in one of the proofs)

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
