### PR TITLE
[Merged by Bors] - feat(group_theory/subgroup/basic): The center can be written as the intersection of centralizers

### DIFF
--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -2761,7 +2761,7 @@ le_antisymm (le_infi $ λ g, le_infi $ λ hg, centralizer_le $ zpowers_le.2 $ su
   $ le_centralizer_iff.1 $ (closure_le _).2
   $ λ g, set_like.mem_coe.2 ∘ zpowers_le.1 ∘ le_centralizer_iff.1 ∘ infi_le_of_le g ∘ infi_le _
 
-@[to_additive] lemma center_eq_infi_zpowers (S : set G) (hS : closure S = ⊤) :
+@[to_additive] lemma center_eq_infi (S : set G) (hS : closure S = ⊤) :
   center G = ⨅ g : S, centralizer (zpowers g) :=
 by rw [←centralizer_top, ←hS, centralizer_closure, ←infi_subtype'']
 

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -2762,8 +2762,12 @@ le_antisymm (le_infi $ λ g, le_infi $ λ hg, centralizer_le $ zpowers_le.2 $ su
   $ λ g, set_like.mem_coe.2 ∘ zpowers_le.1 ∘ le_centralizer_iff.1 ∘ infi_le_of_le g ∘ infi_le _
 
 @[to_additive] lemma center_eq_infi (S : set G) (hS : closure S = ⊤) :
+  center G = ⨅ g ∈ S, centralizer (zpowers g) :=
+by rw [←centralizer_top, ←hS, centralizer_closure]
+
+@[to_additive] lemma center_eq_infi' (S : set G) (hS : closure S = ⊤) :
   center G = ⨅ g : S, centralizer (zpowers g) :=
-by rw [←centralizer_top, ←hS, centralizer_closure, ←infi_subtype'']
+by rw [center_eq_infi S hS, ←infi_subtype'']
 
 end subgroup
 

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -2761,6 +2761,10 @@ le_antisymm (le_infi $ λ g, le_infi $ λ hg, centralizer_le $ zpowers_le.2 $ su
   $ le_centralizer_iff.1 $ (closure_le _).2
   $ λ g, set_like.mem_coe.2 ∘ zpowers_le.1 ∘ le_centralizer_iff.1 ∘ infi_le_of_le g ∘ infi_le _
 
+@[to_additive] lemma center_eq_infi_zpowers (S : set G) (hS : closure S = ⊤) :
+  center G = ⨅ g : S, centralizer (zpowers g) :=
+by rw [←centralizer_top, ←hS, centralizer_closure, ←infi_subtype'']
+
 end subgroup
 
 namespace monoid_hom


### PR DESCRIPTION
This PRs adds a lemma that writes the center as the intersection of centralizers. I kept `S` explicit so that you can `rw center_eq_infi S` (specifying `S` without having to immediately supply a proof of `hS`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
