### PR TITLE
[Merged by Bors] - feat(algebra/gcd_monoid/finset): Generalize `finset.gcd_image`

### DIFF
--- a/src/algebra/gcd_monoid/finset.lean
+++ b/src/algebra/gcd_monoid/finset.lean
@@ -147,11 +147,10 @@ dvd_gcd (λ b hb, (gcd_dvd hb).trans (h b hb))
 lemma gcd_mono (h : s₁ ⊆ s₂) : s₂.gcd f ∣ s₁.gcd f :=
 dvd_gcd $ assume b hb, gcd_dvd (h hb)
 
-theorem gcd_image {g : γ → β} (s: finset γ) [decidable_eq β] [is_idempotent α gcd_monoid.gcd] :
-  (s.image g).gcd f = s.gcd (f ∘ g) := by simp [gcd, fold_image_idem]
+lemma gcd_image [decidable_eq β] {g : γ → β} (s : finset γ) : (s.image g).gcd f = s.gcd (f ∘ g) :=
+by { classical, induction s using finset.induction with c s hc ih; simp [*] }
 
-theorem gcd_eq_gcd_image [decidable_eq α] [is_idempotent α gcd_monoid.gcd] :
-  s.gcd f = (s.image f).gcd id := (@gcd_image _ _ _ _ _ id _ _ _ _).symm
+lemma gcd_eq_gcd_image [decidable_eq α] : s.gcd f = (s.image f).gcd id := eq.symm $ gcd_image _
 
 theorem gcd_eq_zero_iff : s.gcd f = 0 ↔ ∀ (x : β), x ∈ s → f x = 0 :=
 begin

--- a/src/algebra/gcd_monoid/finset.lean
+++ b/src/algebra/gcd_monoid/finset.lean
@@ -87,6 +87,11 @@ lcm_dvd (λ b hb, (h b hb).trans (dvd_lcm hb))
 lemma lcm_mono (h : s₁ ⊆ s₂) : s₁.lcm f ∣ s₂.lcm f :=
 lcm_dvd $ assume b hb, dvd_lcm (h hb)
 
+lemma lcm_image [decidable_eq β] {g : γ → β} (s : finset γ) : (s.image g).lcm f = s.lcm (f ∘ g) :=
+by { classical, induction s using finset.induction with c s hc ih; simp [*] }
+
+lemma lcm_eq_lcm_image [decidable_eq α] : s.lcm f = (s.image f).lcm id := eq.symm $ lcm_image _
+
 theorem lcm_eq_zero_iff [nontrivial α] : s.lcm f = 0 ↔ 0 ∈ f '' s :=
 by simp only [multiset.mem_map, lcm_def, multiset.lcm_eq_zero_iff, set.mem_image, mem_coe,
   ← finset.mem_def]


### PR DESCRIPTION
`finset.gcd_image` and `finset.gcd_eq_gcd_image` were unnecessarily assuming `[is_idempotent α gcd]`. Remove that assumption and add the corresponding `finset.lcm` lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Those lemmas now apply to ` ℤ` and polynomials.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
