### PR TITLE
[Merged by Bors] - feat(analysis/convex/between): `wbtw` and distinct end points

### DIFF
--- a/src/analysis/convex/between.lean
+++ b/src/analysis/convex/between.lean
@@ -241,12 +241,22 @@ end
 
 variables {R}
 
-lemma sbtw.left_ne_right {x y z : P} (h : sbtw R x y z) : x ≠ z :=
+lemma wbtw.left_ne_right_of_ne_left {x y z : P} (h : wbtw R x y z) (hne : y ≠ x) : x ≠ z :=
 begin
   rintro rfl,
-  rw [sbtw, wbtw_self_iff] at h,
-  exact h.2.1 h.1
+  rw wbtw_self_iff at h,
+  exact hne h
 end
+
+lemma wbtw.left_ne_right_of_ne_right {x y z : P} (h : wbtw R x y z) (hne : y ≠ z) : x ≠ z :=
+begin
+  rintro rfl,
+  rw wbtw_self_iff at h,
+  exact hne h
+end
+
+lemma sbtw.left_ne_right {x y z : P} (h : sbtw R x y z) : x ≠ z :=
+h.wbtw.left_ne_right_of_ne_left h.2.1
 
 lemma sbtw_iff_mem_image_Ioo_and_ne [no_zero_smul_divisors R V] {x y z : P} :
   sbtw R x y z ↔ y ∈ line_map x z '' (set.Ioo (0 : R) 1) ∧ x ≠ z :=


### PR DESCRIPTION
Add lemmas that `wbtw`, together with the middle point being distinct from one of the end points, implies the two end points are distinct, and use one of those lemmas in the proof of `sbtw.left_ne_right`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
