### PR TITLE
[Merged by Bors] - chore(.github): add CODEOWNERS stub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# By default, the mathlib maintainers own everything in the repo.
+# Later matches will take precedence over this match.
+*	@leanprover-community/mathlib-maintainers
+
+src/tactic/		@leanprover-community/mathlib-meta
+
+src/category_theory/	@leanprover-community/mathlib-CT
+src/algebraic_topology/ @leanprover-community/mathlib-CT # for now that category theory team can take care of this
+
+src/algebraic_geometry/ @leanprover-community/mathlib-AG

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 src/tactic/		@leanprover-community/mathlib-meta
 
 src/category_theory/	@leanprover-community/mathlib-CT
-src/algebraic_topology/ @leanprover-community/mathlib-CT # for now that category theory team can take care of this
+src/algebraic_topology/ @leanprover-community/mathlib-CT # for now the category theory team can take care of this
 
 src/algebraic_geometry/ @leanprover-community/mathlib-AG

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,5 @@ src/category_theory/	@leanprover-community/mathlib-CT
 src/algebraic_topology/ @leanprover-community/mathlib-CT # for now the category theory team can take care of this
 
 src/algebraic_geometry/ @leanprover-community/mathlib-AG
+
+src/combinatorics/ @leanprover-community/mathlib-CO


### PR DESCRIPTION
This is a first very minimal stub of a CODEOWNERS file. I suggest that we try this out for a few days, and then organically refine it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
