### PR TITLE
[Merged by Bors] - feat(linear_algebra/quadratic_form/basic): algebraic lemmas about `bilin_form.to_quadratic_form`

### DIFF
--- a/src/linear_algebra/quadratic_form/basic.lean
+++ b/src/linear_algebra/quadratic_form/basic.lean
@@ -68,6 +68,8 @@ universes u v w
 variables {S : Type*}
 variables {R R₁: Type*} {M : Type*}
 
+open_locale big_operators
+
 section polar
 variables [ring R] [comm_ring R₁] [add_comm_group M]
 
@@ -161,7 +163,6 @@ protected def copy (Q : quadratic_form R M) (Q' : M → R) (h : Q' = ⇑Q) : qua
   exists_companion' := h.symm ▸ Q.exists_companion' }
 
 end fun_like
-
 
 section semiring
 variables [semiring R] [add_comm_monoid M] [module R M]
@@ -374,7 +375,6 @@ def eval_add_monoid_hom (m : M) : quadratic_form R M →+ R :=
 (pi.eval_add_monoid_hom _ m).comp coe_fn_add_monoid_hom
 
 section sum
-open_locale big_operators
 
 @[simp] lemma coe_fn_sum {ι : Type*} (Q : ι → quadratic_form R M) (s : finset ι) :
   ⇑(∑ i in s, Q i) = ∑ i in s, Q i :=
@@ -521,15 +521,7 @@ quadratic form.
 namespace bilin_form
 open quadratic_form
 
-section ring
-variables [ring R] [add_comm_group M] [module R M]
-variables {B : bilin_form R M}
-
-lemma polar_to_quadratic_form (x y : M) : polar (λ x, B x x) x y = B x y + B y x :=
-by { simp only [add_assoc, add_sub_cancel', add_right, polar, add_left_inj, add_neg_cancel_left,
-  add_left, sub_eq_add_neg _ (B y y), add_comm (B y x) _] }
-
-end ring
+section semiring
 
 variables [semiring R] [add_comm_monoid M] [module R M]
 variables {B : bilin_form R M}
@@ -549,6 +541,52 @@ section
 variables (R M)
 @[simp] lemma to_quadratic_form_zero : (0 : bilin_form R M).to_quadratic_form = 0 := rfl
 end
+
+@[simp] lemma to_quadratic_form_add (B₁ B₂ : bilin_form R M) :
+  (B₁ + B₂).to_quadratic_form = B₁.to_quadratic_form + B₂.to_quadratic_form := rfl
+
+@[simp] lemma to_quadratic_form_smul [monoid S] [distrib_mul_action S R] [smul_comm_class S R R]
+  (a : S) (B : bilin_form R M) :
+  (a • B).to_quadratic_form = a • B.to_quadratic_form := rfl
+
+section
+variables (R M)
+/-- `bilin_form.to_quadratic_form` as an additive homomorphism -/
+@[simps] def to_quadratic_form_add_monoid_hom : bilin_form R M →+ quadratic_form R M :=
+{ to_fun := to_quadratic_form,
+  map_zero' := to_quadratic_form_zero _ _,
+  map_add' := to_quadratic_form_add }
+end
+
+@[simp] lemma to_quadratic_form_list_sum (B : list (bilin_form R M)) :
+  B.sum.to_quadratic_form = (B.map to_quadratic_form).sum :=
+map_list_sum (to_quadratic_form_add_monoid_hom R M) B
+
+@[simp] lemma to_quadratic_form_multiset_sum (B : multiset (bilin_form R M)) :
+  B.sum.to_quadratic_form = (B.map to_quadratic_form).sum :=
+map_multiset_sum (to_quadratic_form_add_monoid_hom R M) B
+
+@[simp] lemma to_quadratic_form_sum {ι : Type*} (s : finset ι) (B : ι → bilin_form R M) :
+  (∑ i in s, B i).to_quadratic_form = ∑ i in s, (B i).to_quadratic_form :=
+map_sum (to_quadratic_form_add_monoid_hom R M) B s
+
+end semiring
+
+section ring
+variables [ring R] [add_comm_group M] [module R M]
+variables {B : bilin_form R M}
+
+lemma polar_to_quadratic_form (x y : M) : polar (λ x, B x x) x y = B x y + B y x :=
+by { simp only [add_assoc, add_sub_cancel', add_right, polar, add_left_inj, add_neg_cancel_left,
+  add_left, sub_eq_add_neg _ (B y y), add_comm (B y x) _] }
+
+@[simp] lemma to_quadratic_form_neg (B : bilin_form R M) :
+  (-B).to_quadratic_form = -B.to_quadratic_form := rfl
+
+@[simp] lemma to_quadratic_form_sub (B₁ B₂ : bilin_form R M) :
+  (B₁ - B₂).to_quadratic_form = B₁.to_quadratic_form - B₂.to_quadratic_form := rfl
+
+end ring
 
 end bilin_form
 
@@ -898,8 +936,6 @@ end
 end bilin_form
 
 namespace quadratic_form
-
-open_locale big_operators
 
 open finset bilin_form
 


### PR DESCRIPTION
Following the usual pattern, we defined the bundle additive morphism so that we can copy across the salient lemmas about sums.

The `polar_to_quadratic_form` lemma in the diff was an existing lemma that has just been moved below the new `semiring` section.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
