### PR TITLE
[Merged by Bors] - perf(topology/sheaves/presheaf_of_functions): speedups

### DIFF
--- a/src/topology/sheaves/presheaf_of_functions.lean
+++ b/src/topology/sheaves/presheaf_of_functions.lean
@@ -41,7 +41,9 @@ There is no requirement that the functions are continuous, here.
 -/
 def presheaf_to_Types (T : X → Type v) : X.presheaf (Type v) :=
 { obj := λ U, Π x : (unop U), T x,
-  map := λ U V i g, λ (x : unop V), g (i.unop x) }
+  map := λ U V i g, λ (x : unop V), g (i.unop x),
+  map_id' := λ U, by { ext g ⟨x, hx⟩, refl },
+  map_comp' := λ U V W i j, rfl }
 
 @[simp] lemma presheaf_to_Types_obj
   {T : X → Type v} {U : (opens X)ᵒᵖ} :
@@ -65,7 +67,9 @@ There is no requirement that the functions are continuous, here.
 -- written as an equality of functions (rather than being applied to some argument).
 def presheaf_to_Type (T : Type v) : X.presheaf (Type v) :=
 { obj := λ U, (unop U) → T,
-  map := λ U V i g, g ∘ i.unop }
+  map := λ U V i g, g ∘ i.unop,
+  map_id' := λ U, by { ext g ⟨x, hx⟩, refl },
+  map_comp' := λ U V W i j, rfl }
 
 @[simp] lemma presheaf_to_Type_obj
   {T : Type v} {U : (opens X)ᵒᵖ} :

--- a/src/topology/sheaves/presheaf_of_functions.lean
+++ b/src/topology/sheaves/presheaf_of_functions.lean
@@ -119,9 +119,14 @@ from `X : Top` to `R : TopCommRing` form a commutative ring, functorial in both 
 def CommRing_yoneda : TopCommRing.{u} ⥤ (Top.{u}ᵒᵖ ⥤ CommRing.{u}) :=
 { obj := λ R,
   { obj := λ X, continuous_functions X R,
-    map := λ X Y f, continuous_functions.pullback f R },
+    map := λ X Y f, continuous_functions.pullback f R,
+    map_id' := λ X, by { ext, refl },
+    map_comp' := λ X Y Z f g, rfl },
   map := λ R S φ,
-  { app := λ X, continuous_functions.map X φ } }
+  { app := λ X, continuous_functions.map X φ,
+    naturality' := λ X Y f, rfl },
+  map_id' := λ X, by { ext, refl },
+  map_comp' := λ X Y Z f g, rfl }
 
 /--
 The presheaf (of commutative rings), consisting of functions on an open set `U ⊆ X` with


### PR DESCRIPTION
Speed up`CommRing_yoneda` (which caused [a bors failure](https://github.com/leanprover-community/mathlib/actions/runs/3211416019/jobs/5249570763)) from >20s to <2.5s by filling in automatic fields. (merged in another PR)

Speed up `presheaf_to_Types` from 13.3s to 0.3s and `presheaf_to_Type` from 4s to 0.1s by filling in automatic fields.

---
[Zulip](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/16721.20coatoms.20in.20a.20t1_space)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
