### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/basic): add `norm_algebra_map_nnreal`

### DIFF
--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -446,6 +446,18 @@ by rw [norm_algebra_map, norm_one, mul_one]
 @[simp] lemma nnnorm_algebra_map' [norm_one_class 𝕜'] (x : 𝕜) : ∥algebra_map 𝕜 𝕜' x∥₊ = ∥x∥₊ :=
 subtype.ext $ norm_algebra_map' _ _
 
+section nnreal
+
+variables [norm_one_class 𝕜'] [normed_algebra ℝ 𝕜']
+
+@[simp] lemma norm_algebra_map_nnreal (x : ℝ≥0) : ∥algebra_map ℝ≥0 𝕜' x∥ = x :=
+(norm_algebra_map' 𝕜' (x : ℝ)).symm ▸ real.norm_of_nonneg x.prop
+
+@[simp] lemma nnnorm_algebra_map_nnreal (x : ℝ≥0) : ∥algebra_map ℝ≥0 𝕜' x∥₊ = x :=
+subtype.ext $ norm_algebra_map_nnreal 𝕜' x
+
+end nnreal
+
 variables (𝕜 𝕜')
 
 /-- In a normed algebra, the inclusion of the base field in the extended field is an isometry. -/


### PR DESCRIPTION
This adds `simp` lemmas saying that `∥algebra_map ℝ≥0 𝕜 x∥ = x` and similarly for `∥⬝∥₊` whenever `𝕜` is a normed `ℝ`-algebra and satisfies `norm_one_class`. These are needed separately from `norm_algebra_map'` and `nnnorm_algebra_map'` because `𝕜` cannot be a normed `ℝ≥0`-algebra for the simple reason that `ℝ≥0` is not a normed field.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
