### PR TITLE
[Merged by Bors] - feat(group_theory/transfer): The kernel of the transfer homomorphism `G →* P` is disjoint from every `p`-group

### DIFF
--- a/src/group_theory/transfer.lean
+++ b/src/group_theory/transfer.lean
@@ -172,9 +172,11 @@ noncomputable def transfer_sylow [fintype (G ⧸ (P : subgroup G))] : G →* (P 
 @transfer G _ P P (@subgroup.is_commutative.comm_group G _ P
   ⟨⟨λ a b, subtype.ext (hP (le_normalizer b.2) a a.2)⟩⟩) (monoid_hom.id P) _
 
+variables [fact p.prime] [finite (sylow p G)]
+
 /-- Auxillary lemma in order to state `transfer_sylow_eq_pow`. -/
-lemma transfer_sylow_eq_pow_aux [fact p.prime] [finite (sylow p G)] (g : G) (hg : g ∈ P) (k : ℕ)
-  (g₀ : G) (h : g₀⁻¹ * g ^ k * g₀ ∈ P) : g₀⁻¹ * g ^ k * g₀ = g ^ k :=
+lemma transfer_sylow_eq_pow_aux (g : G) (hg : g ∈ P) (k : ℕ) (g₀ : G) (h : g₀⁻¹ * g ^ k * g₀ ∈ P) :
+  g₀⁻¹ * g ^ k * g₀ = g ^ k :=
 begin
   haveI : (P : subgroup G).is_commutative := ⟨⟨λ a b, subtype.ext (hP (le_normalizer b.2) a a.2)⟩⟩,
   replace hg := (P : subgroup G).pow_mem hg k,
@@ -182,11 +184,35 @@ begin
   exact h.trans (commute.inv_mul_cancel (hP hn (g ^ k) hg).symm),
 end
 
-lemma transfer_sylow_eq_pow [fact p.prime] [finite (sylow p G)] [fintype (G ⧸ (P : subgroup G))]
-  (hP : P.1.normalizer ≤ P.1.centralizer) (g : G) (hg : g ∈ P) :
-  transfer_sylow P hP g = ⟨g ^ (P : subgroup G).index,
-    transfer_eq_pow_aux g (transfer_sylow_eq_pow_aux P hP g hg)⟩ :=
+variables [fintype (G ⧸ (P : subgroup G))]
+
+lemma transfer_sylow_eq_pow (g : G) (hg : g ∈ P) : transfer_sylow P hP g =
+  ⟨g ^ (P : subgroup G).index, transfer_eq_pow_aux g (transfer_sylow_eq_pow_aux P hP g hg)⟩ :=
 by apply transfer_eq_pow
+
+lemma ker_transfer_sylow_disjoint : disjoint (transfer_sylow P hP).ker ↑P :=
+begin
+  intros g hg,
+  obtain ⟨j, hj⟩ := P.2 ⟨g, hg.2⟩,
+  have := pow_gcd_eq_one (⟨g, hg.2⟩ : (P : subgroup G))
+    ((transfer_sylow_eq_pow P hP g hg.2).symm.trans hg.1) hj,
+  rwa [((fact.out p.prime).coprime_pow_of_not_dvd (not_dvd_index_sylow P _)).gcd_eq_one,
+    pow_one, subtype.ext_iff] at this,
+  exact index_ne_zero_of_finite ∘ (relindex_top_right (P : subgroup G)).symm.trans ∘
+    relindex_eq_zero_of_le_right le_top,
+end
+
+lemma ker_transfer_sylow_disjoint' (Q : sylow p G) : disjoint (transfer_sylow P hP).ker ↑Q :=
+begin
+  obtain ⟨g, hg⟩ := exists_smul_eq G Q P,
+  rw [disjoint_iff, ←smul_left_cancel_iff (mul_aut.conj g), smul_bot, smul_inf, smul_normal,
+    ←sylow.coe_subgroup_smul, hg, ←disjoint_iff],
+  exact ker_transfer_sylow_disjoint P hP,
+end
+
+lemma ker_transfer_sylow_disjoint'' (Q : subgroup G) (hQ : is_p_group p Q) :
+  disjoint (transfer_sylow P hP).ker Q :=
+let ⟨R, hR⟩ := hQ.exists_le_sylow in (ker_transfer_sylow_disjoint' P hP R).mono_right hR
 
 end burnside_transfer
 


### PR DESCRIPTION
This PR proves if `P` is a Sylow `p`-subgroup of `G`, then the kernel of the transfer homomorphism `G →* P` is disjoint from every `p`-group. This is getting very close to Burnside's transfer theorem. I also added variables lines for some typeclass assumptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
