### PR TITLE
[Merged by Bors] - feat(group_theory/schreier): The size of the commutator subgroup is bounded in terms of the index of the center and the number of commutators

### DIFF
--- a/src/group_theory/abelianization.lean
+++ b/src/group_theory/abelianization.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Michael Howes
 -/
 import group_theory.commutator
-import group_theory.quotient_group
+import group_theory.finiteness
 
 /-!
 # The abelianization of a group
@@ -45,6 +45,19 @@ by simp_rw [commutator, subgroup.commutator_def', subgroup.mem_top, exists_true_
 
 instance commutator_characteristic : (commutator G).characteristic :=
 subgroup.commutator_characteristic ⊤ ⊤
+
+instance [finite {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}] : group.fg (commutator G) :=
+begin
+  rw commutator_eq_closure,
+  apply group.closure_finite_fg,
+end
+
+lemma rank_commutator_le_card [finite {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}] :
+  group.rank (commutator G) ≤ nat.card {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} :=
+begin
+  rw subgroup.rank_congr (commutator_eq_closure G),
+  apply subgroup.rank_closure_finite_le_nat_card,
+end
 
 lemma commutator_centralizer_commutator_le_center :
   ⁅(commutator G).centralizer, (commutator G).centralizer⁆ ≤ subgroup.center G :=

--- a/src/group_theory/schreier.lean
+++ b/src/group_theory/schreier.lean
@@ -144,7 +144,8 @@ end
 
 variables (G)
 
-/-- If `G` has `n` commutators `[g₁, g₂]`, then `|G'| ∣ [G : Z(G)] ^ ([G : Z(G)] * n + 1)`. -/
+/-- If `G` has `n` commutators `[g₁, g₂]`, then `|G'| ∣ [G : Z(G)] ^ ([G : Z(G)] * n + 1)`,
+where `G'` denotes the commutator of `G`. -/
 lemma card_commutator_dvd_index_center_pow [finite {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}] :
   nat.card (commutator G) ∣
     (center G).index ^ ((center G).index * nat.card {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} + 1) :=

--- a/src/group_theory/schreier.lean
+++ b/src/group_theory/schreier.lean
@@ -165,7 +165,7 @@ begin
   have h3 := nat.mul_le_mul (nat.le_of_dvd (nat.pos_of_ne_zero hG) h1) (rank_commutator_le_card G),
   -- So we can reduce to proving `|Z(G) ∩ G'| ∣ [G : Z(G)] ^ rk (Z(G) ∩ G')`
   refine dvd_trans _ (pow_dvd_pow (center G).index (h2.trans h3)),
-  -- But `Z(G) ∩ G'` is abelian, so it is enough to prove that `g ^ [G : Z(G)] = 1` for `g ∈ Z(G)`
+  -- `Z(G) ∩ G'` is abelian, so it enough to prove that `g ^ [G : Z(G)] = 1` for `g ∈ Z(G) ∩ G'`
   apply card_dvd_exponent_pow_rank' _ (λ g, _),
   -- This follows from the theory of the transfer homomorphism
   have := abelianization.commutator_subset_ker (monoid_hom.transfer_center_pow' hG) g.1.2,

--- a/src/group_theory/schreier.lean
+++ b/src/group_theory/schreier.lean
@@ -158,11 +158,11 @@ begin
   have h1 := relindex_dvd_index_of_normal (center G) (commutator G),
   -- So we can reduce to proving `|Z(G) ∩ G'| ∣ [G : Z(G)] ^ ([G : Z(G)] * n)`
   refine mul_dvd_mul _ h1,
-  -- We have `h2 : rk (Z(G) ∩ G') ≤ [G' : Z(G) ∩ G'] * rk G'` by Schreier's lemma
+  -- We have `h2 : rank (Z(G) ∩ G') ≤ [G' : Z(G) ∩ G'] * rank G'` by Schreier's lemma
   have h2 := rank_le_index_mul_rank (ne_zero_of_dvd_ne_zero hG h1),
-  -- We have `h3 : [G' : Z(G) ∩ G'] * rk G' ≤ [G : Z(G)] * n` by `h1` and `rk G' ≤ n`
+  -- We have `h3 : [G' : Z(G) ∩ G'] * rank G' ≤ [G : Z(G)] * n` by `h1` and `rank G' ≤ n`
   have h3 := nat.mul_le_mul (nat.le_of_dvd (nat.pos_of_ne_zero hG) h1) (rank_commutator_le_card G),
-  -- So we can reduce to proving `|Z(G) ∩ G'| ∣ [G : Z(G)] ^ rk (Z(G) ∩ G')`
+  -- So we can reduce to proving `|Z(G) ∩ G'| ∣ [G : Z(G)] ^ rank (Z(G) ∩ G')`
   refine dvd_trans _ (pow_dvd_pow (center G).index (h2.trans h3)),
   -- `Z(G) ∩ G'` is abelian, so it enough to prove that `g ^ [G : Z(G)] = 1` for `g ∈ Z(G) ∩ G'`
   apply card_dvd_exponent_pow_rank' _ (λ g, _),

--- a/src/group_theory/schreier.lean
+++ b/src/group_theory/schreier.lean
@@ -144,12 +144,11 @@ end
 
 variables (G)
 
-/-- If `G` has `n` commutators `[g₁, g₂]`, then `|G'| ≤ [G : Z(G)] ^ ([G : Z(G)] * n + 1)`. -/
+/-- If `G` has `n` commutators `[g₁, g₂]`, then `|G'| ∣ [G : Z(G)] ^ ([G : Z(G)] * n + 1)`. -/
 lemma card_commutator_dvd_index_center_pow [finite {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}] :
   nat.card (commutator G) ∣
     (center G).index ^ ((center G).index * nat.card {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} + 1) :=
 begin
-  classical,
   -- First handle the case when `Z(G)` has infinite index and `[G : Z(G)]` is defined to be `0`
   by_cases hG : (center G).index = 0,
   { simp_rw [hG, zero_mul, zero_add, pow_one, dvd_zero] },
@@ -167,8 +166,9 @@ begin
   refine dvd_trans _ (pow_dvd_pow (center G).index (h2.trans h3)),
   -- `Z(G) ∩ G'` is abelian, so it enough to prove that `g ^ [G : Z(G)] = 1` for `g ∈ Z(G) ∩ G'`
   apply card_dvd_exponent_pow_rank' _ (λ g, _),
-  -- This follows from the theory of the transfer homomorphism
+  -- `Z(G)` is abelian, so `Z(G) ∩ G' ≤ G' ≤ ker (transfer : G → Z(G))`
   have := abelianization.commutator_subset_ker (monoid_hom.transfer_center_pow' hG) g.1.2,
+  -- `transfer g` is defeq to `g ^ [G : Z(G)]`, so we are done
   simpa only [monoid_hom.mem_ker, subtype.ext_iff] using this,
 end
 

--- a/src/group_theory/schreier.lean
+++ b/src/group_theory/schreier.lean
@@ -154,19 +154,19 @@ begin
   { simp_rw [hG, zero_mul, zero_add, pow_one, dvd_zero] },
   -- Rewrite as `|Z(G) ∩ G'| * [G' : Z(G) ∩ G'] ∣ [G : Z(G)] ^ ([G : Z(G)] * n) * [G : Z(G)]`
   rw [←((center G).subgroup_of (commutator G)).card_mul_index, pow_succ'],
-  -- h1 : `[G' : Z(G) ∩ G'] ∣ [G : Z(G)]`
+  -- We have `h1 : [G' : Z(G) ∩ G'] ∣ [G : Z(G)]`
   have h1 := relindex_dvd_index_of_normal (center G) (commutator G),
   -- So we can reduce to proving `|Z(G) ∩ G'| ∣ [G : Z(G)] ^ ([G : Z(G)] * n)`
   refine mul_dvd_mul _ h1,
-  -- h2 : `rk (Z(G) ∩ G') ≤ [G' : Z(G) ∩ G'] * rk G'` by Schreier's lemma
+  -- We have `h2 : rk (Z(G) ∩ G') ≤ [G' : Z(G) ∩ G'] * rk G'` by Schreier's lemma
   have h2 := rank_le_index_mul_rank (ne_zero_of_dvd_ne_zero hG h1),
-  -- h3 : `[G' : Z(G) ∩ G'] * rk G' ≤ [G : Z(G)] * n`
+  -- We have `h3 : [G' : Z(G) ∩ G'] * rk G' ≤ [G : Z(G)] * n` by `h1` and `rk G' ≤ n`
   have h3 := nat.mul_le_mul (nat.le_of_dvd (nat.pos_of_ne_zero hG) h1) (rank_commutator_le_card G),
   -- So we can reduce to proving `|Z(G) ∩ G'| ∣ [G : Z(G)] ^ rk (Z(G) ∩ G')`
   refine dvd_trans _ (pow_dvd_pow (center G).index (h2.trans h3)),
   -- `Z(G) ∩ G'` is abelian, so it enough to prove that `g ^ [G : Z(G)] = 1` for `g ∈ Z(G) ∩ G'`
   apply card_dvd_exponent_pow_rank' _ (λ g, _),
-  -- `Z(G)` is abelian, so `Z(G) ∩ G' ≤ G' ≤ ker (transfer : G → Z(G))`
+  -- `Z(G)` is abelian, so `g ∈ Z(G) ∩ G' ≤ G' ≤ ker (transfer : G → Z(G))`
   have := abelianization.commutator_subset_ker (monoid_hom.transfer_center_pow' hG) g.1.2,
   -- `transfer g` is defeq to `g ^ [G : Z(G)]`, so we are done
   simpa only [monoid_hom.mem_ker, subtype.ext_iff] using this,

--- a/src/group_theory/schreier.lean
+++ b/src/group_theory/schreier.lean
@@ -4,11 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
 
-import data.finset.pointwise
-import group_theory.complement
-import group_theory.finiteness
-import group_theory.index
-import tactic.group
+import group_theory.abelianization
+import group_theory.exponent
+import group_theory.transfer
 
 /-!
 # Schreier's Lemma
@@ -142,6 +140,25 @@ begin
   calc group.rank H ≤ T.card : group.rank_le H hT
   ... ≤ H.index * S.card : hT₀
   ... = H.index * group.rank G : congr_arg ((*) H.index) hS₀,
+end
+
+variables (G)
+
+lemma card_commutator_dvd_index_center_pow [finite {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}] :
+  nat.card (commutator G) ∣
+    (center G).index ^ ((center G).index * nat.card {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} + 1) :=
+begin
+  classical,
+  by_cases hG : (center G).index = 0,
+  { simp_rw [hG, zero_mul, zero_add, pow_one, dvd_zero] },
+  rw [←((center G).subgroup_of (commutator G)).card_mul_index, pow_succ'],
+  have h := relindex_dvd_index_of_normal (center G) (commutator G),
+  refine mul_dvd_mul (dvd_trans _
+    (pow_dvd_pow (center G).index ((rank_le_index_mul_rank (ne_zero_of_dvd_ne_zero hG h)).trans
+    (nat.mul_le_mul (nat.le_of_dvd (nat.pos_of_ne_zero hG) h) (rank_commutator_le_card G))))) h,
+  apply card_dvd_exponent_pow_rank' _ (λ g, _),
+  have := abelianization.commutator_subset_ker (monoid_hom.transfer_center_pow' hG) g.1.2,
+  simpa only [monoid_hom.mem_ker, subtype.ext_iff] using this,
 end
 
 end subgroup


### PR DESCRIPTION
This PR proves that the size of the commutator subgroup is bounded in terms of the index of the center and the number of commutators. The proof uses Schreier's lemma and the transfer homomorphism.

I included lots of comments since the proof is rather technical. But please let me know if I went overboard.

Ultimately, this is building up to a bound on the size of the commutator subgroup just in terms of the number of commutators.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
