### PR TITLE
[Merged by Bors] - feat(data/matrix/pequiv): Added `to_pequiv_matrix_mul`

### DIFF
--- a/src/data/matrix/pequiv.lean
+++ b/src/data/matrix/pequiv.lean
@@ -81,6 +81,11 @@ lemma to_pequiv_mul_matrix [fintype m] [decidable_eq m] [semiring α] (f : m ≃
   (M : matrix m n α) : (f.to_pequiv.to_matrix ⬝ M) = λ i, M (f i) :=
 by { ext i j, rw [mul_matrix_apply, equiv.to_pequiv_apply] }
 
+lemma to_pequiv_matrix_mul {m n α : Type*} [fintype n] [decidable_eq n] [semiring α]
+  (f : n ≃ n) (M : matrix m n α) : (M ⬝ f.to_pequiv.to_matrix) = M.submatrix id (f.symm) :=
+matrix.ext $ λ i j, by rw [pequiv.matrix_mul_apply, ←equiv.to_pequiv_symm,
+                           equiv.to_pequiv_apply, matrix.submatrix_apply, id.def]
+
 lemma to_matrix_trans [fintype m] [decidable_eq m] [decidable_eq n] [semiring α]
   (f : l ≃. m) (g : m ≃. n) : ((f.trans g).to_matrix : matrix l n α) = f.to_matrix ⬝ g.to_matrix :=
 begin

--- a/src/data/matrix/pequiv.lean
+++ b/src/data/matrix/pequiv.lean
@@ -81,7 +81,7 @@ lemma to_pequiv_mul_matrix [fintype m] [decidable_eq m] [semiring α] (f : m ≃
   (M : matrix m n α) : (f.to_pequiv.to_matrix ⬝ M) = λ i, M (f i) :=
 by { ext i j, rw [mul_matrix_apply, equiv.to_pequiv_apply] }
 
-lemma to_pequiv_matrix_mul {m n α : Type*} [fintype n] [decidable_eq n] [semiring α]
+lemma mul_to_pequiv_to_matrix {m n α : Type*} [fintype n] [decidable_eq n] [semiring α]
   (f : n ≃ n) (M : matrix m n α) : (M ⬝ f.to_pequiv.to_matrix) = M.submatrix id (f.symm) :=
 matrix.ext $ λ i j, by rw [pequiv.matrix_mul_apply, ←equiv.to_pequiv_symm,
                            equiv.to_pequiv_apply, matrix.submatrix_apply, id.def]


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I was also thinking you could state the theorem as

```lean
lemma to_pequiv_matrix_mul [fintype n] [decidable_eq n] [semiring α] (f : n ≃ n) (M : matrix m n α): 
(M ⬝ f.to_pequiv.to_matrix) = λ i j, M i (f.symm j) :=
matrix.ext $ λ i j, by rw [pequiv.matrix_mul_apply, ←equiv.to_pequiv_symm, equiv.to_pequiv_apply]
```

to be more consistent with to_pequiv_mul_matrix

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
