### PR TITLE
[Merged by Bors] - feat(category_theory/groupoid): simplify groupoid.inv to category_theory.inv

### DIFF
--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -62,11 +62,9 @@ instance is_iso.of_groupoid (f : X ⟶ Y) : is_iso f :=
 @[simp] lemma groupoid.inv_eq_inv (f : X ⟶ Y) : groupoid.inv f = inv f :=
 is_iso.eq_inv_of_hom_inv_id $ groupoid.comp_inv f
 
+/-- `groupoid.inv` is involutive. -/
 @[simps] def groupoid.inv_equiv : (X ⟶ Y) ≃ (Y ⟶ X) :=
-{ to_fun := groupoid.inv,
-  inv_fun := groupoid.inv,
-  left_inv := λ f, by simp,
-  right_inv := λ f, by simp }
+⟨groupoid.inv, groupoid.inv, λ f, by simp, λ f, by simp⟩
 
 variables (X Y)
 

--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -62,7 +62,7 @@ instance is_iso.of_groupoid (f : X ⟶ Y) : is_iso f :=
 @[simp] lemma groupoid.inv_eq_inv (f : X ⟶ Y) : groupoid.inv f = inv f :=
 is_iso.eq_inv_of_hom_inv_id $ groupoid.comp_inv f
 
-@[simps] def inv_equiv : (X ⟶ Y) ≃ (Y ⟶ X) :=
+@[simps] def groupoid.inv_equiv : (X ⟶ Y) ≃ (Y ⟶ X) :=
 { to_fun := groupoid.inv,
   inv_fun := groupoid.inv,
   left_inv := λ f, by simp,

--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -40,7 +40,7 @@ class groupoid (obj : Type u) extends category.{v} obj : Type (max u (v+1)) :=
 restate_axiom groupoid.inv_comp'
 restate_axiom groupoid.comp_inv'
 
-attribute [simp] groupoid.inv_comp groupoid.comp_inv
+attribute [simp, reassoc] groupoid.inv_comp groupoid.comp_inv
 
 /--
 A `large_groupoid` is a groupoid
@@ -60,6 +60,15 @@ variables {C : Type u} [groupoid.{v} C] {X Y : C}
 @[priority 100] -- see Note [lower instance priority]
 instance is_iso.of_groupoid (f : X ⟶ Y) : is_iso f :=
 ⟨⟨groupoid.inv f, by simp⟩⟩
+
+@[simp] lemma groupoid.inv_eq_inv (f : X ⟶ Y) : groupoid.inv f = inv f :=
+is_iso.eq_inv_of_hom_inv_id $ groupoid.comp_inv f
+
+@[simps] def inv_equiv : (X ⟶ Y) ≃ (Y ⟶ X) :=
+{ to_fun := groupoid.inv,
+  inv_fun := groupoid.inv,
+  left_inv := λ f, by simp,
+  right_inv := λ f, by simp }
 
 variables (X Y)
 

--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -40,8 +40,6 @@ class groupoid (obj : Type u) extends category.{v} obj : Type (max u (v+1)) :=
 restate_axiom groupoid.inv_comp'
 restate_axiom groupoid.comp_inv'
 
-attribute [simp, reassoc] groupoid.inv_comp groupoid.comp_inv
-
 /--
 A `large_groupoid` is a groupoid
 where the objects live in `Type (u+1)` while the morphisms live in `Type u`.
@@ -59,7 +57,7 @@ variables {C : Type u} [groupoid.{v} C] {X Y : C}
 
 @[priority 100] -- see Note [lower instance priority]
 instance is_iso.of_groupoid (f : X ⟶ Y) : is_iso f :=
-⟨⟨groupoid.inv f, by simp⟩⟩
+⟨⟨groupoid.inv f, groupoid.comp_inv f, groupoid.inv_comp f⟩⟩
 
 @[simp] lemma groupoid.inv_eq_inv (f : X ⟶ Y) : groupoid.inv f = inv f :=
 is_iso.eq_inv_of_hom_inv_id $ groupoid.comp_inv f


### PR DESCRIPTION
Add simp lemma `groupoid.inv_eq_inv` to simplify `groupoid.inv` to `category_theory.inv` (which uses the `is_iso` instance) to gain access to the developed API around `category_theory.inv`. This isn't a defeq though so I can imagine sometimes we may want to `simp [-groupoid.inv_eq_inv]`, but most of the times this simp lemma makes things smoother.

---

Allows to solve the following lemmas needed for #16611 by simp:
```
@[simp] lemma groupoid.inv_id  [G : groupoid.{v} C] (X : C) :
  G.inv (𝟙 X) = 𝟙 X := by simp

@[simp] lemma groupoid.inv_of_comp  [G : groupoid.{v} C]
  {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : G.inv (f ≫ g) = (G.inv g) ≫ (G.inv f) := by simp

@[simp] lemma groupoid.inv_inv  [G : groupoid.{v} C] (X Y : C) (f : X ⟶ Y) :
  G.inv (G.inv f) = f := by simp

@[simp]
lemma groupoid.functor_map_inv  [G : groupoid.{v} C] {D : Type u₂} [H : groupoid.{v₂} D]
  (φ : C ⥤ D) {c d : C} (f : c ⟶ d) :
  φ.map (G.inv f) = H.inv (φ.map f) := by simp
```

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
