### PR TITLE
[Merged by Bors] - feat(topology): Completable field lemmas

### DIFF
--- a/src/topology/algebra/uniform_field.lean
+++ b/src/topology/algebra/uniform_field.lean
@@ -180,13 +180,12 @@ variables (L : Type*) [field L]  [uniform_space L] [completable_top_field L]
 instance subfield.completable_top_field (K : subfield L) : completable_top_field K :=
 { nice := begin
     intros F F_cau inf_F,
-    let i : K → L := coe,
+    let i : K →+* L := K.subtype,
     have hi : uniform_inducing i, from uniform_embedding_subtype_coe.to_uniform_inducing,
     rw ← hi.cauchy_map_iff at F_cau ⊢,
-    rw [map_comm (show (i ∘ λ x, x⁻¹) = (λ x, x⁻¹) ∘ i, by {ext , refl })],
+    rw [map_comm (show (i ∘ λ x, x⁻¹) = (λ x, x⁻¹) ∘ i, by {ext, refl})],
     apply completable_top_field.nice _ F_cau,
-    rw [← filter.push_pull', show (0 : L) = i 0, from rfl, ← hi.inducing.nhds_eq_comap, inf_F,
-        filter.map_bot]
+    rw [← filter.push_pull', ← map_zero i, ← hi.inducing.nhds_eq_comap, inf_F, filter.map_bot]
   end,
   ..subtype.separated_space (K : set L) }
 

--- a/src/topology/algebra/uniform_field.lean
+++ b/src/topology/algebra/uniform_field.lean
@@ -189,6 +189,7 @@ instance subfield.completable_top_field (K : subfield L) : completable_top_field
   end,
   ..subtype.separated_space (K : set L) }
 
+@[priority 100]
 instance completable_top_field_of_complete (L : Type*) [field L]
   [uniform_space L] [topological_division_ring L] [separated_space L] [complete_space L] :
   completable_top_field L :=

--- a/src/topology/algebra/uniform_field.lean
+++ b/src/topology/algebra/uniform_field.lean
@@ -5,6 +5,7 @@ Authors: Patrick Massot
 -/
 import topology.algebra.uniform_ring
 import topology.algebra.field
+import field_theory.subfield
 
 /-!
 # Completion of topological fields
@@ -173,3 +174,33 @@ instance : topological_division_ring (hat K) :=
 
 end completion
 end uniform_space
+
+variables (L : Type*) [field L]  [uniform_space L] [completable_top_field L]
+
+instance subfield.completable_top_field (K : subfield L) : completable_top_field K :=
+{ nice := begin
+    intros F F_cau inf_F,
+    let i : K → L := coe,
+    have hi : uniform_inducing i, from uniform_embedding_subtype_coe.to_uniform_inducing,
+    rw ← hi.cauchy_map_iff at F_cau ⊢,
+    rw [map_comm (show (i ∘ λ x, x⁻¹) = (λ x, x⁻¹) ∘ i, by {ext , refl })],
+    apply completable_top_field.nice _ F_cau,
+    rw [← filter.push_pull', show (0 : L) = i 0, from rfl, ← hi.inducing.nhds_eq_comap, inf_F,
+        filter.map_bot]
+  end,
+  ..subtype.separated_space (K : set L) }
+
+instance completable_top_field_of_complete (L : Type*) [field L]
+  [uniform_space L] [topological_division_ring L] [separated_space L] [complete_space L] :
+  completable_top_field L :=
+{ nice := λ F cau_F hF, begin
+    haveI : ne_bot F := cau_F.1,
+    rcases complete_space.complete cau_F with ⟨x, hx⟩,
+    have hx' : x ≠ 0,
+    { rintro rfl,
+      rw inf_eq_right.mpr hx at hF,
+      exact cau_F.1.ne hF },
+    exact filter.tendsto.cauchy_map (calc map (λ x, x⁻¹) F ≤ map (λ x, x⁻¹) (𝓝 x) : map_mono hx
+                                                       ... ≤ 𝓝 (x⁻¹) : continuous_at_inv₀ hx')
+  end,
+  ..‹separated_space L›}

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -198,6 +198,9 @@ end
 instance separated_t3 [separated_space α] : t3_space α :=
 by { haveI := separated_iff_t2.mp ‹_›, exact ⟨⟩ }
 
+instance subtype.separated_space [separated_space α] (s : set α) : separated_space s :=
+separated_iff_t2.mpr subtype.t2_space
+
 lemma is_closed_of_spaced_out [separated_space α] {V₀ : set (α × α)} (V₀_in : V₀ ∈ 𝓤 α)
   {s : set α} (hs : s.pairwise (λ x y, (x, y) ∉ V₀)) : is_closed s :=
 begin

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -45,6 +45,10 @@ lemma uniform_inducing.basis_uniformity {f : α → β} (hf : uniform_inducing f
   (𝓤 α).has_basis p (λ i, prod.map f f ⁻¹' s i) :=
 hf.1 ▸ H.comap _
 
+lemma uniform_inducing.cauchy_map_iff {f : α → β} (hf : uniform_inducing f) {F : filter α} :
+  cauchy (map f F) ↔ cauchy F :=
+by simp only [cauchy, map_ne_bot_iff, prod_map_map_eq, map_le_iff_le_comap, ← hf.comap_uniformity]
+
 lemma uniform_inducing_of_compose {f : α → β} {g : β → γ} (hf : uniform_continuous f)
   (hg : uniform_continuous g) (hgf : uniform_inducing (g ∘ f)) : uniform_inducing f :=
 begin


### PR DESCRIPTION
Subfields of completable fields are completable and complete fields are completable. 

---
This was required by Xavier at https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Completable.20top.20field. The PR includes two basic lemmas whose absence is suspicious but I couldn't find them.
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
