### PR TITLE
[Merged by Bors] - feat(topology/uniform_space/basic): separation of compacts and closed sets in a uniform space

### DIFF
--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -709,7 +709,7 @@ begin
                 ... ⊆ U                          : hI z (htK z hzt),
 end
 
-lemma disjoint.exists_thickenings_uniformity {A B : set α}
+lemma disjoint.exists_uniform_thickening {A B : set α}
   (hA : is_compact A) (hB : is_closed B) (h : disjoint A B) :
   ∃ V ∈ 𝓤 α, disjoint (⋃ x ∈ A, ball x V) (⋃ x ∈ B, ball x V) :=
 begin
@@ -724,12 +724,12 @@ begin
   exact hUAB (mem_Union₂_of_mem ha $ hVU $ mem_comp_of_mem_ball hVsymm hxa hxb) hb
 end
 
-lemma disjoint.exists_thickenings_uniformity_of_basis {p : ι → Prop} {s : ι → set (α × α)}
+lemma disjoint.exists_uniform_thickening_of_basis {p : ι → Prop} {s : ι → set (α × α)}
   (hU : (𝓤 α).has_basis p s) {A B : set α}
   (hA : is_compact A) (hB : is_closed B) (h : disjoint A B) :
   ∃ i, p i ∧ disjoint (⋃ x ∈ A, ball x (s i)) (⋃ x ∈ B, ball x (s i)) :=
 begin
-  rcases h.exists_thickenings_uniformity hA hB with ⟨V, hV, hVAB⟩,
+  rcases h.exists_uniform_thickening hA hB with ⟨V, hV, hVAB⟩,
   rcases hU.mem_iff.1 hV with ⟨i, hi, hiV⟩,
   exact ⟨i, hi, hVAB.mono
     (Union₂_mono $ λ a _, ball_mono hiV a) (Union₂_mono $ λ b _, ball_mono hiV b)⟩,

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -709,6 +709,32 @@ begin
                 ... ⊆ U                          : hI z (htK z hzt),
 end
 
+lemma disjoint.exists_thickenings_uniformity {A B : set α}
+  (hA : is_compact A) (hB : is_closed B) (h : disjoint A B) :
+  ∃ V ∈ 𝓤 α, disjoint (⋃ x ∈ A, ball x V) (⋃ x ∈ B, ball x V) :=
+begin
+  have : Bᶜ ∈ 𝓝ˢ A := hB.is_open_compl.mem_nhds_set.mpr h.le_compl_right,
+  rw (hA.nhds_set_basis_uniformity (filter.basis_sets _)).mem_iff at this,
+  rcases this with ⟨U, hU, hUAB⟩,
+  rcases comp_symm_mem_uniformity_sets hU with ⟨V, hV, hVsymm, hVU⟩,
+  refine ⟨V, hV, λ x, _⟩,
+  simp only [inf_eq_inter, mem_inter_iff, mem_Union₂],
+  rintro ⟨⟨a, ha, hxa⟩, ⟨b, hb, hxb⟩⟩,
+  rw mem_ball_symmetry hVsymm at hxa hxb,
+  exact hUAB (mem_Union₂_of_mem ha $ hVU $ mem_comp_of_mem_ball hVsymm hxa hxb) hb
+end
+
+lemma disjoint.exists_thickenings_uniformity_of_basis {p : ι → Prop} {s : ι → set (α × α)}
+  (hU : (𝓤 α).has_basis p s) {A B : set α}
+  (hA : is_compact A) (hB : is_closed B) (h : disjoint A B) :
+  ∃ i, p i ∧ disjoint (⋃ x ∈ A, ball x (s i)) (⋃ x ∈ B, ball x (s i)) :=
+begin
+  rcases h.exists_thickenings_uniformity hA hB with ⟨V, hV, hVAB⟩,
+  rcases hU.mem_iff.1 hV with ⟨i, hi, hiV⟩,
+  exact ⟨i, hi, hVAB.mono
+    (Union₂_mono $ λ a _, ball_mono hiV a) (Union₂_mono $ λ b _, ball_mono hiV b)⟩,
+end
+
 lemma tendsto_right_nhds_uniformity {a : α} : tendsto (λa', (a', a)) (𝓝 a) (𝓤 α) :=
 assume s, mem_nhds_right a
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The names are based on what exists in `topology/metric_space/hausdorff_distance`, but I'm not happy with them at all, so I'd happily take other suggestions.

Zulip: https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Uniform.20separation.20of.20compact.20and.20closed.20set/near/301848882

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
