### PR TITLE
[Merged by Bors] - fix({ tactic/fin_cases + test/interval_cases }): add `focus1` and a test

### DIFF
--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -79,7 +79,7 @@ These should be defeq to and in the same order as the terms in the enumeration o
 -/
 meta def fin_cases_at (nm : option name) : Π (with_list : option pexpr) (e : expr), tactic unit
 | with_list e :=
-do ty ← try_core $ guard_mem_fin e,
+focus1 $ do ty ← try_core $ guard_mem_fin e,
     match ty with
     | none := -- Deal with `x : A`, where `[fintype A]` is available:
       (do
@@ -151,7 +151,7 @@ produces three goals with hypotheses
 -/
 meta def fin_cases :
   parse hyp → parse (tk "with" *> texpr)? → parse (tk "using" *> ident)? → tactic unit
-| none none nm := focus1 $ do
+| none none nm := do
     ctx ← local_context,
     ctx.mfirst (fin_cases_at nm none) <|>
       fail ("No hypothesis of the forms `x ∈ A`, where " ++
@@ -160,7 +160,7 @@ meta def fin_cases :
 | (some n) with_list nm :=
   do
     h ← get_local n,
-    focus1 $ fin_cases_at nm with_list h
+    fin_cases_at nm with_list h
 
 end interactive
 

--- a/src/tactic/fin_cases.lean
+++ b/src/tactic/fin_cases.lean
@@ -78,8 +78,8 @@ for example, to display nats as `n.succ` instead of `n+1`.
 These should be defeq to and in the same order as the terms in the enumeration of `α`.
 -/
 meta def fin_cases_at (nm : option name) : Π (with_list : option pexpr) (e : expr), tactic unit
-| with_list e :=
-focus1 $ do ty ← try_core $ guard_mem_fin e,
+| with_list e := focus1 $
+  do ty ← try_core $ guard_mem_fin e,
     match ty with
     | none := -- Deal with `x : A`, where `[fintype A]` is available:
       (do

--- a/src/tactic/interval_cases.lean
+++ b/src/tactic/interval_cases.lean
@@ -236,7 +236,7 @@ meta def interval_cases (n : parse texpr?)
   (lname : parse (tk "with" *> ident)?) :
   tactic unit :=
 do
-  if h : n.is_some then (do
+  focus1 $ if h : n.is_some then (do
     guard bounds.is_none <|>
       fail "Do not use the `using` keyword if specifying the variable explicitly.",
     n ← to_expr (option.get h),

--- a/src/tactic/interval_cases.lean
+++ b/src/tactic/interval_cases.lean
@@ -236,7 +236,7 @@ meta def interval_cases (n : parse texpr?)
   (lname : parse (tk "with" *> ident)?) :
   tactic unit :=
 do
-  focus1 $ if h : n.is_some then (do
+  if h : n.is_some then (do
     guard bounds.is_none <|>
       fail "Do not use the `using` keyword if specifying the variable explicitly.",
     n ← to_expr (option.get h),

--- a/test/interval_cases.lean
+++ b/test/interval_cases.lean
@@ -132,7 +132,7 @@ example {x : ℕ} (hx2 : x < 2) (h : false) : false :=
 begin
   have : x ≤ 1,
   interval_cases x,
-  exact zero_le_one,  -- this is the left-over goal of `interval_cases`, closing the `have`
+  exact zero_le_one,  -- this solves the side-goal left by `interval_cases`, closing the `have`
   exact h,
 end
 

--- a/test/interval_cases.lean
+++ b/test/interval_cases.lean
@@ -132,7 +132,7 @@ example {x : ℕ} (hx2 : x < 2) (h : false) : false :=
 begin
   have : x ≤ 1,
   interval_cases x,
-  norm_num,
+  exact zero_le_one,  -- this is the left-over goal of `interval_cases`, closing the `have`
   exact h,
 end
 

--- a/test/interval_cases.lean
+++ b/test/interval_cases.lean
@@ -127,6 +127,15 @@ begin
   { right, exact hrv }
 end
 
+/- https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/interval_cases.20bug -/
+example {x : ℕ} (hx2 : x < 2) (h : false) : false :=
+begin
+  have : x ≤ 1,
+  interval_cases x,
+  norm_num,
+  exact h,
+end
+
 /-
 Sadly, this one doesn't work, reporting:
   `deep recursion was detected at 'expression equality test'`


### PR DESCRIPTION
Fix [this bug](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/interval_cases.20bug), reported by @hrmacbeth.

The current solution is to move the `focus1` to `fin_cases_at`, instead of relying on `fin_cases` and `interval_cases` to call `focus1`.  Having `interval_cases` wrapped in `focus1` is the reason for this PR.

An older (compiling) solution was to just use `focus1` inside `interval_cases`, but calling it in `fin_cases_at` seems more stable.

The link above is to a Zulip discussion with more details.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
