### PR TITLE
[Merged by Bors] - feat(category_theory/localization): developing the predicate is_localization

### DIFF
--- a/src/category_theory/localization/predicate.lean
+++ b/src/category_theory/localization/predicate.lean
@@ -72,7 +72,8 @@ def strict_universal_property_fixed_target.for_Q :
 
 /-- When `W` consists of isomorphisms, the identity satisfies the universal property
 of the localization. -/
-def strict_universal_property_fixed_target.for_id (hW : W ⊆ morphism_property.isomorphisms C):
+@[simps]
+def strict_universal_property_fixed_target_id (hW : W ⊆ morphism_property.isomorphisms C):
   strict_universal_property_fixed_target (𝟭 C) W E :=
 { inverts := λ X Y f hf, hW f hf,
   lift := λ F hF, F,

--- a/src/category_theory/localization/predicate.lean
+++ b/src/category_theory/localization/predicate.lean
@@ -133,8 +133,6 @@ namespace localization
 variable [L.is_localization W]
 include L W
 
-lemma as_localization : L.is_localization W := infer_instance
-
 lemma inverts : W.is_inverted_by L := (infer_instance : L.is_localization W).inverts
 
 variable {W}

--- a/src/category_theory/localization/predicate.lean
+++ b/src/category_theory/localization/predicate.lean
@@ -54,7 +54,6 @@ namespace localization
 /-- This universal property states that a functor `L : C ⥤ D` inverts morphisms
 in `W` and the all functors `D ⥤ E` (for a fixed category `E`) uniquely factors
 through `L`. -/
-@[nolint has_nonempty_instance]
 structure strict_universal_property_fixed_target :=
 (inverts : W.is_inverted_by L)
 (lift : Π (F : C ⥤ E) (hF : W.is_inverted_by F), D ⥤ E)
@@ -70,6 +69,9 @@ def strict_universal_property_fixed_target_Q :
   lift := construction.lift,
   fac := construction.fac,
   uniq := construction.uniq, }
+
+instance : inhabited (strict_universal_property_fixed_target W.Q W E) :=
+⟨strict_universal_property_fixed_target_Q _ _⟩
 
 /-- When `W` consists of isomorphisms, the identity satisfies the universal property
 of the localization. -/
@@ -125,8 +127,8 @@ lemma is_localization.mk' :
 lemma is_localization.for_id (hW : W ⊆ morphism_property.isomorphisms C):
   (𝟭 C).is_localization W :=
 is_localization.mk' _ _
-  (localization.strict_universal_property_fixed_target.for_id W _ hW)
-  (localization.strict_universal_property_fixed_target.for_id W _ hW)
+  (localization.strict_universal_property_fixed_target_id W _ hW)
+  (localization.strict_universal_property_fixed_target_id W _ hW)
 
 end functor
 

--- a/src/category_theory/localization/predicate.lean
+++ b/src/category_theory/localization/predicate.lean
@@ -63,7 +63,8 @@ structure strict_universal_property_fixed_target :=
 
 /-- The localized category `W.localization` that was constructed satisfies
 the universal property of the localization. -/
-def strict_universal_property_fixed_target.for_Q :
+@[simps]
+def strict_universal_property_fixed_target_Q :
   strict_universal_property_fixed_target W.Q W E :=
 { inverts := W.Q_inverts,
   lift := construction.lift,

--- a/src/category_theory/localization/predicate.lean
+++ b/src/category_theory/localization/predicate.lean
@@ -87,42 +87,19 @@ end localization
 
 namespace functor
 
-variables (h₁ : localization.strict_universal_property_fixed_target L W D)
-  (h₂ : localization.strict_universal_property_fixed_target L W W.localization)
-
-namespace is_localization.mk'
-
-lemma unit_eq :
-  𝟭 W.localization = localization.construction.lift L h₁.inverts ⋙ h₂.lift W.Q W.Q_inverts :=
-begin
-  apply localization.construction.uniq,
-  rw [← functor.assoc, localization.construction.fac, h₂.fac, functor.comp_id],
-end
-
-lemma counit_eq :
-  h₂.lift W.Q W.Q_inverts ⋙ localization.construction.lift L h₁.inverts = 𝟭 D :=
-begin
-  apply h₁.uniq,
-  rw [← functor.assoc, h₂.fac, localization.construction.fac, functor.comp_id],
-end
-
-/-- The equivalence of categories `W.localization ≅ D` obtained when `L : C ⥤ D`
-satisfies the universal property of the localization. -/
-def equivalence : W.localization ≌ D :=
-{ functor := localization.construction.lift L h₁.inverts,
-  inverse := h₂.lift W.Q W.Q_inverts,
-  unit_iso := eq_to_iso (unit_eq L W h₁ h₂),
-  counit_iso := eq_to_iso (counit_eq L W h₁ h₂),
-  functor_unit_iso_comp' := λ X, by simpa only [eq_to_iso.hom, eq_to_hom_app, eq_to_hom_map,
-    eq_to_hom_trans, eq_to_hom_refl], }
-
-end is_localization.mk'
-
-lemma is_localization.mk' :
+lemma is_localization.mk'
+  (h₁ : localization.strict_universal_property_fixed_target L W D)
+  (h₂ : localization.strict_universal_property_fixed_target L W W.localization) :
   is_localization L W :=
 { inverts := h₁.inverts,
-  nonempty_is_equivalence :=
-    nonempty.intro (is_equivalence.of_equivalence (is_localization.mk'.equivalence L W h₁ h₂)), }
+  nonempty_is_equivalence := nonempty.intro
+  { inverse := h₂.lift W.Q W.Q_inverts,
+    unit_iso := eq_to_iso (localization.construction.uniq _ _
+      (by simp only [← functor.assoc, localization.construction.fac, h₂.fac, functor.comp_id])),
+    counit_iso := eq_to_iso (h₁.uniq _ _ (by simp only [← functor.assoc, h₂.fac,
+      localization.construction.fac, functor.comp_id])),
+    functor_unit_iso_comp' := λ X, by simpa only [eq_to_iso.hom, eq_to_hom_app,
+      eq_to_hom_map, eq_to_hom_trans, eq_to_hom_refl], }, }
 
 lemma is_localization.for_id (hW : W ⊆ morphism_property.isomorphisms C):
   (𝟭 C).is_localization W :=

--- a/src/category_theory/whiskering.lean
+++ b/src/category_theory/whiskering.lean
@@ -201,6 +201,9 @@ and it's usually best to insert explicit associators.)
 { hom := { app := λ _, 𝟙 _ },
   inv := { app := λ _, 𝟙 _ } }
 
+@[protected]
+lemma assoc (F : A ⥤ B) (G : B ⥤ C) (H : C ⥤ D) : ((F ⋙ G) ⋙ H) = (F ⋙ (G ⋙ H)) := rfl
+
 lemma triangle (F : A ⥤ B) (G : B ⥤ C) :
   (associator F (𝟭 B) G).hom ≫ (whisker_left F (left_unitor G).hom) =
     (whisker_right (right_unitor F).hom G) :=


### PR DESCRIPTION
When `L : C ⥤ D` and `W : morphism_property C`, a constructor for the predicate `L.is_localization W` is introduced: it takes as inputs the universal property of the localized category. In this PR, it is also shown that is `L.is_localization W`, the functor `L` is essentially surjective.

---
In future PRs, it shall be shown that the composition with `L` induces equivalence of categories `(D ⥤ E) ≌ (W.functors_inverting E)` for all categories `E` and an API shall be developed for the lifting of functors and lifting of natural transformations.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
