### PR TITLE
[Merged by Bors] - feat(ring_theory/ideals/operations): add induction lemma

### DIFF
--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -95,7 +95,7 @@ begin
   exact Hb _ hi _ hj,
 end
 
-/-- Dependent version of smul_induction_on -/
+/-- Dependent version of `smul_induction_on` -/
 @[elab_as_eliminator]
 theorem smul_induction_on' {x : M} (hx : x ∈ I • N)
   {p : Π x, x ∈ I • N → Prop}
@@ -107,7 +107,7 @@ begin
   refine exists.elim _ (λ (h : x ∈ I • N) (H : p x h), H),
   exact smul_induction_on hx
     (λ a ha x hx, ⟨_, Hb _ ha _ hx⟩)
-    (λ x y ⟨_, hx⟩ ⟨_, hy⟩,  ⟨_, H1 _ _ _ _ hx hy⟩),
+    (λ x y ⟨_, hx⟩ ⟨_, hy⟩, ⟨_, H1 _ _ _ _ hx hy⟩),
 end
 
 theorem mem_smul_span_singleton {I : ideal R} {m : M} {x : M} :

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -100,12 +100,12 @@ end
 theorem smul_induction_on' {x : M} (hx : x ∈ I • N)
   {p : Π x, x ∈ I • N → Prop}
   (Hb : ∀ (r : R) (hr : r ∈ I) (n : M) (hn : n ∈ N),
-    p (r • n) (submodule.smul_mem_smul hr hn))
+    p (r • n) (smul_mem_smul hr hn))
   (H1 : ∀ x hx y hy, p x hx → p y hy → p (x + y) (submodule.add_mem _ ‹_› ‹_›)) :
   p x hx :=
 begin
   refine exists.elim _ (λ (h : x ∈ I • N) (H : p x h), H),
-  exact submodule.smul_induction_on hx
+  exact smul_induction_on hx
     (λ a ha x hx, ⟨_, Hb _ ha _ hx⟩)
     (λ x y ⟨_, hx⟩ ⟨_, hy⟩,  ⟨_, H1 _ _ _ _ hx hy⟩),
 end

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -107,7 +107,7 @@ begin
   refine exists.elim _ (λ (h : x ∈ I • N) (H : p x h), H),
   exact smul_induction_on hx
     (λ a ha x hx, ⟨_, Hb _ ha _ hx⟩)
-    (λ x y ⟨_, hx⟩ ⟨_, hy⟩,  ⟨_, H1 _ _ _ _ hx hy⟩),
+    (λ x y ⟨_, hx⟩ ⟨_, hy⟩, ⟨_, H1 _ _ _ _ hx hy⟩),
 end
 
 theorem mem_smul_span_singleton {I : ideal R} {m : M} {x : M} :

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -95,7 +95,7 @@ begin
   exact Hb _ hi _ hj,
 end
 
-/-- Dependent version of `smul_induction_on` -/
+/-- Dependent version of `submodule.smul_induction_on`. -/
 @[elab_as_eliminator]
 theorem smul_induction_on' {x : M} (hx : x ∈ I • N)
   {p : Π x, x ∈ I • N → Prop}

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -95,6 +95,21 @@ begin
   exact Hb _ hi _ hj,
 end
 
+/-- Dependent version of smul_induction_on -/
+@[elab_as_eliminator]
+theorem smul_induction_on' {x : M} (hx : x ∈ I • N)
+  {p : Π x, x ∈ I • N → Prop}
+  (Hb : ∀ (r : R) (hr : r ∈ I) (n : M) (hn : n ∈ N),
+    p (r • n) (submodule.smul_mem_smul hr hn))
+  (H1 : ∀ x hx y hy, p x hx → p y hy → p (x + y) (submodule.add_mem _ ‹_› ‹_›)) :
+  p x hx :=
+begin
+  refine exists.elim _ (λ (h : x ∈ I • N) (H : p x h), H),
+  exact submodule.smul_induction_on hx
+    (λ a ha x hx, ⟨_, Hb _ ha _ hx⟩)
+    (λ x y ⟨_, hx⟩ ⟨_, hy⟩,  ⟨_, H1 _ _ _ _ hx hy⟩),
+end
+
 theorem mem_smul_span_singleton {I : ideal R} {m : M} {x : M} :
   x ∈ I • span R ({m} : set M) ↔ ∃ y ∈ I, y • m = x :=
 ⟨λ hx, smul_induction_on hx


### PR DESCRIPTION
Add `submodule.smul_induction_on'` 
which is a dependent version of `submodule.smul_induction_on`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
