### PR TITLE
[Merged by Bors] - refactor(analysis/normed_space/spectrum): remove `norm_one_class` hypotheses

### DIFF
--- a/src/analysis/normed_space/algebra.lean
+++ b/src/analysis/normed_space/algebra.lean
@@ -33,25 +33,21 @@ namespace weak_dual
 namespace character_space
 
 variables [nontrivially_normed_field 𝕜] [normed_ring A]
-  [normed_algebra 𝕜 A] [complete_space A] [norm_one_class A]
+  [normed_algebra 𝕜 A] [complete_space A]
 
-lemma norm_one (φ : character_space 𝕜 A) : ∥to_normed_dual (φ : weak_dual 𝕜 A)∥ = 1 :=
-begin
-  refine continuous_linear_map.op_norm_eq_of_bounds zero_le_one (λ a, _) (λ x hx h, _),
-  { rw [one_mul],
-    exact spectrum.norm_le_norm_of_mem (apply_mem_spectrum φ a) },
-  { have : ∥φ 1∥ ≤ x * ∥(1 : A)∥ := h 1,
-    simpa only [norm_one, mul_one, map_one] using this },
-end
+lemma norm_le_norm_one (φ : character_space 𝕜 A) :
+  ∥to_normed_dual (φ : weak_dual 𝕜 A)∥ ≤ ∥(1 : A)∥ :=
+continuous_linear_map.op_norm_le_bound _ (norm_nonneg (1 : A)) $
+  λ a, mul_comm (∥a∥) (∥(1 : A)∥) ▸ spectrum.norm_le_norm_mul_of_mem (apply_mem_spectrum φ a)
 
 instance [proper_space 𝕜] : compact_space (character_space 𝕜 A) :=
 begin
   rw [←is_compact_iff_compact_space],
-  have h : character_space 𝕜 A ⊆ to_normed_dual ⁻¹' metric.closed_ball 0 1,
+  have h : character_space 𝕜 A ⊆ to_normed_dual ⁻¹' metric.closed_ball 0 (∥(1 : A)∥),
   { intros φ hφ,
     rw [set.mem_preimage, mem_closed_ball_zero_iff],
-    exact (le_of_eq $ norm_one ⟨φ, ⟨hφ.1, hφ.2⟩⟩ : _), },
-  exact compact_of_is_closed_subset (is_compact_closed_ball 𝕜 0 1) character_space.is_closed h,
+    exact (norm_le_norm_one ⟨φ, ⟨hφ.1, hφ.2⟩⟩ : _), },
+  exact compact_of_is_closed_subset (is_compact_closed_ball 𝕜 0 _) character_space.is_closed h,
 end
 
 end character_space

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -43,38 +43,6 @@ This file contains the basic theory for the resolvent and spectrum of a Banach a
 
 open_locale ennreal
 
---prereqs
-
-open filter
-
-open_locale nnreal
-
-lemma nnreal.eventually_pow_one_div_le (x : ℝ≥0) {ε : ℝ≥0} (hε : 1 < ε) :
-  ∀ᶠ (n : ℕ) in at_top, x ^ (1 / n : ℝ) ≤ ε :=
-begin
-  obtain ⟨m, hm⟩ := add_one_pow_unbounded_of_pos x (tsub_pos_of_lt hε),
-  rw [tsub_add_cancel_of_le hε.le] at hm,
-  refine eventually_at_top.2 ⟨m + 1, λ n hn, _⟩,
-  simpa only [nnreal.rpow_one_div_le_iff (nat.cast_pos.2 $ m.succ_pos.trans_le hn),
-    nnreal.rpow_nat_cast] using hm.le.trans (pow_le_pow hε.le (m.le_succ.trans hn)),
-end
-
-lemma ennreal.eventually_pow_one_div_le {x : ℝ≥0∞} (hx : x ≠ ∞) {ε : ℝ≥0∞} (hε : 1 < ε) :
-  ∀ᶠ (n : ℕ) in at_top, x ^ (1 / n : ℝ) ≤ ε :=
-begin
-  lift x to ℝ≥0 using hx,
-  by_cases ε = ∞,
-  refine eventually_of_forall (λ n, h.symm ▸ le_top),
-  lift ε to ℝ≥0 using h,
-  have := nnreal.eventually_pow_one_div_le x (by exact_mod_cast hε : 1 < ε),
-  refine this.congr (eventually_of_forall $ λ n, _),
-  rw [ennreal.coe_rpow_of_nonneg x (by positivity : 0 ≤ (1 / n : ℝ)), ennreal.coe_le_coe],
-end
-
-
---prereqs
-
-
 /-- The *spectral radius* is the supremum of the `nnnorm` (`∥⬝∥₊`) of elements in the spectrum,
     coerced into an element of `ℝ≥0∞`. Note that it is possible for `spectrum 𝕜 a = ∅`. In this
     case, `spectral_radius a = 0`.  It is also possible that `spectrum 𝕜 a` be unbounded (though

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -58,7 +58,9 @@ namespace spectrum
 
 section spectrum_compact
 
-variables [nontrivially_normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A]
+open filter
+
+variables [normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A]
 
 local notation `σ` := spectrum 𝕜
 local notation `ρ` := resolvent_set 𝕜

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -58,7 +58,7 @@ namespace spectrum
 
 section spectrum_compact
 
-variables [normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A]
+variables [nontrivially_normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A]
 
 local notation `σ` := spectrum 𝕜
 local notation `ρ` := resolvent_set 𝕜
@@ -73,32 +73,48 @@ variable [complete_space A]
 lemma is_open_resolvent_set (a : A) : is_open (ρ a) :=
 units.is_open.preimage ((continuous_algebra_map 𝕜 A).sub continuous_const)
 
-lemma is_closed (a : A) : is_closed (σ a) :=
+protected lemma is_closed (a : A) : is_closed (σ a) :=
 (is_open_resolvent_set a).is_closed_compl
 
-lemma mem_resolvent_of_norm_lt [norm_one_class A] {a : A} {k : 𝕜} (h : ∥a∥ < ∥k∥) :
+lemma mem_resolvent_set_of_norm_lt_mul {a : A} {k : 𝕜} (h : ∥a∥ * ∥(1 : A)∥ < ∥k∥) :
   k ∈ ρ a :=
 begin
   rw [resolvent_set, set.mem_set_of_eq, algebra.algebra_map_eq_smul_one],
-  have hk : k ≠ 0 := ne_zero_of_norm_ne_zero (by linarith [norm_nonneg a]),
+  nontriviality A,
+  have hk : k ≠ 0,
+    from ne_zero_of_norm_ne_zero ((mul_nonneg (norm_nonneg _) (norm_nonneg _)).trans_lt h).ne',
   let ku := units.map (↑ₐ).to_monoid_hom (units.mk0 k hk),
-  have hku : ∥-a∥ < ∥(↑ku⁻¹:A)∥⁻¹ := by simpa [ku, algebra_map_isometry] using h,
+  rw [←inv_inv (∥(1 : A)∥), mul_inv_lt_iff (inv_pos.2 $ norm_pos_iff.2 (one_ne_zero : (1 : A) ≠ 0))]
+    at h,
+  have hku : ∥-a∥ < ∥(↑ku⁻¹:A)∥⁻¹ := by simpa [ku, norm_algebra_map] using h,
   simpa [ku, sub_eq_add_neg, algebra.algebra_map_eq_smul_one] using (ku.add (-a) hku).is_unit,
 end
 
+lemma mem_resolvent_set_of_norm_lt [norm_one_class A] {a : A} {k : 𝕜} (h : ∥a∥ < ∥k∥) :
+  k ∈ ρ a :=
+mem_resolvent_set_of_norm_lt_mul (by rwa [norm_one, mul_one])
+
+lemma norm_le_norm_mul_of_mem {a : A} {k : 𝕜} (hk : k ∈ σ a) :
+  ∥k∥ ≤ ∥a∥ * ∥(1 : A)∥ :=
+le_of_not_lt $ mt mem_resolvent_set_of_norm_lt_mul hk
+
 lemma norm_le_norm_of_mem [norm_one_class A] {a : A} {k : 𝕜} (hk : k ∈ σ a) :
   ∥k∥ ≤ ∥a∥ :=
-le_of_not_lt $ mt mem_resolvent_of_norm_lt hk
+le_of_not_lt $ mt mem_resolvent_set_of_norm_lt hk
+
+lemma subset_closed_ball_norm_mul (a : A) :
+  σ a ⊆ metric.closed_ball (0 : 𝕜) (∥a∥ * ∥(1 : A)∥) :=
+λ k hk, by simp [norm_le_norm_mul_of_mem hk]
 
 lemma subset_closed_ball_norm [norm_one_class A] (a : A) :
   σ a ⊆ metric.closed_ball (0 : 𝕜) (∥a∥) :=
 λ k hk, by simp [norm_le_norm_of_mem hk]
 
-lemma is_bounded [norm_one_class A] (a : A) : metric.bounded (σ a) :=
-(metric.bounded_iff_subset_ball 0).mpr ⟨∥a∥, subset_closed_ball_norm a⟩
+lemma is_bounded (a : A) : metric.bounded (σ a) :=
+(metric.bounded_iff_subset_ball 0).mpr ⟨∥a∥ * ∥(1 : A)∥, subset_closed_ball_norm_mul a⟩
 
-theorem is_compact [norm_one_class A] [proper_space 𝕜] (a : A) : is_compact (σ a) :=
-metric.is_compact_of_is_closed_bounded (is_closed a) (is_bounded a)
+protected theorem is_compact [proper_space 𝕜] (a : A) : is_compact (σ a) :=
+metric.is_compact_of_is_closed_bounded (spectrum.is_closed a) (is_bounded a)
 
 theorem spectral_radius_le_nnnorm [norm_one_class A] (a : A) :
   spectral_radius 𝕜 a ≤ ∥a∥₊ :=
@@ -420,23 +436,22 @@ end spectrum
 namespace alg_hom
 
 section normed_field
-variables [normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A] [complete_space A]
+variables [nontrivially_normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A] [complete_space A]
 local notation `↑ₐ` := algebra_map 𝕜 A
-
 
 /-- An algebra homomorphism into the base field, as a continuous linear map (since it is
 automatically bounded). -/
-instance [norm_one_class A] : continuous_linear_map_class (A →ₐ[𝕜] 𝕜) 𝕜 A 𝕜 :=
-{ map_continuous := λ φ, add_monoid_hom_class.continuous_of_bound φ 1 $
-    λ a, (one_mul ∥a∥).symm ▸ spectrum.norm_le_norm_of_mem (apply_mem_spectrum φ _),
+instance : continuous_linear_map_class (A →ₐ[𝕜] 𝕜) 𝕜 A 𝕜 :=
+{ map_continuous := λ φ, add_monoid_hom_class.continuous_of_bound φ ∥(1 : A)∥ $
+    λ a, (mul_comm ∥a∥ ∥(1 : A)∥) ▸ spectrum.norm_le_norm_mul_of_mem (apply_mem_spectrum φ _),
   .. alg_hom_class.linear_map_class }
 
 /-- An algebra homomorphism into the base field, as a continuous linear map (since it is
 automatically bounded). -/
-def to_continuous_linear_map [norm_one_class A] (φ : A →ₐ[𝕜] 𝕜) : A →L[𝕜] 𝕜 :=
+def to_continuous_linear_map (φ : A →ₐ[𝕜] 𝕜) : A →L[𝕜] 𝕜 :=
 { cont := map_continuous φ, .. φ.to_linear_map }
 
-@[simp] lemma coe_to_continuous_linear_map [norm_one_class A] (φ : A →ₐ[𝕜] 𝕜) :
+@[simp] lemma coe_to_continuous_linear_map (φ : A →ₐ[𝕜] 𝕜) :
   ⇑φ.to_continuous_linear_map = φ := rfl
 
 end normed_field
@@ -459,7 +474,7 @@ namespace weak_dual
 
 namespace character_space
 
-variables [normed_field 𝕜] [normed_ring A] [complete_space A] [norm_one_class A]
+variables [nontrivially_normed_field 𝕜] [normed_ring A] [complete_space A]
 variables [normed_algebra 𝕜 A]
 
 /-- The equivalence between characters and algebra homomorphisms into the base field. -/

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -461,7 +461,7 @@ end spectrum
 namespace alg_hom
 
 section normed_field
-variables [nontrivially_normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A] [complete_space A]
+variables [normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A] [complete_space A]
 local notation `↑ₐ` := algebra_map 𝕜 A
 
 /-- An algebra homomorphism into the base field, as a continuous linear map (since it is

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -160,7 +160,8 @@ begin
   simp only [ennreal.mul_le_iff_le_inv h (hε.trans_le le_top).ne, mul_comm ε⁻¹,
     liminf_eq_supr_infi_of_nat', ennreal.supr_mul, ennreal.infi_mul hε'],
   rw [←ennreal.inv_lt_inv, inv_one] at hε,
-  obtain ⟨N, hN⟩ := eventually_at_top.mp (ennreal.eventually_pow_one_div_le (ennreal.coe_ne_top : ↑∥(1 : A)∥₊ ≠ ∞) hε),
+  obtain ⟨N, hN⟩ := eventually_at_top.mp
+    (ennreal.eventually_pow_one_div_le (ennreal.coe_ne_top : ↑∥(1 : A)∥₊ ≠ ∞) hε),
   refine (le_trans _ (le_supr _ (N + 1))),
   refine le_infi (λ n, _),
   simp only [←add_assoc],

--- a/src/analysis/normed_space/star/gelfand_duality.lean
+++ b/src/analysis/normed_space/star/gelfand_duality.lean
@@ -104,9 +104,6 @@ end
 instance [nontrivial A] : nonempty (character_space ℂ A) :=
 ⟨classical.some $ weak_dual.character_space.exists_apply_eq_zero $ zero_mem_nonunits.2 zero_ne_one⟩
 
-instance [subsingleton A] : is_empty (character_space ℂ A) :=
-⟨λ φ, φ.prop.1 $ continuous_linear_map.ext (λ x, by simp only [subsingleton.elim x 0, map_zero])⟩
-
 end complex_banach_algebra
 
 section complex_cstar_algebra

--- a/src/analysis/normed_space/star/gelfand_duality.lean
+++ b/src/analysis/normed_space/star/gelfand_duality.lean
@@ -59,7 +59,7 @@ section complex_banach_algebra
 open ideal
 
 variables {A : Type*} [normed_comm_ring A] [normed_algebra ℂ A] [complete_space A]
-  [norm_one_class A] (I : ideal A) [ideal.is_maximal I]
+  (I : ideal A) [ideal.is_maximal I]
 
 /-- Every maximal ideal in a commutative complex Banach algebra gives rise to a character on that
 algebra. In particular, the character, which may be identified as an algebra homomorphism due to
@@ -101,23 +101,23 @@ begin
   exact (continuous_map.spectrum_eq_range (gelfand_transform ℂ A a)).symm ▸ ⟨f, hf.symm⟩,
 end
 
-instance : nonempty (character_space ℂ A) :=
-begin
-  haveI := norm_one_class.nontrivial A,
-  exact ⟨classical.some $
-    weak_dual.character_space.exists_apply_eq_zero (zero_mem_nonunits.mpr zero_ne_one)⟩,
-end
+instance [nontrivial A] : nonempty (character_space ℂ A) :=
+⟨classical.some $ weak_dual.character_space.exists_apply_eq_zero $ zero_mem_nonunits.2 zero_ne_one⟩
+
+instance [subsingleton A] : is_empty (character_space ℂ A) :=
+⟨λ φ, φ.prop.1 $ continuous_linear_map.ext (λ x, by simp only [subsingleton.elim x 0, map_zero])⟩
 
 end complex_banach_algebra
 
 section complex_cstar_algebra
 
 variables (A : Type*) [normed_comm_ring A] [normed_algebra ℂ A] [complete_space A]
-variables [star_ring A] [cstar_ring A] [star_module ℂ A] [nontrivial A]
+variables [star_ring A] [cstar_ring A] [star_module ℂ A]
 
 /-- The Gelfand transform is an isometry when the algebra is a C⋆-algebra over `ℂ`. -/
 lemma gelfand_transform_isometry : isometry (gelfand_transform ℂ A) :=
 begin
+  nontriviality A,
   refine add_monoid_hom_class.isometry_of_norm (gelfand_transform ℂ A) (λ a, _),
   have gt_map_star : gelfand_transform ℂ A (star a) = star (gelfand_transform ℂ A a),
     from continuous_map.ext (λ φ, map_star φ a),

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -62,51 +62,45 @@ lemma is_self_adjoint.spectral_radius_eq_nnnorm {a : A}
   (ha : is_self_adjoint a) :
   spectral_radius ℂ a = ∥a∥₊ :=
 begin
-  unfreezingI { obtain (_ | _) := subsingleton_or_nontrivial A },
-  { simp [subsingleton.elim a 0] },
-  { have hconst : tendsto (λ n : ℕ, (∥a∥₊ : ℝ≥0∞)) at_top _ := tendsto_const_nhds,
-    refine tendsto_nhds_unique _ hconst,
-    convert (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a : A)).comp
-        (nat.tendsto_pow_at_top_at_top_of_one_lt one_lt_two),
-    refine funext (λ n, _),
-    rw [function.comp_app, ha.nnnorm_pow_two_pow, ennreal.coe_pow, ←rpow_nat_cast,
-      ←rpow_mul],
-    simp }
+  have hconst : tendsto (λ n : ℕ, (∥a∥₊ : ℝ≥0∞)) at_top _ := tendsto_const_nhds,
+  refine tendsto_nhds_unique _ hconst,
+  convert (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a : A)).comp
+      (nat.tendsto_pow_at_top_at_top_of_one_lt one_lt_two),
+  refine funext (λ n, _),
+  rw [function.comp_app, ha.nnnorm_pow_two_pow, ennreal.coe_pow, ←rpow_nat_cast,
+    ←rpow_mul],
+  simp
 end
 
 lemma is_star_normal.spectral_radius_eq_nnnorm (a : A) [is_star_normal a] :
   spectral_radius ℂ a = ∥a∥₊ :=
 begin
-  unfreezingI { obtain (_ | _) := subsingleton_or_nontrivial A },
-  { simp [subsingleton.elim a 0] },
-  { refine (ennreal.pow_strict_mono two_ne_zero).injective _,
-    have heq : (λ n : ℕ, ((∥(a⋆ * a) ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞))
-      = (λ x, x ^ 2) ∘ (λ n : ℕ, ((∥a ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞)),
-    { funext,
-      rw [function.comp_apply, ←rpow_nat_cast, ←rpow_mul, mul_comm, rpow_mul, rpow_nat_cast,
-        ←coe_pow, sq, ←nnnorm_star_mul_self, commute.mul_pow (star_comm_self' a), star_pow], },
-    have h₂ := ((ennreal.continuous_pow 2).tendsto (spectral_radius ℂ a)).comp
-      (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius a),
-    rw ←heq at h₂,
-    convert tendsto_nhds_unique h₂ (pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a⋆ * a)),
-    rw [(is_self_adjoint.star_mul_self a).spectral_radius_eq_nnnorm, sq, nnnorm_star_mul_self,
-      coe_mul] }
+  refine (ennreal.pow_strict_mono two_ne_zero).injective _,
+  have heq : (λ n : ℕ, ((∥(a⋆ * a) ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞))
+    = (λ x, x ^ 2) ∘ (λ n : ℕ, ((∥a ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞)),
+  { funext,
+    rw [function.comp_apply, ←rpow_nat_cast, ←rpow_mul, mul_comm, rpow_mul, rpow_nat_cast,
+      ←coe_pow, sq, ←nnnorm_star_mul_self, commute.mul_pow (star_comm_self' a), star_pow], },
+  have h₂ := ((ennreal.continuous_pow 2).tendsto (spectral_radius ℂ a)).comp
+    (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius a),
+  rw ←heq at h₂,
+  convert tendsto_nhds_unique h₂ (pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a⋆ * a)),
+  rw [(is_self_adjoint.star_mul_self a).spectral_radius_eq_nnnorm, sq, nnnorm_star_mul_self,
+    coe_mul]
 end
 
 /-- Any element of the spectrum of a selfadjoint is real. -/
 theorem is_self_adjoint.mem_spectrum_eq_re [star_module ℂ A] {a : A}
   (ha : is_self_adjoint a) {z : ℂ} (hz : z ∈ spectrum ℂ a) : z = z.re :=
 begin
-  unfreezingI { obtain (_ | _) := subsingleton_or_nontrivial A },
-  { exact false.elim (by simpa using hz), },
-  { let Iu := units.mk0 I I_ne_zero,
-    have : exp ℂ (I • z) ∈ spectrum ℂ (exp ℂ (I • a)),
-      by simpa only [units.smul_def, units.coe_mk0]
-        using spectrum.exp_mem_exp (Iu • a) (smul_mem_smul_iff.mpr hz),
-    exact complex.ext (of_real_re _)
-      (by simpa only [←complex.exp_eq_exp_ℂ, mem_sphere_zero_iff_norm, norm_eq_abs, abs_exp,
-        real.exp_eq_one_iff, smul_eq_mul, I_mul, neg_eq_zero]
-        using spectrum.subset_circle_of_unitary ha.exp_i_smul_unitary this), }
+  let Iu := units.mk0 I I_ne_zero,
+  have : exp ℂ (I • z) ∈ spectrum ℂ (exp ℂ (I • a)),
+    by simpa only [units.smul_def, units.coe_mk0]
+      using spectrum.exp_mem_exp (Iu • a) (smul_mem_smul_iff.mpr hz),
+  exact complex.ext (of_real_re _)
+    (by simpa only [←complex.exp_eq_exp_ℂ, mem_sphere_zero_iff_norm, norm_eq_abs, abs_exp,
+      real.exp_eq_one_iff, smul_eq_mul, I_mul, neg_eq_zero]
+      using spectrum.subset_circle_of_unitary ha.exp_i_smul_unitary this),
 end
 
 /-- Any element of the spectrum of a selfadjoint is real. -/

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -23,7 +23,7 @@ open filter ennreal spectrum cstar_ring
 section unitary_spectrum
 
 variables
-{𝕜 : Type*} [nontrivially_normed_field 𝕜]
+{𝕜 : Type*} [normed_field 𝕜]
 {E : Type*} [normed_ring E] [star_ring E] [cstar_ring E]
 [normed_algebra 𝕜 E] [complete_space E]
 

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -25,11 +25,12 @@ section unitary_spectrum
 variables
 {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [normed_ring E] [star_ring E] [cstar_ring E]
-[normed_algebra 𝕜 E] [complete_space E] [nontrivial E]
+[normed_algebra 𝕜 E] [complete_space E]
 
 lemma unitary.spectrum_subset_circle (u : unitary E) :
   spectrum 𝕜 (u : E) ⊆ metric.sphere 0 1 :=
 begin
+  nontriviality E,
   refine λ k hk, mem_sphere_zero_iff_norm.mpr (le_antisymm _ _),
   { simpa only [cstar_ring.norm_coe_unitary u] using norm_le_norm_of_mem hk },
   { rw ←unitary.coe_to_units_apply u at hk,
@@ -54,65 +55,74 @@ variables {A : Type*}
 
 local notation `↑ₐ` := algebra_map ℂ A
 
-lemma is_self_adjoint.spectral_radius_eq_nnnorm [norm_one_class A] {a : A}
+@[simp] lemma foo [subsingleton A] (a : A) : spectral_radius ℂ a = 0 :=
+by simp [spectral_radius]
+
+lemma is_self_adjoint.spectral_radius_eq_nnnorm {a : A}
   (ha : is_self_adjoint a) :
   spectral_radius ℂ a = ∥a∥₊ :=
 begin
-  have hconst : tendsto (λ n : ℕ, (∥a∥₊ : ℝ≥0∞)) at_top _ := tendsto_const_nhds,
-  refine tendsto_nhds_unique _ hconst,
-  convert (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a : A)).comp
-      (nat.tendsto_pow_at_top_at_top_of_one_lt one_lt_two),
-  refine funext (λ n, _),
-  rw [function.comp_app, ha.nnnorm_pow_two_pow, ennreal.coe_pow, ←rpow_nat_cast,
-    ←rpow_mul],
-  simp,
+  unfreezingI { obtain (_ | _) := subsingleton_or_nontrivial A },
+  { simp [subsingleton.elim a 0] },
+  { have hconst : tendsto (λ n : ℕ, (∥a∥₊ : ℝ≥0∞)) at_top _ := tendsto_const_nhds,
+    refine tendsto_nhds_unique _ hconst,
+    convert (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a : A)).comp
+        (nat.tendsto_pow_at_top_at_top_of_one_lt one_lt_two),
+    refine funext (λ n, _),
+    rw [function.comp_app, ha.nnnorm_pow_two_pow, ennreal.coe_pow, ←rpow_nat_cast,
+      ←rpow_mul],
+    simp }
 end
 
-lemma is_star_normal.spectral_radius_eq_nnnorm [norm_one_class A] (a : A) [is_star_normal a] :
+lemma is_star_normal.spectral_radius_eq_nnnorm (a : A) [is_star_normal a] :
   spectral_radius ℂ a = ∥a∥₊ :=
 begin
-  refine (ennreal.pow_strict_mono two_ne_zero).injective _,
-  have heq : (λ n : ℕ, ((∥(a⋆ * a) ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞))
-    = (λ x, x ^ 2) ∘ (λ n : ℕ, ((∥a ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞)),
-  { funext,
-    rw [function.comp_apply, ←rpow_nat_cast, ←rpow_mul, mul_comm, rpow_mul, rpow_nat_cast,
-      ←coe_pow, sq, ←nnnorm_star_mul_self, commute.mul_pow (star_comm_self' a), star_pow], },
-  have h₂ := ((ennreal.continuous_pow 2).tendsto (spectral_radius ℂ a)).comp
-    (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius a),
-  rw ←heq at h₂,
-  convert tendsto_nhds_unique h₂ (pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a⋆ * a)),
-  rw [(is_self_adjoint.star_mul_self a).spectral_radius_eq_nnnorm, sq, nnnorm_star_mul_self,
-    coe_mul],
+  unfreezingI { obtain (_ | _) := subsingleton_or_nontrivial A },
+  { simp [subsingleton.elim a 0] },
+  { refine (ennreal.pow_strict_mono two_ne_zero).injective _,
+    have heq : (λ n : ℕ, ((∥(a⋆ * a) ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞))
+      = (λ x, x ^ 2) ∘ (λ n : ℕ, ((∥a ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞)),
+    { funext,
+      rw [function.comp_apply, ←rpow_nat_cast, ←rpow_mul, mul_comm, rpow_mul, rpow_nat_cast,
+        ←coe_pow, sq, ←nnnorm_star_mul_self, commute.mul_pow (star_comm_self' a), star_pow], },
+    have h₂ := ((ennreal.continuous_pow 2).tendsto (spectral_radius ℂ a)).comp
+      (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius a),
+    rw ←heq at h₂,
+    convert tendsto_nhds_unique h₂ (pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a⋆ * a)),
+    rw [(is_self_adjoint.star_mul_self a).spectral_radius_eq_nnnorm, sq, nnnorm_star_mul_self,
+      coe_mul] }
 end
 
 /-- Any element of the spectrum of a selfadjoint is real. -/
-theorem is_self_adjoint.mem_spectrum_eq_re [star_module ℂ A] [nontrivial A] {a : A}
+theorem is_self_adjoint.mem_spectrum_eq_re [star_module ℂ A] {a : A}
   (ha : is_self_adjoint a) {z : ℂ} (hz : z ∈ spectrum ℂ a) : z = z.re :=
 begin
-  let Iu := units.mk0 I I_ne_zero,
-  have : exp ℂ (I • z) ∈ spectrum ℂ (exp ℂ (I • a)),
-    by simpa only [units.smul_def, units.coe_mk0]
-      using spectrum.exp_mem_exp (Iu • a) (smul_mem_smul_iff.mpr hz),
-  exact complex.ext (of_real_re _)
-    (by simpa only [←complex.exp_eq_exp_ℂ, mem_sphere_zero_iff_norm, norm_eq_abs, abs_exp,
-      real.exp_eq_one_iff, smul_eq_mul, I_mul, neg_eq_zero]
-      using spectrum.subset_circle_of_unitary ha.exp_i_smul_unitary this),
+  unfreezingI { obtain (_ | _) := subsingleton_or_nontrivial A },
+  { exact false.elim (by simpa using hz), },
+  { let Iu := units.mk0 I I_ne_zero,
+    have : exp ℂ (I • z) ∈ spectrum ℂ (exp ℂ (I • a)),
+      by simpa only [units.smul_def, units.coe_mk0]
+        using spectrum.exp_mem_exp (Iu • a) (smul_mem_smul_iff.mpr hz),
+    exact complex.ext (of_real_re _)
+      (by simpa only [←complex.exp_eq_exp_ℂ, mem_sphere_zero_iff_norm, norm_eq_abs, abs_exp,
+        real.exp_eq_one_iff, smul_eq_mul, I_mul, neg_eq_zero]
+        using spectrum.subset_circle_of_unitary ha.exp_i_smul_unitary this), }
 end
 
 /-- Any element of the spectrum of a selfadjoint is real. -/
-theorem self_adjoint.mem_spectrum_eq_re [star_module ℂ A] [nontrivial A]
+theorem self_adjoint.mem_spectrum_eq_re [star_module ℂ A]
   (a : self_adjoint A) {z : ℂ} (hz : z ∈ spectrum ℂ (a : A)) : z = z.re :=
 a.prop.mem_spectrum_eq_re hz
 
 /-- The spectrum of a selfadjoint is real -/
-theorem is_self_adjoint.coe_re_map_spectrum [star_module ℂ A] [nontrivial A] {a : A}
+theorem is_self_adjoint.coe_re_map_spectrum [star_module ℂ A] {a : A}
   (ha : is_self_adjoint a) : spectrum ℂ a = (coe ∘ re '' (spectrum ℂ a) : set ℂ) :=
 le_antisymm (λ z hz, ⟨z, hz, (ha.mem_spectrum_eq_re hz).symm⟩) (λ z, by
   { rintros ⟨z, hz, rfl⟩,
     simpa only [(ha.mem_spectrum_eq_re hz).symm, function.comp_app] using hz })
 
 /-- The spectrum of a selfadjoint is real -/
-theorem self_adjoint.coe_re_map_spectrum [star_module ℂ A] [nontrivial A] (a : self_adjoint A) :
+theorem self_adjoint.coe_re_map_spectrum [star_module ℂ A] (a : self_adjoint A) :
   spectrum ℂ (a : A) = (coe ∘ re '' (spectrum ℂ (a : A)) : set ℂ) :=
 a.property.coe_re_map_spectrum
 
@@ -121,10 +131,8 @@ end complex_scalars
 namespace star_alg_hom
 
 variables {F A B : Type*}
-[normed_ring A] [normed_algebra ℂ A] [norm_one_class A]
-[complete_space A] [star_ring A] [cstar_ring A]
-[normed_ring B] [normed_algebra ℂ B] [norm_one_class B]
-[complete_space B] [star_ring B] [cstar_ring B]
+[normed_ring A] [normed_algebra ℂ A] [complete_space A] [star_ring A] [cstar_ring A]
+[normed_ring B] [normed_algebra ℂ B] [complete_space B] [star_ring B] [cstar_ring B]
 [hF : star_alg_hom_class F ℂ A B] (φ : F)
 include hF
 
@@ -161,7 +169,7 @@ namespace weak_dual
 open continuous_map complex
 open_locale complex_star_module
 
-variables {F A : Type*} [normed_ring A] [normed_algebra ℂ A] [nontrivial A] [complete_space A]
+variables {F A : Type*} [normed_ring A] [normed_algebra ℂ A] [complete_space A]
   [star_ring A] [cstar_ring A] [star_module ℂ A] [hF : alg_hom_class F ℂ A ℂ]
 
 include hF

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -23,7 +23,7 @@ open filter ennreal spectrum cstar_ring
 section unitary_spectrum
 
 variables
-{𝕜 : Type*} [normed_field 𝕜]
+{𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [normed_ring E] [star_ring E] [cstar_ring E]
 [normed_algebra 𝕜 E] [complete_space E] [nontrivial E]
 

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -55,9 +55,6 @@ variables {A : Type*}
 
 local notation `↑ₐ` := algebra_map ℂ A
 
-@[simp] lemma foo [subsingleton A] (a : A) : spectral_radius ℂ a = 0 :=
-by simp [spectral_radius]
-
 lemma is_self_adjoint.spectral_radius_eq_nnnorm {a : A}
   (ha : is_self_adjoint a) :
   spectral_radius ℂ a = ∥a∥₊ :=
@@ -69,7 +66,7 @@ begin
   refine funext (λ n, _),
   rw [function.comp_app, ha.nnnorm_pow_two_pow, ennreal.coe_pow, ←rpow_nat_cast,
     ←rpow_mul],
-  simp
+  simp,
 end
 
 lemma is_star_normal.spectral_radius_eq_nnnorm (a : A) [is_star_normal a] :
@@ -86,7 +83,7 @@ begin
   rw ←heq at h₂,
   convert tendsto_nhds_unique h₂ (pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a⋆ * a)),
   rw [(is_self_adjoint.star_mul_self a).spectral_radius_eq_nnnorm, sq, nnnorm_star_mul_self,
-    coe_mul]
+    coe_mul],
 end
 
 /-- Any element of the spectrum of a selfadjoint is real. -/

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1442,14 +1442,14 @@ begin
   rw [←nnreal.coe_rpow, real.to_nnreal_coe],
 end
 
-lemma eventually_pow_one_div_le (x : ℝ≥0) {ε : ℝ≥0} (hε : 1 < ε) :
-  ∀ᶠ (n : ℕ) in at_top, x ^ (1 / n : ℝ) ≤ ε :=
+lemma eventually_pow_one_div_le (x : ℝ≥0) {y : ℝ≥0} (hy : 1 < y) :
+  ∀ᶠ (n : ℕ) in at_top, x ^ (1 / n : ℝ) ≤ y :=
 begin
-  obtain ⟨m, hm⟩ := add_one_pow_unbounded_of_pos x (tsub_pos_of_lt hε),
-  rw [tsub_add_cancel_of_le hε.le] at hm,
+  obtain ⟨m, hm⟩ := add_one_pow_unbounded_of_pos x (tsub_pos_of_lt hy),
+  rw [tsub_add_cancel_of_le hy.le] at hm,
   refine eventually_at_top.2 ⟨m + 1, λ n hn, _⟩,
   simpa only [nnreal.rpow_one_div_le_iff (nat.cast_pos.2 $ m.succ_pos.trans_le hn),
-    nnreal.rpow_nat_cast] using hm.le.trans (pow_le_pow hε.le (m.le_succ.trans hn)),
+    nnreal.rpow_nat_cast] using hm.le.trans (pow_le_pow hy.le (m.le_succ.trans hn)),
 end
 
 end nnreal
@@ -2013,14 +2013,14 @@ begin
   exact_mod_cast hc a (by exact_mod_cast ha),
 end
 
-lemma eventually_pow_one_div_le {x : ℝ≥0∞} (hx : x ≠ ∞) {ε : ℝ≥0∞} (hε : 1 < ε) :
-  ∀ᶠ (n : ℕ) in at_top, x ^ (1 / n : ℝ) ≤ ε :=
+lemma eventually_pow_one_div_le {x : ℝ≥0∞} (hx : x ≠ ∞) {y : ℝ≥0∞} (hy : 1 < y) :
+  ∀ᶠ (n : ℕ) in at_top, x ^ (1 / n : ℝ) ≤ y :=
 begin
   lift x to ℝ≥0 using hx,
-  by_cases ε = ∞,
+  by_cases y = ∞,
   { exact eventually_of_forall (λ n, h.symm ▸ le_top) },
-  { lift ε to ℝ≥0 using h,
-    have := nnreal.eventually_pow_one_div_le x (by exact_mod_cast hε : 1 < ε),
+  { lift y to ℝ≥0 using h,
+    have := nnreal.eventually_pow_one_div_le x (by exact_mod_cast hy : 1 < y),
     refine this.congr (eventually_of_forall $ λ n, _),
     rw [coe_rpow_of_nonneg x (by positivity : 0 ≤ (1 / n : ℝ)), coe_le_coe] },
 end

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1442,6 +1442,16 @@ begin
   rw [←nnreal.coe_rpow, real.to_nnreal_coe],
 end
 
+lemma eventually_pow_one_div_le (x : ℝ≥0) {ε : ℝ≥0} (hε : 1 < ε) :
+  ∀ᶠ (n : ℕ) in at_top, x ^ (1 / n : ℝ) ≤ ε :=
+begin
+  obtain ⟨m, hm⟩ := add_one_pow_unbounded_of_pos x (tsub_pos_of_lt hε),
+  rw [tsub_add_cancel_of_le hε.le] at hm,
+  refine eventually_at_top.2 ⟨m + 1, λ n hn, _⟩,
+  simpa only [nnreal.rpow_one_div_le_iff (nat.cast_pos.2 $ m.succ_pos.trans_le hn),
+    nnreal.rpow_nat_cast] using hm.le.trans (pow_le_pow hε.le (m.le_succ.trans hn)),
+end
+
 end nnreal
 
 namespace real
@@ -2001,6 +2011,18 @@ begin
   change ↑c < ↑a at ha,
   rw coe_rpow_of_nonneg _ hy.le,
   exact_mod_cast hc a (by exact_mod_cast ha),
+end
+
+lemma eventually_pow_one_div_le {x : ℝ≥0∞} (hx : x ≠ ∞) {ε : ℝ≥0∞} (hε : 1 < ε) :
+  ∀ᶠ (n : ℕ) in at_top, x ^ (1 / n : ℝ) ≤ ε :=
+begin
+  lift x to ℝ≥0 using hx,
+  by_cases ε = ∞,
+  { exact eventually_of_forall (λ n, h.symm ▸ le_top) },
+  { lift ε to ℝ≥0 using h,
+    have := nnreal.eventually_pow_one_div_le x (by exact_mod_cast hε : 1 < ε),
+    refine this.congr (eventually_of_forall $ λ n, _),
+    rw [coe_rpow_of_nonneg x (by positivity : 0 ≤ (1 / n : ℝ)), coe_le_coe] },
 end
 
 private lemma continuous_at_rpow_const_of_pos {x : ℝ≥0∞} {y : ℝ} (h : 0 < y) :

--- a/src/topology/algebra/module/character_space.lean
+++ b/src/topology/algebra/module/character_space.lean
@@ -87,6 +87,9 @@ def to_non_unital_alg_hom (φ : character_space 𝕜 A) : A →ₙₐ[𝕜] 𝕜
 @[simp]
 lemma coe_to_non_unital_alg_hom (φ : character_space 𝕜 A) : ⇑(to_non_unital_alg_hom φ) = φ := rfl
 
+instance [subsingleton A] : is_empty (character_space 𝕜 A) :=
+⟨λ φ, φ.prop.1 $ continuous_linear_map.ext (λ x, by simp only [subsingleton.elim x 0, map_zero])⟩
+
 variables (𝕜 A)
 
 lemma union_zero :


### PR DESCRIPTION
When this file and its main results were created, mathlib had a different definition of `normed_algebra` which automatically entailed `norm_one_class`. When `normed_algebra` was refactored, this hypothesis was added everywhere it was needed, including this file. However, most of the main results here are independent of that assumption, but the proof requires slightly more work. 

Here, we do that work so that we can remove these hypotheses here and a few places downstream. For a few results, we provide both the `norm_one_class` version, and the version without it for convenience (especially because any nontrivial cstar_ring automatically satisfies `norm_one_class`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
