### PR TITLE
[Merged by Bors] - feat(data/set/fintype): Add `to_finset_nonempty`.

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -655,6 +655,9 @@ multiset.card_map subtype.val finset.univ.val
 @[simp] theorem coe_to_finset (s : set α) [fintype s] : (↑s.to_finset : set α) = s :=
 set.ext $ λ _, mem_to_finset
 
+@[simp] lemma to_finset_nonempty {s : set α} [fintype s] : s.to_finset.nonempty ↔ s.nonempty :=
+by rw [←finset.coe_nonempty, coe_to_finset]
+
 @[simp] theorem to_finset_inj {s t : set α} [fintype s] [fintype t] :
   s.to_finset = t.to_finset ↔ s = t :=
 ⟨λ h, by rw [←s.coe_to_finset, h, t.coe_to_finset], λ h, by simp [h]; congr⟩


### PR DESCRIPTION
We have `finset.nonempty_coe` and `finite.nonempty_to_finset`, but we don't have this for fintypes. This PR adds this lemma.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
