### PR TITLE
[Merged by Bors] - chore(data/rat,data/nat): modularize and reduce imports

### DIFF
--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Louis Carlin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Louis Carlin, Mario Carneiro
 -/
-
-import data.int.basic
 import algebra.field.basic
 
 /-!

--- a/src/algebra/field/basic.lean
+++ b/src/algebra/field/basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2014 Robert Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 -/
-import algebra.hom.ring
 import data.rat.defs
+import algebra.group_with_zero.power
 
 /-!
 # Division (semi)rings and (semi)fields

--- a/src/data/nat/fib.lean
+++ b/src/data/nat/fib.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Kevin Kappelmann. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Kappelmann, Kyle Miller, Mario Carneiro
 -/
-import data.nat.gcd
+import data.nat.gcd.basic
 import logic.function.iterate
 import data.finset.nat_antidiagonal
 import algebra.big_operators.basic

--- a/src/data/nat/gcd/basic.lean
+++ b/src/data/nat/gcd/basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
 import algebra.group_power.order
-import algebra.big_operators.basic
 
 /-!
 # Definitions and properties of `gcd`, `lcm`, and `coprime`
@@ -477,24 +476,6 @@ begin
   convert one_mul b,
   exact coprime.coprime_mul_right_right hac,
 end
-
-section big_operators
-
-open_locale big_operators
-
-/-- See `is_coprime.prod_left` for the corresponding lemma about `is_coprime` -/
-lemma coprime_prod_left
-  {ι : Type*} {x : ℕ} {s : ι → ℕ} {t : finset ι} :
-  (∀ (i : ι), i ∈ t → coprime (s i) x) → coprime (∏ (i : ι) in t, s i) x :=
-finset.prod_induction s (λ y, y.coprime x) (λ a b, coprime.mul) (by simp)
-
-/-- See `is_coprime.prod_right` for the corresponding lemma about `is_coprime` -/
-lemma coprime_prod_right
-  {ι : Type*} {x : ℕ} {s : ι → ℕ} {t : finset ι} :
-  (∀ (i : ι), i ∈ t → coprime x (s i)) → coprime x (∏ (i : ι) in t, s i) :=
-finset.prod_induction s (λ y, x.coprime y) (λ a b, coprime.mul_right) (by simp)
-
-end big_operators
 
 lemma coprime.eq_of_mul_eq_zero {m n : ℕ} (h : m.coprime n) (hmn : m * n = 0) :
   m = 0 ∧ n = 1 ∨ m = 1 ∧ n = 0 :=

--- a/src/data/nat/gcd/big_operators.lean
+++ b/src/data/nat/gcd/big_operators.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura
+-/
+import data.nat.gcd.basic
+import algebra.big_operators.basic
+
+/-! # Lemmas about coprimality with big products.
+
+These lemmas are kept separate from `data.nat.gcd.basic` in order to minimize imports.
+-/
+
+namespace nat
+
+open_locale big_operators
+
+/-- See `is_coprime.prod_left` for the corresponding lemma about `is_coprime` -/
+lemma coprime_prod_left
+  {ι : Type*} {x : ℕ} {s : ι → ℕ} {t : finset ι} :
+  (∀ (i : ι), i ∈ t → coprime (s i) x) → coprime (∏ (i : ι) in t, s i) x :=
+finset.prod_induction s (λ y, y.coprime x) (λ a b, coprime.mul) (by simp)
+
+/-- See `is_coprime.prod_right` for the corresponding lemma about `is_coprime` -/
+lemma coprime_prod_right
+  {ι : Type*} {x : ℕ} {s : ι → ℕ} {t : finset ι} :
+  (∀ (i : ι), i ∈ t → coprime x (s i)) → coprime x (∏ (i : ι) in t, s i) :=
+finset.prod_induction s (λ y, x.coprime y) (λ a b, coprime.mul_right) (by simp)
+
+end nat

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import data.list.prime
 import data.list.sort
-import data.nat.gcd
+import data.nat.gcd.basic
 import data.nat.sqrt_norm_num
 import data.set.finite
 import tactic.wlog

--- a/src/data/num/lemmas.lean
+++ b/src/data/num/lemmas.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 -/
 import data.num.bitwise
 import data.int.char_zero
-import data.nat.gcd
+import data.nat.gcd.basic
 import data.nat.psub
 
 /-!

--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -4,10 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import algebra.euclidean_domain
-import data.int.cast
-import data.nat.gcd
-import data.rat.defs
-import logic.encodable.basic
 
 /-!
 # Field Structure on the Rational Numbers

--- a/src/data/rat/cast.lean
+++ b/src/data/rat/cast.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 import data.rat.order
 import data.int.char_zero
 import algebra.field.opposite
+import algebra.big_operators.basic
 
 /-!
 # Casts for Rational Numbers

--- a/src/data/rat/defs.lean
+++ b/src/data/rat/defs.lean
@@ -3,9 +3,10 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
-import data.int.basic
-import data.nat.gcd
-import logic.encodable.basic
+import data.int.cast
+import data.nat.gcd.basic
+import data.pnat.basic
+import tactic.nth_rewrite
 
 /-!
 # Basics for the Rational Numbers
@@ -59,10 +60,6 @@ protected def repr : ℚ → string
 instance : has_repr ℚ := ⟨rat.repr⟩
 instance : has_to_string ℚ := ⟨rat.repr⟩
 meta instance : has_to_format ℚ := ⟨coe ∘ rat.repr⟩
-
-instance : encodable ℚ := encodable.of_equiv (Σ n : ℤ, {d : ℕ // 0 < d ∧ n.nat_abs.coprime d})
-  ⟨λ ⟨a, b, c, d⟩, ⟨a, b, c, d⟩, λ⟨a, b, c, d⟩, ⟨a, b, c, d⟩,
-   λ ⟨a, b, c, d⟩, rfl, λ⟨a, b, c, d⟩, rfl⟩
 
 /-- Embed an integer as a rational number -/
 def of_int (n : ℤ) : ℚ :=

--- a/src/data/rat/encodable.lean
+++ b/src/data/rat/encodable.lean
@@ -8,6 +8,8 @@ import logic.encodable.basic
 
 /-! # The rationals are `encodable`.
 
+As a consequence we also get the instance `countable ℚ`.
+
 This is kept separate from `data.rat.defs` in order to minimize imports.
 -/
 

--- a/src/data/rat/encodable.lean
+++ b/src/data/rat/encodable.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2019 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro
+-/
+import data.rat.defs
+import logic.encodable.basic
+
+/-! # The rationals are `encodable`.
+
+This is kept separate from `data.rat.defs` in order to minimize imports.
+-/
+
+namespace rat
+
+instance : encodable ℚ := encodable.of_equiv (Σ n : ℤ, {d : ℕ // 0 < d ∧ n.nat_abs.coprime d})
+  ⟨λ ⟨a, b, c, d⟩, ⟨a, b, c, d⟩, λ⟨a, b, c, d⟩, ⟨a, b, c, d⟩,
+   λ ⟨a, b, c, d⟩, rfl, λ⟨a, b, c, d⟩, rfl⟩
+
+end rat

--- a/src/group_theory/noncomm_pi_coprod.lean
+++ b/src/group_theory/noncomm_pi_coprod.lean
@@ -6,6 +6,7 @@ Authors: Joachim Breitner
 import group_theory.order_of_element
 import data.finset.noncomm_prod
 import data.fintype.card
+import data.nat.gcd.big_operators
 
 /-!
 # Canonical homomorphism from a finite family of monoids

--- a/src/number_theory/arithmetic_function.lean
+++ b/src/number_theory/arithmetic_function.lean
@@ -6,6 +6,7 @@ Authors: Aaron Anderson
 import algebra.big_operators.ring
 import number_theory.divisors
 import data.nat.squarefree
+import data.nat.gcd.big_operators
 import algebra.invertible
 import data.nat.factorization.basic
 

--- a/src/topology/instances/ereal.lean
+++ b/src/topology/instances/ereal.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import data.rat.encodable
 import data.real.ereal
 import topology.algebra.order.monotone_continuity
 import topology.instances.ennreal

--- a/src/topology/instances/irrational.lean
+++ b/src/topology/instances/irrational.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury G. Kudryashov
 -/
 import data.real.irrational
+import data.rat.encodable
 import topology.metric_space.baire
 
 /-!


### PR DESCRIPTION
While trying to understand the import tree leading to `data.rat.basic`, a small amount of modularization and import reduction.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
