### PR TITLE
[Merged by Bors] - feat(algebra/group_ring_action): add `mul_semiring_action.comp_hom`

### DIFF
--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -68,7 +68,7 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 /-- Compose a `mul_semiring_action` with a `monoid_hom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
 @[reducible] def mul_semiring_action.comp_hom {N M : Type*} [monoid N] [monoid M] (f : N →* M)
-[mul_semiring_action M R] : mul_semiring_action N R :=
+  [mul_semiring_action M R] : mul_semiring_action N R :=
 { smul := has_smul.comp.smul f,
   ..distrib_mul_action.comp_hom R f,
   ..mul_distrib_mul_action.comp_hom R f }

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -41,7 +41,7 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 section semiring
 
 variables (M G K N : Type u) [monoid M] [group G] [ring K] [ring N]
-variables (A R S F B: Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F][ring B]
+variables (A R S F B: Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F] [ring B]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`
 @[priority 100]
@@ -65,14 +65,17 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 { .. distrib_mul_action.to_add_equiv R x,
   .. mul_semiring_action.to_ring_hom G R x }
 
-/-- A multiplicative action of `N` on `B` and a ring homomorphism `K →+* N` induce
+/-- A multiplicative action of `N` on `B` and a group homomorphism `K →* N` induce
 a multiplicative action of `K` on `B`. -/
-
-def mul_semiring_action.comp_hom (g : K →+* N) [mul_semiring_action N B] :
+def mul_semiring_action.comp_hom (g : K →* N) [mul_semiring_action N B] :
 mul_semiring_action K B :=
 { smul := has_smul.comp.smul g,
-  ..distrib_mul_action.comp_hom g.to_monoid_hom,
-  ..mul_distrib_mul_action.comp_hom g.to_monoid_hom }
+  one_smul := λ a, by simp only [has_smul.comp.smul, map_one, one_smul],
+  smul_zero:= λ n, by simp only [has_smul.comp.smul, smul_zero],
+  smul_one := λ x, by simp [has_smul.comp.smul, smul_one],
+  smul_mul := λ n x y, by simp [has_smul.comp.smul, smul_mul'],
+  smul_add := λ n x y, by simp [has_smul.comp.smul, smul_add],
+  mul_smul := λ x y a, by simp only [has_smul.comp.smul, map_mul,mul_smul (g x) (g y) a] }
 
 section
 variables {M G R}

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -65,9 +65,9 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 { .. distrib_mul_action.to_add_equiv R x,
   .. mul_semiring_action.to_ring_hom G R x }
 
-/-- A multiplicative action of `N` on `R` and a group homomorphism `K →* N` induce
-a multiplicative action of `K` on `R`. -/
-def mul_semiring_action.comp_hom (g : K →* N) [mul_semiring_action N R] :
+/-- Compose a `mul_semiring_action` with a `monoid_hom`, with action `f r' • m`.
+See note [reducible non-instances]. -/
+@[reducible] def mul_semiring_action.comp_hom (g : K →* N) [mul_semiring_action N R] :
   mul_semiring_action K R :=
 { smul := has_smul.comp.smul g,
   ..distrib_mul_action.comp_hom R g,

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -40,7 +40,7 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 
 section semiring
 
-variables (M G K : Type*) [monoid M] [monoid K] [group G]
+variables (M G : Type*) [monoid M] [group G]
 variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`
@@ -67,11 +67,11 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 
 /-- Compose a `mul_semiring_action` with a `monoid_hom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
-@[reducible] def mul_semiring_action.comp_hom (g : K →* M) [mul_semiring_action M R] :
-  mul_semiring_action K R :=
-{ smul := has_smul.comp.smul g,
-  ..distrib_mul_action.comp_hom R g,
-  ..mul_distrib_mul_action.comp_hom R g }
+@[reducible] def mul_semiring_action.comp_hom { M N : Type*} [monoid N] [monoid M] (f : N →* M)
+[mul_semiring_action M R] : mul_semiring_action N R :=
+{ smul := has_smul.comp.smul f,
+  ..distrib_mul_action.comp_hom R f,
+  ..mul_distrib_mul_action.comp_hom R f }
 
 section
 variables {M G R}

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -65,8 +65,8 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 { .. distrib_mul_action.to_add_equiv R x,
   .. mul_semiring_action.to_ring_hom G R x }
 
-/-- A multiplicative action of `N` on `B` and a group homomorphism `K →* N` induce
-a multiplicative action of `K` on `B`. -/
+/-- A multiplicative action of `N` on `R` and a group homomorphism `K →* N` induce
+a multiplicative action of `K` on `R`. -/
 def mul_semiring_action.comp_hom (g : K →* N) [mul_semiring_action N R] :
   mul_semiring_action K R :=
 { smul := has_smul.comp.smul g,

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -67,7 +67,7 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 
 /-- Compose a `mul_semiring_action` with a `monoid_hom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
-@[reducible] def mul_semiring_action.comp_hom {N : Type*} [monoid N] (f : N →* M)
+@[reducible] def mul_semiring_action.comp_hom {N M : Type*} [monoid N] [monoid M] (f : N →* M)
 [mul_semiring_action M R] : mul_semiring_action N R :=
 { smul := has_smul.comp.smul f,
   ..distrib_mul_action.comp_hom R f,

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -40,7 +40,7 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 
 section semiring
 
-variables (M G : Type*) [group G] [monoid M]
+variables (M N G : Type*) [monoid M] [monoid N] [group G]
 variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -70,12 +70,8 @@ a multiplicative action of `K` on `R`. -/
 def mul_semiring_action.comp_hom (g : K →* N) [mul_semiring_action N R] :
   mul_semiring_action K R :=
 { smul := has_smul.comp.smul g,
-  one_smul := λ a, by simp only [has_smul.comp.smul, map_one, one_smul],
-  smul_zero:= λ n, by simp only [has_smul.comp.smul, smul_zero],
-  smul_one := λ x, by simp [has_smul.comp.smul, smul_one],
-  smul_mul := λ n x y, by simp [has_smul.comp.smul, smul_mul'],
-  smul_add := λ n x y, by simp [has_smul.comp.smul, smul_add],
-  mul_smul := λ x y a, by simp only [has_smul.comp.smul, map_mul,mul_smul (g x) (g y) a] }
+  ..distrib_mul_action.comp_hom R g,
+  ..mul_distrib_mul_action.comp_hom R g }
 
 section
 variables {M G R}

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -70,8 +70,8 @@ variables {M N}
 
 /-- Compose a `mul_semiring_action` with a `monoid_hom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
-@[reducible] def mul_semiring_action.comp_hom (f : N →* M)
-[mul_semiring_action M R] : mul_semiring_action N R :=
+@[reducible] def mul_semiring_action.comp_hom (f : N →* M) [mul_semiring_action M R] :
+  mul_semiring_action N R :=
 { smul := has_smul.comp.smul f,
   ..distrib_mul_action.comp_hom R f,
   ..mul_distrib_mul_action.comp_hom R f }

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -68,7 +68,7 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 /-- A multiplicative action of `N` on `B` and a group homomorphism `K →* N` induce
 a multiplicative action of `K` on `B`. -/
 def mul_semiring_action.comp_hom (g : K →* N) [mul_semiring_action N B] :
-mul_semiring_action K B :=
+  mul_semiring_action K B :=
 { smul := has_smul.comp.smul g,
   one_smul := λ a, by simp only [has_smul.comp.smul, map_one, one_smul],
   smul_zero:= λ n, by simp only [has_smul.comp.smul, smul_zero],

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -40,8 +40,8 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 
 section semiring
 
-variables (M G : Type u) [monoid M] [group G]
-variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
+variables (M G K N : Type u) [monoid M] [group G] [ring K] [ring N]
+variables (A R S F B: Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F][ring B]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`
 @[priority 100]
@@ -64,6 +64,19 @@ theorem to_ring_hom_injective [mul_semiring_action M R] [has_faithful_smul M R] 
 def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+* R :=
 { .. distrib_mul_action.to_add_equiv R x,
   .. mul_semiring_action.to_ring_hom G R x }
+
+/-- A multiplicative action of `N` on `B` and a ring homomorphism `K →+* N` induce
+a multiplicative action of `K` on `B`. -/
+
+def mul_semiring_action.comp_hom (g : K →+* N) [mul_semiring_action N B] :
+mul_semiring_action K B :=
+{ smul := has_smul.comp.smul g,
+  one_smul := λ a, by simp only [has_smul.comp.smul, map_one, one_smul],
+  smul_zero:= λ n, by simp only [has_smul.comp.smul, smul_zero],
+  smul_one := λ x, by simp [has_smul.comp.smul, smul_one],
+  smul_mul := λ n x y, by simp [has_smul.comp.smul, smul_mul'],
+  smul_add := λ n x y, by simp [has_smul.comp.smul, smul_add],
+  mul_smul := λ x y a, by simp only [has_smul.comp.smul, map_mul,mul_smul (g x) (g y) a] }
 
 section
 variables {M G R}

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -40,7 +40,7 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 
 section semiring
 
-variables (M G K : Type*) [monoid M] [monoid K] [group G]
+variables (M N G : Type*) [monoid M] [monoid N] [group G]
 variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -40,7 +40,7 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 
 section semiring
 
-variables (M G : Type*) [group G] [monoid M]
+variables (M N G : Type*) [monoid M] [monoid N] [group G]
 variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`
@@ -65,13 +65,18 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 { .. distrib_mul_action.to_add_equiv R x,
   .. mul_semiring_action.to_ring_hom G R x }
 
+section
+variables {M N}
+
 /-- Compose a `mul_semiring_action` with a `monoid_hom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
-@[reducible] def mul_semiring_action.comp_hom {N M : Type*} [monoid N] [monoid M] (f : N →* M)
+@[reducible] def mul_semiring_action.comp_hom (f : N →* M)
 [mul_semiring_action M R] : mul_semiring_action N R :=
 { smul := has_smul.comp.smul f,
   ..distrib_mul_action.comp_hom R f,
   ..mul_distrib_mul_action.comp_hom R f }
+
+end
 
 section
 variables {M G R}

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -40,7 +40,7 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 
 section semiring
 
-variables (M G K : Type u) [monoid M] [monoid K] [group G]
+variables (M G K : Type*) [monoid M] [monoid K] [group G]
 variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -68,7 +68,7 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 /-- A multiplicative action of `N` on `B` and a ring homomorphism `K →+* N` induce
 a multiplicative action of `K` on `B`. -/
 
-def mul_semiring_action.comp_hom (g : K →+* N) [mul_semiring_action N B] :
+def mul_semiring_action.comp_hom (g : K →* N) [mul_semiring_action N B] :
 mul_semiring_action K B :=
 { smul := has_smul.comp.smul g,
   ..distrib_mul_action.comp_hom g.to_monoid_hom,

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -40,8 +40,8 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 
 section semiring
 
-variables (M G K N : Type u) [monoid M] [group G] [ring K] [ring N]
-variables (A R S F B: Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F] [ring B]
+variables (M G K N : Type u) [monoid M] [group G] [semiring K] [semiring N]
+variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`
 @[priority 100]
@@ -67,8 +67,8 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 
 /-- A multiplicative action of `N` on `B` and a group homomorphism `K →* N` induce
 a multiplicative action of `K` on `B`. -/
-def mul_semiring_action.comp_hom (g : K →* N) [mul_semiring_action N B] :
-  mul_semiring_action K B :=
+def mul_semiring_action.comp_hom (g : K →* N) [mul_semiring_action N R] :
+  mul_semiring_action K R :=
 { smul := has_smul.comp.smul g,
   one_smul := λ a, by simp only [has_smul.comp.smul, map_one, one_smul],
   smul_zero:= λ n, by simp only [has_smul.comp.smul, smul_zero],

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -70,7 +70,7 @@ variables {M N}
 
 /-- Compose a `mul_semiring_action` with a `monoid_hom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
-@[reducible] def mul_semiring_action.comp_hom {N M : Type*} [monoid N] [monoid M] (f : N →* M)
+@[reducible] def mul_semiring_action.comp_hom (f : N →* M)
 [mul_semiring_action M R] : mul_semiring_action N R :=
 { smul := has_smul.comp.smul f,
   ..distrib_mul_action.comp_hom R f,

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -40,7 +40,7 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 
 section semiring
 
-variables (M G K: Type u) [monoid M] [monoid K] [group G]
+variables (M G K : Type u) [monoid M] [monoid K] [group G]
 variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -40,11 +40,7 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 
 section semiring
 
-<<<<<<< HEAD
-variables (M G : Type*) [monoid M] [group G]
-=======
-variables (M N G : Type*) [monoid M] [monoid N] [group G]
->>>>>>> 52593b3d999f9b0d76af36baf659ec1638110f35
+variables (M G : Type*) [group G] [monoid M]
 variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`
@@ -71,7 +67,7 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 
 /-- Compose a `mul_semiring_action` with a `monoid_hom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
-@[reducible] def mul_semiring_action.comp_hom { M N : Type*} [monoid N] [monoid M] (f : N →* M)
+@[reducible] def mul_semiring_action.comp_hom {N : Type*} [monoid N] (f : N →* M)
 [mul_semiring_action M R] : mul_semiring_action N R :=
 { smul := has_smul.comp.smul f,
   ..distrib_mul_action.comp_hom R f,

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -40,7 +40,7 @@ class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
 
 section semiring
 
-variables (M G K N : Type u) [monoid M] [group G] [semiring K] [semiring N]
+variables (M G K: Type u) [monoid M] [monoid K] [group G]
 variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`
@@ -67,7 +67,7 @@ def mul_semiring_action.to_ring_equiv [mul_semiring_action G R] (x : G) : R ≃+
 
 /-- Compose a `mul_semiring_action` with a `monoid_hom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
-@[reducible] def mul_semiring_action.comp_hom (g : K →* N) [mul_semiring_action N R] :
+@[reducible] def mul_semiring_action.comp_hom (g : K →* M) [mul_semiring_action M R] :
   mul_semiring_action K R :=
 { smul := has_smul.comp.smul g,
   ..distrib_mul_action.comp_hom R g,

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -71,12 +71,8 @@ a multiplicative action of `K` on `B`. -/
 def mul_semiring_action.comp_hom (g : K →+* N) [mul_semiring_action N B] :
 mul_semiring_action K B :=
 { smul := has_smul.comp.smul g,
-  one_smul := λ a, by simp only [has_smul.comp.smul, map_one, one_smul],
-  smul_zero:= λ n, by simp only [has_smul.comp.smul, smul_zero],
-  smul_one := λ x, by simp [has_smul.comp.smul, smul_one],
-  smul_mul := λ n x y, by simp [has_smul.comp.smul, smul_mul'],
-  smul_add := λ n x y, by simp [has_smul.comp.smul, smul_add],
-  mul_smul := λ x y a, by simp only [has_smul.comp.smul, map_mul,mul_smul (g x) (g y) a] }
+  ..distrib_mul_action.comp_hom g.to_monoid_hom,
+  ..mul_distrib_mul_action.comp_hom g.to_monoid_hom }
 
 section
 variables {M G R}


### PR DESCRIPTION
A multiplicative action of a monoid `M` on a semiring `R` and a monoid homomorphism `N →* M` induce a multiplicative action of a monoid `N` on `R`.

I need this for my study of the decomposition and inertia groups

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
