### PR TITLE
[Merged by Bors] - feat(measure_theory/group/prod): use measure_preserving predicate

### DIFF
--- a/src/analysis/convolution.lean
+++ b/src/analysis/convolution.lean
@@ -205,12 +205,14 @@ variables [sigma_finite μ] [is_add_left_invariant μ]
 lemma measure_theory.ae_strongly_measurable.convolution_integrand_snd
   (hf : ae_strongly_measurable f μ) (hg : ae_strongly_measurable g μ)
   (x : G) : ae_strongly_measurable (λ t, L (f t) (g (x - t))) μ :=
-hf.convolution_integrand_snd' L $ hg.mono' $ map_sub_left_absolutely_continuous μ x
+hf.convolution_integrand_snd' L $ hg.mono' $
+  (quasi_measure_preserving_sub_left μ x).absolutely_continuous
 
 lemma measure_theory.ae_strongly_measurable.convolution_integrand_swap_snd
   (hf : ae_strongly_measurable f μ) (hg : ae_strongly_measurable g μ)
   (x : G) : ae_strongly_measurable (λ t, L (f (x - t)) (g t)) μ :=
-(hf.mono' (map_sub_left_absolutely_continuous μ x)).convolution_integrand_swap_snd' L hg
+(hf.mono' (quasi_measure_preserving_sub_left μ x).absolutely_continuous)
+  .convolution_integrand_swap_snd' L hg
 
 end left
 
@@ -309,7 +311,7 @@ lemma bdd_above.convolution_exists_at [sigma_finite μ] {x₀ : G}
 begin
   refine bdd_above.convolution_exists_at' L _ hs h2s hf hmf _,
   { simp_rw [← sub_eq_neg_add, hbg] },
-  { exact hmg.mono' (map_sub_left_absolutely_continuous μ x₀) }
+  { exact hmg.mono' (quasi_measure_preserving_sub_left μ x₀).absolutely_continuous }
 end
 
 variables {L} [is_neg_invariant μ]

--- a/src/measure_theory/constructions/prod.lean
+++ b/src/measure_theory/constructions/prod.lean
@@ -468,15 +468,15 @@ begin
   { simp_rw [Union_unpair_prod, hμ.spanning, hν.spanning, univ_prod_univ] }
 end
 
-lemma prod_fst_absolutely_continuous : map prod.fst (μ.prod ν) ≪ μ :=
+lemma quasi_measure_preserving_fst : quasi_measure_preserving prod.fst (μ.prod ν) μ :=
 begin
-  refine absolutely_continuous.mk (λ s hs h2s, _),
+  refine ⟨measurable_fst, absolutely_continuous.mk (λ s hs h2s, _)⟩,
   rw [map_apply measurable_fst hs, ← prod_univ, prod_prod, h2s, zero_mul],
 end
 
-lemma prod_snd_absolutely_continuous : map prod.snd (μ.prod ν) ≪ ν :=
+lemma quasi_measure_preserving_snd : quasi_measure_preserving prod.snd (μ.prod ν) ν :=
 begin
-  refine absolutely_continuous.mk (λ s hs h2s, _),
+  refine ⟨measurable_snd, absolutely_continuous.mk (λ s hs h2s, _)⟩,
   rw [map_apply measurable_snd hs, ← univ_prod, prod_prod, h2s, mul_zero]
 end
 
@@ -514,6 +514,9 @@ begin
   intros s t hs ht,
   simp_rw [map_apply measurable_swap (hs.prod ht), preimage_swap_prod, prod_prod, mul_comm]
 end
+
+lemma measure_preserving_swap : measure_preserving prod.swap (μ.prod ν) (ν.prod μ) :=
+⟨measurable_swap, prod_swap⟩
 
 lemma prod_apply_symm {s : set (α × β)} (hs : measurable_set s) :
   μ.prod ν s = ∫⁻ y, μ ((λ x, (x, y)) ⁻¹' s) ∂ν :=
@@ -697,21 +700,21 @@ by { rw ← prod_swap at hf, exact hf.comp_measurable measurable_swap }
 
 lemma ae_measurable.fst [sigma_finite ν] {f : α → γ}
   (hf : ae_measurable f μ) : ae_measurable (λ (z : α × β), f z.1) (μ.prod ν) :=
-hf.comp_measurable' measurable_fst prod_fst_absolutely_continuous
+hf.comp_quasi_measure_preserving quasi_measure_preserving_fst
 
 lemma ae_measurable.snd [sigma_finite ν] {f : β → γ}
   (hf : ae_measurable f ν) : ae_measurable (λ (z : α × β), f z.2) (μ.prod ν) :=
-hf.comp_measurable' measurable_snd prod_snd_absolutely_continuous
+hf.comp_quasi_measure_preserving quasi_measure_preserving_snd
 
 lemma measure_theory.ae_strongly_measurable.fst {γ} [topological_space γ] [sigma_finite ν]
   {f : α → γ} (hf : ae_strongly_measurable f μ) :
   ae_strongly_measurable (λ (z : α × β), f z.1) (μ.prod ν) :=
-hf.comp_measurable' measurable_fst prod_fst_absolutely_continuous
+hf.comp_quasi_measure_preserving quasi_measure_preserving_fst
 
 lemma measure_theory.ae_strongly_measurable.snd {γ} [topological_space γ] [sigma_finite ν]
   {f : β → γ} (hf : ae_strongly_measurable f ν) :
   ae_strongly_measurable (λ (z : α × β), f z.2) (μ.prod ν) :=
-hf.comp_measurable' measurable_snd prod_snd_absolutely_continuous
+hf.comp_quasi_measure_preserving quasi_measure_preserving_snd
 
 /-- The Bochner integral is a.e.-measurable.
   This shows that the integrand of (the right-hand-side of) Fubini's theorem is a.e.-measurable. -/
@@ -897,9 +900,7 @@ lemma integrable_prod_mul {f : α → ℝ} {g : β → ℝ} (hf : integrable f �
   integrable (λ (z : α × β), f z.1 * g z.2) (μ.prod ν) :=
 begin
   refine (integrable_prod_iff _).2 ⟨_, _⟩,
-  { apply ae_strongly_measurable.mul,
-    { exact (hf.1.mono' prod_fst_absolutely_continuous).comp_measurable measurable_fst },
-    { exact (hg.1.mono' prod_snd_absolutely_continuous).comp_measurable measurable_snd } },
+  { exact hf.1.fst.mul hg.1.snd },
   { exact eventually_of_forall (λ x, hg.const_mul (f x)) },
   { simpa only [norm_mul, integral_mul_left] using hf.norm.mul_const _ }
 end

--- a/src/measure_theory/function/strongly_measurable.lean
+++ b/src/measure_theory/function/strongly_measurable.lean
@@ -1466,10 +1466,10 @@ lemma comp_measurable {γ : Type*} {mγ : measurable_space γ} {mα : measurable
   ae_strongly_measurable (g ∘ f) μ :=
 hg.comp_ae_measurable hf.ae_measurable
 
-lemma comp_measurable' {γ : Type*} {mγ : measurable_space γ} {mα : measurable_space α} {f : γ → α}
-  {μ : measure γ} {ν : measure α} (hg : ae_strongly_measurable g ν) (hf : measurable f)
-  (h : μ.map f ≪ ν) : ae_strongly_measurable (g ∘ f) μ :=
-(hg.mono' h).comp_measurable hf
+lemma comp_quasi_measure_preserving {γ : Type*} {mγ : measurable_space γ} {mα : measurable_space α}
+  {f : γ → α} {μ : measure γ} {ν : measure α} (hg : ae_strongly_measurable g ν)
+  (hf : quasi_measure_preserving f μ ν) : ae_strongly_measurable (g ∘ f) μ :=
+(hg.mono' hf.absolutely_continuous).comp_measurable hf.measurable
 
 lemma is_separable_ae_range (hf : ae_strongly_measurable f μ) :
   ∃ (t : set β), is_separable t ∧ ∀ᵐ x ∂μ, f x ∈ t :=

--- a/src/measure_theory/group/measure.lean
+++ b/src/measure_theory/group/measure.lean
@@ -159,8 +159,12 @@ lemma map_div_right_eq_self (μ : measure G) [is_mul_right_invariant μ] (g : G)
   map (/ g) μ = μ :=
 by simp_rw [div_eq_mul_inv, map_mul_right_eq_self μ g⁻¹]
 
-
 variables [has_measurable_mul G]
+
+@[to_additive]
+lemma measure_preserving_div_right (μ : measure G) [is_mul_right_invariant μ]
+  (g : G) : measure_preserving (/ g) μ μ :=
+by simp_rw [div_eq_mul_inv, measure_preserving_mul_right μ g⁻¹]
 
 /-- We shorten this from `measure_preimage_mul_left`, since left invariant is the preferred option
   for measures in this formalization. -/

--- a/src/measure_theory/group/prod.lean
+++ b/src/measure_theory/group/prod.lean
@@ -68,7 +68,7 @@ lemma measure_preserving_prod_mul [is_mul_left_invariant ν] :
 This is the map `SR` in [Halmos, §59].
 `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
 @[to_additive measure_preserving_prod_add_swap
-  /-" The map `(x, y) ↦ (y, y + x)` semds the measure `μ × ν` to `ν × μ`. "-/]
+  /-" The map `(x, y) ↦ (y, y + x)` sends the measure `μ × ν` to `ν × μ`. "-/]
 lemma measure_preserving_prod_mul_swap [is_mul_left_invariant μ] :
   measure_preserving (λ z : G × G, (z.2, z.2 * z.1)) (μ.prod ν) (ν.prod μ) :=
 (measure_preserving_prod_mul ν μ).comp measure_preserving_swap

--- a/src/measure_theory/group/prod.lean
+++ b/src/measure_theory/group/prod.lean
@@ -64,7 +64,7 @@ lemma measure_preserving_prod_mul [is_mul_left_invariant ν] :
 (measure_preserving.id μ).skew_product measurable_mul $
   filter.eventually_of_forall $ map_mul_left_eq_self ν
 
-/-- The map `(x, y) ↦ (y, yx)` semds the measure `μ × ν` to `ν × μ`.
+/-- The map `(x, y) ↦ (y, yx)` sends the measure `μ × ν` to `ν × μ`.
 This is the map `SR` in [Halmos, §59].
 `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
 @[to_additive measure_preserving_prod_add_swap

--- a/src/measure_theory/group/prod.lean
+++ b/src/measure_theory/group/prod.lean
@@ -187,7 +187,9 @@ lemma measure_mul_right_ne_zero
 
 /-- A *left*-invariant is quasi-preserved by *right*-multiplication.
 This should not be confused with `(measure_preserving_mul_right μ g).quasi_measure_preserving`. -/
-@[to_additive] lemma quasi_measure_preserving_mul_right (g : G) :
+@[to_additive /-"A *left*-invariant is quasi-preserved by *right*-addition.
+This should not be confused with `(measure_preserving_add_right μ g).quasi_measure_preserving`. "-/]
+lemma quasi_measure_preserving_mul_right (g : G) :
   quasi_measure_preserving (λ h : G, h * g) μ μ :=
 begin
   refine ⟨measurable_mul_const g, absolutely_continuous.mk $ λ s hs, _⟩,

--- a/src/measure_theory/group/prod.lean
+++ b/src/measure_theory/group/prod.lean
@@ -222,8 +222,7 @@ begin
 end
 
 /-- This is the computation performed in the proof of [Halmos, §60 Th. A]. -/
-@[to_additive
-  "This is the computation performed in the proof of [Halmos, §60 Th. A]."]
+@[to_additive "This is the computation performed in the proof of [Halmos, §60 Th. A]."]
 lemma measure_mul_lintegral_eq
   [is_mul_left_invariant ν] (Em : measurable_set E) (f : G → ℝ≥0∞) (hf : measurable f) :
   μ E * ∫⁻ y, f y ∂ν = ∫⁻ x, ν ((λ z, z * x) ⁻¹' E) * f (x⁻¹) ∂μ :=

--- a/src/measure_theory/group/prod.lean
+++ b/src/measure_theory/group/prod.lean
@@ -67,8 +67,9 @@ lemma measure_preserving_prod_mul [is_mul_left_invariant ν] :
 /-- The map `(x, y) ↦ (y, yx)` semds the measure `μ × ν` to `ν × μ`.
 This is the map `SR` in [Halmos, §59].
 `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
-@[to_additive measure_preserving_prod_add_prod_add_swap /-"  "-/]
-lemma measure_preserving_prod_add_prod_mul_swap [is_mul_left_invariant μ] :
+@[to_additive measure_preserving_prod_add_swap
+  /-" The map `(x, y) ↦ (y, y + x)` semds the measure `μ × ν` to `ν × μ`. "-/]
+lemma measure_preserving_prod_mul_swap [is_mul_left_invariant μ] :
   measure_preserving (λ z : G × G, (z.2, z.2 * z.1)) (μ.prod ν) (ν.prod μ) :=
 (measure_preserving_prod_mul ν μ).comp measure_preserving_swap
 
@@ -122,7 +123,7 @@ lemma measure_preserving_mul_prod_inv [is_mul_left_invariant ν] :
   measure_preserving (λ z : G × G, (z.2 * z.1, z.1⁻¹)) (μ.prod ν) (μ.prod ν) :=
 begin
   convert (measure_preserving_prod_inv_mul_swap ν μ).comp
-    (measure_preserving_prod_add_prod_mul_swap μ ν),
+    (measure_preserving_prod_mul_swap μ ν),
   ext1 ⟨x, y⟩,
   simp_rw [function.comp_apply, mul_inv_rev, inv_mul_cancel_right]
 end
@@ -221,7 +222,8 @@ begin
 end
 
 /-- This is the computation performed in the proof of [Halmos, §60 Th. A]. -/
-@[to_additive "This is the computation performed in the proof of [Halmos, §60 Th. A]."]
+@[to_additive
+  "This is the computation performed in the proof of [Halmos, §60 Th. A]."]
 lemma measure_mul_lintegral_eq
   [is_mul_left_invariant ν] (Em : measurable_set E) (f : G → ℝ≥0∞) (hf : measurable f) :
   μ E * ∫⁻ y, f y ∂ν = ∫⁻ x, ν ((λ z, z * x) ⁻¹' E) * f (x⁻¹) ∂μ :=

--- a/src/measure_theory/group/prod.lean
+++ b/src/measure_theory/group/prod.lean
@@ -54,11 +54,11 @@ namespace measure_theory
 
 open measure
 
-/-- The shear mapping `(x, y) ↦ (x, xy)` preserves the measure `μ × ν`.
+/-- The multiplicative shear mapping `(x, y) ↦ (x, xy)` preserves the measure `μ × ν`.
 This condition is part of the definition of a measurable group in [Halmos, §59].
 There, the map in this lemma is called `S`. -/
 @[to_additive measure_preserving_prod_add
-  /-" An additive shear mapping `(x, y) ↦ (x, x + y)` preserves the measure `μ.prod ν`. "-/]
+  /-" The shear mapping `(x, y) ↦ (x, x + y)` preserves the measure `μ.prod ν`. "-/]
 lemma measure_preserving_prod_mul [is_mul_left_invariant ν] :
   measure_preserving (λ z : G × G, (z.1, z.1 * z.2)) (μ.prod ν) (μ.prod ν) :=
 (measure_preserving.id μ).skew_product measurable_mul $
@@ -185,9 +185,9 @@ lemma measure_mul_right_ne_zero
   (h2E : μ E ≠ 0) (y : G) : μ ((λ x, x * y) ⁻¹' E) ≠ 0 :=
 (not_iff_not_of_iff (measure_mul_right_null μ y)).mpr h2E
 
-/-- A *left*-invariant is quasi-preserved by *right*-multiplication.
+/-- A *left*-invariant measure is quasi-preserved by *right*-multiplication.
 This should not be confused with `(measure_preserving_mul_right μ g).quasi_measure_preserving`. -/
-@[to_additive /-"A *left*-invariant is quasi-preserved by *right*-addition.
+@[to_additive /-"A *left*-invariant measure is quasi-preserved by *right*-addition.
 This should not be confused with `(measure_preserving_add_right μ g).quasi_measure_preserving`. "-/]
 lemma quasi_measure_preserving_mul_right (g : G) :
   quasi_measure_preserving (λ h : G, h * g) μ μ :=

--- a/src/measure_theory/group/prod.lean
+++ b/src/measure_theory/group/prod.lean
@@ -54,25 +54,23 @@ namespace measure_theory
 
 open measure
 
-/-- A shear mapping preserves the measure `μ.prod ν`.
+/-- The shear mapping `(x, y) ↦ (x, xy)` preserves the measure `μ × ν`.
 This condition is part of the definition of a measurable group in [Halmos, §59].
 There, the map in this lemma is called `S`. -/
-@[to_additive map_prod_add_eq /-" An additive shear mapping preserves the measure `μ.prod ν`. "-/]
-lemma map_prod_mul_eq [is_mul_left_invariant ν] :
-  map (λ z : G × G, (z.1, z.1 * z.2)) (μ.prod ν) = μ.prod ν :=
-((measure_preserving.id μ).skew_product measurable_mul
-  (filter.eventually_of_forall $ map_mul_left_eq_self ν)).map_eq
+@[to_additive measure_preserving_prod_add
+  /-" An additive shear mapping `(x, y) ↦ (x, x + y)` preserves the measure `μ.prod ν`. "-/]
+lemma measure_preserving_prod_mul [is_mul_left_invariant ν] :
+  measure_preserving (λ z : G × G, (z.1, z.1 * z.2)) (μ.prod ν) (μ.prod ν) :=
+(measure_preserving.id μ).skew_product measurable_mul $
+  filter.eventually_of_forall $ map_mul_left_eq_self ν
 
-/-- The function we are mapping along is `SR` in [Halmos, §59],
-  where `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
-@[to_additive map_prod_add_eq_swap /-"  "-/]
-lemma map_prod_mul_eq_swap [is_mul_left_invariant μ] :
-  map (λ z : G × G, (z.2, z.2 * z.1)) (μ.prod ν) = ν.prod μ :=
-begin
-  rw [← prod_swap],
-  simp_rw [map_map (measurable_snd.prod_mk (measurable_snd.mul measurable_fst)) measurable_swap],
-  exact map_prod_mul_eq ν μ
-end
+/-- The map `(x, y) ↦ (y, yx)` semds the measure `μ × ν` to `ν × μ`.
+This is the map `SR` in [Halmos, §59].
+`S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
+@[to_additive measure_preserving_prod_add_prod_add_swap /-"  "-/]
+lemma measure_preserving_prod_add_prod_mul_swap [is_mul_left_invariant μ] :
+  measure_preserving (λ z : G × G, (z.2, z.2 * z.1)) (μ.prod ν) (ν.prod μ) :=
+(measure_preserving_prod_mul ν μ).comp measure_preserving_swap
 
 @[to_additive]
 lemma measurable_measure_mul_right (hE : measurable_set E) :
@@ -82,56 +80,51 @@ begin
     μ ((λ x, (x, y)) ⁻¹' ((λ z : G × G, ((1 : G), z.1 * z.2)) ⁻¹' (univ ×ˢ E)))),
   { convert this, ext1 x, congr' 1 with y : 1, simp },
   apply measurable_measure_prod_mk_right,
-  exact measurable_const.prod_mk (measurable_fst.mul measurable_snd) (measurable_set.univ.prod hE)
+  exact measurable_const.prod_mk measurable_mul (measurable_set.univ.prod hE)
 end
 
 variables [has_measurable_inv G]
 
-/-- The function we are mapping along is `S⁻¹` in [Halmos, §59],
-  where `S` is the map in `map_prod_mul_eq`. -/
-@[to_additive map_prod_neg_add_eq "The function we are mapping along is `-S` in [Halmos, §59], where
-`S` is the map in `map_prod_add_eq`."]
-lemma map_prod_inv_mul_eq [is_mul_left_invariant ν] :
-  map (λ z : G × G, (z.1, z.1⁻¹ * z.2)) (μ.prod ν) = μ.prod ν :=
-(measurable_equiv.shear_mul_right G).map_apply_eq_iff_map_symm_apply_eq.mp $ map_prod_mul_eq μ ν
+/-- The map `(x, y) ↦ (x, x⁻¹y)` is measure-preserving.
+This is the function `S⁻¹` in [Halmos, §59],
+where `S` is the map in `measure_preserving_prod_mul`. -/
+@[to_additive measure_preserving_prod_neg_add
+  "The map `(x, y) ↦ (x, - x + y)` is measure-preserving."]
+lemma measure_preserving_prod_inv_mul [is_mul_left_invariant ν] :
+  measure_preserving (λ z : G × G, (z.1, z.1⁻¹ * z.2)) (μ.prod ν) (μ.prod ν) :=
+(measure_preserving_prod_mul μ ν).symm $ measurable_equiv.shear_mul_right G
 
 @[to_additive]
 lemma quasi_measure_preserving_div [is_mul_right_invariant μ] :
   quasi_measure_preserving (λ (p : G × G), p.1 / p.2) (μ.prod μ) μ :=
 begin
-  refine quasi_measure_preserving.prod_of_left measurable_div _,
-  simp_rw [div_eq_mul_inv],
-  apply eventually_of_forall,
-  refine λ y, ⟨measurable_mul_const y⁻¹, (map_mul_right_eq_self μ y⁻¹).absolutely_continuous⟩
+  refine quasi_measure_preserving.prod_of_left measurable_div (eventually_of_forall $ λ y, _),
+  exact (measure_preserving_div_right μ y).quasi_measure_preserving
 end
 
 variables [is_mul_left_invariant μ]
 
-/-- The function we are mapping along is `S⁻¹R` in [Halmos, §59],
-  where `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
-@[to_additive map_prod_neg_add_eq_swap "The function we are mapping along is `-S + R` in
-[Halmos, §59], where `S` is the map in `map_prod_add_eq` and `R` is `prod.swap`."]
-lemma map_prod_inv_mul_eq_swap : map (λ z : G × G, (z.2, z.2⁻¹ * z.1)) (μ.prod ν) = ν.prod μ :=
-begin
-  rw [← prod_swap],
-  simp_rw
-    [map_map (measurable_snd.prod_mk $ measurable_snd.inv.mul measurable_fst) measurable_swap],
-  exact map_prod_inv_mul_eq ν μ
-end
+/-- The map `(x, y) ↦ (y, y⁻¹x)` sends `μ × ν` to `ν × μ`.
+This is the function `S⁻¹R` in [Halmos, §59],
+where `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
+@[to_additive measure_preserving_prod_neg_add_swap
+  "The map `(x, y) ↦ (y, - y + x)` sends `μ × ν` to `ν × μ`."]
+lemma measure_preserving_prod_inv_mul_swap :
+  measure_preserving (λ z : G × G, (z.2, z.2⁻¹ * z.1)) (μ.prod ν) (ν.prod μ) :=
+(measure_preserving_prod_inv_mul ν μ).comp measure_preserving_swap
 
-/-- The function we are mapping along is `S⁻¹RSR` in [Halmos, §59],
-  where `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
-@[to_additive map_prod_add_neg_eq "The function we are mapping along is `-S + R + S + R ` in
-[Halmos, §59], where `S` is the map in `map_prod_add_eq` and `R` is `prod.swap`."]
-lemma map_prod_mul_inv_eq [is_mul_left_invariant ν] :
-  map (λ z : G × G, (z.2 * z.1, z.1⁻¹)) (μ.prod ν) = μ.prod ν :=
+/-- The map `(x, y) ↦ (yx, x⁻¹)` is measure-preserving.
+This is the function `S⁻¹RSR` in [Halmos, §59],
+where `S` is the map in `map_prod_mul_eq` and `R` is `prod.swap`. -/
+@[to_additive measure_preserving_add_prod_neg
+  "The map `(x, y) ↦ (y + x, - x)` is measure-preserving."]
+lemma measure_preserving_mul_prod_inv [is_mul_left_invariant ν] :
+  measure_preserving (λ z : G × G, (z.2 * z.1, z.1⁻¹)) (μ.prod ν) (μ.prod ν) :=
 begin
-  suffices : map ((λ z : G × G, (z.2, z.2⁻¹ * z.1)) ∘ (λ z : G × G, (z.2, z.2 * z.1))) (μ.prod ν) =
-    μ.prod ν,
-  { convert this, ext1 ⟨x, y⟩, simp },
-  simp_rw [← map_map (measurable_snd.prod_mk (measurable_snd.inv.mul measurable_fst))
-    (measurable_snd.prod_mk (measurable_snd.mul measurable_fst)), map_prod_mul_eq_swap μ ν,
-    map_prod_inv_mul_eq_swap ν μ]
+  convert (measure_preserving_prod_inv_mul_swap ν μ).comp
+    (measure_preserving_prod_add_prod_mul_swap μ ν),
+  ext1 ⟨x, y⟩,
+  simp_rw [function.comp_apply, mul_inv_rev, inv_mul_cancel_right]
 end
 
 @[to_additive] lemma quasi_measure_preserving_inv :
@@ -142,15 +135,12 @@ begin
   have hf : measurable (λ z : G × G, (z.2 * z.1, z.1⁻¹)) :=
     (measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv,
   suffices : map (λ z : G × G, (z.2 * z.1, z.1⁻¹)) (μ.prod μ) (s⁻¹ ×ˢ s⁻¹) = 0,
-  { simpa only [map_prod_mul_inv_eq μ μ, prod_prod, mul_eq_zero, or_self] using this },
+  { simpa only [(measure_preserving_mul_prod_inv μ μ).map_eq,
+      prod_prod, mul_eq_zero, or_self] using this },
   have hsm' : measurable_set (s⁻¹ ×ˢ s⁻¹) := hsm.inv.prod hsm.inv,
   simp_rw [map_apply hf hsm', prod_apply_symm (hf hsm'), preimage_preimage, mk_preimage_prod,
     inv_preimage, inv_inv, measure_mono_null (inter_subset_right _ _) hμs, lintegral_zero]
 end
-
-@[to_additive]
-lemma map_inv_absolutely_continuous : map has_inv.inv μ ≪ μ :=
-(quasi_measure_preserving_inv μ).absolutely_continuous
 
 @[to_additive]
 lemma measure_inv_null : μ E⁻¹ = 0 ↔ μ E = 0 :=
@@ -174,12 +164,13 @@ lemma lintegral_lintegral_mul_inv [is_mul_left_invariant ν]
 begin
   have h : measurable (λ z : G × G, (z.2 * z.1, z.1⁻¹)) :=
   (measurable_snd.mul measurable_fst).prod_mk measurable_fst.inv,
-  have h2f : ae_measurable (uncurry $ λ x y, f (y * x) x⁻¹) (μ.prod ν),
-  { apply hf.comp_measurable' h (map_prod_mul_inv_eq μ ν).absolutely_continuous },
+  have h2f : ae_measurable (uncurry $ λ x y, f (y * x) x⁻¹) (μ.prod ν) :=
+    hf.comp_quasi_measure_preserving (measure_preserving_mul_prod_inv μ ν).quasi_measure_preserving,
   simp_rw [lintegral_lintegral h2f, lintegral_lintegral hf],
-  conv_rhs { rw [← map_prod_mul_inv_eq μ ν] },
+  conv_rhs { rw [← (measure_preserving_mul_prod_inv μ ν).map_eq] },
   symmetry,
-  exact lintegral_map' (hf.mono' (map_prod_mul_inv_eq μ ν).absolutely_continuous) h.ae_measurable,
+  exact lintegral_map' (hf.mono' (measure_preserving_mul_prod_inv μ ν).map_eq.absolutely_continuous)
+    h.ae_measurable,
 end
 
 @[to_additive]
@@ -215,11 +206,9 @@ end
 @[to_additive] lemma quasi_measure_preserving_div_left (g : G) :
   quasi_measure_preserving (λ h : G, g / h) μ μ :=
 begin
-  refine ⟨measurable_const.div measurable_id, _⟩,
   simp_rw [div_eq_mul_inv],
-  rw [← map_map (measurable_const_mul g) measurable_inv],
-  refine ((map_inv_absolutely_continuous μ).map $ measurable_const_mul g).trans _,
-  rw [map_mul_left_eq_self],
+  exact (measure_preserving_mul_left μ g).quasi_measure_preserving.comp
+    (quasi_measure_preserving_inv μ)
 end
 
 @[to_additive]

--- a/src/measure_theory/group/prod.lean
+++ b/src/measure_theory/group/prod.lean
@@ -185,16 +185,14 @@ lemma measure_mul_right_ne_zero
   (h2E : μ E ≠ 0) (y : G) : μ ((λ x, x * y) ⁻¹' E) ≠ 0 :=
 (not_iff_not_of_iff (measure_mul_right_null μ y)).mpr h2E
 
+/-- A *left*-invariant is quasi-preserved by *right*-multiplication.
+This should not be confused with `(measure_preserving_mul_right μ g).quasi_measure_preserving`. -/
 @[to_additive] lemma quasi_measure_preserving_mul_right (g : G) :
   quasi_measure_preserving (λ h : G, h * g) μ μ :=
 begin
   refine ⟨measurable_mul_const g, absolutely_continuous.mk $ λ s hs, _⟩,
   rw [map_apply (measurable_mul_const g) hs, measure_mul_right_null], exact id,
 end
-
-@[to_additive]
-lemma map_mul_right_absolutely_continuous (g : G) : map (* g) μ ≪ μ :=
-(quasi_measure_preserving_mul_right μ g).absolutely_continuous
 
 @[to_additive]
 lemma absolutely_continuous_map_mul_right (g : G) : μ ≪ map (* g) μ :=
@@ -210,10 +208,6 @@ begin
   exact (measure_preserving_mul_left μ g).quasi_measure_preserving.comp
     (quasi_measure_preserving_inv μ)
 end
-
-@[to_additive]
-lemma map_div_left_absolutely_continuous (g : G) : map (λ h, g / h) μ ≪ μ :=
-(quasi_measure_preserving_div_left μ g).absolutely_continuous
 
 @[to_additive]
 lemma absolutely_continuous_map_div_left (g : G) : μ ≪ map (λ h, g / h) μ :=

--- a/src/measure_theory/measure/ae_measurable.lean
+++ b/src/measure_theory/measure/ae_measurable.lean
@@ -129,9 +129,9 @@ lemma comp_measurable {f : α → δ} {g : δ → β}
   (hg : ae_measurable g (μ.map f)) (hf : measurable f) : ae_measurable (g ∘ f) μ :=
 hg.comp_ae_measurable hf.ae_measurable
 
-lemma comp_measurable' {ν : measure δ} {f : α → δ} {g : δ → β} (hg : ae_measurable g ν)
-  (hf : measurable f) (h : μ.map f ≪ ν) : ae_measurable (g ∘ f) μ :=
-(hg.mono' h).comp_measurable hf
+lemma comp_quasi_measure_preserving {ν : measure δ} {f : α → δ} {g : δ → β} (hg : ae_measurable g ν)
+  (hf : quasi_measure_preserving f μ ν) : ae_measurable (g ∘ f) μ :=
+(hg.mono' hf.absolutely_continuous).comp_measurable hf.measurable
 
 lemma map_map_of_ae_measurable {g : β → γ} {f : α → β}
   (hg : ae_measurable g (measure.map f μ)) (hf : ae_measurable f μ) :

--- a/src/measure_theory/measure/lebesgue.lean
+++ b/src/measure_theory/measure/lebesgue.lean
@@ -488,11 +488,8 @@ begin
     (μ.restrict s).prod volume (region_between (ae_measurable.mk f hf) (ae_measurable.mk g hg) s),
   { apply measure_congr,
     apply eventually_eq.rfl.inter,
-    exact
-      ((ae_eq_comp' measurable_fst.ae_measurable
-        hf.ae_eq_mk measure.prod_fst_absolutely_continuous).comp₂ _ eventually_eq.rfl).inter
-      (eventually_eq.rfl.comp₂ _ (ae_eq_comp' measurable_fst.ae_measurable
-        hg.ae_eq_mk measure.prod_fst_absolutely_continuous)) },
+    exact ((quasi_measure_preserving_fst.ae_eq_comp hf.ae_eq_mk).comp₂ _ eventually_eq.rfl).inter
+      (eventually_eq.rfl.comp₂ _ $ quasi_measure_preserving_fst.ae_eq_comp hg.ae_eq_mk) },
   rw [lintegral_congr_ae h₁,
       ← volume_region_between_eq_lintegral' hf.measurable_mk hg.measurable_mk hs],
   convert h₂ using 1,

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -2092,6 +2092,10 @@ lemma ae_eq_comp' {ν : measure β} {f : α → β} {g g' : β → δ} (hf : ae_
   (h : g =ᵐ[ν] g') (h2 : μ.map f ≪ ν) : g ∘ f =ᵐ[μ] g' ∘ f :=
 (tendsto_ae_map hf).mono_right h2.ae_le h
 
+lemma measure.quasi_measure_preserving.ae_eq_comp {ν : measure β} {f : α → β} {g g' : β → δ}
+  (hf : quasi_measure_preserving f μ ν) (h : g =ᵐ[ν] g') : g ∘ f =ᵐ[μ] g' ∘ f :=
+ae_eq_comp' hf.ae_measurable h hf.absolutely_continuous
+
 lemma ae_eq_comp {f : α → β} {g g' : β → δ} (hf : ae_measurable f μ)
   (h : g =ᵐ[μ.map f] g') : g ∘ f =ᵐ[μ] g' ∘ f :=
 ae_eq_comp' hf h absolutely_continuous.rfl


### PR DESCRIPTION
* Also use `quasi_measure_preserving` more in various files. In particular, `ae_[strongly_]measurable.comp_measurable'` is now `.comp_quasi_measure_preserving`.
* Remove lemmas that are direct consequences of `[quasi_]measure_preserving` properties.
* This simplifies various proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
