### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal/local_ring): add ​local_ring.residue_field.map_id & local_ring.residue_field.map_comp

### DIFF
--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -359,16 +359,16 @@ begin
   exact map_nonunit f a ha
 end
 
-/-- Applying `map` to the identity ring homomorphism gives the identity ring homomorphism. -/
-def map_id :
-  local_ring.residue_field.map(ring_hom.id R) = ring_hom.id (local_ring.residue_field R) :=
+/-- Applying `residue_field.map` to the identity ring homomorphism gives the identity
+ring homomorphism. -/
+lemma map_id :
+  local_ring.residue_field.map (ring_hom.id R) = ring_hom.id (local_ring.residue_field R) :=
 ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
 
 /-- The composite of two `map`s is the `map` of the composite. -/
-lemma map_comp (f : T →+* R) (g : R →+* S)
-[is_local_ring_hom f] [is_local_ring_hom g] :
-  local_ring.residue_field.map(g.comp (f)) =
-  (local_ring.residue_field.map(g)).comp(local_ring.residue_field.map(f)) :=
+lemma map_comp (f : T →+* R) (g : R →+* S) [is_local_ring_hom f] [is_local_ring_hom g] :
+  local_ring.residue_field.map (g.comp f) =
+  (local_ring.residue_field.map g).comp(local_ring.residue_field.map f) :=
 ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
 
 end residue_field

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -368,7 +368,7 @@ ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
 /-- The composite of two `residue_field.map`s is the `residue_field.map` of the composite. -/
 lemma map_comp (f : T →+* R) (g : R →+* S) [is_local_ring_hom f] [is_local_ring_hom g] :
   local_ring.residue_field.map (g.comp f) =
-  (local_ring.residue_field.map g).comp(local_ring.residue_field.map f) :=
+  (local_ring.residue_field.map g).comp (local_ring.residue_field.map f) :=
 ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
 
 end residue_field

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -328,7 +328,7 @@ begin
 end
 
 section
-variables (R) [comm_ring R] [local_ring R] [comm_ring S] [local_ring S]
+variables (R) [comm_ring R] [local_ring R] [comm_ring S] [local_ring S] [comm_ring T] [local_ring T]
 
 /-- The residue field of a local ring is the quotient of the ring by its maximal ideal. -/
 def residue_field := R ⧸ maximal_ideal R
@@ -358,6 +358,18 @@ begin
   erw ideal.quotient.eq_zero_iff_mem,
   exact map_nonunit f a ha
 end
+
+/-- Applying `map` to the identity ring homomorphism gives the identity ring homomorphism. -/
+def map_id :
+  local_ring.residue_field.map(ring_hom.id R) = ring_hom.id (local_ring.residue_field R) :=
+ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
+
+/-- The composite of two `map`s is the `map` of the composite. -/
+lemma map_comp (f : T →+* R) (g : R →+* S)
+[is_local_ring_hom f] [is_local_ring_hom g] :
+  local_ring.residue_field.map(g.comp (f)) =
+  (local_ring.residue_field.map(g)).comp(local_ring.residue_field.map(f)) :=
+ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
 
 end residue_field
 

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -365,7 +365,7 @@ lemma map_id :
   local_ring.residue_field.map (ring_hom.id R) = ring_hom.id (local_ring.residue_field R) :=
 ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
 
-/-- The composite of two `map`s is the `map` of the composite. -/
+/-- The composite of two `residue_field.map`s is the `residue_field.map` of the composite. -/
 lemma map_comp (f : T →+* R) (g : R →+* S) [is_local_ring_hom f] [is_local_ring_hom g] :
   local_ring.residue_field.map (g.comp f) =
   (local_ring.residue_field.map g).comp(local_ring.residue_field.map f) :=


### PR DESCRIPTION
Applying `map` to the identity ring homomorphism gives the identity ring homomorphism. 

The composite of two `map`s is the `map` of the composite.

I need these for my study of the inertia group

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
