### PR TITLE
[Merged by Bors] - chore(number_theory/legendre_symbol/norm_num): remove now unnecessary instance

### DIFF
--- a/src/number_theory/legendre_symbol/norm_num.lean
+++ b/src/number_theory/legendre_symbol/norm_num.lean
@@ -231,9 +231,6 @@ end lemmas
 
 section evaluation
 
--- The following is to prevent strange error messages from occurring.
-instance : ring ℚ := division_ring.to_ring ℚ
-
 /-!
 ### Certified evaluation of the Jacobi symbol
 


### PR DESCRIPTION
This just removes a shortcut instance in `number_theory/legendre_symnol/norm_num` that was necessary to avoid computability trouble with the meta code, but is no longer so, since the root cause was fixed by #16463.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
