### PR TITLE
[Merged by Bors] - refactor(algebra/periodic): use `neg_zero_class` for `antiperiodic.nat_mul_eq_of_eq_zero`

### DIFF
--- a/src/algebra/periodic.lean
+++ b/src/algebra/periodic.lean
@@ -408,14 +408,13 @@ lemma antiperiodic.int_odd_mul_antiperiodic [ring α] [has_involutive_neg β]
   antiperiodic f (n * (2 * c) + c) :=
 λ x, by rw [← add_assoc, h, h.periodic.int_mul]
 
-lemma antiperiodic.nat_mul_eq_of_eq_zero [comm_semiring α] [subtraction_monoid β]
+lemma antiperiodic.nat_mul_eq_of_eq_zero [comm_semiring α] [neg_zero_class β]
   (h : antiperiodic f c) (hi : f 0 = 0) (n : ℕ) :
   f (n * c) = 0 :=
 begin
-  rcases nat.even_or_odd n with ⟨k, rfl⟩ | ⟨k, rfl⟩;
-  have hk : (k : α) * (2 * c) = 2 * k * c := by rw [mul_left_comm, ← mul_assoc],
-  { simpa [← two_mul, hk, hi] using (h.nat_even_mul_periodic k).eq },
-  { simpa [add_mul, hk, hi] using (h.nat_odd_mul_antiperiodic k).eq },
+  induction n with k hk,
+  { simp [hi] },
+  { simp [hk, add_mul, h (k * c)] }
 end
 
 lemma antiperiodic.int_mul_eq_of_eq_zero [comm_ring α] [subtraction_monoid β]


### PR DESCRIPTION
Weaken the typeclass assumption on the codomain of the antiperiodic function in `antiperiodic.nat_mul_eq_of_eq_zero` from `subtraction_monoid` to `neg_zero_class`.

The corresponding `int` lemma also requires involutive `neg` so will be dealt with separately once we have a further typeclass for the combination of `neg_zero_class` with `has_involutive_neg`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
