### PR TITLE
[Merged by Bors] - feat(linear_algebra/ray): `iff` versions of some lemmas

### DIFF
--- a/src/linear_algebra/ray.lean
+++ b/src/linear_algebra/ray.lean
@@ -601,14 +601,6 @@ begin
     exact (exists_pos_left_iff_same_ray hx hy).2 hxy }
 end
 
-lemma exists_pos_right_iff_same_ray (hx : x ≠ 0) (hy : y ≠ 0) :
-  (∃ r : R, 0 < r ∧ x = r • y) ↔ same_ray R x y :=
-by simpa only [same_ray_comm, eq_comm] using exists_pos_left_iff_same_ray hy hx
-
-lemma exists_pos_right_iff_same_ray_and_ne_zero (hy : y ≠ 0) :
-  (∃ r : R, 0 < r ∧ x = r • y) ↔ (same_ray R x y ∧ x ≠ 0) :=
-by simpa only [same_ray_comm, eq_comm] using exists_pos_left_iff_same_ray_and_ne_zero hy
-
 lemma exists_nonneg_left_iff_same_ray (hx : x ≠ 0) :
   (∃ r : R, 0 ≤ r ∧ r • x = y) ↔ same_ray R x y :=
 begin
@@ -616,6 +608,14 @@ begin
   rcases h with ⟨r, hr, rfl⟩,
   exact same_ray_nonneg_smul_right x hr
 end
+
+lemma exists_pos_right_iff_same_ray (hx : x ≠ 0) (hy : y ≠ 0) :
+  (∃ r : R, 0 < r ∧ x = r • y) ↔ same_ray R x y :=
+by simpa only [same_ray_comm, eq_comm] using exists_pos_left_iff_same_ray hy hx
+
+lemma exists_pos_right_iff_same_ray_and_ne_zero (hy : y ≠ 0) :
+  (∃ r : R, 0 < r ∧ x = r • y) ↔ (same_ray R x y ∧ x ≠ 0) :=
+by simpa only [same_ray_comm, eq_comm] using exists_pos_left_iff_same_ray_and_ne_zero hy
 
 lemma exists_nonneg_right_iff_same_ray (hy : y ≠ 0) :
   (∃ r : R, 0 ≤ r ∧ x = r • y) ↔ same_ray R x y :=

--- a/src/linear_algebra/ray.lean
+++ b/src/linear_algebra/ray.lean
@@ -603,21 +603,11 @@ end
 
 lemma exists_pos_right_iff_same_ray (hx : x ≠ 0) (hy : y ≠ 0) :
   (∃ r : R, 0 < r ∧ x = r • y) ↔ same_ray R x y :=
-begin
-  refine ⟨λ h, _, λ h, h.exists_pos_right hx hy⟩,
-  rcases h with ⟨r, hr, rfl⟩,
-  exact same_ray_pos_smul_left y hr
-end
+by simpa only [same_ray_comm, eq_comm] using exists_pos_left_iff_same_ray hy hx
 
 lemma exists_pos_right_iff_same_ray_and_ne_zero (hy : y ≠ 0) :
   (∃ r : R, 0 < r ∧ x = r • y) ↔ (same_ray R x y ∧ x ≠ 0) :=
-begin
-  split,
-  { rintro ⟨r, hr, rfl⟩,
-    simp [hy, hr.le, hr.ne'] },
-  { rintro ⟨hxy, hx⟩,
-    exact (exists_pos_right_iff_same_ray hx hy).2 hxy }
-end
+by simpa only [same_ray_comm, eq_comm] using exists_pos_left_iff_same_ray_and_ne_zero hy
 
 lemma exists_nonneg_left_iff_same_ray (hx : x ≠ 0) :
   (∃ r : R, 0 ≤ r ∧ r • x = y) ↔ same_ray R x y :=
@@ -629,10 +619,6 @@ end
 
 lemma exists_nonneg_right_iff_same_ray (hy : y ≠ 0) :
   (∃ r : R, 0 ≤ r ∧ x = r • y) ↔ same_ray R x y :=
-begin
-  refine ⟨λ h, _, λ h, h.exists_nonneg_right hy⟩,
-  rcases h with ⟨r, hr, rfl⟩,
-  exact same_ray_nonneg_smul_left y hr
-end
+by simpa only [same_ray_comm, eq_comm] using exists_nonneg_left_iff_same_ray hy
 
 end linear_ordered_field

--- a/src/linear_algebra/ray.lean
+++ b/src/linear_algebra/ray.lean
@@ -581,7 +581,7 @@ end same_ray
 section linear_ordered_field
 
 variables {R : Type*} [linear_ordered_field R]
-variables {M : Type*} [add_comm_group M] [module R M] {x y v₁ v₂ : M}
+variables {M : Type*} [add_comm_group M] [module R M] {x y : M}
 
 lemma exists_pos_left_iff_same_ray (hx : x ≠ 0) (hy : y ≠ 0) :
   (∃ r : R, 0 < r ∧ r • x = y) ↔ same_ray R x y :=

--- a/src/linear_algebra/ray.lean
+++ b/src/linear_algebra/ray.lean
@@ -577,3 +577,62 @@ lemma exists_eq_smul (h : same_ray R v₁ v₂) :
 ⟨v₁ + v₂, h.exists_eq_smul_add⟩
 
 end same_ray
+
+section linear_ordered_field
+
+variables {R : Type*} [linear_ordered_field R]
+variables {M : Type*} [add_comm_group M] [module R M] {x y v₁ v₂ : M}
+
+lemma exists_pos_left_iff_same_ray (hx : x ≠ 0) (hy : y ≠ 0) :
+  (∃ r : R, 0 < r ∧ r • x = y) ↔ same_ray R x y :=
+begin
+  refine ⟨λ h, _, λ h, h.exists_pos_left hx hy⟩,
+  rcases h with ⟨r, hr, rfl⟩,
+  exact same_ray_pos_smul_right x hr
+end
+
+lemma exists_pos_left_iff_same_ray_and_ne_zero (hx : x ≠ 0) :
+  (∃ r : R, 0 < r ∧ r • x = y) ↔ (same_ray R x y ∧ y ≠ 0) :=
+begin
+  split,
+  { rintro ⟨r, hr, rfl⟩,
+    simp [hx, hr.le, hr.ne'] },
+  { rintro ⟨hxy, hy⟩,
+    exact (exists_pos_left_iff_same_ray hx hy).2 hxy }
+end
+
+lemma exists_pos_right_iff_same_ray (hx : x ≠ 0) (hy : y ≠ 0) :
+  (∃ r : R, 0 < r ∧ x = r • y) ↔ same_ray R x y :=
+begin
+  refine ⟨λ h, _, λ h, h.exists_pos_right hx hy⟩,
+  rcases h with ⟨r, hr, rfl⟩,
+  exact same_ray_pos_smul_left y hr
+end
+
+lemma exists_pos_right_iff_same_ray_and_ne_zero (hy : y ≠ 0) :
+  (∃ r : R, 0 < r ∧ x = r • y) ↔ (same_ray R x y ∧ x ≠ 0) :=
+begin
+  split,
+  { rintro ⟨r, hr, rfl⟩,
+    simp [hy, hr.le, hr.ne'] },
+  { rintro ⟨hxy, hx⟩,
+    exact (exists_pos_right_iff_same_ray hx hy).2 hxy }
+end
+
+lemma exists_nonneg_left_iff_same_ray (hx : x ≠ 0) :
+  (∃ r : R, 0 ≤ r ∧ r • x = y) ↔ same_ray R x y :=
+begin
+  refine ⟨λ h, _, λ h, h.exists_nonneg_left hx⟩,
+  rcases h with ⟨r, hr, rfl⟩,
+  exact same_ray_nonneg_smul_right x hr
+end
+
+lemma exists_nonneg_right_iff_same_ray (hy : y ≠ 0) :
+  (∃ r : R, 0 ≤ r ∧ x = r • y) ↔ same_ray R x y :=
+begin
+  refine ⟨λ h, _, λ h, h.exists_nonneg_right hy⟩,
+  rcases h with ⟨r, hr, rfl⟩,
+  exact same_ray_nonneg_smul_left y hr
+end
+
+end linear_ordered_field


### PR DESCRIPTION
Add `iff` versions of some `same_ray` lemmas.  These are lemmas where we already have some form of both directions, but not the `iff` version (and the separate directions are still useful on their own, since one direction is true for weaker typeclass assumptions than the `iff` version and the other is available with dot notation).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
