### PR TITLE
[Merged by Bors] - feat(ring_theory/roots_of_unity): add geom_sum_eq_zero

### DIFF
--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -319,8 +319,8 @@ end
 lemma pow_ne_one_of_pos_of_lt (h0 : 0 < l) (hl : l < k) : ζ ^ l ≠ 1 :=
 mt (nat.le_of_dvd h0 ∘ h.dvd_of_pow_eq_one _) $ not_le_of_lt hl
 
-lemma ne_one {ζ : M} (hζ : is_primitive_root ζ k) (hk : 1 < k) : ζ ≠ 1 :=
-hζ.pow_ne_one_of_pos_of_lt zero_lt_one hk ∘ (pow_one ζ).trans
+lemma ne_one {ζ : M} (h : is_primitive_root ζ k) (hk : 1 < k) : ζ ≠ 1 :=
+h.pow_ne_one_of_pos_of_lt zero_lt_one hk ∘ (pow_one ζ).trans
 
 lemma pow_inj (h : is_primitive_root ζ k) ⦃i j : ℕ⦄ (hi : i < k) (hj : j < k) (H : ζ ^ i = ζ ^ j) :
   i = j :=

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -599,6 +599,29 @@ begin
   rwa ring_char.eq_iff.mpr h
 end
 
+/-- If `1 < k` then `(∑ i in range k, ζ ^ i) = 0`. -/
+lemma geom_sum_eq_zero [is_domain R] {ζ : R} (hζ : is_primitive_root ζ k) (hk : 1 < k) :
+  (∑ i in range k, ζ ^ i) = 0 :=
+begin
+  have : 1 - ζ ≠ 0,
+  { intro h,
+    have := hζ.dvd_of_pow_eq_one 1,
+    simp only [(eq_of_sub_eq_zero h).symm, one_pow, eq_self_iff_true, nat.dvd_one,
+      forall_true_left] at this,
+    simpa [this] using hk },
+  refine eq_zero_of_ne_zero_of_mul_left_eq_zero this _,
+  rw [mul_neg_geom_sum, hζ.pow_eq_one, sub_self]
+end
+
+/-- If `1 < k`, then `ζ ^ k.pred = -(∑ i in range k.pred, ζ ^ i)`. -/
+lemma pow_sub_one_eq [is_domain R] {ζ : R} (hζ : is_primitive_root ζ k) (hk : 1 < k) :
+  ζ ^ k.pred = -(∑ i in range k.pred, ζ ^ i) :=
+begin
+  have := hζ.geom_sum_eq_zero hk,
+  rwa [← nat.succ_pred_eq_of_pos (lt_trans zero_lt_one hk), range_succ,
+    sum_insert not_mem_range_self, add_eq_zero_iff_eq_neg] at this
+end
+
 /-- The (additive) monoid equivalence between `zmod k`
 and the powers of a primitive root of unity `ζ`. -/
 def zmod_equiv_zpowers (h : is_primitive_root ζ k) : zmod k ≃+ additive (subgroup.zpowers ζ) :=

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -319,6 +319,9 @@ end
 lemma pow_ne_one_of_pos_of_lt (h0 : 0 < l) (hl : l < k) : ζ ^ l ≠ 1 :=
 mt (nat.le_of_dvd h0 ∘ h.dvd_of_pow_eq_one _) $ not_le_of_lt hl
 
+lemma ne_one {ζ : M} (hζ : is_primitive_root ζ k) (hk : 1 < k) : ζ ≠ 1 :=
+hζ.pow_ne_one_of_pos_of_lt zero_lt_one hk ∘ (pow_one ζ).trans
+
 lemma pow_inj (h : is_primitive_root ζ k) ⦃i j : ℕ⦄ (hi : i < k) (hj : j < k) (H : ζ ^ i = ζ ^ j) :
   i = j :=
 begin
@@ -598,9 +601,6 @@ begin
   rw [order_of_neg_one, if_neg],
   rwa ring_char.eq_iff.mpr h
 end
-
-lemma ne_one {ζ : R} (hζ : is_primitive_root ζ k) (hk : 1 < k) : ζ ≠ 1 :=
-hζ.pow_ne_one_of_pos_of_lt zero_lt_one hk ∘ (pow_one ζ).trans
 
 /-- If `1 < k` then `(∑ i in range k, ζ ^ i) = 0`. -/
 lemma geom_sum_eq_zero [is_domain R] {ζ : R} (hζ : is_primitive_root ζ k) (hk : 1 < k) :

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -599,17 +599,14 @@ begin
   rwa ring_char.eq_iff.mpr h
 end
 
+lemma ne_one {ζ : R} (hζ : is_primitive_root ζ k) (hk : 1 < k) : ζ ≠ 1 :=
+hζ.pow_ne_one_of_pos_of_lt zero_lt_one hk ∘ (pow_one ζ).trans
+
 /-- If `1 < k` then `(∑ i in range k, ζ ^ i) = 0`. -/
 lemma geom_sum_eq_zero [is_domain R] {ζ : R} (hζ : is_primitive_root ζ k) (hk : 1 < k) :
   (∑ i in range k, ζ ^ i) = 0 :=
 begin
-  have : 1 - ζ ≠ 0,
-  { intro h,
-    have := hζ.dvd_of_pow_eq_one 1,
-    simp only [(eq_of_sub_eq_zero h).symm, one_pow, eq_self_iff_true, nat.dvd_one,
-      forall_true_left] at this,
-    simpa [this] using hk },
-  refine eq_zero_of_ne_zero_of_mul_left_eq_zero this _,
+  refine eq_zero_of_ne_zero_of_mul_left_eq_zero (sub_ne_zero_of_ne (hζ.ne_one hk).symm) _,
   rw [mul_neg_geom_sum, hζ.pow_eq_one, sub_self]
 end
 

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -616,11 +616,8 @@ end
 /-- If `1 < k`, then `ζ ^ k.pred = -(∑ i in range k.pred, ζ ^ i)`. -/
 lemma pow_sub_one_eq [is_domain R] {ζ : R} (hζ : is_primitive_root ζ k) (hk : 1 < k) :
   ζ ^ k.pred = -(∑ i in range k.pred, ζ ^ i) :=
-begin
-  have := hζ.geom_sum_eq_zero hk,
-  rwa [← nat.succ_pred_eq_of_pos (lt_trans zero_lt_one hk), range_succ,
-    sum_insert not_mem_range_self, add_eq_zero_iff_eq_neg] at this
-end
+by rw [eq_neg_iff_add_eq_zero, add_comm, ←sum_range_succ, ←nat.succ_eq_add_one,
+  nat.succ_pred_eq_of_pos (pos_of_gt hk), hζ.geom_sum_eq_zero hk]
 
 /-- The (additive) monoid equivalence between `zmod k`
 and the powers of a primitive root of unity `ζ`. -/


### PR DESCRIPTION
We add `geom_sum_eq_zero`: the geometric sum of a primitive root of unity is `0`.

From flt-regular

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
