### PR TITLE
[Merged by Bors] - feat(analysis/normed/ring/seminorm): Multiplicative ring norms

### DIFF
--- a/src/analysis/normed/ring/seminorm.lean
+++ b/src/analysis/normed/ring/seminorm.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 María Inés de Frutos-Fernández. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: María Inés de Frutos-Fernández
+Authors: María Inés de Frutos-Fernández, Yaël Dillies
 -/
 import analysis.seminorm
 
@@ -18,6 +18,9 @@ For a ring `R`:
   nonnegative values, is subadditive and submultiplicative and such that `f (-x) = f x` for all
   `x ∈ R`.
 * `ring_norm`: A seminorm `f` is a norm if `f x = 0` if and only if `x = 0`.
+* `mul_ring_seminorm`: A multiplicative seminorm on a ring `R` is a ring seminorm that preserves
+  multiplication.
+* `mul_ring_norm`: A multiplicative norm on a ring `R` is a ring norm that preserves multiplication.
 
 ## References
 
@@ -31,32 +34,68 @@ set_option old_structure_cmd true
 
 open_locale nnreal
 
-variables {R S : Type*} (x y : R) (r : ℝ)
+variables {F R S : Type*} (x y : R) (r : ℝ)
 
 /-- A seminorm on a ring `R` is a function `f : R → ℝ` that preserves zero, takes nonnegative
   values, is subadditive and submultiplicative and such that `f (-x) = f x` for all `x ∈ R`. -/
-structure ring_seminorm (R : Type*) [non_unital_ring R]
+structure ring_seminorm (R : Type*) [non_unital_non_assoc_ring R]
   extends add_group_seminorm R :=
 (mul_le' : ∀ x y : R, to_fun (x * y) ≤ to_fun x * to_fun y)
 
 /-- A function `f : R → ℝ` is a norm on a (nonunital) ring if it is a seminorm and `f x = 0`
   implies `x = 0`. -/
-structure ring_norm (R : Type*) [non_unital_ring R] extends add_group_norm R, ring_seminorm R
+structure ring_norm (R : Type*) [non_unital_non_assoc_ring R]
+  extends ring_seminorm R, add_group_norm R
+
+/-- A multiplicative seminorm on a ring `R` is a function `f : R → ℝ` that preserves zero and
+multiplication, takes nonnegative values, is subadditive and such that `f (-x) = f x` for all `x`.
+-/
+structure mul_ring_seminorm (R : Type*) [non_assoc_ring R]
+  extends add_group_seminorm R, monoid_with_zero_hom R ℝ
+
+/-- A multiplicative norm on a ring `R` is a ring seminorm such that `f x = 0` implies `x = 0`. -/
+structure mul_ring_norm (R : Type*) [non_assoc_ring R] extends mul_ring_seminorm R, add_group_norm R
 
 attribute [nolint doc_blame] ring_seminorm.to_add_group_seminorm ring_norm.to_add_group_norm
-  ring_norm.to_ring_seminorm
+  ring_norm.to_ring_seminorm mul_ring_seminorm.to_add_group_seminorm
+  mul_ring_seminorm.to_monoid_with_zero_hom mul_ring_norm.to_add_group_norm
+  mul_ring_norm.to_mul_ring_seminorm
 
 /-- `ring_seminorm_class F α` states that `F` is a type of seminorms on the ring `α`.
 
 You should extend this class when you extend `ring_seminorm`. -/
-class ring_seminorm_class (F : Type*) (α : out_param $ Type*) [non_unital_ring α]
+class ring_seminorm_class (F : Type*) (α : out_param $ Type*) [non_unital_non_assoc_ring α]
   extends add_group_seminorm_class F α, submultiplicative_hom_class F α ℝ
 
 /-- `ring_norm_class F α` states that `F` is a type of norms on the ring `α`.
 
 You should extend this class when you extend `ring_norm`. -/
-class ring_norm_class (F : Type*) (α : out_param $ Type*) [non_unital_ring α]
+class ring_norm_class (F : Type*) (α : out_param $ Type*) [non_unital_non_assoc_ring α]
   extends ring_seminorm_class F α, add_group_norm_class F α
+
+/-- `mul_ring_seminorm_class F α` states that `F` is a type of multiplicative seminorms on the ring
+`α`.
+
+You should extend this class when you extend `mul_ring_seminorm`. -/
+class mul_ring_seminorm_class (F : Type*) (α : out_param $ Type*) [non_assoc_ring α]
+  extends add_group_seminorm_class F α, monoid_with_zero_hom_class F α ℝ
+
+/-- `mul_ring_norm_class F α` states that `F` is a type of multiplicative norms on the ring `α`.
+
+You should extend this class when you extend `mul_ring_norm`. -/
+class mul_ring_norm_class (F : Type*) (α : out_param $ Type*) [non_assoc_ring α]
+  extends mul_ring_seminorm_class F α, add_group_norm_class F α
+
+@[priority 100] -- See note [lower instance priority]
+instance mul_ring_seminorm_class.to_ring_seminorm_class [non_assoc_ring R]
+  [mul_ring_seminorm_class F R] : ring_seminorm_class F R :=
+{ map_mul_le_mul := λ f a b, (map_mul _ _ _).le,
+  ..‹mul_ring_seminorm_class F R› }
+
+@[priority 100] -- See note [lower instance priority]
+instance mul_ring_norm_class.to_ring_norm_class [non_assoc_ring R] [mul_ring_norm_class F R] :
+  ring_norm_class F R :=
+{ ..‹mul_ring_norm_class F R›, ..mul_ring_seminorm_class.to_ring_seminorm_class }
 
 namespace ring_seminorm
 
@@ -166,6 +205,79 @@ rfl
 instance [decidable_eq R] : inhabited (ring_norm R) := ⟨1⟩
 
 end ring_norm
+
+namespace mul_ring_seminorm
+variables [non_assoc_ring R]
+
+instance mul_ring_seminorm_class : mul_ring_seminorm_class (mul_ring_seminorm R) R :=
+{ coe := λ f, f.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_zero := λ f, f.map_zero',
+  map_one := λ f, f.map_one',
+  map_add_le_add := λ f, f.add_le',
+  map_mul := λ f, f.map_mul',
+  map_neg_eq_map := λ f, f.neg' }
+
+/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`. -/
+instance : has_coe_to_fun (mul_ring_seminorm R) (λ _, R → ℝ) := fun_like.has_coe_to_fun
+
+@[simp] lemma to_fun_eq_coe (p : mul_ring_seminorm R) : p.to_fun = p := rfl
+
+@[ext] lemma ext {p q : mul_ring_seminorm R} : (∀ x, p x = q x) → p = q := fun_like.ext p q
+
+variables [decidable_eq R] [no_zero_divisors R] [nontrivial R]
+
+/-- The trivial seminorm on a ring `R` is the `mul_ring_seminorm` taking value `0` at `0` and `1` at
+every other element. -/
+instance : has_one (mul_ring_seminorm R) :=
+⟨{ map_one' := if_neg one_ne_zero,
+  map_mul' := λ x y, begin
+    obtain rfl | hx := eq_or_ne x 0,
+    { simp },
+    obtain rfl | hy := eq_or_ne y 0,
+    { simp },
+    { simp [hx, hy] }
+  end,
+  ..(1 : add_group_seminorm R) }⟩
+
+@[simp] lemma apply_one (x : R) : (1 : mul_ring_seminorm R) x = if x = 0 then 0 else 1 := rfl
+
+instance : inhabited (mul_ring_seminorm R) := ⟨1⟩
+
+end mul_ring_seminorm
+
+namespace mul_ring_norm
+variable [non_assoc_ring R]
+
+instance mul_ring_norm_class : mul_ring_norm_class (mul_ring_norm R) R :=
+{ coe := λ f, f.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_zero := λ f, f.map_zero',
+  map_one := λ f, f.map_one',
+  map_add_le_add := λ f, f.add_le',
+  map_mul := λ f, f.map_mul',
+  map_neg_eq_map := λ f, f.neg',
+  eq_zero_of_map_eq_zero := λ f, f.eq_zero_of_map_eq_zero' }
+
+/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`. -/
+instance : has_coe_to_fun (mul_ring_norm R) (λ _, R → ℝ) := ⟨λ p, p.to_fun⟩
+
+@[simp] lemma to_fun_eq_coe (p : mul_ring_norm R) : p.to_fun = p := rfl
+
+@[ext] lemma ext {p q : mul_ring_norm R} : (∀ x, p x = q x) → p = q := fun_like.ext p q
+
+variables (R) [decidable_eq R] [no_zero_divisors R] [nontrivial R]
+
+/-- The trivial norm on a ring `R` is the `mul_ring_norm` taking value `0` at `0` and `1` at every
+other element. -/
+instance : has_one (mul_ring_norm R) :=
+⟨{ ..(1 : mul_ring_seminorm R), ..(1 : add_group_norm R) }⟩
+
+@[simp] lemma apply_one (x : R) : (1 : mul_ring_norm R) x = if x = 0 then 0 else 1 := rfl
+
+instance : inhabited (mul_ring_norm R) := ⟨1⟩
+
+end mul_ring_norm
 
 /-- A nonzero ring seminorm on a field `K` is a ring norm. -/
 def ring_seminorm.to_ring_norm {K : Type*} [field K] (f : ring_seminorm K) (hnt : f ≠ 0) :

--- a/src/analysis/normed/ring/seminorm.lean
+++ b/src/analysis/normed/ring/seminorm.lean
@@ -53,7 +53,8 @@ multiplication, takes nonnegative values, is subadditive and such that `f (-x) =
 structure mul_ring_seminorm (R : Type*) [non_assoc_ring R]
   extends add_group_seminorm R, monoid_with_zero_hom R ℝ
 
-/-- A multiplicative norm on a ring `R` is a ring seminorm such that `f x = 0` implies `x = 0`. -/
+/-- A multiplicative norm on a ring `R` is a multiplicative ring seminorm such that `f x = 0`
+implies `x = 0`. -/
 structure mul_ring_norm (R : Type*) [non_assoc_ring R] extends mul_ring_seminorm R, add_group_norm R
 
 attribute [nolint doc_blame] ring_seminorm.to_add_group_seminorm ring_norm.to_add_group_norm


### PR DESCRIPTION
Define `mul_ring_seminorm`/`mul_ring_norm`, the type of multiplicative `ring_seminorm`/`ring_norm`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Requested by @mariainesdff

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
