### PR TITLE
[Merged by Bors] - feat(is_cyclotomic_extension/basic): add is_cyclotomic_extension.equiv

### DIFF
--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -32,7 +32,7 @@ primitive roots of unity, for all `n ∈ S`.
 
 * `is_cyclotomic_extension.trans` : if `is_cyclotomic_extension S A B` and
   `is_cyclotomic_extension T B C`, then `is_cyclotomic_extension (S ∪ T) A C` if
-  `no_zero_smul_divisors B C` and `nontrivial C`.
+  `function.injective (algebra_map B C)`.
 * `is_cyclotomic_extension.union_right` : given `is_cyclotomic_extension (S ∪ T) A B`, then
   `is_cyclotomic_extension T (adjoin A { b : B | ∃ a : ℕ+, a ∈ S ∧ b ^ (a : ℕ) = 1 }) B`.
 * `is_cyclotomic_extension.union_right` : given `is_cyclotomic_extension T A B` and `S ⊆ T`, then

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -118,7 +118,7 @@ end
 variables (A B)
 
 /-- Transitivity of cyclotomic extensions. -/
-lemma trans (C : Type w) [comm_ring C] [nontrivial C] [algebra A C] [algebra B C]
+lemma trans (C : Type w) [comm_ring C] [algebra A C] [algebra B C]
   [is_scalar_tower A B C] [hS : is_cyclotomic_extension S A B]
   [hT : is_cyclotomic_extension T B C] (h : function.injective (algebra_map B C)) :
   is_cyclotomic_extension (S ∪ T) A C :=
@@ -295,11 +295,7 @@ begin
   letI : algebra B C := f.to_alg_hom.to_ring_hom.to_algebra,
   haveI : is_cyclotomic_extension {1} B C := singleton_one_of_algebra_map_bijective f.surjective,
   haveI : is_scalar_tower A B C := is_scalar_tower.of_ring_hom f.to_alg_hom,
-  by_cases hC : nontrivial C,
-  { exactI (iff_union_singleton_one _ _ _).2 (trans S {1} A B C f.injective) },
-  { haveI := not_nontrivial_iff_subsingleton.1 hC,
-    haveI := equiv.subsingleton.symm f.to_equiv.symm,
-    rwa [is_cyclotomic_extension.subsingleton_iff] at ⊢ h }
+  exact (iff_union_singleton_one _ _ _).2 (trans S {1} A B C f.injective)
 end
 
 @[protected]
@@ -335,10 +331,12 @@ begin
 end
 
 /-- If `S` is finite and `is_cyclotomic_extension S A B`, then `B` is a finite `A`-algebra. -/
-lemma finite [is_domain B] [h₁ : fintype S] [h₂ : is_cyclotomic_extension S A B] : finite A B :=
+lemma finite [is_domain B] [h₁ : _root_.finite S] [h₂ : is_cyclotomic_extension S A B] :
+  finite A B :=
 begin
+  casesI nonempty_fintype S with h,
   unfreezingI {revert h₂ A B},
-  refine set.finite.induction_on (set.finite.intro h₁) (λ A B, _) (λ n S hn hS H A B, _),
+  refine set.finite.induction_on (set.finite.intro h) (λ A B, _) (λ n S hn hS H A B, _),
   { introsI _ _ _ _ _,
     refine module.finite_def.2 ⟨({1} : finset B), _⟩,
     simp [← top_to_submodule, ← empty, to_submodule_bot] },
@@ -354,7 +352,7 @@ begin
 end
 
 /-- A cyclotomic finite extension of a number field is a number field. -/
-lemma number_field [h : number_field K] [fintype S] [is_cyclotomic_extension S K L] :
+lemma number_field [h : number_field K] [_root_.finite S] [is_cyclotomic_extension S K L] :
   number_field L :=
 { to_char_zero := char_zero_of_injective_algebra_map (algebra_map K L).injective,
   to_finite_dimensional := @finite.trans _ K L _ _ _ _
@@ -364,12 +362,12 @@ lemma number_field [h : number_field K] [fintype S] [is_cyclotomic_extension S K
 localized "attribute [instance] is_cyclotomic_extension.number_field" in cyclotomic
 
 /-- A finite cyclotomic extension of an integral noetherian domain is integral -/
-lemma integral [is_domain B] [is_noetherian_ring A] [fintype S] [is_cyclotomic_extension S A B] :
-  algebra.is_integral A B :=
+lemma integral [is_domain B] [is_noetherian_ring A] [_root_.finite S]
+  [is_cyclotomic_extension S A B] : algebra.is_integral A B :=
 is_integral_of_noetherian $ is_noetherian_of_fg_of_noetherian' $ (finite S A B).out
 
 /-- If `S` is finite and `is_cyclotomic_extension S K A`, then `finite_dimensional K A`. -/
-lemma finite_dimensional (C : Type z) [fintype S] [comm_ring C] [algebra K C] [is_domain C]
+lemma finite_dimensional (C : Type z) [_root_.finite S] [comm_ring C] [algebra K C] [is_domain C]
   [is_cyclotomic_extension S K C] : finite_dimensional K C :=
 finite S K C
 
@@ -726,3 +724,5 @@ instance is_alg_closed_of_char_zero.is_cyclotomic_extension [char_zero K] :
 λ S, is_alg_closed.is_cyclotomic_extension S K (λ a ha, infer_instance)
 
 end is_alg_closed
+
+#lint

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -724,5 +724,3 @@ instance is_alg_closed_of_char_zero.is_cyclotomic_extension [char_zero K] :
 λ S, is_alg_closed.is_cyclotomic_extension S K (λ a ha, infer_instance)
 
 end is_alg_closed
-
-#lint

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -405,7 +405,7 @@ lemma splitting_field_X_pow_sub_one : is_splitting_field K L (X ^ (n : ℕ) - 1)
       eval_sub, eval_pow, eval_C, eval_X, sub_eq_zero]
   end }
 
-/-- Any two `n`-th cyclotomic extension are isomorphic. -/
+/-- Any two `n`-th cyclotomic extensions are isomorphic. -/
 def alg_equiv (L' : Type*) [field L'] [algebra K L'] [is_cyclotomic_extension {n} K L'] :
   L ≃ₐ[K] L' :=
 let _ := splitting_field_X_pow_sub_one n K L in let _ := splitting_field_X_pow_sub_one n K L' in

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -59,7 +59,7 @@ included in the `cyclotomic` locale.
 
 -/
 
-open polynomial algebra finite_dimensional module set
+open polynomial algebra finite_dimensional set
 
 open_locale big_operators
 
@@ -316,7 +316,7 @@ end basic
 
 section fintype
 
-lemma finite_of_singleton [is_domain B] [h : is_cyclotomic_extension {n} A B] : finite A B :=
+lemma finite_of_singleton [is_domain B] [h : is_cyclotomic_extension {n} A B] : module.finite A B :=
 begin
   classical,
   rw [module.finite_def, ← top_to_submodule, ← ((iff_adjoin_eq_top _ _ _).1 h).2],
@@ -331,8 +331,9 @@ begin
 end
 
 /-- If `S` is finite and `is_cyclotomic_extension S A B`, then `B` is a finite `A`-algebra. -/
-lemma finite [is_domain B] [h₁ : _root_.finite S] [h₂ : is_cyclotomic_extension S A B] :
-  finite A B :=
+@[protected]
+lemma finite [is_domain B] [h₁ : finite S] [h₂ : is_cyclotomic_extension S A B] :
+  module.finite A B :=
 begin
   casesI nonempty_fintype S with h,
   unfreezingI {revert h₂ A B},
@@ -344,18 +345,18 @@ begin
     haveI : is_cyclotomic_extension S A (adjoin A { b : B | ∃ (n : ℕ+),
       n ∈ S ∧ b ^ (n : ℕ) = 1 }) := union_left _ (insert n S) _ _ (subset_insert n S),
     haveI := H A (adjoin A { b : B | ∃ (n : ℕ+), n ∈ S ∧ b ^ (n : ℕ) = 1 }),
-    haveI : finite (adjoin A { b : B | ∃ (n : ℕ+), n ∈ S ∧ b ^ (n : ℕ) = 1 }) B,
+    haveI : module.finite (adjoin A { b : B | ∃ (n : ℕ+), n ∈ S ∧ b ^ (n : ℕ) = 1 }) B,
     { rw [← union_singleton] at h,
       letI := @union_right S {n} A B _ _ _ h,
       exact finite_of_singleton n _ _ },
-    exact finite.trans (adjoin A { b : B | ∃ (n : ℕ+), n ∈ S ∧ b ^ (n : ℕ) = 1 }) _ }
+    exact module.finite.trans (adjoin A { b : B | ∃ (n : ℕ+), n ∈ S ∧ b ^ (n : ℕ) = 1 }) _ }
 end
 
 /-- A cyclotomic finite extension of a number field is a number field. -/
 lemma number_field [h : number_field K] [_root_.finite S] [is_cyclotomic_extension S K L] :
   number_field L :=
 { to_char_zero := char_zero_of_injective_algebra_map (algebra_map K L).injective,
-  to_finite_dimensional := @finite.trans _ K L _ _ _ _
+  to_finite_dimensional := @module.finite.trans _ K L _ _ _ _
     (@algebra_rat L _ (char_zero_of_injective_algebra_map (algebra_map K L).injective)) _ _
     h.to_finite_dimensional (finite S K L) }
 
@@ -369,7 +370,7 @@ is_integral_of_noetherian $ is_noetherian_of_fg_of_noetherian' $ (finite S A B).
 /-- If `S` is finite and `is_cyclotomic_extension S K A`, then `finite_dimensional K A`. -/
 lemma finite_dimensional (C : Type z) [_root_.finite S] [comm_ring C] [algebra K C] [is_domain C]
   [is_cyclotomic_extension S K C] : finite_dimensional K C :=
-finite S K C
+is_cyclotomic_extension.finite S K C
 
 localized "attribute [instance] is_cyclotomic_extension.finite_dimensional" in cyclotomic
 

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -298,7 +298,7 @@ begin
   by_cases hC : nontrivial C,
   { exactI (iff_union_singleton_one _ _ _).2 (trans S {1} A B C f.injective) },
   { haveI := not_nontrivial_iff_subsingleton.1 hC,
-    haveI : subsingleton B := equiv.subsingleton.symm f.to_equiv.symm,
+    haveI := equiv.subsingleton.symm f.to_equiv.symm,
     rwa [is_cyclotomic_extension.subsingleton_iff] at ⊢ h }
 end
 

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -95,6 +95,37 @@ lemma iff_singleton : is_cyclotomic_extension {n} A B ↔
  (∀ x, x ∈ adjoin A { b : B | b ^ (n : ℕ) = 1 }) :=
 by simp [is_cyclotomic_extension_iff]
 
+/-- Given `(f : B ≃ₐ[A] C)`, if `is_cyclotomic_extension S A B` then
+`is_cyclotomic_extension S A C`. -/
+@[protected] lemma equiv {C : Type*} [comm_ring C] [algebra A C] [h : is_cyclotomic_extension S A B]
+  (f : B ≃ₐ[A] C) : is_cyclotomic_extension S A C :=
+begin
+  refine (iff_adjoin_eq_top _ _ _).2 ⟨λ s hs, _, _⟩,
+  { obtain ⟨a, ha⟩ := ((is_cyclotomic_extension_iff S A B).1 h).1 hs,
+    exact ⟨f a, ha.map_of_injective f.injective⟩ },
+  { have : (f.symm) '' {c : C | ∃ (s : ℕ+), s ∈ S ∧ c ^ (s : ℕ) = 1} =
+      {b : B | ∃ (s : ℕ+), s ∈ S ∧ b ^ (s : ℕ) = 1},
+    { refine set.ext (λ x, ⟨λ hx, _, λ hx, _⟩),
+      { simp only [set.mem_image, set.mem_set_of_eq] at ⊢ hx,
+        obtain ⟨c, ⟨n, ⟨hn, hcn⟩⟩, hxc⟩ := hx,
+        refine ⟨n, ⟨hn, _⟩⟩,
+        rw [← hxc, ← alg_equiv.map_pow, hcn, alg_equiv.map_one] },
+      { simp only [set.mem_image, set.mem_set_of_eq] at ⊢ hx,
+        obtain ⟨n, ⟨hn, hxn⟩⟩ := hx,
+        refine ⟨f x, ⟨⟨n, ⟨hn, _⟩⟩, by simp⟩⟩,
+        { rw [← alg_equiv.map_pow, hxn, alg_equiv.map_one] } } },
+    refine _root_.eq_top_iff.2 (λ x hx, _),
+    suffices : f.symm x ∈
+      (adjoin A {c : C | ∃ (s : ℕ+), s ∈ S ∧ c ^ ↑s = 1}).map f.symm.to_alg_hom,
+    { obtain ⟨c, hc, Hc⟩ := subalgebra.mem_map.1 this,
+      simp only [alg_equiv.to_alg_hom_eq_coe, alg_equiv.coe_alg_hom,
+        embedding_like.apply_eq_iff_eq] at Hc,
+      rwa [← Hc] },
+    rw [← adjoin_image, alg_equiv.to_alg_hom_eq_coe, alg_equiv.coe_alg_hom, this,
+      ((iff_adjoin_eq_top _ _ _).1 h).2],
+    exact mem_top }
+end
+
 /-- If `is_cyclotomic_extension ∅ A B`, then the image of `A` in `B` equals `B`. -/
 lemma empty [h : is_cyclotomic_extension ∅ A B] : (⊥ : subalgebra A B) = ⊤ :=
 by simpa [algebra.eq_top_iff, is_cyclotomic_extension_iff] using h

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -405,6 +405,13 @@ lemma splitting_field_X_pow_sub_one : is_splitting_field K L (X ^ (n : ℕ) - 1)
       eval_sub, eval_pow, eval_C, eval_X, sub_eq_zero]
   end }
 
+/-- Any two `n`-th cyclotomic extension are isomorphic. -/
+def alg_equiv (L' : Type*) [field L'] [algebra K L'] [is_cyclotomic_extension {n} K L'] :
+  L ≃ₐ[K] L' :=
+let _ := splitting_field_X_pow_sub_one n K L in let _ := splitting_field_X_pow_sub_one n K L' in
+  by exactI (is_splitting_field.alg_equiv L (X ^ (n : ℕ) - 1)).trans
+  (is_splitting_field.alg_equiv L' (X ^ (n : ℕ) - 1)).symm
+
 localized "attribute [instance] is_cyclotomic_extension.splitting_field_X_pow_sub_one" in cyclotomic
 
 include n

--- a/src/number_theory/cyclotomic/primitive_roots.lean
+++ b/src/number_theory/cyclotomic/primitive_roots.lean
@@ -28,7 +28,7 @@ in the implementation details section.
   and `primitive_roots n A` given by the choice of `ζ`.
 
 ## Main results
-* `is_cyclotomic_extension.zeta_primitive_root`: `zeta n A B` is a primitive `n`-th root of unity.
+* `is_cyclotomic_extension.zeta_spec`: `zeta n A B` is a primitive `n`-th root of unity.
 * `is_cyclotomic_extension.finrank`: if `irreducible (cyclotomic n K)` (in particular for
   `K = ℚ`), then the `finrank` of a cyclotomic extension is `n.totient`.
 * `is_primitive_root.norm_eq_one`: if `irreducible (cyclotomic n K)` (in particular for `K = ℚ`),

--- a/src/number_theory/cyclotomic/rat.lean
+++ b/src/number_theory/cyclotomic/rat.lean
@@ -181,6 +181,12 @@ unity and `K` is a `p ^ k`-th cyclotomic extension of `ℚ`. -/
 let _ := is_integral_closure_adjoin_singleton_of_prime_pow hζ in
   by exactI (is_integral_closure.equiv ℤ (adjoin ℤ ({ζ} : set K)) K (𝓞 K))
 
+/-- The ring of integers of a `p ^ k`-th cyclotomic extension of `ℚ` is a cyclotomic extension. -/
+instance _root_.is_cyclotomic_extension.ring_of_integers
+  [is_cyclotomic_extension {p ^ k} ℚ K] : is_cyclotomic_extension {p ^ k} ℤ (𝓞 K) :=
+let _ := (zeta_spec (p ^ k) ℚ K).adjoin_is_cyclotomic_extension ℤ in by exactI
+  is_cyclotomic_extension.equiv _ ℤ _ ((zeta_spec (p ^ k) ℚ K).adjoin_equiv_ring_of_integers)
+
 /-- The integral `power_basis` of `𝓞 K` given by a primitive root of unity, where `K` is a `p ^ k`
 cyclotomic extension of `ℚ`. -/
 noncomputable def integral_power_basis [hcycl : is_cyclotomic_extension {p ^ k} ℚ K]
@@ -202,6 +208,12 @@ unity and `K` is a `p`-th cyclotomic extension of `ℚ`. -/
   [hcycl : is_cyclotomic_extension {p} ℚ K] (hζ : is_primitive_root ζ p) :
   adjoin ℤ ({ζ} : set K) ≃ₐ[ℤ] (𝓞 K) :=
 @adjoin_equiv_ring_of_integers p 1 K _ _ _ _ (by { convert hcycl, rw pow_one }) (by rwa pow_one)
+
+/-- The ring of integers of a `p`-th cyclotomic extension of `ℚ` is a cyclotomic extension. -/
+instance _root_.is_cyclotomic_extension.ring_of_integers'
+  [is_cyclotomic_extension {p} ℚ K] : is_cyclotomic_extension {p} ℤ (𝓞 K) :=
+let _ := (zeta_spec p ℚ K).adjoin_is_cyclotomic_extension ℤ in by exactI
+  is_cyclotomic_extension.equiv _ ℤ _ ((zeta_spec p ℚ K).adjoin_equiv_ring_of_integers')
 
 /-- The integral `power_basis` of `𝓞 K` given by a primitive root of unity, where `K` is a `p`-th
 cyclotomic extension of `ℚ`. -/


### PR DESCRIPTION
We add `add is_cyclotomic_extension.equiv`: being a cyclotomic extension is preserved by `alg_equiv`, and others lemmas about cyclotomic extensions.

From flt-regular

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
