### PR TITLE
feat(data/complex/is_R_or_C): add maps directly from `ℝ≥0`

### DIFF
--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -899,7 +899,7 @@ end linear_maps
 section nnreal
 open_locale nnreal
 
-/- The natural coercion from `ℝ≥0` to `K` as an `ℝ≥0`-algebra map. -/
+/-- The natural coercion from `ℝ≥0` to `K` as an `ℝ≥0`-algebra map. -/
 noncomputable def of_nnreal_am : ℝ≥0 →ₐ[ℝ≥0] K := algebra.of_id ℝ≥0 K
 
 /-- This is not registered as a `simp` lemma because the reason `is_R_or_C.of_nnreal_am` exists

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -896,4 +896,47 @@ end
 
 end linear_maps
 
+section nnreal
+open_locale nnreal
+
+/- The natural coercion from `ℝ≥0` to `K` as an `ℝ≥0`-algebra map. -/
+noncomputable def of_nnreal_am : ℝ≥0 →ₐ[ℝ≥0] K := algebra.of_id ℝ≥0 K
+
+/-- This is not registered as a `simp` lemma because the reason `is_R_or_C.of_nnreal_am` exists
+is to go directly from `ℝ≥0` to `K` with nice properties without first passing through `ℝ`. -/
+lemma of_nnreal_am_coe : (of_nnreal_am : ℝ≥0 → K) = coe := funext $ λ x, rfl
+
+/-- The natural coercion from `ℝ≥0` to `K` as a continuous `ℝ≥0`-linear map. -/
+noncomputable def of_nnreal_clm : ℝ≥0 →L[ℝ≥0] K :=
+{ to_fun := of_nnreal_am,
+  cont := by simpa only [←(funext (λ x, rfl) : (coe : ℝ → K) ∘ coe = of_nnreal_am)]
+    using is_R_or_C.continuous_of_real.comp continuous_induced_dom,
+  .. of_nnreal_am.to_linear_map }
+
+@[simp] lemma of_nnreal_clm_coe : (of_nnreal_clm : ℝ≥0 → K) = of_nnreal_am := rfl
+
+@[continuity] lemma continuous_of_nnreal : continuous (coe : ℝ≥0 → K) :=
+map_continuous (of_nnreal_clm : ℝ≥0 →L[ℝ≥0] K)
+
+/-- The natural coercion from `ℝ≥0` to `K` as a continuous map. -/
+noncomputable def of_nnreal_cm : C(ℝ≥0, K) :=
+{ to_fun := of_nnreal_am, continuous_to_fun := continuous_of_nnreal }
+
+@[simp] lemma of_nnreal_cm_coe : (of_nnreal_cm : ℝ≥0 → K) = of_nnreal_am :=
+rfl
+
+@[simp] lemma nnnorm_of_nnreal (x : ℝ≥0) : ∥((x : ℝ) : K)∥₊ = x :=
+subtype.ext $ by simp only [coe_nnnorm, is_R_or_C.norm_of_real, real.norm_of_nonneg x.prop]
+
+@[simp] lemma norm_of_nnreal (x : ℝ≥0) : ∥((x : ℝ) : K)∥ = x :=
+congr_arg coe (nnnorm_of_nnreal x)
+
+@[simp] lemma nnnorm_of_nnreal_am (x : ℝ≥0) : ∥(of_nnreal_am x : K)∥₊ = x :=
+nnnorm_of_nnreal x
+
+@[simp] lemma norm_of_nnreal_am (x : ℝ≥0) : ∥(of_nnreal_am x : K)∥ = x :=
+norm_of_nnreal x
+
+end nnreal
+
 end is_R_or_C

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -899,43 +899,30 @@ end linear_maps
 section nnreal
 open_locale nnreal
 
-/-- The natural coercion from `ℝ≥0` to `K` as an `ℝ≥0`-algebra map. -/
-noncomputable def of_nnreal_am : ℝ≥0 →ₐ[ℝ≥0] K := algebra.of_id ℝ≥0 K
-
-/-- This is not registered as a `simp` lemma because the reason `is_R_or_C.of_nnreal_am` exists
-is to go directly from `ℝ≥0` to `K` with nice properties without first passing through `ℝ`. -/
-lemma of_nnreal_am_coe : (of_nnreal_am : ℝ≥0 → K) = coe := funext $ λ x, rfl
-
 /-- The natural coercion from `ℝ≥0` to `K` as a continuous `ℝ≥0`-linear map. -/
 noncomputable def of_nnreal_clm : ℝ≥0 →L[ℝ≥0] K :=
-{ to_fun := of_nnreal_am,
-  cont := by simpa only [←(funext (λ x, rfl) : (coe : ℝ → K) ∘ coe = of_nnreal_am)]
-    using is_R_or_C.continuous_of_real.comp continuous_induced_dom,
-  .. of_nnreal_am.to_linear_map }
+{ to_fun := algebra_map ℝ≥0 K,
+  cont := is_R_or_C.continuous_of_real.comp continuous_induced_dom,
+  .. (algebra.of_id ℝ≥0 K).to_linear_map }
 
-@[simp] lemma of_nnreal_clm_coe : (of_nnreal_clm : ℝ≥0 → K) = of_nnreal_am := rfl
+@[simp] lemma of_nnreal_clm_coe : (of_nnreal_clm : ℝ≥0 → K) = algebra_map ℝ≥0 K := rfl
 
 @[continuity] lemma continuous_of_nnreal : continuous (coe : ℝ≥0 → K) :=
 map_continuous (of_nnreal_clm : ℝ≥0 →L[ℝ≥0] K)
 
 /-- The natural coercion from `ℝ≥0` to `K` as a continuous map. -/
-noncomputable def of_nnreal_cm : C(ℝ≥0, K) :=
-{ to_fun := of_nnreal_am, continuous_to_fun := continuous_of_nnreal }
+noncomputable def of_nnreal_cm : C(ℝ≥0, K) := ⟨algebra_map ℝ≥0 K, continuous_of_nnreal⟩
 
-@[simp] lemma of_nnreal_cm_coe : (of_nnreal_cm : ℝ≥0 → K) = of_nnreal_am :=
-rfl
+@[simp] lemma of_nnreal_cm_coe : (of_nnreal_cm : ℝ≥0 → K) = algebra_map ℝ≥0 K := rfl
 
-@[simp] lemma nnnorm_of_nnreal (x : ℝ≥0) : ∥((x : ℝ) : K)∥₊ = x :=
+@[simp] lemma nnnorm_coe_coe (x : ℝ≥0) : ∥((x : ℝ) : K)∥₊ = x :=
 subtype.ext $ by simp only [coe_nnnorm, is_R_or_C.norm_of_real, real.norm_of_nonneg x.prop]
 
-@[simp] lemma norm_of_nnreal (x : ℝ≥0) : ∥((x : ℝ) : K)∥ = x :=
-congr_arg coe (nnnorm_of_nnreal x)
+@[simp] lemma norm_coe_coe (x : ℝ≥0) : ∥((x : ℝ) : K)∥ = x := congr_arg coe (nnnorm_coe_coe x)
 
-@[simp] lemma nnnorm_of_nnreal_am (x : ℝ≥0) : ∥(of_nnreal_am x : K)∥₊ = x :=
-nnnorm_of_nnreal x
+@[simp] lemma nnnorm_of_nnreal (x : ℝ≥0) : ∥algebra_map ℝ≥0 K x∥₊ = x := nnnorm_coe_coe x
 
-@[simp] lemma norm_of_nnreal_am (x : ℝ≥0) : ∥(of_nnreal_am x : K)∥ = x :=
-norm_of_nnreal x
+@[simp] lemma norm_of_nnreal (x : ℝ≥0) : ∥algebra_map ℝ≥0 K x∥ = x := norm_coe_coe x
 
 end nnreal
 


### PR DESCRIPTION
This adds a map `is_R_or_C.of_nnreal_am : ℝ≥0 →ₐ[ℝ≥0] K := algebra_map.of_id ℝ≥0 K`. While this map is definitionally equal to `coe : ℝ≥0 → K`, we do not provide this as a `simp` lemma. The purpose of this new map (as well as a few others, like a continuous linear version and a continuous map version) is to provide a direct route from `ℝ≥0` to `K` with nice properties. Currently, `coe : ℝ≥0 → K` often ends up forcing the user to pass first through `ℝ` due to `simp` lemmas like `coe_coe`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
