### PR TITLE
[Merged by Bors] - feat(group_theory/sylow): Technical fusion lemma for Burnside's transfer theorem

### DIFF
--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -296,6 +296,30 @@ lemma sylow.stabilizer_eq_normalizer (P : sylow p G) :
   stabilizer G P = (P : subgroup G).normalizer :=
 ext (λ g, sylow.smul_eq_iff_mem_normalizer)
 
+lemma sylow.conj_eq_normalizer_conj_of_mem_centralizer
+  [fact p.prime] [finite (sylow p G)] (P : sylow p G) (x g : G)
+  (hx : x ∈ (P : subgroup G).centralizer) (hy : g⁻¹ * x * g ∈ (P : subgroup G).centralizer) :
+  ∃ n ∈ (P : subgroup G).normalizer, g⁻¹ * x * g = n⁻¹ * x * n :=
+begin
+  have h1 : ↑P ≤ (zpowers x).centralizer,
+  { rwa [le_centralizer_iff, zpowers_le] },
+  have h2 : ↑(g • P) ≤ (zpowers x).centralizer,
+  { rw [le_centralizer_iff, zpowers_le],
+    rintros - ⟨z, hz, rfl⟩,
+    specialize hy z hz,
+    rwa [←mul_assoc, ←eq_mul_inv_iff_mul_eq, mul_assoc, mul_assoc, mul_assoc, ←mul_assoc,
+      eq_inv_mul_iff_mul_eq, ←mul_assoc, ←mul_assoc] at hy },
+  obtain ⟨h, hh⟩ := exists_smul_eq (zpowers x).centralizer ((g • P).subtype h2) (P.subtype h1),
+  simp_rw [sylow.smul_subtype, smul_def, smul_smul] at hh,
+  refine ⟨h * g, sylow.smul_eq_iff_mem_normalizer.mp (sylow.subtype_injective hh), _⟩,
+  rw [←mul_assoc, commute.right_comm (h.prop x (mem_zpowers x)), mul_inv_rev, inv_mul_cancel_right]
+end
+
+lemma sylow.conj_eq_normalizer_conj_of_mem [fact p.prime] [finite (sylow p G)] (P : sylow p G)
+  [hP : (P : subgroup G).is_commutative] (x g : G) (hx : x ∈ P) (hy : g⁻¹ * x * g ∈ P) :
+  ∃ n ∈ (P : subgroup G).normalizer, g⁻¹ * x * g = n⁻¹ * x * n :=
+P.conj_eq_normalizer_conj_of_mem_centralizer x g (le_centralizer P hx) (le_centralizer P hy)
+
 /-- Sylow `p`-subgroups are in bijection with cosets of the normalizer of a Sylow `p`-subgroup -/
 noncomputable def sylow.equiv_quotient_normalizer [fact p.prime] [fintype (sylow p G)]
   (P : sylow p G) : sylow p G ≃ G ⧸ (P : subgroup G).normalizer :=


### PR DESCRIPTION
Burnside's transfer theorem requires a technical lemma obtained by applying Sylow's second theorem to the centralizer of an element. This technical lemmas states that if `P` is abelian, then `G`-conjugate elements of `P` are `N(P)`-conjugate. The fancy way of saying this is that "`N(P)` controls fusion in `P`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
