### PR TITLE
[Merged by Bors] - feat(analysis/convex/topology): connectedness and `same_ray`

### DIFF
--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -404,4 +404,20 @@ begin
   simpa only [sub_add_sub_cancel', norm_sub_rev] using h.norm_add.symm
 end
 
+/-- The set of vectors in the same ray as `x` is connected. -/
+lemma is_connected_set_of_same_ray (x : E) : is_connected {y | same_ray ℝ x y} :=
+begin
+  by_cases hx : x = 0, { simpa [hx] using is_connected_univ },
+  simp_rw ←exists_nonneg_left_iff_same_ray hx,
+  exact is_connected_Ici.image _ ((continuous_id.smul continuous_const).continuous_on)
+end
+
+/-- The set of nonzero vectors in the same ray as the nonzero vector `x` is connected. -/
+lemma is_connected_set_of_same_ray_and_ne_zero {x : E} (hx : x ≠ 0) :
+  is_connected {y | same_ray ℝ x y ∧ y ≠ 0} :=
+begin
+  simp_rw ←exists_pos_left_iff_same_ray_and_ne_zero hx,
+  exact is_connected_Ioi.image _ ((continuous_id.smul continuous_const).continuous_on)
+end
+
 end normed_space


### PR DESCRIPTION
Add lemmas that the set of vectors in the same ray as a given vector, and the set of nonzero vectors in the same ray as a given nonzero vector, are connected (in a real normed space).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
