### PR TITLE
[Merged by Bors] - feat(tactic/positivity): Extensions for `nat` constructions

### DIFF
--- a/src/tactic/positivity.lean
+++ b/src/tactic/positivity.lean
@@ -457,6 +457,25 @@ meta def positivity_coe : expr → tactic strictness
   end
 | _ := failed
 
+/-- Extension for the `positivity` tactic: `nat.succ` is always positive. -/
+@[positivity]
+meta def positivity_succ : expr → tactic strictness
+| `(nat.succ %%a) := positive <$> mk_app `nat.succ_pos [a]
+| e := pp e >>= fail ∘ format.bracket "The expression `" "` isn't of the form `nat.succ n`"
+
+/-- Extension for the `positivity` tactic: `nat.factorial` is always positive. -/
+@[positivity]
+meta def positivity_factorial : expr → tactic strictness
+| `(nat.factorial %%a) := positive <$> mk_app ``nat.factorial_pos [a]
+| e := pp e >>= fail ∘ format.bracket "The expression `" "` isn't of the form `n!`"
+
+/-- Extension for the `positivity` tactic: `nat.asc_factorial` is always positive. -/
+@[positivity]
+meta def positivity_asc_factorial : expr → tactic strictness
+| `(nat.asc_factorial %%a %%b) := positive <$> mk_app ``nat.asc_factorial_pos [a, b]
+| e := pp e >>= fail ∘ format.bracket "The expression `"
+         "` isn't of the form `nat.asc_factorial n k`"
+
 private lemma card_univ_pos (α : Type*) [fintype α] [nonempty α] :
   0 < (finset.univ : finset α).card :=
 finset.univ_nonempty.card_pos

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -14,16 +14,7 @@ import tactic.positivity
 This tactic proves goals of the form `0 ≤ a` and `0 < a`.
 -/
 
-/-  Test for instantiating meta-variables.  Reported on
-https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/New.20tactic.3A.20.60positivity.60/near/300639970
--/
-example : 0 ≤ 0 :=
-begin
-  apply le_trans _ le_rfl,
-  positivity,
-end
-
-open_locale ennreal nnrat nnreal
+open_locale ennreal nat nnrat nnreal
 
 universe u
 variables {α β : Type*}
@@ -142,6 +133,10 @@ example : 0 ≤ max (-3 : ℤ) 5 := by positivity
 example [ordered_semiring α] [ordered_add_comm_monoid β] [smul_with_zero α β]
   [ordered_smul α β] {a : α} (ha : 0 < a) {b : β} (hb : 0 < b) : 0 ≤ a • b := by positivity
 
+example (n : ℕ) : 0 < n.succ := by positivity
+example (n : ℕ) : 0 < n! := by positivity
+example (n k : ℕ) : 0 < n.asc_factorial k := by positivity
+
 example {α : Type*} (s : finset α) (hs : s.nonempty) : 0 < s.card := by positivity
 example {α : Type*} [fintype α] [nonempty α] : 0 < fintype.card α := by positivity
 
@@ -197,3 +192,12 @@ example {a : ℤ} (ha : a > 0) : 0 ≤ a := by positivity
 example {a : ℤ} (ha : 0 < a) : a ≥ 0 := by positivity
 
 example {a : ℤ} (ha : a > 0) : a ≥ 0 := by positivity
+
+/-
+## Test for meta-variable instantiation
+
+Reported on
+https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/New.20tactic.3A.20.60positivity.60/near/300639970
+-/
+
+example : 0 ≤ 0 := by { apply le_trans _ le_rfl, positivity }


### PR DESCRIPTION
Introduce the following `positivity` extensions:
* `positivity_succ`
* `positivity_factorial`
* `positivity_asc_factorial`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
