### PR TITLE
[Merged by Bors] - perf(analysis/normed_space/continuous_affine_map): Speedup

### DIFF
--- a/src/analysis/normed_space/continuous_affine_map.lean
+++ b/src/analysis/normed_space/continuous_affine_map.lean
@@ -220,9 +220,9 @@ def to_const_prod_continuous_linear_map : (V →A[𝕜] W) ≃ₗᵢ[𝕜] W × 
   inv_fun   := λ p, p.2.to_continuous_affine_map + const 𝕜 V p.1,
   left_inv  := λ f, by { ext, rw f.decomp, simp, },
   right_inv := by { rintros ⟨v, f⟩, ext; simp, },
-  map_add'  := by simp,
-  map_smul' := by simp,
-  norm_map' := λ f, by simp [prod.norm_def, norm_def], }
+  map_add'  := λ _ _, rfl,
+  map_smul' := λ _ _, rfl,
+  norm_map' := λ f, rfl }
 
 @[simp] lemma to_const_prod_continuous_linear_map_fst (f : V →A[𝕜] W) :
   (to_const_prod_continuous_linear_map 𝕜 V W f).fst = f 0 :=


### PR DESCRIPTION
This changes the compilation time of `continuous_affine_map.to_const_prod_continuous_linear_map` from 19s to 3s for me locally.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
