### PR TITLE
[Merged by Bors] - feat(analysis/calculus/cont_diff): strengthen lemma

### DIFF
--- a/src/analysis/asymptotics/asymptotics.lean
+++ b/src/analysis/asymptotics/asymptotics.lean
@@ -467,6 +467,21 @@ is_o.of_is_O_with $ λ c cpos, (h.forall_is_O_with cpos).sup (h'.forall_is_O_wit
 @[simp] lemma is_o_sup : f =o[l ⊔ l'] g ↔ f =o[l] g ∧ f =o[l'] g :=
 ⟨λ h, ⟨h.mono le_sup_left, h.mono le_sup_right⟩, λ h, h.1.sup h.2⟩
 
+lemma is_O_with_insert [topological_space α] {x : α} {s : set α} {C : ℝ} {g : α → E} {g' : α → F}
+  (h : ∥g x∥ ≤ C * ∥g' x∥) :
+  is_O_with C (𝓝[insert x s] x) g g' ↔ is_O_with C (𝓝[s] x) g g' :=
+by simp_rw [is_O_with, nhds_within_insert, eventually_sup, eventually_pure, h, true_and]
+
+lemma is_o_insert [topological_space α] {x : α} {s : set α} {g : α → E'} {g' : α → F'}
+  (h : g x = 0) : g =o[𝓝[insert x s] x] g' ↔ g =o[𝓝[s] x] g' :=
+begin
+  simp_rw [is_o],
+  refine forall_congr (λ c, forall_congr (λ hc, _)),
+  rw [is_O_with_insert],
+  rw [h, norm_zero],
+  exact mul_nonneg hc.le (norm_nonneg _)
+end
+
 /-! ### Simplification : norm, abs -/
 
 section norm_abs

--- a/src/analysis/asymptotics/asymptotics.lean
+++ b/src/analysis/asymptotics/asymptotics.lean
@@ -487,7 +487,7 @@ begin
   exact mul_nonneg hc.le (norm_nonneg _)
 end
 
-lemma is_o_insert [topological_space α] {x : α} {s : set α} {g : α → E'} {g' : α → F'}
+lemma is_o.insert [topological_space α] {x : α} {s : set α} {g : α → E'} {g' : α → F'}
   (h1 : g =o[𝓝[s] x] g') (h2 : g x = 0) : g =o[𝓝[insert x s] x] g' :=
 (is_o_insert h2).mpr h1
 

--- a/src/analysis/asymptotics/asymptotics.lean
+++ b/src/analysis/asymptotics/asymptotics.lean
@@ -472,6 +472,11 @@ lemma is_O_with_insert [topological_space α] {x : α} {s : set α} {C : ℝ} {g
   is_O_with C (𝓝[insert x s] x) g g' ↔ is_O_with C (𝓝[s] x) g g' :=
 by simp_rw [is_O_with, nhds_within_insert, eventually_sup, eventually_pure, h, true_and]
 
+lemma is_O_with.insert [topological_space α] {x : α} {s : set α} {C : ℝ} {g : α → E} {g' : α → F}
+  (h1 : is_O_with C (𝓝[s] x) g g') (h2 : ∥g x∥ ≤ C * ∥g' x∥) :
+  is_O_with C (𝓝[insert x s] x) g g' :=
+(is_O_with_insert h2).mpr h1
+
 lemma is_o_insert [topological_space α] {x : α} {s : set α} {g : α → E'} {g' : α → F'}
   (h : g x = 0) : g =o[𝓝[insert x s] x] g' ↔ g =o[𝓝[s] x] g' :=
 begin
@@ -481,6 +486,10 @@ begin
   rw [h, norm_zero],
   exact mul_nonneg hc.le (norm_nonneg _)
 end
+
+lemma is_o_insert [topological_space α] {x : α} {s : set α} {g : α → E'} {g' : α → F'}
+  (h1 : g =o[𝓝[s] x] g') (h2 : g x = 0) : g =o[𝓝[insert x s] x] g' :=
+(is_o_insert h2).mpr h1
 
 /-! ### Simplification : norm, abs -/
 

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -511,6 +511,21 @@ lemma cont_diff_within_at_inter (h : t ∈ 𝓝 x) :
   cont_diff_within_at 𝕜 n f (s ∩ t) x ↔ cont_diff_within_at 𝕜 n f s x :=
 cont_diff_within_at_inter' (mem_nhds_within_of_mem_nhds h)
 
+lemma cont_diff_within_at_insert {y : E} :
+  cont_diff_within_at 𝕜 n f (insert y s) x ↔ cont_diff_within_at 𝕜 n f s x :=
+begin
+  simp_rw [cont_diff_within_at],
+  rcases eq_or_ne x y with rfl|h,
+  { simp_rw [insert_eq_of_mem (mem_insert _ _)] },
+  simp_rw [insert_comm x y, nhds_within_insert_of_ne h]
+end
+
+alias cont_diff_within_at_insert ↔ cont_diff_within_at.of_insert cont_diff_within_at.insert'
+
+lemma cont_diff_within_at.insert (h : cont_diff_within_at 𝕜 n f s x) :
+  cont_diff_within_at 𝕜 n f (insert x s) x :=
+h.insert'
+
 /-- If a function is `C^n` within a set at a point, with `n ≥ 1`, then it is differentiable
 within this set at this point. -/
 lemma cont_diff_within_at.differentiable_within_at'
@@ -576,36 +591,27 @@ begin
           rw [snoc_last, init_snoc] } } } }
 end
 
-/-- One direction of `cont_diff_within_at_succ_iff_has_fderiv_within_at`, but where all derivatives
-  are taken within the same set. -/
-lemma cont_diff_within_at.has_fderiv_within_at_nhds {n : ℕ}
-  (hf : cont_diff_within_at 𝕜 (n + 1 : ℕ) f s x) :
-  ∃ u ∈ 𝓝[insert x s] x, u ⊆ insert x s ∧ ∃ f' : E → E →L[𝕜] F,
-    (∀ x ∈ u, has_fderiv_within_at f (f' x) s x) ∧ cont_diff_within_at 𝕜 n f' s x :=
-begin
-  obtain ⟨u, hu, f', huf', hf'⟩ := cont_diff_within_at_succ_iff_has_fderiv_within_at.mp hf,
-  obtain ⟨w, hw, hxw, hwu⟩ := mem_nhds_within.mp hu,
-  rw [inter_comm] at hwu,
-  refine ⟨insert x s ∩ w, inter_mem_nhds_within _ (hw.mem_nhds hxw), inter_subset_left _ _,
-    f', λ y hy, _, _⟩,
-  { refine ((huf' y $ hwu hy).mono hwu).mono_of_mem _,
-    refine mem_of_superset _ (inter_subset_inter_left _ (subset_insert _ _)),
-    refine inter_mem_nhds_within _ (hw.mem_nhds hy.2) },
-  { exact hf'.mono_of_mem (nhds_within_mono _ (subset_insert _ _) hu) }
-end
-
 /-- A version of `cont_diff_within_at_succ_iff_has_fderiv_within_at` where all derivatives
-  are taken within the same set. This lemma assumes `x ∈ s`. -/
-lemma cont_diff_within_at_succ_iff_has_fderiv_within_at_of_mem {n : ℕ} (hx : x ∈ s) :
+  are taken within the same set. -/
+lemma cont_diff_within_at_succ_iff_has_fderiv_within_at' {n : ℕ} :
   cont_diff_within_at 𝕜 (n + 1 : ℕ) f s x
-  ↔ ∃ u ∈ 𝓝[s] x, u ⊆ s ∧ ∃ f' : E → E →L[𝕜] F,
+  ↔ ∃ u ∈ 𝓝[insert x s] x, u ⊆ insert x s ∧ ∃ f' : E → E →L[𝕜] F,
     (∀ x ∈ u, has_fderiv_within_at f (f' x) s x) ∧ cont_diff_within_at 𝕜 n f' s x :=
 begin
-  split,
-  { intro hf, simpa only [insert_eq_of_mem hx] using hf.has_fderiv_within_at_nhds },
-  rw [cont_diff_within_at_succ_iff_has_fderiv_within_at, insert_eq_of_mem hx],
-  rintro ⟨u, hu, hus, f', huf', hf'⟩,
-  exact ⟨u, hu, f', λ y hy, (huf' y hy).mono hus, hf'.mono hus⟩
+  refine ⟨λ hf, _, _⟩,
+  { obtain ⟨u, hu, f', huf', hf'⟩ := cont_diff_within_at_succ_iff_has_fderiv_within_at.mp hf,
+    obtain ⟨w, hw, hxw, hwu⟩ := mem_nhds_within.mp hu,
+    rw [inter_comm] at hwu,
+    refine ⟨insert x s ∩ w, inter_mem_nhds_within _ (hw.mem_nhds hxw), inter_subset_left _ _,
+      f', λ y hy, _, _⟩,
+    { refine ((huf' y $ hwu hy).mono hwu).mono_of_mem _,
+      refine mem_of_superset _ (inter_subset_inter_left _ (subset_insert _ _)),
+      refine inter_mem_nhds_within _ (hw.mem_nhds hy.2) },
+    { exact hf'.mono_of_mem (nhds_within_mono _ (subset_insert _ _) hu) } },
+  { rw [← cont_diff_within_at_insert, cont_diff_within_at_succ_iff_has_fderiv_within_at,
+      insert_eq_of_mem (mem_insert _ _)],
+    rintro ⟨u, hu, hus, f', huf', hf'⟩,
+    refine ⟨u, hu, f', λ y hy, (huf' y hy).insert'.mono hus, hf'.insert.mono hus⟩ }
 end
 
 /-! ### Smooth functions within a set -/
@@ -1145,7 +1151,8 @@ lemma cont_diff_within_at.fderiv_within'
 begin
   have : ∀ k : ℕ, (k + 1 : ℕ∞) ≤ n → cont_diff_within_at 𝕜 k (fderiv_within 𝕜 f s) s x,
   { intros k hkn,
-    obtain ⟨v, hv, -, f', hvf', hf'⟩ := (hf.of_le hkn).has_fderiv_within_at_nhds,
+    obtain ⟨v, hv, -, f', hvf', hf'⟩ :=
+      cont_diff_within_at_succ_iff_has_fderiv_within_at'.mp (hf.of_le hkn),
     apply hf'.congr_of_eventually_eq_insert,
     filter_upwards [hv, hs],
     exact λ y hy h2y, (hvf' y hy).fderiv_within h2y },
@@ -2099,6 +2106,15 @@ begin
     exact filter.inter_mem this v_nhd },
   rwa [insert_eq_of_mem xmem, this] at Z,
 end
+
+/-- The composition of `C^n` functions at points in domains is `C^n`,
+  with a weaker condition on `s` and `t`. -/
+lemma cont_diff_within_at.comp_of_mem
+  {s : set E} {t : set F} {g : F → G} {f : E → F} (x : E)
+  (hg : cont_diff_within_at 𝕜 n g t (f x))
+  (hf : cont_diff_within_at 𝕜 n f s x) (hs : t ∈ 𝓝[f '' s] f x) :
+  cont_diff_within_at 𝕜 n (g ∘ f) s x :=
+(hg.mono_of_mem hs).comp x hf (subset_preimage_image f s)
 
 /-- The composition of `C^n` functions at points in domains is `C^n`. -/
 lemma cont_diff_within_at.comp' {s : set E} {t : set F} {g : F → G}

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -346,6 +346,23 @@ lemma has_fderiv_at.differentiable_at (h : has_fderiv_at f f' x) : differentiabl
   has_fderiv_within_at f f' univ x ↔ has_fderiv_at f f' x :=
 by { simp only [has_fderiv_within_at, nhds_within_univ], refl }
 
+lemma has_fderiv_within_at_insert {y : E} {g' : E →L[𝕜] F}  :
+  has_fderiv_within_at g g' (insert y s) x ↔ has_fderiv_within_at g g' s x :=
+begin
+  rcases eq_or_ne x y with rfl|h,
+  { simp_rw [has_fderiv_within_at, has_fderiv_at_filter],
+    apply asymptotics.is_o_insert,
+    simp only [sub_self, g'.map_zero] },
+  refine ⟨λ h, h.mono $ subset_insert y s, λ hg, hg.mono_of_mem _⟩,
+  simp_rw [nhds_within_insert_of_ne h, self_mem_nhds_within]
+end
+
+alias has_fderiv_within_at_insert ↔ has_fderiv_within_at.of_insert has_fderiv_within_at.insert'
+
+lemma has_fderiv_within_at.insert {y : E} {g' : E →L[𝕜] F} (h : has_fderiv_within_at g g' s x) :
+  has_fderiv_within_at g g' (insert x s) x :=
+h.insert'
+
 lemma has_strict_fderiv_at.is_O_sub (hf : has_strict_fderiv_at f f' x) :
   (λ p : E × E, f p.1 - f p.2) =O[𝓝 (x, x)] (λ p : E × E, p.1 - p.2) :=
 hf.is_O.congr_of_sub.2 (f'.is_O_comp _ _)
@@ -1085,6 +1102,12 @@ theorem has_fderiv_at.comp_has_fderiv_within_at {g : F → G} {g' : F →L[𝕜]
   (hg : has_fderiv_at g g' (f x)) (hf : has_fderiv_within_at f f' s x) :
   has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
 hg.comp x hf hf.continuous_within_at
+
+theorem has_fderiv_within_at.comp_of_mem {g : F → G} {g' : F →L[𝕜] G} {t : set F}
+  (hg : has_fderiv_within_at g g' t (f x)) (hf : has_fderiv_within_at f f' s x)
+  (hst : tendsto f (𝓝[s] x) (𝓝[t] f x)) :
+  has_fderiv_within_at (g ∘ f) (g'.comp f') s x :=
+has_fderiv_at_filter.comp x hg hf hst
 
 /-- The chain rule. -/
 theorem has_fderiv_at.comp {g : F → G} {g' : F →L[𝕜] G}

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -359,7 +359,7 @@ end
 
 alias has_fderiv_within_at_insert ↔ has_fderiv_within_at.of_insert has_fderiv_within_at.insert'
 
-lemma has_fderiv_within_at.insert {y : E} {g' : E →L[𝕜] F} (h : has_fderiv_within_at g g' s x) :
+lemma has_fderiv_within_at.insert {g' : E →L[𝕜] F} (h : has_fderiv_within_at g g' s x) :
   has_fderiv_within_at g g' (insert x s) x :=
 h.insert'
 

--- a/src/analysis/normed/field/basic.lean
+++ b/src/analysis/normed/field/basic.lean
@@ -638,6 +638,8 @@ abs_of_nonneg hx
 lemma norm_of_nonpos {x : ℝ} (hx : x ≤ 0) : ∥x∥ = -x :=
 abs_of_nonpos hx
 
+lemma le_norm_self (r : ℝ) : r ≤ ∥r∥ := le_abs_self r
+
 @[simp] lemma norm_coe_nat (n : ℕ) : ∥(n : ℝ)∥ = n := abs_of_nonneg n.cast_nonneg
 
 @[simp] lemma nnnorm_coe_nat (n : ℕ) : ∥(n : ℝ)∥₊ = n := nnreal.eq $ by simp

--- a/src/analysis/normed/field/basic.lean
+++ b/src/analysis/normed/field/basic.lean
@@ -638,8 +638,6 @@ abs_of_nonneg hx
 lemma norm_of_nonpos {x : ℝ} (hx : x ≤ 0) : ∥x∥ = -x :=
 abs_of_nonpos hx
 
-lemma le_norm_self (r : ℝ) : r ≤ ∥r∥ := le_abs_self r
-
 @[simp] lemma norm_coe_nat (n : ℕ) : ∥(n : ℝ)∥ = n := abs_of_nonneg n.cast_nonneg
 
 @[simp] lemma nnnorm_coe_nat (n : ℕ) : ∥(n : ℝ)∥₊ = n := nnreal.eq $ by simp

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -997,6 +997,9 @@ theorem diff_eq (s t : set α) : s \ t = s ∩ tᶜ := rfl
 theorem mem_diff_of_mem {s t : set α} {x : α} (h1 : x ∈ s) (h2 : x ∉ t) : x ∈ s \ t :=
 ⟨h1, h2⟩
 
+lemma not_mem_diff_of_mem {s t : set α} {x : α} (hx : x ∈ t) : x ∉ s \ t :=
+λ h, h.2 hx
+
 theorem mem_of_mem_diff {s t : set α} {x : α} (h : x ∈ s \ t) : x ∈ s :=
 h.left
 

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -275,6 +275,9 @@ lemma maps_to_iff_exists_map_subtype : maps_to f s t ↔ ∃ g : s → t, ∀ x 
 theorem maps_to' : maps_to f s t ↔ f '' s ⊆ t :=
 image_subset_iff.symm
 
+lemma maps_to.subset_preimage {f : α → β} {s : set α} {t : set β} (hf : maps_to f s t) :
+  s ⊆ f ⁻¹' t := hf
+
 @[simp] theorem maps_to_singleton {x : α} : maps_to f {x} t ↔ f x ∈ t := singleton_subset_iff
 
 theorem maps_to_empty (f : α → β) (t : set β) : maps_to f ∅ t := empty_subset _

--- a/src/data/set/prod.lean
+++ b/src/data/set/prod.lean
@@ -192,6 +192,11 @@ lemma prod_sub_preimage_iff {W : set γ} {f : α × β → γ} :
   s ×ˢ t ⊆ f ⁻¹' W ↔ ∀ a b, a ∈ s → b ∈ t → f (a, b) ∈ W :=
 by simp [subset_def]
 
+
+lemma image_prod_mk_subset_prod {f : α → β} {g : α → γ} {s : set α} :
+  (λ x, (f x, g x)) '' s ⊆ (f '' s) ×ˢ (g '' s) :=
+by { rintros _ ⟨x, hx, rfl⟩, exact mk_mem_prod (mem_image_of_mem f hx) (mem_image_of_mem g hx) }
+
 lemma image_prod_mk_subset_prod_left (hb : b ∈ t) : (λ a, (a, b)) '' s ⊆ s ×ˢ t :=
 by { rintro _ ⟨a, ha, rfl⟩, exact ⟨ha, hb⟩ }
 

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -543,6 +543,29 @@ lemma is_closed_map_const {α β} [topological_space α] [topological_space β] 
   is_closed_map (function.const α y) :=
 is_closed_map.of_nonempty $ λ s hs h2s, by simp_rw [h2s.image_const, is_closed_singleton]
 
+lemma nhds_within_insert_of_ne [t1_space α] {x y : α} {s : set α} (hxy : x ≠ y) :
+  𝓝[insert y s] x = 𝓝[s] x :=
+begin
+  refine le_antisymm (λ t ht, _) (nhds_within_mono x $ subset_insert y s),
+  obtain ⟨o, ho, hxo, host⟩ := mem_nhds_within.mp ht,
+  refine mem_nhds_within.mpr ⟨o \ {y}, ho.sdiff is_closed_singleton, ⟨hxo, hxy⟩, _⟩,
+  rw [inter_insert_of_not_mem $ not_mem_diff_of_mem (mem_singleton y)],
+  exact (inter_subset_inter (diff_subset _ _) subset.rfl).trans host
+end
+
+/-- If `t` is a subset of `s`, except for one point,
+then `insert x s` is a neighborhood of `x` within `t`. -/
+lemma insert_mem_nhds_within_of_subset_insert [t1_space α] {x y : α} {s t : set α}
+  (hu : t ⊆ insert y s) :
+  insert x s ∈ 𝓝[t] x :=
+begin
+  rcases eq_or_ne x y with rfl|h,
+  { exact mem_of_superset self_mem_nhds_within hu },
+  refine nhds_within_mono x hu _,
+  rw [nhds_within_insert_of_ne h],
+  exact mem_of_superset self_mem_nhds_within (subset_insert x s)
+end
+
 lemma bInter_basis_nhds [t1_space α] {ι : Sort*} {p : ι → Prop} {s : ι → set α} {x : α}
   (h : (𝓝 x).has_basis p s) : (⋂ i (h : p i), s i) = {x} :=
 begin


### PR DESCRIPTION
* The new `cont_diff_within_at_succ_iff_has_fderiv_within_at'` generalizes `cont_diff_within_at.has_fderiv_within_at_nhds` and `cont_diff_within_at_succ_iff_has_fderiv_within_at_of_mem`
* Prove that `has_fderiv_within_at` and `cont_diff_within_at` are not dependent on adding a single point to the set
* Add some more lemmas needed for a follow-up PR
* From the sphere eversion project

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
