### PR TITLE
[Merged by Bors] - feat(algebra/order/hom/basic): Non-archimedean homomorphisms

### DIFF
--- a/src/algebra/order/hom/basic.lean
+++ b/src/algebra/order/hom/basic.lean
@@ -19,6 +19,7 @@ This file defines hom classes for common properties at the intersection of order
 * `subadditive_hom_class`: Homs are subadditive: `∀ f a b, f (a + b) ≤ f a + f b`
 * `submultiplicative_hom_class`: Homs are submultiplicative: `∀ f a b, f (a * b) ≤ f a * f b`
 * `mul_le_add_hom_class`: `∀ f a b, f (a * b) ≤ f a + f b`
+* `nonarchimedean_hom_class`: `∀ a b, f (a + b) ≤ max (f a) (f b)`
 
 ## TODO
 

--- a/src/algebra/order/hom/basic.lean
+++ b/src/algebra/order/hom/basic.lean
@@ -19,13 +19,17 @@ This file defines hom classes for common properties at the intersection of order
 * `subadditive_hom_class`: Homs are subadditive: `∀ f a b, f (a + b) ≤ f a + f b`
 * `submultiplicative_hom_class`: Homs are submultiplicative: `∀ f a b, f (a * b) ≤ f a * f b`
 * `mul_le_add_hom_class`: `∀ f a b, f (a * b) ≤ f a + f b`
+
+## TODO
+
+Finitary versions of the current lemmas.
 -/
 
 set_option old_structure_cmd true
 
 open function
 
-variables {F α β γ δ : Type*}
+variables {ι F α β γ δ : Type*}
 
 /-- `nonneg_hom_class F α β` states that `F` is a type of nonnegative morphisms. -/
 class nonneg_hom_class (F : Type*) (α β : out_param $ Type*) [has_zero β] [has_le β]
@@ -43,16 +47,22 @@ class submultiplicative_hom_class (F : Type*) (α β : out_param $ Type*) [has_m
   [has_le β] extends fun_like F α (λ _, β) :=
 (map_mul_le_mul (f : F) : ∀ a b, f (a * b) ≤ f a * f b)
 
-/-- `map_add_le_class F α β` states that `F` is a type of subadditive morphisms. -/
+/-- `mul_le_add_hom_class F α β` states that `F` is a type of subadditive morphisms. -/
 @[to_additive subadditive_hom_class]
 class mul_le_add_hom_class (F : Type*) (α β : out_param $ Type*) [has_mul α] [has_add β] [has_le β]
   extends fun_like F α (λ _, β) :=
 (map_mul_le_add (f : F) : ∀ a b, f (a * b) ≤ f a + f b)
 
+/-- `nonarchimedean_hom_class F α β` states that `F` is a type of non-archimedean morphisms. -/
+class nonarchimedean_hom_class (F : Type*) (α β : out_param $ Type*) [has_add α] [linear_order β]
+  extends fun_like F α (λ _, β) :=
+(map_add_le_max (f : F) : ∀ a b, f (a + b) ≤ max (f a) (f b))
+
 export nonneg_hom_class (map_nonneg)
 export subadditive_hom_class (map_add_le_add)
 export submultiplicative_hom_class (map_mul_le_mul)
 export mul_le_add_hom_class (map_mul_le_add)
+export nonarchimedean_hom_class (map_add_le_max)
 
 attribute [simp] map_nonneg
 


### PR DESCRIPTION
Define `nonarchimedean_hom_class `a general hom class for homs respecting `f (a + b) ≤ max (f a) (f b)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is meant to be extended by more exciting homs later.

Requested by @mariainesdff

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
