### PR TITLE
[Merged by Bors] - feat(algebra/hom/equiv): two little `simp` lemmas for `units.map_equiv`

### DIFF
--- a/src/algebra/hom/equiv.lean
+++ b/src/algebra/hom/equiv.lean
@@ -515,6 +515,14 @@ def map_equiv (h : M ≃* N) : Mˣ ≃* Nˣ :=
   right_inv := λ u, ext $ h.right_inv u,
   .. map h.to_monoid_hom }
 
+@[simp]
+lemma units.map_equiv_symm (h : M ≃* N) : (map_equiv h).symm = map_equiv h.symm :=
+rfl
+
+@[simp]
+lemma units.coe_map_equiv (h : M ≃* N) (x : Mˣ) : (map_equiv h x : N) = h x :=
+rfl
+
 /-- Left multiplication by a unit of a monoid is a permutation of the underlying type. -/
 @[to_additive "Left addition of an additive unit is a permutation of the underlying type.",
   simps apply {fully_applied := ff}]

--- a/src/algebra/hom/equiv.lean
+++ b/src/algebra/hom/equiv.lean
@@ -516,11 +516,11 @@ def map_equiv (h : M ≃* N) : Mˣ ≃* Nˣ :=
   .. map h.to_monoid_hom }
 
 @[simp]
-lemma units.map_equiv_symm (h : M ≃* N) : (map_equiv h).symm = map_equiv h.symm :=
+lemma map_equiv_symm (h : M ≃* N) : (map_equiv h).symm = map_equiv h.symm :=
 rfl
 
 @[simp]
-lemma units.coe_map_equiv (h : M ≃* N) (x : Mˣ) : (map_equiv h x : N) = h x :=
+lemma coe_map_equiv (h : M ≃* N) (x : Mˣ) : (map_equiv h x : N) = h x :=
 rfl
 
 /-- Left multiplication by a unit of a monoid is a permutation of the underlying type. -/


### PR DESCRIPTION
Two lemmas I needed for working with the class group of rings.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
