### PR TITLE
[Merged by Bors] - feat(algebraic_topology/dold_kan): N₁ reflects isomorphisms

### DIFF
--- a/src/algebraic_topology/dold_kan/n_reflects_iso.lean
+++ b/src/algebraic_topology/dold_kan/n_reflects_iso.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2022 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import algebraic_topology.dold_kan.functor_n
+import algebraic_topology.dold_kan.decomposition
+import category_theory.idempotents.homological_complex
+
+/-!
+
+# N₁ and N₂ reflects isomorphisms
+
+In this file, it is shown that the functor
+`N₁ : simplicial_object C ⥤ karoubi (chain_complex C ℕ)`
+reflects isomorphisms for any preadditive category `C`.
+
+TODO @joelriou: deduce that `N₂ : karoubi (simplicial_object C) ⥤ karoubi (chain_complex C ℕ)`
+also reflects isomorphisms.
+
+-/
+
+
+open category_theory
+open category_theory.category
+open category_theory.idempotents
+open opposite
+open_locale simplicial
+
+namespace algebraic_topology
+
+namespace dold_kan
+
+variables {C : Type*} [category C] [preadditive C]
+
+open morph_components
+
+instance : reflects_isomorphisms
+  (N₁ : simplicial_object C ⥤ karoubi (chain_complex C ℕ)) :=
+⟨λ X Y f, begin
+  introI,
+  /- restating the result in a way that allows induction on the degree n -/
+  suffices : ∀ (n : ℕ), is_iso (f.app (op [n])),
+  { haveI : ∀ (Δ : simplex_categoryᵒᵖ), is_iso (f.app Δ) := λ Δ, this Δ.unop.len,
+    apply nat_iso.is_iso_of_is_iso_app, },
+  /- restating the assumption in a more practical form -/
+  have h₁ := homological_complex.congr_hom (karoubi.hom_ext.mp (is_iso.hom_inv_id (N₁.map f))),
+  have h₂ := homological_complex.congr_hom (karoubi.hom_ext.mp (is_iso.inv_hom_id (N₁.map f))),
+  have h₃ := λ n, karoubi.homological_complex.f_p_comm_assoc (inv (N₁.map f)) (n) (f.app (op [n])),
+  simp only [N₁_map_f, karoubi.comp, homological_complex.comp_f,
+    alternating_face_map_complex.map_f, N₁_obj_p, karoubi.id_eq, assoc] at h₁ h₂ h₃,
+  /- we have to construct an inverse to f in degree n, by induction on n -/
+  intro n,
+  induction n with n hn,
+  /- degree 0 -/
+  { use (inv (N₁.map f)).f.f 0,
+    have h₁₀ := h₁ 0,
+    have h₂₀ := h₂ 0,
+    dsimp at h₁₀ h₂₀,
+    simp only [id_comp, comp_id] at h₁₀ h₂₀,
+    tauto, },
+  /- induction step -/
+  { haveI := hn,
+    use φ
+      { a := P_infty.f (n+1) ≫ (inv (N₁.map f)).f.f (n+1),
+        b := λ i, inv (f.app (op [n])) ≫ X.σ i, },
+    simp only [morph_components.id, ← id_φ, ← pre_comp_φ, pre_comp, ← post_comp_φ,
+      post_comp, P_infty_f_naturality_assoc, is_iso.hom_inv_id_assoc, assoc,
+      is_iso.inv_hom_id_assoc, simplicial_object.σ_naturality, h₁, h₂, h₃],
+    tauto, },
+end⟩
+
+end dold_kan
+
+end algebraic_topology

--- a/src/algebraic_topology/dold_kan/n_reflects_iso.lean
+++ b/src/algebraic_topology/dold_kan/n_reflects_iso.lean
@@ -36,8 +36,7 @@ variables {C : Type*} [category C] [preadditive C]
 
 open morph_components
 
-instance : reflects_isomorphisms
-  (N₁ : simplicial_object C ⥤ karoubi (chain_complex C ℕ)) :=
+instance : reflects_isomorphisms (N₁ : simplicial_object C ⥤ karoubi (chain_complex C ℕ)) :=
 ⟨λ X Y f, begin
   introI,
   /- restating the result in a way that allows induction on the degree n -/

--- a/src/algebraic_topology/dold_kan/n_reflects_iso.lean
+++ b/src/algebraic_topology/dold_kan/n_reflects_iso.lean
@@ -21,7 +21,6 @@ also reflects isomorphisms.
 
 -/
 
-
 open category_theory
 open category_theory.category
 open category_theory.idempotents
@@ -46,7 +45,7 @@ instance : reflects_isomorphisms (N₁ : simplicial_object C ⥤ karoubi (chain_
   /- restating the assumption in a more practical form -/
   have h₁ := homological_complex.congr_hom (karoubi.hom_ext.mp (is_iso.hom_inv_id (N₁.map f))),
   have h₂ := homological_complex.congr_hom (karoubi.hom_ext.mp (is_iso.inv_hom_id (N₁.map f))),
-  have h₃ := λ n, karoubi.homological_complex.f_p_comm_assoc (inv (N₁.map f)) (n) (f.app (op [n])),
+  have h₃ := λ n, karoubi.homological_complex.p_comm_f_assoc (inv (N₁.map f)) (n) (f.app (op [n])),
   simp only [N₁_map_f, karoubi.comp, homological_complex.comp_f,
     alternating_face_map_complex.map_f, N₁_obj_p, karoubi.id_eq, assoc] at h₁ h₂ h₃,
   /- we have to construct an inverse to f in degree n, by induction on n -/

--- a/src/category_theory/idempotents/homological_complex.lean
+++ b/src/category_theory/idempotents/homological_complex.lean
@@ -17,7 +17,6 @@ TODO @joelriou : Get an equivalence of categories
 `karoubi (homological_complex C c) ≌ homological_complex (karoubi C) c`
 for all preadditive categories `C` and complex shape `c`.
 
-
 -/
 
 namespace category_theory
@@ -33,15 +32,15 @@ namespace homological_complex
 variables {P Q : karoubi (homological_complex C c)} (f : P ⟶ Q) (n : ι)
 
 @[simp, reassoc]
-lemma f_p_comp : P.p.f n ≫ f.f.f n = f.f.f n :=
+lemma p_comp_d : P.p.f n ≫ f.f.f n = f.f.f n :=
 homological_complex.congr_hom (p_comp f) n
 
 @[simp, reassoc]
-lemma f_comp_p : f.f.f n ≫ Q.p.f n = f.f.f n :=
+lemma comp_p_d : f.f.f n ≫ Q.p.f n = f.f.f n :=
 homological_complex.congr_hom (comp_p f) n
 
 @[reassoc]
-lemma f_p_comm : P.p.f n ≫ f.f.f n = f.f.f n ≫ Q.p.f n :=
+lemma p_comm_f : P.p.f n ≫ f.f.f n = f.f.f n ≫ Q.p.f n :=
 homological_complex.congr_hom (p_comm f) n
 
 end homological_complex

--- a/src/category_theory/idempotents/homological_complex.lean
+++ b/src/category_theory/idempotents/homological_complex.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2022 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import algebra.homology.homological_complex
+import category_theory.idempotents.karoubi
+
+/-!
+# Idempotent completeness and homological complexes
+
+This file contains simplifications lemmas for categories
+`karoubi (homological_complex C c)`.
+
+TODO @joelriou : Get an equivalence of categories
+`karoubi (homological_complex C c) ≌ homological_complex (karoubi C) c`
+for all preadditive categories `C` and complex shape `c`.
+
+
+-/
+
+namespace category_theory
+
+variables {C : Type*} [category C] [preadditive C] {ι : Type*} {c : complex_shape ι}
+
+namespace idempotents
+
+namespace karoubi
+
+namespace homological_complex
+
+variables {P Q : karoubi (homological_complex C c)} (f : P ⟶ Q) (n : ι)
+
+@[simp, reassoc]
+lemma f_p_comp : P.p.f n ≫ f.f.f n = f.f.f n :=
+homological_complex.congr_hom (p_comp f) n
+
+@[simp, reassoc]
+lemma f_comp_p : f.f.f n ≫ Q.p.f n = f.f.f n :=
+homological_complex.congr_hom (comp_p f) n
+
+@[reassoc]
+lemma f_p_comm : P.p.f n ≫ f.f.f n = f.f.f n ≫ Q.p.f n :=
+homological_complex.congr_hom (p_comm f) n
+
+end homological_complex
+
+end karoubi
+
+end idempotents
+
+end category_theory


### PR DESCRIPTION
In this PR, it is shown that `N₁ : simplicial_object C ⥤ karoubi (chain_complex C ℕ)` reflects isomorphisms for any preadditive category `C`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
