### PR TITLE
[Merged by Bors] - perf(algebraic_topology/simplicial_object): Speedup `simplicial_cosimplicial_augmented_equiv`

### DIFF
--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -567,21 +567,14 @@ def cosimplicial_to_simplicial_augmented :
 
 /-- The contravariant categorical equivalence between augmented simplicial
 objects and augmented cosimplicial objects in the opposite category. -/
-@[simps]
+@[simps functor inverse]
 def simplicial_cosimplicial_augmented_equiv :
   (simplicial_object.augmented C)ᵒᵖ ≌ cosimplicial_object.augmented Cᵒᵖ :=
-{ functor := simplicial_to_cosimplicial_augmented _,
-  inverse := cosimplicial_to_simplicial_augmented _,
-  unit_iso := nat_iso.of_components
-    (λ X, X.unop.right_op_left_op_iso.op) begin
-      intros X Y f,
-      dsimp,
-      rw (show f = f.unop.op, by simp),
-      simp_rw ← op_comp,
-      congr' 1,
-      tidy,
-    end,
-  counit_iso := nat_iso.of_components
-    (λ X, X.left_op_right_op_iso) (by tidy) }
+equivalence.mk
+  (simplicial_to_cosimplicial_augmented _)
+  (cosimplicial_to_simplicial_augmented _)
+  (nat_iso.of_components (λ X, X.unop.right_op_left_op_iso.op) $ λ X Y f,
+    by { dsimp, rw ←f.op_unop, simp_rw ← op_comp, congr' 1, tidy })
+  (nat_iso.of_components (λ X, X.left_op_right_op_iso) $ by tidy)
 
 end category_theory


### PR DESCRIPTION
Use `equivalence.mk` rather than `equivalence.mk'`. Restrict the `simps` to `functor` and `inverse`.

This roughly speeds everything up by a factor of 2.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is making bors batches time out.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
