### PR TITLE
[Merged by Bors] - fix(docs/references.bib): re-introduce authors in Cassels-Frohlich

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -430,7 +430,7 @@
 
 @Book{            cassels1967algebraic,
   title         = {Algebraic number theory},
-  author        = {Cassels, John William Scott and Fr{\"o}lich, Albrecht},
+  author        = {Cassels, John William Scott and Fr{\"o}hlich, Albrecht},
   booktitle     = {Proceedings of an instructional conference organized by
                   the {L}ondon {M}athematical {S}ociety (a {NATO} {A}dvanced
                   {S}tudy {I}nstitute) with the support of the

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -430,6 +430,7 @@
 
 @Book{            cassels1967algebraic,
   title         = {Algebraic number theory},
+  author        = {Cassels, John William Scott and Fr{\"o}lich, Albrecht},
   booktitle     = {Proceedings of an instructional conference organized by
                   the {L}ondon {M}athematical {S}ociety (a {NATO} {A}dvanced
                   {S}tudy {I}nstitute) with the support of the


### PR DESCRIPTION
authors were missing in the reference to Cassels-Frohlich

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
