### PR TITLE
[Merged by Bors] - chore(algebra/hom/non_unital_alg): add missing `non_unital_ring_hom_class` instance

### DIFF
--- a/src/algebra/hom/non_unital_alg.lean
+++ b/src/algebra/hom/non_unital_alg.lean
@@ -73,6 +73,15 @@ attribute [nolint dangerous_instance] non_unital_alg_hom_class.to_mul_hom_class
 
 namespace non_unital_alg_hom_class
 
+@[priority 100] -- See note [lower instance priority]
+instance {F R A B : Type*} [monoid R] [non_unital_non_assoc_semiring A] [distrib_mul_action R A]
+  [non_unital_non_assoc_semiring B] [distrib_mul_action R B]
+  [hF : non_unital_alg_hom_class F R A B] : non_unital_ring_hom_class F A B :=
+{ coe := coe_fn, .. hF }
+
+-- `R` becomes a metavariable but that's fine because it's an `out_param`
+attribute [nolint dangerous_instance] non_unital_alg_hom_class.non_unital_ring_hom_class
+
 variables [semiring R]
   [non_unital_non_assoc_semiring A] [module R A]
   [non_unital_non_assoc_semiring B] [module R B]

--- a/src/algebra/hom/non_unital_alg.lean
+++ b/src/algebra/hom/non_unital_alg.lean
@@ -75,7 +75,8 @@ namespace non_unital_alg_hom_class
 
 -- `R` becomes a metavariable but that's fine because it's an `out_param`
 @[priority 100, nolint dangerous_instance] -- See note [lower instance priority]
-instance non_unital_alg_hom_class.to_non_unital_ring_hom_class {F R A B : Type*} [monoid R] [non_unital_non_assoc_semiring A] [distrib_mul_action R A]
+instance non_unital_alg_hom_class.to_non_unital_ring_hom_class {F R A B : Type*} [monoid R]
+  [non_unital_non_assoc_semiring A] [distrib_mul_action R A]
   [non_unital_non_assoc_semiring B] [distrib_mul_action R B]
   [non_unital_alg_hom_class F R A B] : non_unital_ring_hom_class F A B :=
 { coe := coe_fn, ..‹non_unital_alg_hom_class F R A B› }

--- a/src/algebra/hom/non_unital_alg.lean
+++ b/src/algebra/hom/non_unital_alg.lean
@@ -73,14 +73,12 @@ attribute [nolint dangerous_instance] non_unital_alg_hom_class.to_mul_hom_class
 
 namespace non_unital_alg_hom_class
 
-@[priority 100] -- See note [lower instance priority]
-instance {F R A B : Type*} [monoid R] [non_unital_non_assoc_semiring A] [distrib_mul_action R A]
-  [non_unital_non_assoc_semiring B] [distrib_mul_action R B]
-  [hF : non_unital_alg_hom_class F R A B] : non_unital_ring_hom_class F A B :=
-{ coe := coe_fn, .. hF }
-
 -- `R` becomes a metavariable but that's fine because it's an `out_param`
-attribute [nolint dangerous_instance] non_unital_alg_hom_class.non_unital_ring_hom_class
+@[priority 100, nolint dangerous_instance] -- See note [lower instance priority]
+instance non_unital_alg_hom_class.to_non_unital_ring_hom_class {F R A B : Type*} [monoid R] [non_unital_non_assoc_semiring A] [distrib_mul_action R A]
+  [non_unital_non_assoc_semiring B] [distrib_mul_action R B]
+  [non_unital_alg_hom_class F R A B] : non_unital_ring_hom_class F A B :=
+{ coe := coe_fn, ..‹non_unital_alg_hom_class F R A B› }
 
 variables [semiring R]
   [non_unital_non_assoc_semiring A] [module R A]


### PR DESCRIPTION
This instance was missing because `non_unital_alg_hom` was defined before `non_unital_ring_hom`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
