### PR TITLE
[Merged by Bors] - refactor(data/real/ennreal): `div_inv_one_monoid` instance

### DIFF
--- a/src/analysis/specific_limits/basic.lean
+++ b/src/analysis/specific_limits/basic.lean
@@ -309,7 +309,7 @@ end
 /-- If `edist (f n) (f (n+1))` is bounded by `C * 2^-n`, then the distance from
 `f 0` to the limit of `f` is bounded above by `2 * C`. -/
 lemma edist_le_of_edist_le_geometric_two_of_tendsto₀: edist (f 0) a ≤ 2 * C :=
-by simpa only [pow_zero, div_eq_mul_inv, ennreal.inv_one, mul_one]
+by simpa only [pow_zero, div_eq_mul_inv, inv_one, mul_one]
   using edist_le_of_edist_le_geometric_two_of_tendsto C hu ha 0
 
 end edist_le_geometric_two

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1018,11 +1018,9 @@ by rw [div_eq_mul_inv, div_eq_mul_inv, coe_mul, coe_inv hr]
 
 lemma div_zero (h : a ≠ 0) : a / 0 = ∞ := by simp [div_eq_mul_inv, h]
 
-@[simp] lemma inv_one : (1 : ℝ≥0∞)⁻¹ = 1 :=
-by simpa only [coe_inv one_ne_zero, coe_one] using coe_eq_coe.2 inv_one
-
-@[simp] lemma div_one {a : ℝ≥0∞} : a / 1 = a :=
-by rw [div_eq_mul_inv, inv_one, mul_one]
+instance : div_inv_one_monoid ℝ≥0∞ :=
+{ inv_one := by simpa only [coe_inv one_ne_zero, coe_one] using coe_eq_coe.2 inv_one,
+  ..ennreal.div_inv_monoid }
 
 protected lemma inv_pow {n : ℕ} : (a^n)⁻¹ = (a⁻¹)^n :=
 begin

--- a/src/measure_theory/integral/average.lean
+++ b/src/measure_theory/integral/average.lean
@@ -78,7 +78,7 @@ by rw [average_def, integral_smul_measure, ennreal.to_real_inv]
 
 lemma average_eq_integral [is_probability_measure μ] (f : α → E) :
   ⨍ x, f x ∂μ = ∫ x, f x ∂μ :=
-by rw [average, measure_univ, ennreal.inv_one, one_smul]
+by rw [average, measure_univ, inv_one, one_smul]
 
 @[simp] lemma measure_smul_average [is_finite_measure μ] (f : α → E) :
   (μ univ).to_real • ⨍ x, f x ∂μ = ∫ x, f x ∂μ :=

--- a/src/measure_theory/measure/haar.lean
+++ b/src/measure_theory/measure/haar.lean
@@ -595,7 +595,7 @@ theorem haar_measure_unique (μ : measure G) [sigma_finite μ] [is_mul_left_inva
   (K₀ : positive_compacts G) : μ = μ K₀ • haar_measure K₀ :=
 (measure_eq_div_smul μ (haar_measure K₀) K₀.compact.measurable_set
   (measure_pos_of_nonempty_interior _ K₀.interior_nonempty).ne'
-  K₀.compact.measure_lt_top.ne).trans (by rw [haar_measure_self, ennreal.div_one])
+  K₀.compact.measure_lt_top.ne).trans (by rw [haar_measure_self, div_one])
 
 example [locally_compact_space G] (μ : measure G) [is_haar_measure μ] (K₀ : positive_compacts G) :
   μ = μ K₀.1 • haar_measure K₀ :=

--- a/src/probability/cond_count.lean
+++ b/src/probability/cond_count.lean
@@ -87,7 +87,7 @@ lemma cond_count_singleton (ω : Ω) (t : set Ω) [decidable (ω ∈ t)] :
   cond_count {ω} t = if ω ∈ t then 1 else 0 :=
 begin
   rw [cond_count, cond_apply _ (measurable_set_singleton ω), measure.count_singleton,
-    ennreal.inv_one, one_mul],
+    inv_one, one_mul],
   split_ifs,
   { rw [(by simpa : ({ω} : set Ω) ∩ t = {ω}), measure.count_singleton] },
   { rw [(by simpa : ({ω} : set Ω) ∩ t = ∅), measure.count_empty] },

--- a/src/topology/metric_space/hausdorff_dimension.lean
+++ b/src/topology/metric_space/hausdorff_dimension.lean
@@ -345,7 +345,7 @@ lemma dimH_image_le_of_locally_lipschitz_on [second_countable_topology X] {f : X
 begin
   have : ∀ x ∈ s, ∃ (C : ℝ≥0) (t ∈ 𝓝[s] x), holder_on_with C 1 f t,
     by simpa only [holder_on_with_one] using hf,
-  simpa only [ennreal.coe_one, ennreal.div_one]
+  simpa only [ennreal.coe_one, div_one]
     using dimH_image_le_of_locally_holder_on zero_lt_one this
 end
 


### PR DESCRIPTION
Add a `div_inv_one_monoid` instance for `ennreal`, so eliminating its `inv_one` and `div_one` lemmas.  (Once we have typeclasses for antitone `inv`, more separate `ennreal` lemmas can be eliminated.)



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
