### PR TITLE
[Merged by Bors] - feat(topology/algebra/module/character_space): kernels of terms of the `character_space`

### DIFF
--- a/src/analysis/normed_space/algebra.lean
+++ b/src/analysis/normed_space/algebra.lean
@@ -51,7 +51,7 @@ begin
   { intros φ hφ,
     rw [set.mem_preimage, mem_closed_ball_zero_iff],
     exact (le_of_eq $ norm_one ⟨φ, ⟨hφ.1, hφ.2⟩⟩ : _), },
-  exact compact_of_is_closed_subset (is_compact_closed_ball 𝕜 0 1) is_closed h,
+  exact compact_of_is_closed_subset (is_compact_closed_ball 𝕜 0 1) character_space.is_closed h,
 end
 
 end character_space

--- a/src/topology/algebra/module/character_space.lean
+++ b/src/topology/algebra/module/character_space.lean
@@ -62,6 +62,8 @@ instance : continuous_linear_map_class (character_space 𝕜 A) 𝕜 A 𝕜 :=
   map_add := λ φ, (φ : weak_dual 𝕜 A).map_add,
   map_continuous := λ φ, (φ : weak_dual 𝕜 A).cont }
 
+@[ext] lemma ext {φ ψ : character_space 𝕜 A} (h : ∀ x, φ x = ψ x) : φ = ψ := fun_like.ext _ _ h
+
 /-- An element of the character space, as a continuous linear map. -/
 def to_clm (φ : character_space 𝕜 A) : A →L[𝕜] 𝕜 := (φ : weak_dual 𝕜 A)
 
@@ -145,7 +147,7 @@ end
 
 /-- under suitable mild assumptions on `𝕜`, the character space is a closed set in
 `weak_dual 𝕜 A`. -/
-lemma is_closed [nontrivial 𝕜] [t2_space 𝕜] [has_continuous_mul 𝕜] :
+protected lemma is_closed [nontrivial 𝕜] [t2_space 𝕜] [has_continuous_mul 𝕜] :
   is_closed (character_space 𝕜 A) :=
 begin
   rw [eq_set_map_one_map_mul, set.set_of_and],
@@ -163,9 +165,29 @@ variables [comm_ring 𝕜] [no_zero_divisors 𝕜] [topological_space 𝕜] [has
 lemma apply_mem_spectrum [nontrivial 𝕜] (φ : character_space 𝕜 A) (a : A) : φ a ∈ spectrum 𝕜 a :=
 alg_hom.apply_mem_spectrum φ a
 
+lemma ext_ker {φ ψ : character_space 𝕜 A} (h : ring_hom.ker φ = ring_hom.ker ψ) : φ = ψ :=
+begin
+  ext,
+  have : x - algebra_map 𝕜 A (ψ x) ∈ ring_hom.ker φ,
+  { simpa only [h, ring_hom.mem_ker, map_sub, alg_hom_class.commutes] using sub_self (ψ x) },
+  { rwa [ring_hom.mem_ker, map_sub, alg_hom_class.commutes, sub_eq_zero] at this, }
+end
+
 end ring
 
 end character_space
+
+section kernel
+
+variables [field 𝕜] [topological_space 𝕜] [has_continuous_add 𝕜] [has_continuous_const_smul 𝕜 𝕜]
+variables [ring A] [topological_space A] [algebra 𝕜 A]
+
+/-- The `ring_hom.ker` of `φ : character_space 𝕜 A` is maximal. -/
+instance ker_is_maximal (φ : character_space 𝕜 A) : (ring_hom.ker φ).is_maximal :=
+ring_hom.ker_is_maximal_of_surjective φ $ λ z, ⟨algebra_map 𝕜 A z,
+  by simp only [alg_hom_class.commutes, algebra.id.map_eq_id, ring_hom.id_apply]⟩
+
+end kernel
 
 section gelfand_transform
 


### PR DESCRIPTION
This shows that the kernel of a element `φ` of `character_space 𝕜 A` is a maximal ideal. Moreover, `φ` and `ψ` are equal if their kernels coincide.

In addition, we provide a missing `ext` lemma, and protect a lemma named `is_closed` in this namespace.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
