### PR TITLE
[Merged by Bors] - chore(number_theory/number_field/basic): fix a name

### DIFF
--- a/src/number_theory/number_field/basic.lean
+++ b/src/number_theory/number_field/basic.lean
@@ -102,7 +102,7 @@ integral_closure.is_integrally_closed_of_finite_extension ℚ
 lemma is_integral_coe (x : 𝓞 K) : is_integral ℤ (x : K) :=
 x.2
 
-lemma map_mem_ring_of_integers {F L : Type*} [field L] [char_zero K] [char_zero L]
+lemma map_mem {F L : Type*} [field L] [char_zero K] [char_zero L]
   [alg_hom_class F ℚ K L] (f : F) (x : 𝓞 K) : f x ∈ 𝓞 L :=
 (mem_ring_of_integers _ _).2 $ map_is_integral_int f $ ring_of_integers.is_integral_coe x
 


### PR DESCRIPTION
This lemma is in the `ring_of_integers` namespace, so the name was redundant.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
