### PR TITLE
[Merged by Bors] - feat(tactic/positivity): Extension for `int.nat_abs`

### DIFF
--- a/src/tactic/positivity.lean
+++ b/src/tactic/positivity.lean
@@ -413,6 +413,17 @@ meta def positivity_abs : expr → tactic strictness
   nonnegative <$> mk_app ``abs_nonneg [a] -- else report nonnegativity
 | _ := failed
 
+private lemma int_nat_abs_pos {n : ℤ} (hn : 0 < n) : 0 < n.nat_abs :=
+int.nat_abs_pos_of_ne_zero hn.ne'
+
+/-- Extension for the `positivity` tactic: `int.nat_abs` is positive when its input is. -/
+@[positivity]
+meta def positivity_nat_abs : expr → tactic strictness
+| `(int.nat_abs %%a) := do
+    positive p ← core a,
+    positive <$> mk_app ``int_nat_abs_pos [p]
+| _ := failed
+
 private lemma nat_cast_pos [ordered_semiring α] [nontrivial α] {n : ℕ} : 0 < n → 0 < (n : α) :=
 nat.cast_pos.2
 

--- a/src/tactic/positivity.lean
+++ b/src/tactic/positivity.lean
@@ -416,7 +416,10 @@ meta def positivity_abs : expr → tactic strictness
 private lemma int_nat_abs_pos {n : ℤ} (hn : 0 < n) : 0 < n.nat_abs :=
 int.nat_abs_pos_of_ne_zero hn.ne'
 
-/-- Extension for the `positivity` tactic: `int.nat_abs` is positive when its input is. -/
+/-- Extension for the `positivity` tactic: `int.nat_abs` is positive when its input is.
+
+Since the output type of `int.nat_abs` is `ℕ`, the nonnegative case is handled by the default `positivity` tactic.
+-/
 @[positivity]
 meta def positivity_nat_abs : expr → tactic strictness
 | `(int.nat_abs %%a) := do

--- a/src/tactic/positivity.lean
+++ b/src/tactic/positivity.lean
@@ -418,7 +418,8 @@ int.nat_abs_pos_of_ne_zero hn.ne'
 
 /-- Extension for the `positivity` tactic: `int.nat_abs` is positive when its input is.
 
-Since the output type of `int.nat_abs` is `ℕ`, the nonnegative case is handled by the default `positivity` tactic.
+Since the output type of `int.nat_abs` is `ℕ`, the nonnegative case is handled by the default
+`positivity` tactic.
 -/
 @[positivity]
 meta def positivity_nat_abs : expr → tactic strictness

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -105,6 +105,8 @@ example {a : ℤ} : 0 ≤ |a| := by positivity
 
 example {a : ℤ} : 0 < |a| + 3 := by positivity
 
+example {n : ℤ} (hn : 0 < n) : 0 < n.nat_abs := by positivity
+
 example {a : ℤ} (ha : 1 < a) : 0 < |(3:ℤ) + a| := by positivity
 
 example {a : ℝ} (ha : 0 ≤ a) : 0 ≤ real.sqrt a := by positivity


### PR DESCRIPTION
Add `positivity_nat_abs`, a positivity extension for `int.nat_abs`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
