### PR TITLE
[Merged by Bors] - fix(tactic/positivity + test): instantiate meta-variables and add a test

### DIFF
--- a/src/tactic/positivity.lean
+++ b/src/tactic/positivity.lean
@@ -179,7 +179,7 @@ example {b : ℤ} : 0 ≤ max (-3) (b ^ 2) := by positivity
 ```
 -/
 meta def positivity : tactic unit := focus1 $ do
-  t ← target,
+  t ← target >>= instantiate_mvars,
   (rel_desired, a) ← match t with
   | `(0 ≤ %%e₂) := pure (ff, e₂)
   | `(%%e₂ ≥ 0) := pure (ff, e₂)

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -14,6 +14,16 @@ import tactic.positivity
 This tactic proves goals of the form `0 ≤ a` and `0 < a`.
 -/
 
+/-  Test for instantiating meta-variables.  Reported on
+Stream: metaprogramming/tactics
+Topic: New tactic: `positivity`
+Date: Sept 25th, 2022.   -/
+example : 0 ≤ 1 :=
+begin
+  apply le_trans _ (le_rfl : 1 ≤ 1),
+  positivity,
+end
+
 open_locale ennreal nnrat nnreal
 
 universe u

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -15,12 +15,11 @@ This tactic proves goals of the form `0 ≤ a` and `0 < a`.
 -/
 
 /-  Test for instantiating meta-variables.  Reported on
-Stream: metaprogramming/tactics
-Topic: New tactic: `positivity`
-Date: Sept 25th, 2022.   -/
-example : 0 ≤ 1 :=
+https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/New.20tactic.3A.20.60positivity.60/near/300639970
+-/
+example : 0 ≤ 0 :=
 begin
-  apply le_trans _ (le_rfl : 1 ≤ 1),
+  apply le_trans _ le_rfl,
   positivity,
 end
 


### PR DESCRIPTION
Fix an issue with `positivity` reported by @YaelDillies [here](https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/New.20tactic.3A.20.60positivity.60/near/300639970).

For the fix, it seems that instantiating meta-variables is enough.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
