### PR TITLE
[Merged by Bors] - feat(order/atoms): Galois (co)insertions and (co)atoms

### DIFF
--- a/src/order/atoms.lean
+++ b/src/order/atoms.lean
@@ -50,7 +50,7 @@ which are lattices with only two elements, and related ideas.
 
 -/
 
-variable {α : Type*}
+variables {α β : Type*}
 
 section atoms
 
@@ -567,18 +567,18 @@ end set
 
 namespace galois_insertion
 
-variables {β : Type*}
+variables [partial_order α] [partial_order β]
 
-lemma is_atom_of_u_bot [partial_order α] [order_bot α] [partial_order β]
-  [order_bot β] {l : α → β} {u : β → α} (gi : galois_insertion l u) (hbot : u ⊥ = ⊥)
-  {b : β} (hb : is_atom (u b)) : is_atom b :=
+
+lemma is_atom_of_u_bot [order_bot α] [order_bot β] {l : α → β} {u : β → α}
+  (gi : galois_insertion l u) (hbot : u ⊥ = ⊥) {b : β} (hb : is_atom (u b)) : is_atom b :=
 let ⟨hb₁, hb₂⟩ := hb in
   ⟨λ hb, hb₁ $ hbot ▸ congr_arg u hb,
    λ b' hb', gi.gc.l_bot ▸ gi.l_u_eq b' ▸ congr_arg l (hb₂ (u b') (gi.strict_mono_u hb'))⟩
 
-lemma is_atom_iff [partial_order α] [order_bot α] [is_atomic α] [partial_order β]
-  [order_bot β] {l : α → β} {u : β → α} (gi : galois_insertion l u) (hbot : u ⊥ = ⊥)
-  (h_atom : ∀ a, is_atom a → u (l a) = a) (a : α) : is_atom (l a) ↔ is_atom a :=
+lemma is_atom_iff [order_bot α] [is_atomic α] [order_bot β] {l : α → β} {u : β → α}
+  (gi : galois_insertion l u) (hbot : u ⊥ = ⊥) (h_atom : ∀ a, is_atom a → u (l a) = a) (a : α) :
+  is_atom (l a) ↔ is_atom a :=
 begin
   refine ⟨λ hla, _, λ ha, gi.is_atom_of_u_bot hbot ((h_atom a ha).symm ▸ ha)⟩,
   obtain ⟨a', ha', hab'⟩ := (eq_bot_or_exists_atom_le (u (l a))).resolve_left
@@ -591,21 +591,20 @@ begin
   exact haa'.symm ▸ ha'
 end
 
-lemma is_atom_iff' [partial_order α] [order_bot α] [is_atomic α] [partial_order β]
-  [order_bot β] {l : α → β} {u : β → α} (gi : galois_insertion l u) (hbot : u ⊥ = ⊥)
-  (h_atom : ∀ a, is_atom a → u (l a) = a) (b : β) : is_atom (u b) ↔ is_atom b :=
+lemma is_atom_iff' [order_bot α] [is_atomic α] [order_bot β] {l : α → β} {u : β → α}
+  (gi : galois_insertion l u) (hbot : u ⊥ = ⊥) (h_atom : ∀ a, is_atom a → u (l a) = a) (b : β) :
+  is_atom (u b) ↔ is_atom b :=
 by rw [←gi.is_atom_iff hbot h_atom, gi.l_u_eq]
 
-lemma is_coatom_of_l_top [partial_order α] [order_top α] [partial_order β] [order_top β]
-  {l : α → β} {u : β → α} (gi : galois_insertion l u) (htop : l ⊤ = ⊤) {b : β}
-  (hb : is_coatom (u b)) : is_coatom b :=
+lemma is_coatom_of_l_top [order_top α] [order_top β] {l : α → β} {u : β → α}
+  (gi : galois_insertion l u) (htop : l ⊤ = ⊤) {b : β} (hb : is_coatom (u b)) : is_coatom b :=
 let ⟨hb₁, hb₂⟩ := hb in
   ⟨mt (congr_arg u) (gi.gc.u_top.symm ▸ hb₁),
    λ b' hb', htop ▸ gi.l_u_eq b' ▸ congr_arg l (hb₂ _ (gi.strict_mono_u hb'))⟩
 
-lemma is_coatom_iff [partial_order α] [order_top α] [is_coatomic α] [partial_order β] [order_top β]
-  {l : α → β} {u : β → α} (gi : galois_insertion l u) (htop : l ⊤ = ⊤)
-  (h_coatom : ∀ a, is_coatom a → u (l a) = a) (b : β) : is_coatom (u b) ↔ is_coatom b :=
+lemma is_coatom_iff [order_top α] [is_coatomic α] [order_top β] {l : α → β} {u : β → α}
+  (gi : galois_insertion l u) (htop : l ⊤ = ⊤) (h_coatom : ∀ a, is_coatom a → u (l a) = a) (b : β) :
+  is_coatom (u b) ↔ is_coatom b :=
 begin
   refine ⟨λ hb, gi.is_coatom_of_l_top htop hb, λ hb, _⟩,
   obtain ⟨a, ha, hab⟩ := (eq_top_or_exists_le_coatom (u b)).resolve_left
@@ -619,63 +618,56 @@ end galois_insertion
 
 namespace galois_coinsertion
 
-variables {β : Type*}
+variables [partial_order α] [partial_order β]
 
-lemma is_coatom_of_l_top [partial_order α] [order_top α] [partial_order β] [order_top β]
-  {l : α → β} {u : β → α} (gi : galois_coinsertion l u) (hbot : l ⊤ = ⊤) {a : α}
-  (hb : is_coatom (l a)) : is_coatom a :=
+lemma is_coatom_of_l_top [order_top α] [order_top β] {l : α → β} {u : β → α}
+  (gi : galois_coinsertion l u) (hbot : l ⊤ = ⊤) {a : α} (hb : is_coatom (l a)) : is_coatom a :=
 gi.dual.is_atom_of_u_bot hbot hb.dual
 
-lemma is_coatom_iff [partial_order α] [order_top α] [partial_order β] [order_top β] [is_coatomic β]
-  {l : α → β} {u : β → α} (gi : galois_coinsertion l u) (htop : l ⊤ = ⊤)
-  (h_coatom : ∀ b, is_coatom b → l (u b) = b) (b : β) : is_coatom (u b) ↔ is_coatom b :=
+lemma is_coatom_iff [order_top α] [order_top β] [is_coatomic β] {l : α → β} {u : β → α}
+  (gi : galois_coinsertion l u) (htop : l ⊤ = ⊤) (h_coatom : ∀ b, is_coatom b → l (u b) = b)
+  (b : β) : is_coatom (u b) ↔ is_coatom b :=
 gi.dual.is_atom_iff htop h_coatom b
 
-lemma is_coatom_iff' [partial_order α] [order_top α] [partial_order β] [order_top β] [is_coatomic β]
-  {l : α → β} {u : β → α} (gi : galois_coinsertion l u) (htop : l ⊤ = ⊤)
-  (h_coatom : ∀ b, is_coatom b → l (u b) = b) (a : α) : is_coatom (l a) ↔ is_coatom a :=
+lemma is_coatom_iff' [order_top α] [order_top β] [is_coatomic β] {l : α → β} {u : β → α}
+  (gi : galois_coinsertion l u) (htop : l ⊤ = ⊤) (h_coatom : ∀ b, is_coatom b → l (u b) = b)
+  (a : α) : is_coatom (l a) ↔ is_coatom a :=
 gi.dual.is_atom_iff' htop h_coatom a
 
-lemma is_atom_of_u_bot [partial_order α] [order_bot α] [partial_order β] [order_bot β]
-  {l : α → β} {u : β → α} (gi : galois_coinsertion l u) (hbot : u ⊥ = ⊥) {a : α}
-  (hb : is_atom (l a)) : is_atom a :=
+lemma is_atom_of_u_bot [order_bot α] [order_bot β] {l : α → β} {u : β → α}
+  (gi : galois_coinsertion l u) (hbot : u ⊥ = ⊥) {a : α} (hb : is_atom (l a)) : is_atom a :=
 gi.dual.is_coatom_of_l_top hbot hb.dual
 
-lemma is_atom_iff [partial_order α] [order_bot α]  [partial_order β] [order_bot β] [is_atomic β]
-  {l : α → β} {u : β → α} (gi : galois_coinsertion l u) (hbot : u ⊥ = ⊥)
-  (h_atom : ∀ b, is_atom b → l (u b) = b) (a : α) : is_atom (l a) ↔ is_atom a :=
+lemma is_atom_iff [order_bot α] [order_bot β] [is_atomic β] {l : α → β} {u : β → α}
+  (gi : galois_coinsertion l u) (hbot : u ⊥ = ⊥) (h_atom : ∀ b, is_atom b → l (u b) = b) (a : α) :
+  is_atom (l a) ↔ is_atom a :=
 gi.dual.is_coatom_iff hbot h_atom a
 
 end galois_coinsertion
 
 namespace order_iso
 
-variables {β : Type*}
+variables [partial_order α] [partial_order β]
 
-@[simp] lemma is_atom_iff [partial_order α] [order_bot α] [partial_order β] [order_bot β]
-  (f : α ≃o β) (a : α) :
+@[simp] lemma is_atom_iff [order_bot α] [order_bot β] (f : α ≃o β) (a : α) :
   is_atom (f a) ↔ is_atom a :=
 ⟨f.to_galois_coinsertion.is_atom_of_u_bot (map_bot f.symm),
  λ ha, f.to_galois_insertion.is_atom_of_u_bot (map_bot f.symm) $ (f.symm_apply_apply a).symm ▸ ha⟩
 
-@[simp] lemma is_coatom_iff [partial_order α] [order_top α] [partial_order β] [order_top β]
-  (f : α ≃o β) (a : α) :
+@[simp] lemma is_coatom_iff [order_top α] [order_top β] (f : α ≃o β) (a : α) :
   is_coatom (f a) ↔ is_coatom a :=
 f.dual.is_atom_iff a
 
-lemma is_simple_order_iff [partial_order α] [bounded_order α] [partial_order β] [bounded_order β]
-  (f : α ≃o β) :
+lemma is_simple_order_iff [bounded_order α] [bounded_order β] (f : α ≃o β) :
   is_simple_order α ↔ is_simple_order β :=
 by rw [is_simple_order_iff_is_atom_top, is_simple_order_iff_is_atom_top,
   ← f.is_atom_iff ⊤, f.map_top]
 
-lemma is_simple_order [partial_order α] [bounded_order α] [partial_order β] [bounded_order β]
-  [h : is_simple_order β] (f : α ≃o β) :
+lemma is_simple_order [bounded_order α] [bounded_order β] [h : is_simple_order β] (f : α ≃o β) :
   is_simple_order α :=
 f.is_simple_order_iff.mpr h
 
-lemma is_atomic_iff [partial_order α] [order_bot α] [partial_order β] [order_bot β] (f : α ≃o β) :
-  is_atomic α ↔ is_atomic β :=
+lemma is_atomic_iff [order_bot α] [order_bot β] (f : α ≃o β) : is_atomic α ↔ is_atomic β :=
 begin
   suffices : (∀ b : α, b = ⊥ ∨ ∃ (a : α), is_atom a ∧ a ≤ b) ↔
     (∀ b : β, b = ⊥ ∨ ∃ (a : β), is_atom a ∧ a ≤ b),
@@ -691,8 +683,7 @@ begin
       rwa [←f.le_iff_le, f.apply_symm_apply], }, },
 end
 
-lemma is_coatomic_iff [partial_order α] [order_top α] [partial_order β] [order_top β] (f : α ≃o β) :
-  is_coatomic α ↔ is_coatomic β :=
+lemma is_coatomic_iff [order_top α] [order_top β] (f : α ≃o β) : is_coatomic α ↔ is_coatomic β :=
 by { rw [←is_atomic_dual_iff_is_coatomic, ←is_atomic_dual_iff_is_coatomic],
   exact f.dual.is_atomic_iff }
 

--- a/src/order/atoms.lean
+++ b/src/order/atoms.lean
@@ -565,6 +565,89 @@ is_simple_order_iff_is_coatom_bot.trans $ and_congr (not_congr subtype.mk_eq_mk)
 
 end set
 
+namespace galois_insertion
+
+variables {β : Type*}
+
+lemma is_atom_of_u_bot [partial_order α] [order_bot α] [partial_order β]
+  [order_bot β] {l : α → β} {u : β → α} (gi : galois_insertion l u) (hbot : u ⊥ = ⊥)
+  {b : β} (hb : is_atom (u b)) : is_atom b :=
+let ⟨hb₁, hb₂⟩ := hb in
+  ⟨λ hb, hb₁ $ hbot ▸ congr_arg u hb,
+   λ b' hb', gi.gc.l_bot ▸ gi.l_u_eq b' ▸ congr_arg l (hb₂ (u b') (gi.strict_mono_u hb'))⟩
+
+lemma is_atom_iff [partial_order α] [order_bot α] [is_atomic α] [partial_order β]
+  [order_bot β] {l : α → β} {u : β → α} (gi : galois_insertion l u) (hbot : u ⊥ = ⊥)
+  (h_atom : ∀ a, is_atom a → u (l a) = a) (a : α) : is_atom (l a) ↔ is_atom a :=
+begin
+  refine ⟨λ hla, _, λ ha, gi.is_atom_of_u_bot hbot ((h_atom a ha).symm ▸ ha)⟩,
+  obtain ⟨a', ha', hab'⟩ := (eq_bot_or_exists_atom_le (u (l a))).resolve_left
+    (hbot ▸ λ h, hla.1 (gi.u_injective h)),
+  have := (hla.le_iff.mp $ (gi.l_u_eq (l a) ▸ gi.gc.monotone_l hab' : l a' ≤ l a)).resolve_left
+    (λ h, ha'.1 (hbot ▸ (h_atom a' ha') ▸ congr_arg u h)),
+  have haa' : a = a' := (ha'.le_iff.mp $
+    (gi.gc.le_u_l a).trans_eq (h_atom a' ha' ▸ congr_arg u this.symm)).resolve_left
+    (mt (congr_arg l) (gi.gc.l_bot.symm ▸ hla.1)),
+  exact haa'.symm ▸ ha'
+end
+
+lemma is_atom_iff' [partial_order α] [order_bot α] [is_atomic α] [partial_order β]
+  [order_bot β] {l : α → β} {u : β → α} (gi : galois_insertion l u) (hbot : u ⊥ = ⊥)
+  (h_atom : ∀ a, is_atom a → u (l a) = a) (b : β) : is_atom (u b) ↔ is_atom b :=
+by rw [←gi.is_atom_iff hbot h_atom, gi.l_u_eq]
+
+lemma is_coatom_of_l_top [partial_order α] [order_top α] [partial_order β] [order_top β]
+  {l : α → β} {u : β → α} (gi : galois_insertion l u) (htop : l ⊤ = ⊤) {b : β}
+  (hb : is_coatom (u b)) : is_coatom b :=
+let ⟨hb₁, hb₂⟩ := hb in
+  ⟨mt (congr_arg u) (gi.gc.u_top.symm ▸ hb₁),
+   λ b' hb', htop ▸ gi.l_u_eq b' ▸ congr_arg l (hb₂ _ (gi.strict_mono_u hb'))⟩
+
+lemma is_coatom_iff [partial_order α] [order_top α] [is_coatomic α] [partial_order β] [order_top β]
+  {l : α → β} {u : β → α} (gi : galois_insertion l u) (htop : l ⊤ = ⊤)
+  (h_coatom : ∀ a, is_coatom a → u (l a) = a) (b : β) : is_coatom (u b) ↔ is_coatom b :=
+begin
+  refine ⟨λ hb, gi.is_coatom_of_l_top htop hb, λ hb, _⟩,
+  obtain ⟨a, ha, hab⟩ := (eq_top_or_exists_le_coatom (u b)).resolve_left
+    (λ h, hb.1 $ htop ▸ gi.l_u_eq b ▸ congr_arg l h),
+  have : l a = b := (hb.le_iff.mp ((gi.l_u_eq b ▸ gi.gc.monotone_l hab) : b ≤ l a)).resolve_left
+    (λ hla, ha.1 (gi.gc.u_top ▸ h_coatom a ha ▸ congr_arg u hla)),
+  exact this ▸ (h_coatom a ha).symm ▸ ha,
+end
+
+end galois_insertion
+
+namespace galois_coinsertion
+
+variables {β : Type*}
+
+lemma is_coatom_of_l_top [partial_order α] [order_top α] [partial_order β] [order_top β]
+  {l : α → β} {u : β → α} (gi : galois_coinsertion l u) (hbot : l ⊤ = ⊤) {a : α}
+  (hb : is_coatom (l a)) : is_coatom a :=
+gi.dual.is_atom_of_u_bot hbot hb.dual
+
+lemma is_coatom_iff [partial_order α] [order_top α] [partial_order β] [order_top β] [is_coatomic β]
+  {l : α → β} {u : β → α} (gi : galois_coinsertion l u) (htop : l ⊤ = ⊤)
+  (h_coatom : ∀ b, is_coatom b → l (u b) = b) (b : β) : is_coatom (u b) ↔ is_coatom b :=
+gi.dual.is_atom_iff htop h_coatom b
+
+lemma is_coatom_iff' [partial_order α] [order_top α] [partial_order β] [order_top β] [is_coatomic β]
+  {l : α → β} {u : β → α} (gi : galois_coinsertion l u) (htop : l ⊤ = ⊤)
+  (h_coatom : ∀ b, is_coatom b → l (u b) = b) (a : α) : is_coatom (l a) ↔ is_coatom a :=
+gi.dual.is_atom_iff' htop h_coatom a
+
+lemma is_atom_of_u_bot [partial_order α] [order_bot α] [partial_order β] [order_bot β]
+  {l : α → β} {u : β → α} (gi : galois_coinsertion l u) (hbot : u ⊥ = ⊥) {a : α}
+  (hb : is_atom (l a)) : is_atom a :=
+gi.dual.is_coatom_of_l_top hbot hb.dual
+
+lemma is_atom_iff [partial_order α] [order_bot α]  [partial_order β] [order_bot β] [is_atomic β]
+  {l : α → β} {u : β → α} (gi : galois_coinsertion l u) (hbot : u ⊥ = ⊥)
+  (h_atom : ∀ b, is_atom b → l (u b) = b) (a : α) : is_atom (l a) ↔ is_atom a :=
+gi.dual.is_coatom_iff hbot h_atom a
+
+end galois_coinsertion
+
 namespace order_iso
 
 variables {β : Type*}
@@ -572,14 +655,8 @@ variables {β : Type*}
 @[simp] lemma is_atom_iff [partial_order α] [order_bot α] [partial_order β] [order_bot β]
   (f : α ≃o β) (a : α) :
   is_atom (f a) ↔ is_atom a :=
-and_congr (not_congr ⟨λ h, f.injective (f.map_bot.symm ▸ h), λ h, f.map_bot ▸ (congr rfl h)⟩)
-  ⟨λ h b hb, f.injective ((h (f b) ((f : α ↪o β).lt_iff_lt.2 hb)).trans f.map_bot.symm),
-  λ h b hb, f.symm.injective begin
-    rw f.symm.map_bot,
-    apply h,
-    rw [← f.symm_apply_apply a],
-    exact (f.symm : β ↪o α).lt_iff_lt.2 hb,
-  end⟩
+⟨f.to_galois_coinsertion.is_atom_of_u_bot (map_bot f.symm),
+ λ ha, f.to_galois_insertion.is_atom_of_u_bot (map_bot f.symm) $ (f.symm_apply_apply a).symm ▸ ha⟩
 
 @[simp] lemma is_coatom_iff [partial_order α] [order_top α] [partial_order β] [order_top β]
   (f : α ≃o β) (a : α) :


### PR DESCRIPTION
---

While some of the hypotheses may seem stringent, I found myself proving these in two different (but related) situations, so I decided to generalize. The two contexts were:
1. the Galois insertion from `topological_space.closeds X` to `set X`. When `X` is a `t1_space`, then the atoms of `set X` correspond exactly to those of `topological_space.closeds X`. This can be summed up with `galois_insertion.is_atom_iff` and `galois_insertion.is_atom_iff'`
2. the Galois insertion from `{I : ideal R // is_closed (I : set R}` to `ideal R` where `R` is a complete normed ring. Here the maximal ideals in `ideal R` are closed, and hence this insertion satisfies the hypotheses of `galois_insertion.is_atom_iff`. 

Note there is no theorem of the form:

```lean
lemma is_coatom_iff [partial_order α] [order_top α] [is_coatomic α] [partial_order β] [order_top β]
  {l : α → β} {u : β → α} (gi : galois_insertion l u)
  (h_coatom : ∀ a, is_coatom a → u (l a) = a) (a : α) : is_coatom (l a) ↔ is_coatom a := sorry
```

This can be seen by considering the Galois insertion described above for ideals of `R = C(X, ℝ)` with `X` compact Hausdorff. In particular, there are ideals which are not maximal, but whose closures are maximal (e.g., `I = {f : C(X, ℝ) | ∀ᶠ x in 𝓝 a, f x = 0}` whenever `a` is an accumulation point).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
