### PR TITLE
feat(analysis/normed_space/category/CStarAlg): categories of C⋆-algebras

### DIFF
--- a/src/algebra/star/star_alg_hom.lean
+++ b/src/algebra/star/star_alg_hom.lean
@@ -40,6 +40,15 @@ TODO: add `star_alg_equiv`.
 non-unital, algebra, morphism, star
 -/
 
+------------------ prereq
+@[priority 100] -- See note [lower instance priority]
+instance non_unital_alg_hom_class.non_unital_ring_hom_class
+  (F R A B : Type*) [monoid R] [non_unital_non_assoc_semiring A] [distrib_mul_action R A]
+  [non_unital_non_assoc_semiring B] [distrib_mul_action R B]
+  [hF : non_unital_alg_hom_class F R A B] : non_unital_ring_hom_class F A B :=
+{ coe := coe_fn, .. hF }
+------------------ prereq
+
 set_option old_structure_cmd true
 
 /-! ### Non-unital star algebra homomorphisms -/
@@ -247,6 +256,8 @@ instance : star_alg_hom_class (A →⋆ₐ[R] B) R A B :=
 directly. -/
 instance : has_coe_to_fun (A →⋆ₐ[R] B) (λ _, A → B) := fun_like.has_coe_to_fun
 
+initialize_simps_projections star_alg_hom (to_fun → apply)
+
 @[simp] lemma coe_to_alg_hom {f : A →⋆ₐ[R] B} :
   (f.to_alg_hom : A → B) = f := rfl
 
@@ -436,3 +447,221 @@ their codomains. -/
   right_inv := λ f, by ext; refl }
 
 end star_alg_hom
+
+/-! ### Star algebra equivalences -/
+
+/-- A *⋆-algebra* equivalence is an equivalence preserving addition, multiplication, scalar
+multiplication and the star operation, which allows for considering both unital and non-unital
+equivalences with a single structure.  Currently, `alg_equiv` requires unital algebras, which is
+why this structure does not extend it. -/
+structure star_alg_equiv (R A B : Type*) [has_add A] [has_mul A] [has_smul R A] [has_star A]
+  [has_add B] [has_mul B] [has_smul R B] [has_star B] extends A ≃+* B :=
+(map_star' : ∀ a : A, to_fun (star a) = star (to_fun a))
+(map_smul' : ∀ (r : R) (a : A), to_fun (r • a) = r • to_fun a)
+
+infixr ` ≃⋆ₐ `:25 := star_alg_equiv _
+notation A ` ≃⋆ₐ[`:25 R `] ` B := star_alg_equiv R A B
+
+/-- Reinterpret a star algebra equivalence as a `ring_equiv` by forgetting the interaction with
+the star operation and scalar multiplication. -/
+add_decl_doc star_alg_equiv.to_ring_equiv
+
+/-- `star_alg_equiv_class F R A B` asserts `F` is a type of bundled ⋆-algebra equivalences between
+`A` and `B`.
+
+You should also extend this typeclass when you extend `star_alg_equiv`. -/
+class star_alg_equiv_class (F : Type*) (R : out_param Type*) (A : out_param Type*)
+  (B : out_param Type*) [has_add A] [has_mul A] [has_smul R A] [has_star A] [has_add B] [has_mul B]
+  [has_smul R B] [has_star B] extends ring_equiv_class F A B :=
+(map_star : ∀ (f : F) (a : A), f (star a) = star (f a))
+(map_smul : ∀ (f : F) (r : R) (a : A), f (r • a) = r • f a)
+
+-- `R` becomes a metavariable but that's fine because it's an `out_param`
+attribute [nolint dangerous_instance] star_alg_equiv_class.to_ring_equiv_class
+
+namespace star_alg_equiv_class
+
+@[priority 50] -- See note [lower instance priority]
+instance {F R A B : Type*} [has_add A] [has_mul A] [has_smul R A] [has_star A] [has_add B]
+  [has_mul B] [has_smul R B] [has_star B] [hF : star_alg_equiv_class F R A B] :
+  star_hom_class F A B :=
+{ coe := λ f, f,
+  coe_injective' := fun_like.coe_injective,
+  .. hF }
+
+-- `R` becomes a metavariable but that's fine because it's an `out_param`
+attribute [nolint dangerous_instance] star_alg_equiv_class.star_hom_class
+
+@[priority 50] -- See note [lower instance priority]
+instance {F R A B : Type*} [has_add A] [has_mul A] [has_star A] [has_smul R A] [has_add B]
+  [has_mul B] [has_smul R B] [has_star B] [hF : star_alg_equiv_class F R A B] :
+  smul_hom_class F R A B :=
+{ coe := λ f, f,
+  coe_injective' := fun_like.coe_injective,
+  .. hF }
+
+-- `R` becomes a metavariable but that's fine because it's an `out_param`
+attribute [nolint dangerous_instance] star_alg_equiv_class.smul_hom_class
+
+@[priority 100] -- See note [lower instance priority]
+instance {F R A B : Type*} [monoid R] [non_unital_non_assoc_semiring A] [distrib_mul_action R A]
+  [has_star A] [non_unital_non_assoc_semiring B] [distrib_mul_action R B] [has_star B]
+  [hF : star_alg_equiv_class F R A B] : non_unital_star_alg_hom_class F R A B :=
+{ coe := λ f, f,
+  coe_injective' := fun_like.coe_injective,
+  map_zero := map_zero,
+  .. hF }
+
+@[priority 100] -- See note [lower instance priority]
+instance (F R A B : Type*) [comm_semiring R] [semiring A] [algebra R A] [has_star A]
+  [semiring B] [algebra R B] [has_star B] [hF : star_alg_equiv_class F R A B] :
+  star_alg_hom_class F R A B :=
+{ coe := λ f, f,
+  coe_injective' := fun_like.coe_injective,
+  map_one := map_one,
+  map_zero := map_zero,
+  commutes := λ f r, by simp only [algebra.algebra_map_eq_smul_one, map_smul, map_one],
+  .. hF}
+
+end star_alg_equiv_class
+
+namespace star_alg_equiv
+
+variables {F R A B C : Type*}
+  [has_add A] [has_mul A] [has_smul R A] [has_star A]
+  [has_add B] [has_mul B] [has_smul R B] [has_star B]
+  [has_add C] [has_mul C] [has_smul R C] [has_star C]
+  (e : A ≃⋆ₐ[R] B)
+
+instance : star_alg_equiv_class (A ≃⋆ₐ[R] B) R A B :=
+{ coe := to_fun,
+  inv := inv_fun,
+  left_inv := left_inv,
+  right_inv := right_inv,
+  coe_injective' := λ f g h₁ h₂, by { cases f, cases g, congr' },
+  map_mul := map_mul',
+  map_add := map_add',
+  map_star := map_star',
+  map_smul := map_smul' }
+
+/--  Helper instance for when there's too many metavariables to apply
+`fun_like.has_coe_to_fun` directly. -/
+instance : has_coe_to_fun (A ≃⋆ₐ[R] B) (λ _, A → B) := ⟨star_alg_equiv.to_fun⟩
+
+@[ext]
+lemma ext {f g : A ≃⋆ₐ[R] B} (h : ∀ a, f a = g a) : f = g := fun_like.ext f g h
+
+---- `copy` and other lemmas?
+
+
+/-- Star algebra equivalences are reflexive. -/
+@[refl] def refl : A ≃⋆ₐ[R] A := { map_smul' := λ r a, rfl, map_star' := λ a, rfl, ..(1 : A ≃+* A) }
+
+instance : inhabited (A ≃⋆ₐ[R] A) := ⟨refl⟩
+
+@[simp] lemma coe_refl : ⇑(refl : A ≃⋆ₐ[R] A) = id := rfl
+
+/-- Star algebra equivalences are symmetric. -/
+@[symm]
+def symm (e : A ≃⋆ₐ[R] B) : B ≃⋆ₐ[R] A :=
+{ map_star' := λ b, by simpa only [e.left_inv (star (e.inv_fun b)), e.right_inv b]
+    using congr_arg e.inv_fun (e.map_star' (e.inv_fun b)).symm,
+  map_smul' := λ r b, by simpa only [e.left_inv (r • e.inv_fun b), e.right_inv b]
+    using congr_arg e.inv_fun (e.map_smul' r (e.inv_fun b)).symm,
+  ..e.to_ring_equiv.symm, }
+
+/-- See Note [custom simps projection] -/
+def simps.symm_apply (e : A ≃⋆ₐ[R] B) : B → A := e.symm
+
+initialize_simps_projections star_alg_equiv (to_fun → apply, inv_fun → simps.symm_apply)
+
+@[simp] lemma inv_fun_eq_symm {e : A ≃⋆ₐ[R] B} : e.inv_fun = e.symm := rfl
+
+@[simp] lemma symm_symm (e : A ≃⋆ₐ[R] B) : e.symm.symm = e :=
+by { ext, refl, }
+
+lemma symm_bijective : function.bijective (symm : (A ≃⋆ₐ[R] B) → (B ≃⋆ₐ[R] A)) :=
+equiv.bijective ⟨symm, symm, symm_symm, symm_symm⟩
+
+@[simp] lemma mk_coe' (e : A ≃⋆ₐ[R] B) (f h₁ h₂ h₃ h₄ h₅ h₆) :
+  (⟨f, e, h₁, h₂, h₃, h₄, h₅, h₆⟩ : B ≃⋆ₐ[R] A) = e.symm :=
+symm_bijective.injective $ ext $ λ x, rfl
+
+@[simp] lemma symm_mk (f f') (h₁ h₂ h₃ h₄ h₅ h₆) :
+  (⟨f, f', h₁, h₂, h₃, h₄, h₅, h₆⟩ : A ≃⋆ₐ[R] B).symm =
+  { to_fun := f', inv_fun := f,
+    ..(⟨f, f', h₁, h₂, h₃, h₄, h₅, h₆⟩ : A ≃⋆ₐ[R] B).symm } := rfl
+
+@[simp] lemma refl_symm : (star_alg_equiv.refl : A ≃⋆ₐ[R] A).symm = star_alg_equiv.refl := rfl
+
+@[simp] lemma to_ring_equiv_symm (f : A ≃⋆ₐ[R] B) : (f : A ≃+* B).symm = f.symm := rfl
+
+@[simp] lemma symm_to_ring_equiv : (e.symm : B ≃+* A) = (e : A ≃+* B).symm := rfl
+
+/-- Star algebra equivalences are transitive. -/
+@[trans]
+def trans (e₁ : A ≃⋆ₐ[R] B) (e₂ : B ≃⋆ₐ[R] C) : A ≃⋆ₐ[R] C :=
+{ map_smul' := λ r a, show e₂.to_fun (e₁.to_fun (r • a)) = r • e₂.to_fun (e₁.to_fun a),
+    by rw [e₁.map_smul', e₂.map_smul'],
+  map_star' := λ a, show e₂.to_fun (e₁.to_fun (star a)) = star (e₂.to_fun (e₁.to_fun a)),
+    by rw [e₁.map_star', e₂.map_star'],
+  ..(e₁.to_ring_equiv.trans e₂.to_ring_equiv), }
+
+@[simp] lemma apply_symm_apply (e : A ≃⋆ₐ[R] B) : ∀ x, e (e.symm x) = x :=
+  e.to_ring_equiv.apply_symm_apply
+
+@[simp] lemma symm_apply_apply (e : A ≃⋆ₐ[R] B) : ∀ x, e.symm (e x) = x :=
+  e.to_ring_equiv.symm_apply_apply
+
+@[simp] lemma symm_trans_apply (e₁ : A ≃⋆ₐ[R] B) (e₂ : B ≃⋆ₐ[R] C) (x : C) :
+  (e₁.trans e₂).symm x = e₁.symm (e₂.symm x) := rfl
+
+@[simp] lemma coe_trans (e₁ : A ≃⋆ₐ[R] B) (e₂ : B ≃⋆ₐ[R] C) :
+  ⇑(e₁.trans e₂) = e₂ ∘ e₁ := rfl
+
+@[simp] lemma trans_apply (e₁ : A ≃⋆ₐ[R] B) (e₂ : B ≃⋆ₐ[R] C) (x : A) :
+  (e₁.trans e₂) x = e₂ (e₁ x) := rfl
+
+theorem left_inverse_symm (e : A ≃⋆ₐ[R] B) : function.left_inverse e.symm e := e.left_inv
+
+theorem right_inverse_symm (e : A ≃⋆ₐ[R] B) : function.right_inverse e.symm e := e.right_inv
+
+/-- If a (unital or non-unital) star algebra morphism has an inverse, it is an isomorphism of
+star algebras. -/
+@[simps] def of_star_alg_hom {F G R A B : Type*} [monoid R]
+  [non_unital_non_assoc_semiring A] [distrib_mul_action R A] [has_star A]
+  [non_unital_non_assoc_semiring B] [distrib_mul_action R B] [has_star B]
+  [non_unital_star_alg_hom_class F R A B] [non_unital_star_alg_hom_class G R B A]
+  (f : F) (g : G) (h₁ : ∀ x, g (f x) = x) (h₂ : ∀ x, f (g x) = x) : A ≃⋆ₐ[R] B :=
+{ to_fun    := f,
+  inv_fun   := g,
+  left_inv  := h₁,
+  right_inv := h₂,
+  map_add' := map_add f,
+  map_mul' := map_mul f,
+  map_smul' := map_smul f,
+  map_star' := map_star f }
+
+/-- Promotes a bijective star algebra homomorphism to a star algebra equivalence. -/
+noncomputable def of_bijective {F R A B : Type*} [monoid R]
+  [non_unital_non_assoc_semiring A] [distrib_mul_action R A] [has_star A]
+  [non_unital_non_assoc_semiring B] [distrib_mul_action R B] [has_star B]
+  [non_unital_star_alg_hom_class F R A B] (f : F) (hf : function.bijective f) : A ≃⋆ₐ[R] B :=
+{ to_fun := f,
+  map_star' := map_star f,
+  map_smul' := map_smul f,
+  .. ring_equiv.of_bijective f (hf : function.bijective (f : A → B)), }
+
+@[simp] lemma coe_of_bijective {F R A B : Type*} [monoid R]
+  [non_unital_non_assoc_semiring A] [distrib_mul_action R A] [has_star A]
+  [non_unital_non_assoc_semiring B] [distrib_mul_action R B] [has_star B]
+  [non_unital_star_alg_hom_class F R A B] {f : F} (hf : function.bijective f) :
+  (star_alg_equiv.of_bijective f hf : A → B) = f := rfl
+
+lemma of_bijective_apply {F R A B : Type*} [monoid R]
+  [non_unital_non_assoc_semiring A] [distrib_mul_action R A] [has_star A]
+  [non_unital_non_assoc_semiring B] [distrib_mul_action R B] [has_star B]
+  [non_unital_star_alg_hom_class F R A B] {f : F} (hf : function.bijective f) (a : A) :
+  (star_alg_equiv.of_bijective f hf) a = f a := rfl
+
+end star_alg_equiv

--- a/src/analysis/normed_space/category/CStarAlg.lean
+++ b/src/analysis/normed_space/category/CStarAlg.lean
@@ -11,8 +11,6 @@ import category_theory.elementwise
 import category_theory.concrete_category.reflects_isomorphisms
 import algebra.category.Algebra.basic
 
-.
-
 /-!
 # Category instances for C⋆-algebras.
 

--- a/src/analysis/normed_space/category/CStarAlg.lean
+++ b/src/analysis/normed_space/category/CStarAlg.lean
@@ -17,11 +17,14 @@ import algebra.category.Algebra.basic
 # Category instances for C⋆-algebras.
 
 We introduce the bundled categories:
-* `CStarAlg`
-* `CStarAlg₁`
-* `CommCStarAlg` -- actually we have to hold off on this
-* `CommCStarAlg₁`
+* `CStarAlg`: not necessarily unital C⋆-algebras with `non_unital_star_alg_hom`s
+* `CStarAlg₁`: unital C⋆-algebras with `star_alg_hom`s
+* `CommCStarAlg₁`: commutative unital C⋆-algebras with `star_alg_hom`s
 along with the relevant forgetful functors between them.
+
+## TODO
+
+* add `CommCStarAlg` once we have `non_unital_normed_comm_ring`
 -/
 
 section prerequisites
@@ -88,20 +91,6 @@ structure CStarAlg₁ :=
 [is_normed_algebra : normed_algebra ℂ α]
 [is_star_module : star_module ℂ α]
 [is_complete_space : complete_space α]
-
-/-
-/-- The type of commutative C⋆-algebras with ⋆-algebra morphisms. -/
-structure CommCStarAlg :=
-(α : Type u)
-[is_non_unital_normed_comm_ring : non_unital_normed_comm_ring α]
-[is_star_ring : star_ring α]
-[is_cstar_ring : cstar_ring α]
-[is_normed_space : normed_space ℂ α]
-[is_is_scalar_tower : is_scalar_tower ℂ α α]
-[is_smul_comm_class : smul_comm_class ℂ α α]
-[is_star_module : star_module ℂ α]
-[is_complete_space : complete_space α]
--/
 
 /-- The type of commutative unital C⋆-algebras with unital ⋆-algebra morphisms. -/
 structure CommCStarAlg₁ :=
@@ -195,11 +184,6 @@ noncomputable instance has_forget_to_Algebra : has_forget₂ CStarAlg₁ (Algebr
   { obj := λ A, ⟨A⟩,
     map := λ A B f, f.to_alg_hom } }
 
-/- need more imports for this, and probably we can get stronger statements, like `lipschitz_with 1`
-Any morphism of `CStarAlg₁` is continuous.
-lemma iso_of_bijective {X Y : CStarAlg₁.{u}} (f : X ⟶ Y) : continuous f :=
-map_continuous (f : X →⋆ₐ[ℂ] Y) -/
-
 end CStarAlg₁
 
 namespace CommCStarAlg₁
@@ -231,11 +215,6 @@ instance has_forget_to_CStarAlg₁ : has_forget₂ CommCStarAlg₁ CStarAlg₁ :
 { forget₂ :=
   { obj := λ A, ⟨A⟩,
     map := λ A B f, f } }
-
-/- need more imports for this, and probably we can get stronger statements, like `lipschitz_with 1`
-Any morphism of `CStarAlg₁` is continuous.
-lemma iso_of_bijective {X Y : CStarAlg₁.{u}} (f : X ⟶ Y) : continuous f :=
-map_continuous (f : X →⋆ₐ[ℂ] Y) -/
 
 end CommCStarAlg₁
 

--- a/src/analysis/normed_space/star/CStarAlg.lean
+++ b/src/analysis/normed_space/star/CStarAlg.lean
@@ -1,10 +1,27 @@
+/-
+Copyright (c) 2022 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+
 import algebra.star.star_alg_hom
 import analysis.normed_space.star.basic
-import category_theory.concrete_category.basic
 import analysis.complex.basic
+import category_theory.elementwise
+import category_theory.concrete_category.reflects_isomorphisms
 
 .
 
+/-!
+# Category instances for C⋆-algebras.
+
+We introduce the bundled categories:
+* `CStarAlg`
+* `CStarAlg₁`
+* `CommCStarAlg` -- actually we have to hold off on this
+* `CommCStarAlg₁`
+along with the relevant forgetful functors between them.
+-/
 
 section prerequisites
 
@@ -49,7 +66,19 @@ universes u v
 
 open category_theory
 
-/-- The type of unital C⋆-algebras -/
+/-- The type of C⋆-algebras with ⋆-algebra morphisms. -/
+structure CStarAlg :=
+(α : Type u)
+[is_non_unital_normed_ring : non_unital_normed_ring α]
+[is_star_ring : star_ring α]
+[is_cstar_ring : cstar_ring α]
+[is_normed_space : normed_space ℂ α]
+[is_is_scalar_tower : is_scalar_tower ℂ α α]
+[is_smul_comm_class : smul_comm_class ℂ α α]
+[is_star_module : star_module ℂ α]
+[is_complete_space : complete_space α]
+
+/-- The type of unital C⋆-algebras with unital ⋆-algebra morphisms. -/
 structure CStarAlg₁ :=
 (α : Type u)
 [is_normed_ring : normed_ring α]
@@ -59,11 +88,82 @@ structure CStarAlg₁ :=
 [is_star_module : star_module ℂ α]
 [is_complete_space : complete_space α]
 
+/-
+/-- The type of commutative C⋆-algebras with ⋆-algebra morphisms. -/
+structure CommCStarAlg :=
+(α : Type u)
+[is_non_unital_normed_comm_ring : non_unital_normed_comm_ring α]
+[is_star_ring : star_ring α]
+[is_cstar_ring : cstar_ring α]
+[is_normed_space : normed_space ℂ α]
+[is_is_scalar_tower : is_scalar_tower ℂ α α]
+[is_smul_comm_class : smul_comm_class ℂ α α]
+[is_star_module : star_module ℂ α]
+[is_complete_space : complete_space α]
+-/
+
+/-- The type of commutative unital C⋆-algebras with unital ⋆-algebra morphisms. -/
+structure CommCStarAlg₁ :=
+(α : Type u)
+[is_normed_comm_ring : normed_comm_ring α]
+[is_star_ring : star_ring α]
+[is_cstar_ring : cstar_ring α]
+[is_normed_algebra : normed_algebra ℂ α]
+[is_star_module : star_module ℂ α]
+[is_complete_space : complete_space α]
+
+namespace CStarAlg
+
+noncomputable instance : inhabited CStarAlg := ⟨⟨ℂ⟩⟩
+
+instance : has_coe_to_sort CStarAlg (Type u) := ⟨CStarAlg.α⟩
+
+attribute [instance] is_non_unital_normed_ring is_star_ring is_cstar_ring is_normed_space
+  is_is_scalar_tower is_smul_comm_class is_star_module is_complete_space
+
+noncomputable instance : category CStarAlg.{u} :=
+{ hom := λ A B, A →⋆ₙₐ[ℂ] B,
+  id := λ A, non_unital_star_alg_hom.id ℂ A,
+  comp := λ A B C f g, g.comp f }
+
+noncomputable instance : concrete_category CStarAlg.{u} :=
+{ forget := { obj := λ A, A, map := λ A B f, f },
+  forget_faithful := { } }
+
+/-- Construct a bundled `CStarAlg` from the underlying typa and appropriate type classes. -/
+def of (A : Type u) [non_unital_normed_ring A] [star_ring A] [cstar_ring A] [normed_space ℂ A]
+  [is_scalar_tower ℂ A A] [smul_comm_class ℂ A A] [star_module ℂ A] [complete_space A] :
+  CStarAlg := ⟨A⟩
+
+@[simp] lemma coe_of (A : Type u) [non_unital_normed_ring A] [star_ring A] [cstar_ring A]
+  [normed_space ℂ A] [is_scalar_tower ℂ A A] [smul_comm_class ℂ A A] [star_module ℂ A]
+  [complete_space A] : (of A : Type u) = A := rfl
+
+instance forget_non_unital_normed_ring (A : CStarAlg) :
+  non_unital_normed_ring ((forget CStarAlg).obj A) :=
+A.is_non_unital_normed_ring
+instance forget_star_ring (A : CStarAlg) : star_ring ((forget CStarAlg).obj A) :=
+A.is_star_ring
+instance forget_cstar_ring (A : CStarAlg) : cstar_ring ((forget CStarAlg).obj A) :=
+A.is_cstar_ring
+instance forget_normed_space (A : CStarAlg) : normed_space ℂ ((forget CStarAlg).obj A) :=
+A.is_normed_space
+instance forget_is_scalar_tower (A : CStarAlg) :
+  is_scalar_tower ℂ ((forget CStarAlg).obj A) ((forget CStarAlg).obj A) := A.is_is_scalar_tower
+instance forget_is_smul_comm_class (A : CStarAlg) :
+  smul_comm_class ℂ ((forget CStarAlg).obj A) ((forget CStarAlg).obj A) := A.is_smul_comm_class
+instance forget_star_module (A : CStarAlg) : star_module ℂ ((forget CStarAlg).obj A) :=
+A.is_star_module
+instance forget_complete_space (A : CStarAlg) : complete_space ((forget CStarAlg).obj A) :=
+A.is_complete_space
+
+end CStarAlg
+
 namespace CStarAlg₁
 
 noncomputable instance : inhabited CStarAlg₁ := ⟨⟨ℂ⟩⟩
 
-instance : has_coe_to_sort CStarAlg₁ (Type u) := ⟨CStarAlg₁.α⟩
+instance : has_coe_to_sort CStarAlg₁ Type* := ⟨CStarAlg₁.α⟩
 
 attribute [instance] is_normed_ring is_star_ring is_cstar_ring is_normed_algebra is_star_module
   is_complete_space
@@ -84,18 +184,10 @@ def of (A : Type u) [normed_ring A] [star_ring A] [cstar_ring A] [normed_algebra
 @[simp] lemma coe_of (A : Type u) [normed_ring A] [star_ring A] [cstar_ring A] [normed_algebra ℂ A]
   [star_module ℂ A] [complete_space A] : (of A : Type u) = A := rfl
 
-instance forget_normed_ring (A : CStarAlg₁) : normed_ring ((forget CStarAlg₁).obj A) :=
-A.is_normed_ring
-instance forget_star_ring (A : CStarAlg₁) : star_ring ((forget CStarAlg₁).obj A) :=
-A.is_star_ring
-instance forget_cstar_ring (A : CStarAlg₁) : cstar_ring ((forget CStarAlg₁).obj A) :=
-A.is_cstar_ring
-instance forget_normed_algebra (A : CStarAlg₁) : normed_algebra ℂ ((forget CStarAlg₁).obj A) :=
-A.is_normed_algebra
-instance forget_star_module (A : CStarAlg₁) : star_module ℂ ((forget CStarAlg₁).obj A) :=
-A.is_star_module
-instance forget_complete_space (A : CStarAlg₁) : complete_space ((forget CStarAlg₁).obj A) :=
-A.is_complete_space
+noncomputable instance has_forget_to_CStarAlg : has_forget₂ CStarAlg₁ CStarAlg :=
+{ forget₂ :=
+  { obj := λ A, ⟨A⟩,
+    map := λ A B f, (f : A →⋆ₙₐ[ℂ] B), } }
 
 /- need more imports for this, and probably we can get stronger statements, like `lipschitz_with 1`
 Any morphism of `CStarAlg₁` is continuous.
@@ -104,7 +196,56 @@ map_continuous (f : X →⋆ₐ[ℂ] Y) -/
 
 end CStarAlg₁
 
+namespace CommCStarAlg₁
+
+noncomputable instance : inhabited CommCStarAlg₁ := ⟨⟨ℂ⟩⟩
+
+instance : has_coe_to_sort CommCStarAlg₁ Type* := ⟨CommCStarAlg₁.α⟩
+
+attribute [instance] is_normed_comm_ring is_star_ring is_cstar_ring is_normed_algebra is_star_module
+  is_complete_space
+
+noncomputable instance : category CommCStarAlg₁.{u} :=
+{ hom := λ A B, A →⋆ₐ[ℂ] B,
+  id := λ A, star_alg_hom.id ℂ A,
+  comp := λ A B C f g, g.comp f }
+
+noncomputable instance : concrete_category CommCStarAlg₁.{u} :=
+{ forget := { obj := λ A, A, map := λ A B f, f },
+  forget_faithful := { } }
+
+/-- Construct a bundled `CommCStarAlg₁` from the underlying typa and appropriate type classes. -/
+def of (A : Type u) [normed_comm_ring A] [star_ring A] [cstar_ring A] [normed_algebra ℂ A]
+  [star_module ℂ A] [complete_space A] : CommCStarAlg₁ := ⟨A⟩
+
+@[simp] lemma coe_of (A : Type u) [normed_comm_ring A] [star_ring A] [cstar_ring A]
+  [normed_algebra ℂ A] [star_module ℂ A] [complete_space A] : (of A : Type u) = A := rfl
+
+instance has_forget_to_CStarAlg₁ : has_forget₂ CommCStarAlg₁ CStarAlg₁ :=
+{ forget₂ :=
+  { obj := λ A, ⟨A⟩,
+    map := λ A B f, f } }
+
+/- need more imports for this, and probably we can get stronger statements, like `lipschitz_with 1`
+Any morphism of `CStarAlg₁` is continuous.
+lemma iso_of_bijective {X Y : CStarAlg₁.{u}} (f : X ⟶ Y) : continuous f :=
+map_continuous (f : X →⋆ₐ[ℂ] Y) -/
+
+end CommCStarAlg₁
+
 namespace star_alg_equiv
+
+/-- Build an isomorphism in the category `CStarAlg` from a `star_alg_equiv` between C⋆-algebras -/
+@[simps]
+noncomputable def to_CStarAlg_iso {A B : Type u} [non_unital_normed_ring A] [star_ring A]
+  [cstar_ring A] [normed_space ℂ A] [is_scalar_tower ℂ A A] [smul_comm_class ℂ A A]
+  [star_module ℂ A] [complete_space A] [non_unital_normed_ring B] [star_ring B] [cstar_ring B]
+  [normed_space ℂ B] [is_scalar_tower ℂ B B] [smul_comm_class ℂ B B] [star_module ℂ B]
+  [complete_space B] (e : A ≃⋆ₐ[ℂ] B) : CStarAlg.of A ≅ CStarAlg.of B :=
+{ hom := (e : A →⋆ₙₐ[ℂ] B),
+  inv := (e.symm : B →⋆ₙₐ[ℂ] A),
+  hom_inv_id' := non_unital_star_alg_hom.ext $ λ _, e.symm_apply_apply _,
+  inv_hom_id' := non_unital_star_alg_hom.ext $ λ _, e.apply_symm_apply _ }
 
 /-- Build an isomorphism in the category `CStarAlg₁` from a `star_alg_equiv` between unital
 C⋆-algebras -/
@@ -118,4 +259,81 @@ noncomputable def to_CStarAlg₁_iso {A B : Type u} [normed_ring A] [star_ring A
   hom_inv_id' := star_alg_hom.ext $ λ _, e.symm_apply_apply _,
   inv_hom_id' := star_alg_hom.ext $ λ _, e.apply_symm_apply _ }
 
+/-- Build an isomorphism in the category `CommCStarAlg₁` from a `star_alg_equiv` between
+commutative unital C⋆-algebras -/
+@[simps]
+noncomputable def to_CommCStarAlg₁_iso {A B : Type u} [normed_comm_ring A] [star_ring A]
+  [cstar_ring A] [normed_algebra ℂ A] [star_module ℂ A] [complete_space A] [normed_comm_ring B]
+  [star_ring B] [cstar_ring B] [normed_algebra ℂ B] [star_module ℂ B] [complete_space B]
+  (e : A ≃⋆ₐ[ℂ] B) : CommCStarAlg₁.of A ≅ CommCStarAlg₁.of B :=
+{ hom := (e : A →⋆ₐ[ℂ] B),
+  inv := (e.symm : B →⋆ₐ[ℂ] A),
+  hom_inv_id' := star_alg_hom.ext $ λ _, e.symm_apply_apply _,
+  inv_hom_id' := star_alg_hom.ext $ λ _, e.apply_symm_apply _ }
+
 end star_alg_equiv
+
+namespace category_theory.iso
+
+/-- Build a `star_alg_equiv` from an isomorphism in the category `CStarAlg`. -/
+noncomputable def CStarAlg_iso_to_star_alg_equiv {X Y : CStarAlg} (i : X ≅ Y) : X ≃⋆ₐ[ℂ] Y :=
+{ to_fun    := i.hom,
+  inv_fun   := i.inv,
+  left_inv  := i.hom_inv_id_apply,
+  right_inv := i.inv_hom_id_apply,
+  map_add'  := map_add i.hom,
+  map_mul'  := map_mul i.hom,
+  map_smul' := map_smul i.hom,
+  map_star' := map_star i.hom, }
+
+/-- Build a `star_alg_equiv` from an isomorphism in the category `CStarAlg₁`. -/
+noncomputable def CStarAlg₁_iso_to_star_alg_equiv {X Y : CStarAlg₁} (i : X ≅ Y) : X ≃⋆ₐ[ℂ] Y :=
+{ to_fun    := i.hom,
+  inv_fun   := i.inv,
+  left_inv  := i.hom_inv_id_apply,
+  right_inv := i.inv_hom_id_apply,
+  map_add'  := map_add i.hom,
+  map_mul'  := map_mul i.hom,
+  map_smul' := map_smul i.hom,
+  map_star' := map_star i.hom, }
+
+/-- Build a `star_alg_equiv` from an isomorphism in the category `CommCStarAlg₁`. -/
+noncomputable def CommCStarAlg₁_iso_to_star_alg_equiv {X Y : CommCStarAlg₁} (i : X ≅ Y) :
+  X ≃⋆ₐ[ℂ] Y :=
+{ to_fun    := i.hom,
+  inv_fun   := i.inv,
+  left_inv  := i.hom_inv_id_apply,
+  right_inv := i.inv_hom_id_apply,
+  map_add'  := map_add i.hom,
+  map_mul'  := map_mul i.hom,
+  map_smul' := map_smul i.hom,
+  map_star' := map_star i.hom, }
+
+end category_theory.iso
+
+instance CStarAlg.forget_reflects_isos : reflects_isomorphisms (forget CStarAlg.{u}) :=
+{ reflects := λ X Y f _,
+  begin
+    resetI,
+    let i := as_iso ((forget CStarAlg).map f),
+    let e : X ≃⋆ₐ[ℂ] Y := { ..f, ..i.to_equiv },
+    exact ⟨(is_iso.of_iso e.to_CStarAlg_iso).1⟩,
+  end }
+
+instance CStarAlg₁.forget_reflects_isos : reflects_isomorphisms (forget CStarAlg₁.{u}) :=
+{ reflects := λ X Y f _,
+  begin
+    resetI,
+    let i := as_iso ((forget CStarAlg₁).map f),
+    let e : X ≃⋆ₐ[ℂ] Y := { map_smul' := map_smul f, ..f, ..i.to_equiv },
+    exact ⟨(is_iso.of_iso e.to_CStarAlg₁_iso).1⟩,
+  end }
+
+instance CommCStarAlg₁.forget_reflects_isos : reflects_isomorphisms (forget CommCStarAlg₁.{u}) :=
+{ reflects := λ X Y f _,
+  begin
+    resetI,
+    let i := as_iso ((forget CommCStarAlg₁).map f),
+    let e : X ≃⋆ₐ[ℂ] Y := { map_smul' := map_smul f, ..f, ..i.to_equiv },
+    exact ⟨(is_iso.of_iso e.to_CommCStarAlg₁_iso).1⟩,
+  end }

--- a/src/analysis/normed_space/star/CStarAlg.lean
+++ b/src/analysis/normed_space/star/CStarAlg.lean
@@ -9,6 +9,7 @@ import analysis.normed_space.star.basic
 import analysis.complex.basic
 import category_theory.elementwise
 import category_theory.concrete_category.reflects_isomorphisms
+import algebra.category.Algebra.basic
 
 .
 
@@ -188,6 +189,11 @@ noncomputable instance has_forget_to_CStarAlg : has_forget₂ CStarAlg₁ CStarA
 { forget₂ :=
   { obj := λ A, ⟨A⟩,
     map := λ A B f, (f : A →⋆ₙₐ[ℂ] B), } }
+
+noncomputable instance has_forget_to_Algebra : has_forget₂ CStarAlg₁ (Algebra ℂ) :=
+{ forget₂ :=
+  { obj := λ A, ⟨A⟩,
+    map := λ A B f, f.to_alg_hom } }
 
 /- need more imports for this, and probably we can get stronger statements, like `lipschitz_with 1`
 Any morphism of `CStarAlg₁` is continuous.

--- a/src/analysis/normed_space/star/CStarAlg.lean
+++ b/src/analysis/normed_space/star/CStarAlg.lean
@@ -1,0 +1,121 @@
+import algebra.star.star_alg_hom
+import analysis.normed_space.star.basic
+import category_theory.concrete_category.basic
+import analysis.complex.basic
+
+.
+
+
+section prerequisites
+
+namespace non_unital_star_alg_hom
+
+variables {F R A B : Type*} [monoid R] [has_star A] [has_star B] [non_unital_non_assoc_semiring A]
+variables [non_unital_non_assoc_semiring B] [distrib_mul_action R A] [distrib_mul_action R B]
+variables [non_unital_star_alg_hom_class F R A B]
+
+instance  : has_coe_t F (A →⋆ₙₐ[R] B) :=
+{ coe := λ f,
+  { to_fun := f,
+    map_smul' := map_smul f,
+    map_zero' := map_zero f,
+    map_add' := map_add f,
+    map_mul' := map_mul f,
+    map_star' := map_star f } }
+
+@[simp, protected] lemma coe_coe (f : F) : ⇑(f : A →⋆ₙₐ[R] B) = f := rfl
+
+end non_unital_star_alg_hom
+
+namespace star_alg_hom
+variables {F R A B : Type*} [comm_semiring R] [semiring A] [algebra R A] [has_star A] [semiring B]
+variables [algebra R B] [has_star B] [star_alg_hom_class F R A B]
+
+instance  : has_coe_t F (A →⋆ₐ[R] B) :=
+{ coe := λ f,
+  { to_fun := f,
+    map_one' := map_one f,
+    commutes' := alg_hom_class.commutes f,
+    ..(f : A →⋆ₙₐ[R] B) } }
+
+@[simp, protected] lemma coe_coe (f : F) : ⇑(f : A →⋆ₐ[R] B) = f := rfl
+
+end star_alg_hom
+
+end prerequisites
+
+
+universes u v
+
+open category_theory
+
+/-- The type of unital C⋆-algebras -/
+structure CStarAlg₁ :=
+(α : Type u)
+[is_normed_ring : normed_ring α]
+[is_star_ring : star_ring α]
+[is_cstar_ring : cstar_ring α]
+[is_normed_algebra : normed_algebra ℂ α]
+[is_star_module : star_module ℂ α]
+[is_complete_space : complete_space α]
+
+namespace CStarAlg₁
+
+noncomputable instance : inhabited CStarAlg₁ := ⟨⟨ℂ⟩⟩
+
+instance : has_coe_to_sort CStarAlg₁ (Type u) := ⟨CStarAlg₁.α⟩
+
+attribute [instance] is_normed_ring is_star_ring is_cstar_ring is_normed_algebra is_star_module
+  is_complete_space
+
+noncomputable instance : category CStarAlg₁.{u} :=
+{ hom := λ A B, A →⋆ₐ[ℂ] B,
+  id := λ A, star_alg_hom.id ℂ A,
+  comp := λ A B C f g, g.comp f }
+
+noncomputable instance : concrete_category CStarAlg₁.{u} :=
+{ forget := { obj := λ A, A, map := λ A B f, f },
+  forget_faithful := { } }
+
+/-- Construct a bundled `CStarAlg₁` from the underlying typa and appropriate type classes. -/
+def of (A : Type u) [normed_ring A] [star_ring A] [cstar_ring A] [normed_algebra ℂ A]
+  [star_module ℂ A] [complete_space A] : CStarAlg₁ := ⟨A⟩
+
+@[simp] lemma coe_of (A : Type u) [normed_ring A] [star_ring A] [cstar_ring A] [normed_algebra ℂ A]
+  [star_module ℂ A] [complete_space A] : (of A : Type u) = A := rfl
+
+instance forget_normed_ring (A : CStarAlg₁) : normed_ring ((forget CStarAlg₁).obj A) :=
+A.is_normed_ring
+instance forget_star_ring (A : CStarAlg₁) : star_ring ((forget CStarAlg₁).obj A) :=
+A.is_star_ring
+instance forget_cstar_ring (A : CStarAlg₁) : cstar_ring ((forget CStarAlg₁).obj A) :=
+A.is_cstar_ring
+instance forget_normed_algebra (A : CStarAlg₁) : normed_algebra ℂ ((forget CStarAlg₁).obj A) :=
+A.is_normed_algebra
+instance forget_star_module (A : CStarAlg₁) : star_module ℂ ((forget CStarAlg₁).obj A) :=
+A.is_star_module
+instance forget_complete_space (A : CStarAlg₁) : complete_space ((forget CStarAlg₁).obj A) :=
+A.is_complete_space
+
+/- need more imports for this, and probably we can get stronger statements, like `lipschitz_with 1`
+Any morphism of `CStarAlg₁` is continuous.
+lemma iso_of_bijective {X Y : CStarAlg₁.{u}} (f : X ⟶ Y) : continuous f :=
+map_continuous (f : X →⋆ₐ[ℂ] Y) -/
+
+end CStarAlg₁
+
+namespace star_alg_equiv
+
+/-- Build an isomorphism in the category `CStarAlg₁` from a `star_alg_equiv` between unital
+C⋆-algebras -/
+@[simps]
+noncomputable def to_CStarAlg₁_iso {A B : Type u} [normed_ring A] [star_ring A] [cstar_ring A]
+  [normed_algebra ℂ A] [star_module ℂ A] [complete_space A] [normed_ring B] [star_ring B]
+  [cstar_ring B] [normed_algebra ℂ B] [star_module ℂ B] [complete_space B]
+  (e : A ≃⋆ₐ[ℂ] B) : CStarAlg₁.of A ≅ CStarAlg₁.of B :=
+{ hom := (e : A →⋆ₐ[ℂ] B),
+  inv := (e.symm : B →⋆ₐ[ℂ] A),
+  hom_inv_id' := star_alg_hom.ext $ λ _, e.symm_apply_apply _,
+  inv_hom_id' := star_alg_hom.ext $ λ _, e.apply_symm_apply _ }
+
+end star_alg_equiv


### PR DESCRIPTION
This introduces three categories of C⋆-algebras (over `ℂ`), namely:

* `CStarAlg`: not necessarily unital C⋆-algebras with `non_unital_star_alg_hom`s
* `CStarAlg₁`: unital C⋆-algebras with `star_alg_hom`s
* `CommCStarAlg₁`: commutative unital C⋆-algebras with `star_alg_hom`s

We currently have to avoid the natural `CommCStarAlg` because we don't have `non_unital_normed_comm_ring` since #13719 is blocked by timeouts.

- [x] depends on: #16784

---

This is my first foray into category theory in mathlib, so please don't hesitate to tell me I've done something horribly wrong! :smile:

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
