### PR TITLE
[Merged by Bors] - feat(algebraic_topology/dold_kan): very basic defs for split simplicial objects in preadditive categories

### DIFF
--- a/src/algebraic_topology/dold_kan/split_simplicial_object.lean
+++ b/src/algebraic_topology/dold_kan/split_simplicial_object.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2022 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import algebraic_topology.split_simplicial_object
+import category_theory.preadditive
+
+/-!
+
+# Split simplicial objects in preadditive categories
+
+TODO @joelriou: Define a functor `N' : simplicial_object.split C ⥤ chain_complex C ℕ`
+when `C` is a preadditive category, and get an isomorphism
+`N' ⋙ to_karoubi (chain_complex C ℕ) ≅ forget C ⋙ dold_kan.N₁`
+
+-/
+
+noncomputable theory
+
+open category_theory category_theory.limits category_theory.category
+  category_theory.preadditive opposite
+
+open_locale big_operators simplicial
+
+namespace simplicial_object
+
+namespace splitting
+
+variables {C : Type*} [category C] [has_finite_coproducts C]
+  {X : simplicial_object C} (s : splitting X)
+
+/-- The projection on a summand of the coproduct decomposition given
+by a splitting of a simplicial object. -/
+def π_summand [has_zero_morphisms C] {Δ : simplex_categoryᵒᵖ} (A : index_set Δ) :
+  X.obj Δ ⟶ s.N A.1.unop.len :=
+begin
+  refine (s.iso Δ).inv ≫ sigma.desc (λ B, _),
+  by_cases B = A,
+  { exact eq_to_hom (by { subst h, refl, }), },
+  { exact 0, },
+end
+
+@[simp, reassoc]
+lemma ι_π_summand_eq_id [has_zero_morphisms C] {Δ : simplex_categoryᵒᵖ} (A : index_set Δ) :
+  s.ι_summand A ≫ s.π_summand A = 𝟙 _ :=
+begin
+  dsimp [ι_summand, π_summand],
+  simp only [summand, assoc, is_iso.hom_inv_id_assoc],
+  erw [colimit.ι_desc, cofan.mk_ι_app],
+  dsimp,
+  simp only [eq_self_iff_true, if_true],
+end
+
+@[simp, reassoc]
+lemma ι_π_summand_eq_zero [has_zero_morphisms C] {Δ : simplex_categoryᵒᵖ} (A B : index_set Δ)
+  (h : B ≠ A) : s.ι_summand A ≫ s.π_summand B = 0 :=
+begin
+  dsimp [ι_summand, π_summand],
+  simp only [summand, assoc, is_iso.hom_inv_id_assoc],
+  erw [colimit.ι_desc, cofan.mk_ι_app],
+  apply dif_neg,
+  exact h.symm,
+end
+
+variable [preadditive C]
+
+lemma decomposition_id (Δ : simplex_categoryᵒᵖ) :
+  𝟙 (X.obj Δ) = ∑ (A : index_set Δ), s.π_summand A ≫ s.ι_summand A :=
+begin
+  apply s.hom_ext',
+  intro A,
+  rw [comp_id, comp_sum, finset.sum_eq_single A, ι_π_summand_eq_id_assoc],
+  { intros B h₁ h₂,
+    rw [s.ι_π_summand_eq_zero_assoc _ _ h₂, zero_comp], },
+  { simp only [finset.mem_univ, not_true, is_empty.forall_iff], },
+end
+
+@[simp, reassoc]
+lemma σ_comp_π_summand_id_eq_zero {n : ℕ} (i : fin (n+1)) :
+  X.σ i ≫ s.π_summand (index_set.id (op [n+1])) = 0 :=
+begin
+  apply s.hom_ext',
+  intro A,
+  dsimp only [simplicial_object.σ],
+  rw [comp_zero, s.ι_summand_epi_naturality_assoc A (simplex_category.σ i).op,
+    ι_π_summand_eq_zero],
+  symmetry,
+  change ¬ (A.epi_comp (simplex_category.σ i).op).eq_id,
+  rw index_set.eq_id_iff_len_eq,
+  have h := simplex_category.len_le_of_epi (infer_instance : epi A.e),
+  dsimp at ⊢ h,
+  linarith,
+end
+
+end splitting
+
+end simplicial_object

--- a/src/algebraic_topology/split_simplicial_object.lean
+++ b/src/algebraic_topology/split_simplicial_object.lean
@@ -104,6 +104,49 @@ def id : index_set Δ := ⟨Δ, ⟨𝟙 _, by apply_instance,⟩⟩
 
 instance : inhabited (index_set Δ) := ⟨id Δ⟩
 
+variable {Δ}
+
+/-- The condition that an element `splitting.index_set Δ` is the distinguished
+element `splitting.index_set.id Δ`. -/
+@[simp]
+def eq_id : Prop := A = id _
+
+lemma eq_id_iff_eq : A.eq_id ↔ A.1 = Δ :=
+begin
+  split,
+  { intro h,
+    dsimp at h,
+    rw h,
+    refl, },
+  { intro h,
+    rcases A with ⟨Δ', ⟨f, hf⟩⟩,
+    simp only at h,
+    subst h,
+    refine ext _ _ rfl _,
+    { haveI := hf,
+      simp only [eq_to_hom_refl, comp_id],
+      exact simplex_category.eq_id_of_epi f, }, },
+end
+
+lemma eq_id_iff_len_eq : A.eq_id ↔ A.1.unop.len = Δ.unop.len :=
+begin
+  rw eq_id_iff_eq,
+  split,
+  { intro h,
+    rw h, },
+  { intro h,
+    rw ← unop_inj_iff,
+    ext,
+    exact h, },
+end
+
+/-- Given `A : index_set Δ₁`, if `p.unop : unop Δ₂ ⟶ unop Δ₁` is an epi, this
+is the obvious element in `A : index_set Δ₂` associated to the composition
+of epimorphisms `p.unop ≫ A.e`. -/
+@[simps]
+def epi_comp {Δ₁ Δ₂ : simplex_categoryᵒᵖ} (A : index_set Δ₁) (p : Δ₁ ⟶ Δ₂) [epi p.unop] :
+  index_set Δ₂ := ⟨A.1, ⟨p.unop ≫ A.e, epi_comp _ _⟩⟩
+
 end index_set
 
 variables (N : ℕ → C) (Δ : simplex_categoryᵒᵖ)
@@ -236,6 +279,17 @@ def of_iso (e : X ≅ Y) : splitting Y :=
     convert (infer_instance : is_iso ((s.iso Δ).hom ≫ e.hom.app Δ)),
     tidy,
   end, }
+
+@[reassoc]
+lemma ι_summand_epi_naturality {Δ₁ Δ₂ : simplex_categoryᵒᵖ} (A : index_set Δ₁)
+  (p : Δ₁ ⟶ Δ₂) [epi p.unop] :
+  s.ι_summand A ≫ X.map p = s.ι_summand (A.epi_comp p) :=
+begin
+  dsimp [ι_summand],
+  erw [colimit.ι_desc, colimit.ι_desc, cofan.mk_ι_app, cofan.mk_ι_app],
+  dsimp only [index_set.epi_comp, index_set.e],
+  rw [op_comp, X.map_comp, assoc, quiver.hom.op_unop],
+end
 
 end splitting
 


### PR DESCRIPTION
This PR introduces very basic definitions for split simplicial objects in preadditive category, mostly the projections `s.π_summand A` on a summand (with index `A`) in the coproduct decomposition given by `s : splitting X` where `X` is a simplicial object.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
