### PR TITLE
[Merged by Bors] - chore(.github/CODEOWNERS): two new rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,6 @@
 # Disabled until we have better coverage by other patterns. Reenable in the future.
 # *        @leanprover-community/mathlib-maintainers
 
-src/tactic/             @leanprover-community/mathlib-meta
-
 src/category_theory/    @leanprover-community/mathlib-CT
 
 src/measure_theory/     @leanprover-community/mathlib-meas
@@ -17,3 +15,5 @@ src/algebraic_geometry/ @leanprover-community/mathlib-AG
 src/combinatorics/      @leanprover-community/mathlib-CO
 
 src/probability/        @leanprover-community/mathlib-PR
+
+src/tactic/             @leanprover-community/mathlib-meta

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,19 @@
 # By default, the mathlib maintainers own everything in the repo.
 # Later matches will take precedence over this match.
+
 # Disabled until we have better coverage by other patterns. Reenable in the future.
-# *	@leanprover-community/mathlib-maintainers
+# *        @leanprover-community/mathlib-maintainers
 
-src/tactic/		@leanprover-community/mathlib-meta
+src/tactic/             @leanprover-community/mathlib-meta
 
-src/category_theory/	@leanprover-community/mathlib-CT
+src/category_theory/    @leanprover-community/mathlib-CT
+
+src/measure_theory/     @leanprover-community/mathlib-meas
+
 src/algebraic_topology/ @leanprover-community/mathlib-CT # for now the category theory team can take care of this
 
 src/algebraic_geometry/ @leanprover-community/mathlib-AG
 
-src/combinatorics/ @leanprover-community/mathlib-CO
+src/combinatorics/      @leanprover-community/mathlib-CO
+
+src/probability/        @leanprover-community/mathlib-PR


### PR DESCRIPTION
There is an attempt to order the rules from generic to specific.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
