### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/star/basic): in a C⋆-ring `star x * x = 0 ↔ x = 0`

### DIFF
--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -110,6 +110,20 @@ by rw [norm_star_mul_self, norm_star]
 lemma nnnorm_star_mul_self {x : E} : ∥x⋆ * x∥₊ = ∥x∥₊ * ∥x∥₊ :=
 subtype.ext norm_star_mul_self
 
+@[simp]
+lemma star_mul_self_eq_zero_iff (x : E) : star x * x = 0 ↔ x = 0 :=
+by { rw [←norm_eq_zero, norm_star_mul_self], exact mul_self_eq_zero.trans norm_eq_zero }
+
+lemma star_mul_self_ne_zero_iff (x : E) : star x * x ≠ 0 ↔ x ≠ 0 :=
+by simp only [ne.def, star_mul_self_eq_zero_iff]
+
+@[simp]
+lemma mul_star_self_eq_zero_iff (x : E) : x * star x = 0 ↔ x = 0 :=
+by simpa only [star_eq_zero, star_star] using @star_mul_self_eq_zero_iff _ _ _ _ (star x)
+
+lemma mul_star_self_ne_zero_iff (x : E) : x * star x ≠ 0 ↔ x ≠ 0 :=
+by simp only [ne.def, mul_star_self_eq_zero_iff]
+
 end non_unital
 
 section prod_pi


### PR DESCRIPTION
This adds a few convenience lemmas for C⋆-rings regarding criteria for being equal, or not equal, to zero.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
