### PR TITLE
[Merged by Bors] - feat(algebraic_topology): extra degeneracies and homotopy equivalences

### DIFF
--- a/src/algebra/homology/single.lean
+++ b/src/algebra/homology/single.lean
@@ -205,12 +205,7 @@ def to_single₀_equiv (C : chain_complex V ℕ) (X : V) :
 @[ext]
 lemma to_single₀_ext {C : chain_complex V ℕ} {X : V}
   (f g : (C ⟶ (single₀ V).obj X)) (h : f.f 0 = g.f 0) : f = g :=
-begin
-  rw [← (to_single₀_equiv C X).left_inv f, ← (to_single₀_equiv C X).left_inv g],
-  congr' 1,
-  ext,
-  exact h,
-end
+(to_single₀_equiv C X).injective (by { ext, exact h, })
 
 /--
 Morphisms from a single object chain complex with `X` concentrated in degree 0
@@ -236,7 +231,7 @@ def from_single₀_equiv (C : chain_complex V ℕ) (X : V) :
     { refl, },
     { ext, },
   end,
-  right_inv := by tidy, }
+  right_inv := λ g, rfl, }
 
 variables (V)
 

--- a/src/algebra/homology/single.lean
+++ b/src/algebra/homology/single.lean
@@ -179,6 +179,7 @@ Morphisms from a `ℕ`-indexed chain complex `C`
 to a single object chain complex with `X` concentrated in degree 0
 are the same as morphisms `f : C.X 0 ⟶ X` such that `C.d 1 0 ≫ f = 0`.
 -/
+@[simps]
 def to_single₀_equiv (C : chain_complex V ℕ) (X : V) :
   (C ⟶ (single₀ V).obj X) ≃ { f : C.X 0 ⟶ X // C.d 1 0 ≫ f = 0 } :=
 { to_fun := λ f, ⟨f.f 0, by { rw ←f.comm 1 0, simp, }⟩,
@@ -196,6 +197,42 @@ def to_single₀_equiv (C : chain_complex V ℕ) (X : V) :
   left_inv := λ f, begin
     ext i,
     rcases i,
+    { refl, },
+    { ext, },
+  end,
+  right_inv := by tidy, }
+
+@[ext]
+lemma to_single₀_ext {C : chain_complex V ℕ} {X : V}
+  (f g : (C ⟶ (single₀ V).obj X)) (h : f.f 0 = g.f 0) : f = g :=
+begin
+  rw [← (to_single₀_equiv C X).left_inv f, ← (to_single₀_equiv C X).left_inv g],
+  congr' 1,
+  ext,
+  exact h,
+end
+
+/--
+Morphisms from a single object chain complex with `X` concentrated in degree 0
+to a `ℕ`-indexed chain complex `C` are the same as morphisms `f : X → C.X`.
+-/
+@[simps]
+def from_single₀_equiv (C : chain_complex V ℕ) (X : V) :
+  ((single₀ V).obj X ⟶ C) ≃ (X ⟶ C.X 0) :=
+{ to_fun := λ f, f.f 0,
+  inv_fun := λ f,
+  { f := λ i, match i with
+    | 0 := f
+    | (n+1) := 0
+    end,
+    comm' := λ i j h, begin
+      cases i; cases j; unfold_aux;
+      simp only [shape, complex_shape.down_rel, nat.one_ne_zero, not_false_iff,
+        comp_zero, zero_comp, nat.succ_ne_zero, single₀_obj_X_d],
+    end },
+  left_inv := λ f, begin
+    ext i,
+    cases i,
     { refl, },
     { ext, },
   end,

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -8,6 +8,7 @@ import algebra.homology.additive
 import algebraic_topology.Moore_complex
 import algebra.big_operators.fin
 import category_theory.preadditive.opposite
+import tactic.equiv_rw
 
 /-!
 
@@ -202,6 +203,27 @@ begin
     { ext n,
       refl, }, },
 end
+
+namespace alternating_face_map_complex
+
+/-- The natural transformation which gives the augmentation of the alternating face map
+complex attached to an augmented simplicial object. -/
+@[simps]
+def ε [limits.has_zero_object C] :
+  simplicial_object.augmented.drop ⋙ algebraic_topology.alternating_face_map_complex C ⟶
+  simplicial_object.augmented.point ⋙ chain_complex.single₀ C :=
+{ app := λ X, begin
+    equiv_rw chain_complex.to_single₀_equiv _ _,
+    refine ⟨X.hom.app (op [0]), _⟩,
+    dsimp,
+    simp only [alternating_face_map_complex_obj_d, obj_d, fin.sum_univ_two,
+      fin.coe_zero, pow_zero, one_zsmul, fin.coe_one, pow_one, neg_smul, add_comp,
+      simplicial_object.δ_naturality, neg_comp],
+    apply add_right_neg,
+  end,
+  naturality' := λ X Y f, by { ext, exact congr_app f.w _, }, }
+
+end alternating_face_map_complex
 
 /-!
 ## Construction of the natural inclusion of the normalized Moore complex

--- a/src/algebraic_topology/extra_degeneracy.lean
+++ b/src/algebraic_topology/extra_degeneracy.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 
+import algebraic_topology.alternating_face_map_complex
 import algebraic_topology.simplicial_set
 import algebraic_topology.cech_nerve
+import algebra.homology.homotopy
 import tactic.fin_cases
 
 /-!
@@ -31,12 +33,10 @@ functor `C ⥤ D`
 an extra degeneracy
 - `arrow.augmented_cech_nerve.extra_degeneracy`: the Čech nerve of a split
 epimorphism has an extra degeneracy
-
-TODO @joelriou:
-1) when the category `C` is preadditive and has a zero object, and
-`X : simplicial_object.augmented C` has an extra degeneracy, then the augmentation
-on the alternating face map complex of `X` is a homotopy equivalence of chain
-complexes.
+- `extra_degeneracy.homotopy_equiv`: in the case the category `C` is preadditive,
+if we have an extra degeneracy on `X : simplicial_object.augmented C`, then
+the augmentation on the alternating face map complex of `X` is a homotopy
+equivalence.
 
 ## References
 * [Paul G. Goerss, John F. Jardine, *Simplical Homotopy Theory*][goerss-jardine-2009]
@@ -337,3 +337,61 @@ end augmented_cech_nerve
 end arrow
 
 end category_theory
+
+namespace simplicial_object
+
+namespace augmented
+
+namespace extra_degeneracy
+
+open algebraic_topology category_theory category_theory.limits
+
+/-- If `C` is a preadditive category and `X` is an augmented simplicial object
+in `C` that has an extra degeneracy, then the augmentation on the alternating
+face map complex of `X` is an homotopy equivalence. -/
+noncomputable
+def homotopy_equiv {C : Type*} [category C]
+  [preadditive C] [has_zero_object C] {X : simplicial_object.augmented C}
+  (ed : extra_degeneracy X) :
+  homotopy_equiv (algebraic_topology.alternating_face_map_complex.obj (drop.obj X))
+    ((chain_complex.single₀ C).obj (point.obj X)) :=
+{ hom := alternating_face_map_complex.ε.app X,
+  inv := (chain_complex.from_single₀_equiv _ _).inv_fun ed.s',
+  homotopy_inv_hom_id := homotopy.of_eq (by { ext, exact ed.s'_comp_ε, }),
+  homotopy_hom_inv_id :=
+  { hom := λ i j, begin
+      by_cases i+1 = j,
+      { exact (-ed.s i) ≫ eq_to_hom (by congr'), },
+      { exact 0, },
+    end,
+    zero' := λ i j hij, begin
+      split_ifs,
+      { exfalso, exact hij h, },
+      { simp only [eq_self_iff_true], },
+    end,
+    comm := λ i, begin
+      cases i,
+      { rw [homotopy.prev_d_chain_complex, homotopy.d_next_zero_chain_complex, zero_add],
+        dsimp [chain_complex.from_single₀_equiv, chain_complex.to_single₀_equiv],
+        simp only [zero_add, eq_self_iff_true, preadditive.neg_comp, comp_id, if_true,
+          alternating_face_map_complex.obj_d_eq, fin.sum_univ_two, fin.coe_zero, pow_zero,
+          one_zsmul, fin.coe_one, pow_one, neg_smul, preadditive.comp_add, ← s₀_comp_δ₁,
+          s_comp_δ₀, preadditive.comp_neg, neg_add_rev, neg_neg, neg_add_cancel_right,
+          neg_add_cancel_comm], },
+      { rw [homotopy.prev_d_chain_complex, homotopy.d_next_succ_chain_complex],
+        dsimp [chain_complex.to_single₀_equiv, chain_complex.from_single₀_equiv],
+        simp only [zero_comp, alternating_face_map_complex.obj_d_eq, eq_self_iff_true,
+          preadditive.neg_comp, comp_id, if_true, preadditive.comp_neg,
+          @fin.sum_univ_succ _ _ (i+2), preadditive.comp_add, fin.coe_zero, pow_zero, one_zsmul,
+          s_comp_δ₀, fin.coe_succ, pow_add, pow_one, mul_neg, neg_zsmul,
+          preadditive.comp_sum, preadditive.sum_comp, neg_neg, mul_one,
+          preadditive.comp_zsmul, preadditive.zsmul_comp, s_comp_δ, zsmul_neg],
+        rw [add_comm (-𝟙 _), add_assoc, add_assoc, add_left_neg, add_zero,
+          finset.sum_neg_distrib, add_left_neg], },
+    end, }, }
+
+end extra_degeneracy
+
+end augmented
+
+end simplicial_object

--- a/src/category_theory/preadditive/projective_resolution.lean
+++ b/src/category_theory/preadditive/projective_resolution.lean
@@ -172,11 +172,7 @@ chain_complex.mk_hom _ _ (lift_f_zero f _ _) (lift_f_one f _ _) (lift_f_one_zero
 lemma lift_commutes
   {Y Z : C} (f : Y ⟶ Z) (P : ProjectiveResolution Y) (Q : ProjectiveResolution Z) :
   lift f P Q ≫ Q.π = P.π ≫ (chain_complex.single₀ C).map f :=
-begin
-  ext n,
-  rcases n with (_|_|n);
-  { dsimp [lift, lift_f_zero, lift_f_one], simp, }
-end
+by { ext, dsimp [lift, lift_f_zero], apply factor_thru_comp, }
 
 -- Now that we've checked this property of the lift,
 -- we can seal away the actual definition.


### PR DESCRIPTION
In this PR, it is shown that if an augmented simplicial object `X` in a preadditive category has an extra degeneracy, then the augmentation is a homotopy equivalence on the alternating face map complex.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
