### PR TITLE
chore(analysis/normed_space/continuous_affine_map): squeeze the simps

### DIFF
--- a/src/analysis/normed_space/continuous_affine_map.lean
+++ b/src/analysis/normed_space/continuous_affine_map.lean
@@ -218,11 +218,16 @@ linear part. -/
 def to_const_prod_continuous_linear_map : (V →A[𝕜] W) ≃ₗᵢ[𝕜] W × (V →L[𝕜] W) :=
 { to_fun    := λ f, ⟨f 0, f.cont_linear⟩,
   inv_fun   := λ p, p.2.to_continuous_affine_map + const 𝕜 V p.1,
-  left_inv  := λ f, by { ext, rw f.decomp, simp, },
-  right_inv := by { rintros ⟨v, f⟩, ext; simp, },
-  map_add'  := by simp,
-  map_smul' := by simp,
-  norm_map' := λ f, by simp [prod.norm_def, norm_def], }
+  left_inv  := λ f, by { ext, rw f.decomp, simp only [coe_add,
+    continuous_linear_map.coe_to_continuous_affine_map, coe_const], },
+  right_inv := by { rintros ⟨v, f⟩, ext, simp only [coe_add, coe_const, map_zero, zero_add,
+    continuous_linear_map.coe_to_continuous_affine_map, pi.add_apply],
+    simp only [add_cont_linear, to_affine_map_cont_linear, const_cont_linear, add_zero], },
+  map_add'  := by simp only [coe_add, pi.add_apply, add_cont_linear, prod.mk_add_mk,
+    eq_self_iff_true, forall_const],
+  map_smul' := by simp only [coe_smul, pi.smul_apply, smul_cont_linear, ring_hom.id_apply,
+    prod.smul_mk, eq_self_iff_true, forall_const],
+  norm_map' := λ f, by { simp only [prod.norm_def, norm_def, linear_equiv.coe_mk] }, }
 
 @[simp] lemma to_const_prod_continuous_linear_map_fst (f : V →A[𝕜] W) :
   (to_const_prod_continuous_linear_map 𝕜 V W f).fst = f 0 :=


### PR DESCRIPTION
`to_const_prod_continuous_linear_map` is randomly timing out in #16403 and #15259. So I squeezed them out.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
