### PR TITLE
[Merged by Bors] - perf(number_theory/padics/hensel): fix timeout in `calc_eval_z'

### DIFF
--- a/src/number_theory/padics/hensel.lean
+++ b/src/number_theory/padics/hensel.lean
@@ -154,23 +154,23 @@ calc
 private def calc_eval_z'  {z z' z1 : ℤ_[p]} (hz' : z' = z - z1) {n} (hz : ih n z)
   (h1 : ∥(↑(F.eval z) : ℚ_[p]) / ↑(F.derivative.eval z)∥ ≤ 1) (hzeq : z1 = ⟨_, h1⟩) :
   {q : ℤ_[p] // F.eval z' = q * z1^2} :=
-have hdzne' : (↑(F.derivative.eval z) : ℚ_[p]) ≠ 0, from
-  have hdzne : F.derivative.eval z ≠ 0,
-    from mt norm_eq_zero.2 (by rw hz.1; apply deriv_norm_ne_zero; assumption),
-  λ h, hdzne $ subtype.ext_iff_val.2 h,
-let ⟨q, hq⟩ := F.binom_expansion z (-z1) in
-have ∥(↑(F.derivative.eval z) * (↑(F.eval z) / ↑(F.derivative.eval z)) : ℚ_[p])∥ ≤ 1,
-  by { rw padic_norm_e.mul, exact mul_le_one (padic_int.norm_le_one _) (norm_nonneg _) h1 },
-have F.derivative.eval z * (-z1) = -F.eval z, from calc
-  F.derivative.eval z * (-z1)
-    = (F.derivative.eval z) * -⟨↑(F.eval z) / ↑(F.derivative.eval z), h1⟩ : by rw [hzeq]
-... = -((F.derivative.eval z) * ⟨↑(F.eval z) / ↑(F.derivative.eval z), h1⟩) : mul_neg _ _
-... = -(⟨↑(F.derivative.eval z) * (↑(F.eval z) / ↑(F.derivative.eval z)), this⟩) :
-  subtype.ext $ by simp only [padic_int.coe_neg, padic_int.coe_mul, subtype.coe_mk]
-... = -(F.eval z) : by simp only [mul_div_cancel' _ hdzne', subtype.coe_eta],
-have heq : F.eval z' = q * z1^2, by simpa only [sub_eq_add_neg, this, hz', add_right_neg, neg_sq,
-  zero_add] using hq,
-⟨q, heq⟩
+begin
+  have hdzne : F.derivative.eval z ≠ 0 :=
+    mt norm_eq_zero.2 (by rw hz.1; apply deriv_norm_ne_zero; assumption),
+  have hdzne' : (↑(F.derivative.eval z) : ℚ_[p]) ≠ 0 :=
+    λ h, hdzne $ subtype.ext_iff_val.2 h,
+  obtain ⟨q, hq⟩ := F.binom_expansion z (-z1),
+  have : ∥(↑(F.derivative.eval z) * (↑(F.eval z) / ↑(F.derivative.eval z)) : ℚ_[p])∥ ≤ 1,
+  { rw padic_norm_e.mul, exact mul_le_one (padic_int.norm_le_one _) (norm_nonneg _) h1 },
+  have : F.derivative.eval z * (-z1) = -F.eval z,
+  { calc F.derivative.eval z * (-z1)
+        = (F.derivative.eval z) * -⟨↑(F.eval z) / ↑(F.derivative.eval z), h1⟩ : by rw [hzeq]
+    ... = -((F.derivative.eval z) * ⟨↑(F.eval z) / ↑(F.derivative.eval z), h1⟩) : mul_neg _ _
+    ... = -(⟨↑(F.derivative.eval z) * (↑(F.eval z) / ↑(F.derivative.eval z)), this⟩) :
+      subtype.ext $ by simp only [padic_int.coe_neg, padic_int.coe_mul, subtype.coe_mk]
+    ... = -(F.eval z) : by simp only [mul_div_cancel' _ hdzne', subtype.coe_eta] },
+  exact ⟨q, by simpa only [sub_eq_add_neg, this, hz', add_right_neg, neg_sq, zero_add] using hq⟩,
+end
 
 private def calc_eval_z'_norm {z z' z1 : ℤ_[p]} {n} (hz : ih n z) {q}
   (heq : F.eval z' = q * z1^2) (h1 : ∥(↑(F.eval z) : ℚ_[p]) / ↑(F.derivative.eval z)∥ ≤ 1)

--- a/src/number_theory/padics/hensel.lean
+++ b/src/number_theory/padics/hensel.lean
@@ -157,8 +157,7 @@ private def calc_eval_z'  {z z' z1 : ℤ_[p]} (hz' : z' = z - z1) {n} (hz : ih n
 begin
   have hdzne : F.derivative.eval z ≠ 0 :=
     mt norm_eq_zero.2 (by rw hz.1; apply deriv_norm_ne_zero; assumption),
-  have hdzne' : (↑(F.derivative.eval z) : ℚ_[p]) ≠ 0 :=
-    λ h, hdzne $ subtype.ext_iff_val.2 h,
+  have hdzne' : (↑(F.derivative.eval z) : ℚ_[p]) ≠ 0 := λ h, hdzne (subtype.ext_iff_val.2 h),
   obtain ⟨q, hq⟩ := F.binom_expansion z (-z1),
   have : ∥(↑(F.derivative.eval z) * (↑(F.eval z) / ↑(F.derivative.eval z)) : ℚ_[p])∥ ≤ 1,
   { rw padic_norm_e.mul, exact mul_le_one (padic_int.norm_le_one _) (norm_nonneg _) h1 },


### PR DESCRIPTION
Simply replace the term-mode def by a tactic-mode one appears to fix the timeout observed in multiple branches.

---

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2316819.20define.20.60filter.2Eblimsup.60.2C.20.60filter.2Ebliminf.60)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
