### PR TITLE
[Merged by Bors] - feat(geometry/euclidean/oriented_angle): oriented angles and betweenness

### DIFF
--- a/src/geometry/euclidean/oriented_angle.lean
+++ b/src/geometry/euclidean/oriented_angle.lean
@@ -1971,4 +1971,141 @@ by rw [oangle_swap₁₃_sign, ←oangle_swap₁₂_sign, oangle_swap₁₃_sign
 lemma oangle_rotate_sign (p₁ p₂ p₃ : P) : (∡ p₂ p₃ p₁).sign = (∡ p₁ p₂ p₃).sign :=
 by rw [←oangle_swap₁₂_sign, oangle_swap₁₃_sign]
 
+/-- The oriented angle between three points is π if and only if the second point is strictly
+between the other two. -/
+lemma oangle_eq_pi_iff_sbtw {p₁ p₂ p₃ : P} : ∡ p₁ p₂ p₃ = π ↔ sbtw ℝ p₁ p₂ p₃ :=
+by rw [oangle_eq_pi_iff_angle_eq_pi, angle_eq_pi_iff_sbtw]
+
+/-- If the second of three points is strictly between the other two, the oriented angle at that
+point is π. -/
+lemma _root_.sbtw.oangle₁₂₃_eq_pi {p₁ p₂ p₃ : P} (h : sbtw ℝ p₁ p₂ p₃) : ∡ p₁ p₂ p₃ = π :=
+oangle_eq_pi_iff_sbtw.2 h
+
+/-- If the second of three points is strictly between the other two, the oriented angle at that
+point (reversed) is π. -/
+lemma _root_.sbtw.oangle₃₂₁_eq_pi {p₁ p₂ p₃ : P} (h : sbtw ℝ p₁ p₂ p₃) : ∡ p₃ p₂ p₁ = π :=
+by rw [oangle_eq_pi_iff_oangle_rev_eq_pi, ←h.oangle₁₂₃_eq_pi]
+
+/-- If the second of three points is weakly between the other two, the oriented angle at the
+first point is zero. -/
+lemma _root_.wbtw.oangle₂₁₃_eq_zero {p₁ p₂ p₃ : P} (h : wbtw ℝ p₁ p₂ p₃) : ∡ p₂ p₁ p₃ = 0 :=
+begin
+  by_cases hp₂p₁ : p₂ = p₁, { simp [hp₂p₁] },
+  by_cases hp₃p₁ : p₃ = p₁, { simp [hp₃p₁] },
+  rw oangle_eq_zero_iff_angle_eq_zero hp₂p₁ hp₃p₁,
+  exact h.angle₂₁₃_eq_zero_of_ne hp₂p₁
+end
+
+/-- If the second of three points is strictly between the other two, the oriented angle at the
+first point is zero. -/
+lemma _root_.sbtw.oangle₂₁₃_eq_zero {p₁ p₂ p₃ : P} (h : sbtw ℝ p₁ p₂ p₃) : ∡ p₂ p₁ p₃ = 0 :=
+h.wbtw.oangle₂₁₃_eq_zero
+
+/-- If the second of three points is weakly between the other two, the oriented angle at the
+first point (reversed) is zero. -/
+lemma _root_.wbtw.oangle₃₁₂_eq_zero {p₁ p₂ p₃ : P} (h : wbtw ℝ p₁ p₂ p₃) : ∡ p₃ p₁ p₂ = 0 :=
+by rw [oangle_eq_zero_iff_oangle_rev_eq_zero, h.oangle₂₁₃_eq_zero]
+
+/-- If the second of three points is strictly between the other two, the oriented angle at the
+first point (reversed) is zero. -/
+lemma _root_.sbtw.oangle₃₁₂_eq_zero {p₁ p₂ p₃ : P} (h : sbtw ℝ p₁ p₂ p₃) : ∡ p₃ p₁ p₂ = 0 :=
+h.wbtw.oangle₃₁₂_eq_zero
+
+/-- If the second of three points is weakly between the other two, the oriented angle at the
+third point is zero. -/
+lemma _root_.wbtw.oangle₂₃₁_eq_zero {p₁ p₂ p₃ : P} (h : wbtw ℝ p₁ p₂ p₃) : ∡ p₂ p₃ p₁ = 0 :=
+h.symm.oangle₂₁₃_eq_zero
+
+/-- If the second of three points is strictly between the other two, the oriented angle at the
+third point is zero. -/
+lemma _root_.sbtw.oangle₂₃₁_eq_zero {p₁ p₂ p₃ : P} (h : sbtw ℝ p₁ p₂ p₃) : ∡ p₂ p₃ p₁ = 0 :=
+h.wbtw.oangle₂₃₁_eq_zero
+
+/-- If the second of three points is weakly between the other two, the oriented angle at the
+third point (reversed) is zero. -/
+lemma _root_.wbtw.oangle₁₃₂_eq_zero {p₁ p₂ p₃ : P} (h : wbtw ℝ p₁ p₂ p₃) : ∡ p₁ p₃ p₂ = 0 :=
+h.symm.oangle₃₁₂_eq_zero
+
+/-- If the second of three points is strictly between the other two, the oriented angle at the
+third point (reversed) is zero. -/
+lemma _root_.sbtw.oangle₁₃₂_eq_zero {p₁ p₂ p₃ : P} (h : sbtw ℝ p₁ p₂ p₃) : ∡ p₁ p₃ p₂ = 0 :=
+h.wbtw.oangle₁₃₂_eq_zero
+
+/-- The oriented angle between three points is zero if and only if one of the first and third
+points is weakly between the other two. -/
+lemma oangle_eq_zero_iff_wbtw {p₁ p₂ p₃ : P} :
+  ∡ p₁ p₂ p₃ = 0 ↔ wbtw ℝ p₂ p₁ p₃ ∨ wbtw ℝ p₂ p₃ p₁ :=
+begin
+  by_cases hp₁p₂ : p₁ = p₂, { simp [hp₁p₂] },
+  by_cases hp₃p₂ : p₃ = p₂, { simp [hp₃p₂] },
+  rw [oangle_eq_zero_iff_angle_eq_zero hp₁p₂ hp₃p₂, angle_eq_zero_iff_ne_and_wbtw],
+  simp [hp₁p₂, hp₃p₂]
+end
+
+/-- An oriented angle is unchanged by replacing the first point by one weakly further away on the
+same ray. -/
+lemma _root_.wbtw.oangle_eq_left {p₁ p₁' p₂ p₃ : P} (h : wbtw ℝ p₂ p₁ p₁') (hp₁p₂ : p₁ ≠ p₂) :
+  ∡ p₁ p₂ p₃ = ∡ p₁' p₂ p₃ :=
+begin
+  by_cases hp₃p₂ : p₃ = p₂, { simp [hp₃p₂] },
+  by_cases hp₁'p₂ : p₁' = p₂, { rw [hp₁'p₂, wbtw_self_iff] at h, exact false.elim (hp₁p₂ h) },
+  rw [←oangle_add hp₁'p₂ hp₁p₂ hp₃p₂, h.oangle₃₁₂_eq_zero, zero_add]
+end
+
+/-- An oriented angle is unchanged by replacing the first point by one strictly further away on
+the same ray. -/
+lemma _root_.sbtw.oangle_eq_left {p₁ p₁' p₂ p₃ : P} (h : sbtw ℝ p₂ p₁ p₁') :
+  ∡ p₁ p₂ p₃ = ∡ p₁' p₂ p₃ :=
+h.wbtw.oangle_eq_left h.ne_left
+
+/-- An oriented angle is unchanged by replacing the third point by one weakly further away on the
+same ray. -/
+lemma _root_.wbtw.oangle_eq_right {p₁ p₂ p₃ p₃' : P} (h : wbtw ℝ p₂ p₃ p₃') (hp₃p₂ : p₃ ≠ p₂) :
+  ∡ p₁ p₂ p₃ = ∡ p₁ p₂ p₃' :=
+by rw [oangle_rev, h.oangle_eq_left hp₃p₂, ←oangle_rev]
+
+/-- An oriented angle is unchanged by replacing the third point by one strictly further away on
+the same ray. -/
+lemma _root_.sbtw.oangle_eq_right {p₁ p₂ p₃ p₃' : P} (h : sbtw ℝ p₂ p₃ p₃') :
+  ∡ p₁ p₂ p₃ = ∡ p₁ p₂ p₃' :=
+h.wbtw.oangle_eq_right h.ne_left
+
+/-- Replacing the first point by one on the same line but the opposite ray adds π to the oriented
+angle. -/
+lemma _root_.sbtw.oangle_eq_add_pi_left {p₁ p₁' p₂ p₃ : P} (h : sbtw ℝ p₁ p₂ p₁')
+  (hp₃p₂ : p₃ ≠ p₂) : ∡ p₁ p₂ p₃ = ∡ p₁' p₂ p₃ + π :=
+by rw [←h.oangle₁₂₃_eq_pi, oangle_add_swap h.left_ne h.right_ne hp₃p₂]
+
+/-- Replacing the third point by one on the same line but the opposite ray adds π to the oriented
+angle. -/
+lemma _root_.sbtw.oangle_eq_add_pi_right {p₁ p₂ p₃ p₃' : P} (h : sbtw ℝ p₃ p₂ p₃')
+  (hp₁p₂ : p₁ ≠ p₂) : ∡ p₁ p₂ p₃ = ∡ p₁ p₂ p₃' + π :=
+by rw [←h.oangle₃₂₁_eq_pi, oangle_add hp₁p₂ h.right_ne h.left_ne]
+
+/-- Replacing both the first and third points by ones on the same lines but the opposite rays
+does not change the oriented angle (vertically opposite angles). -/
+lemma _root_.sbtw.oangle_eq_left_right {p₁ p₁' p₂ p₃ p₃' : P} (h₁ : sbtw ℝ p₁ p₂ p₁')
+  (h₃ : sbtw ℝ p₃ p₂ p₃') : ∡ p₁ p₂ p₃ = ∡ p₁' p₂ p₃' :=
+by rw [h₁.oangle_eq_add_pi_left h₃.left_ne, h₃.oangle_eq_add_pi_right h₁.right_ne, add_assoc,
+       real.angle.coe_pi_add_coe_pi, add_zero]
+
+/-- Replacing the first point by one on the same line does not change twice the oriented angle. -/
+lemma _root_.collinear.two_zsmul_oangle_eq_left {p₁ p₁' p₂ p₃ : P}
+  (h : collinear ℝ ({p₁, p₂, p₁'} : set P)) (hp₁p₂ : p₁ ≠ p₂) (hp₁'p₂ : p₁' ≠ p₂) :
+  (2 : ℤ) • ∡ p₁ p₂ p₃ = (2 : ℤ) • ∡ p₁' p₂ p₃ :=
+begin
+  by_cases hp₃p₂ : p₃ = p₂, { simp [hp₃p₂] },
+  rcases h.wbtw_or_wbtw_or_wbtw with hw | hw | hw,
+  { have hw' : sbtw ℝ p₁ p₂ p₁' := ⟨hw, hp₁p₂.symm, hp₁'p₂.symm⟩,
+    rw [hw'.oangle_eq_add_pi_left hp₃p₂, smul_add, real.angle.two_zsmul_coe_pi, add_zero] },
+  { rw hw.oangle_eq_left hp₁'p₂ },
+  { rw hw.symm.oangle_eq_left hp₁p₂ }
+end
+
+/-- Replacing the third point by one on the same line does not change twice the oriented angle. -/
+lemma _root_.collinear.two_zsmul_oangle_eq_right {p₁ p₂ p₃ p₃' : P}
+  (h : collinear ℝ ({p₃, p₂, p₃'} : set P)) (hp₃p₂ : p₃ ≠ p₂) (hp₃'p₂ : p₃' ≠ p₂) :
+  (2 : ℤ) • ∡ p₁ p₂ p₃ = (2 : ℤ) • ∡ p₁ p₂ p₃' :=
+by rw [oangle_rev, smul_neg, h.two_zsmul_oangle_eq_left hp₃p₂ hp₃'p₂, ←smul_neg, ←oangle_rev]
+
 end euclidean_geometry


### PR DESCRIPTION
Add lemmas relating oriented angles to strict and weak betweenness of points.

---

Further such lemmas depending on #16733, #16806, #16815 and #16822 are also ready to PR once their dependencies are in.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
