### PR TITLE
[Merged by Bors] - chore(data/pfunctor/univariate): remove use of `h_generalize`

### DIFF
--- a/src/data/pfunctor/univariate/M.lean
+++ b/src/data/pfunctor/univariate/M.lean
@@ -295,7 +295,9 @@ begin
   { rw [← head_succ' n,h,head'], apply x.consistent },
   revert ch, rw h', intros, congr,
   { ext a, dsimp only [children],
-    h_generalize! hh : a == a'',
+    generalize hh : cast _ a = a'',
+    rw cast_eq_iff_heq at hh,
+    revert a'',
     rw h, intros, cases hh, refl },
 end
 


### PR DESCRIPTION
to help with the port we remove all uses of the tactic `h_generalize`, there is only one in fact



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
