### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/operator_norm): characterize the operator norm over a `densely_normed_field` in terms of the supremum

### DIFF
--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -504,7 +504,7 @@ begin
     exact f.exists_lt_apply_of_lt_op_nnnorm hr, }
 end
 
-lemma op_nnnorm_eq_Sup_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+lemma Sup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥₊) '' ball 0 1) = ∥f∥₊ :=
@@ -517,13 +517,13 @@ begin
     exact ⟨_, ⟨x, mem_ball_zero_iff.2 hx, rfl⟩, hxf⟩ },
 end
 
-lemma op_norm_eq_Sup_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+lemma Sup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥) '' ball 0 1) = ∥f∥ :=
-by simpa only [nnreal.coe_Sup, set.image_image] using nnreal.coe_eq.2 f.op_nnnorm_eq_Sup_unit_ball
+by simpa only [nnreal.coe_Sup, set.image_image] using nnreal.coe_eq.2 f.Sup_unit_ball_eq_nnnorm
 
-lemma op_nnnorm_eq_Sup_closed_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+lemma Sup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥₊) '' closed_ball 0 1) = ∥f∥₊ :=
@@ -531,17 +531,17 @@ begin
   have hbdd : ∀ y ∈ (λ x, ∥f x∥₊) '' closed_ball 0 1, y ≤ ∥f∥₊,
   { rintro - ⟨x, hx, rfl⟩, exact f.unit_le_op_norm x (mem_closed_ball_zero_iff.1 hx) },
   refine le_antisymm (cSup_le ((nonempty_closed_ball.mpr zero_le_one).image _) hbdd) _,
-  rw ←op_nnnorm_eq_Sup_unit_ball,
+  rw ←Sup_unit_ball_eq_nnnorm,
   exact cSup_le_cSup ⟨∥f∥₊, hbdd⟩ ((nonempty_ball.2 zero_lt_one).image _)
     (set.image_subset _ ball_subset_closed_ball),
 end
 
-lemma op_norm_eq_Sup_closed_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+lemma Sup_closed_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥) '' closed_ball 0 1) = ∥f∥ :=
 by simpa only [nnreal.coe_Sup, set.image_image] using nnreal.coe_eq.2
-  f.op_nnnorm_eq_Sup_closed_unit_ball
+  f.Sup_closed_unit_ball_eq_nnnorm
 
 end Sup
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -499,7 +499,7 @@ lemma exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_
   (f : E →SL[σ₁₂] F) {r : ℝ} (hr : r < ∥f∥) : ∃ x : E, ∥x∥ < 1 ∧ r < ∥f x∥ :=
 begin
   by_cases hr₀ : r < 0,
-  { refine ⟨0, by simpa using hr₀⟩, },
+  { exact ⟨0, by simpa using hr₀⟩, },
   { lift r to ℝ≥0 using not_lt.1 hr₀,
     exact f.exists_lt_apply_of_lt_op_nnnorm hr, }
 end

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -482,13 +482,13 @@ lemma exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type*} [normed_add_com
   (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ∥f∥₊) : ∃ x : E, ∥x∥₊ < 1 ∧ r < ∥f x∥₊ :=
 begin
   obtain ⟨y, hy⟩ := f.exists_mul_lt_apply_of_lt_op_nnnorm hr,
-  have hy'' : ∥y∥₊ ≠ 0 := nnnorm_ne_zero_iff.2
+  have hy' : ∥y∥₊ ≠ 0 := nnnorm_ne_zero_iff.2
     (λ heq, by simpa only [heq, nnnorm_zero, map_zero, not_lt_zero'] using hy),
   have hfy : ∥f y∥₊ ≠ 0 := (zero_le'.trans_lt hy).ne',
   rw [←inv_inv (∥f y∥₊), nnreal.lt_inv_iff_mul_lt (inv_ne_zero hfy), mul_assoc, mul_comm (∥y∥₊),
-    ←mul_assoc, ←nnreal.lt_inv_iff_mul_lt hy''] at hy,
+    ←mul_assoc, ←nnreal.lt_inv_iff_mul_lt hy'] at hy,
   obtain ⟨k, hk₁, hk₂⟩ := normed_field.exists_lt_nnnorm_lt 𝕜 hy,
-  refine ⟨k • y, (nnnorm_smul k y).symm ▸ (nnreal.lt_inv_iff_mul_lt hy'').1 hk₂, _⟩,
+  refine ⟨k • y, (nnnorm_smul k y).symm ▸ (nnreal.lt_inv_iff_mul_lt hy').1 hk₂, _⟩,
   have : ∥σ₁₂ k∥₊ = ∥k∥₊ := subtype.ext ring_hom_isometric.is_iso,
   rwa [map_smulₛₗ f, nnnorm_smul, ←nnreal.div_lt_iff hfy, div_eq_mul_inv, this],
 end

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -507,40 +507,39 @@ end
 lemma op_nnnorm_eq_Sup_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
-  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥₊) '' {x : E | ∥x∥₊ < 1}) = ∥f∥₊ :=
+  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥₊) '' ball 0 1) = ∥f∥₊ :=
 begin
-  have hball : {x : E | ∥x∥₊ < 1}.nonempty := ⟨0, nnnorm_zero.trans_lt zero_lt_one⟩,
-  refine cSup_eq_of_forall_le_of_forall_lt_exists_gt (hball.image _) _ (λ ub hub, _),
+  refine cSup_eq_of_forall_le_of_forall_lt_exists_gt ((nonempty_ball.mpr zero_lt_one).image _)
+    _ (λ ub hub, _),
   { rintro - ⟨x, hx, rfl⟩,
-    simpa only [nonneg.coe_one, mul_one] using f.le_op_norm_of_le (mem_set_of.mp hx).le },
+    simpa only [mul_one] using f.le_op_norm_of_le (mem_ball_zero_iff.1 hx).le },
   { obtain ⟨x, hx, hxf⟩ := f.exists_lt_apply_of_lt_op_nnnorm hub,
-    exact ⟨_, ⟨x, hx, rfl⟩, hxf⟩, }
+    exact ⟨_, ⟨x, mem_ball_zero_iff.2 hx, rfl⟩, hxf⟩ },
 end
 
 lemma op_norm_eq_Sup_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
-  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥) '' {x : E | ∥x∥ < 1}) = ∥f∥ :=
+  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥) '' ball 0 1) = ∥f∥ :=
 by simpa only [nnreal.coe_Sup, set.image_image] using nnreal.coe_eq.2 f.op_nnnorm_eq_Sup_unit_ball
 
 lemma op_nnnorm_eq_Sup_closed_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
-  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥₊) '' {x : E | ∥x∥₊ ≤ 1}) = ∥f∥₊ :=
+  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥₊) '' closed_ball 0 1) = ∥f∥₊ :=
 begin
-  have hball : {x : E | ∥x∥₊ < 1}.nonempty := ⟨0, nnnorm_zero.trans_lt zero_lt_one⟩,
-  have hbdd : ∀ y ∈ (λ x, ∥f x∥₊) '' {x : E | ∥x∥₊ ≤ 1}, y ≤ ∥f∥₊,
-  { rintro _ ⟨x, hx, rfl⟩, exact f.unit_le_op_norm x hx },
-  have hsubset : {x : E | ∥x∥₊ < 1} ⊆ {x : E | ∥x∥₊ ≤ 1} := λ x hx, le_of_lt hx,
-  refine le_antisymm (cSup_le ((hball.mono hsubset).image _) hbdd) _,
+  have hbdd : ∀ y ∈ (λ x, ∥f x∥₊) '' closed_ball 0 1, y ≤ ∥f∥₊,
+  { rintro - ⟨x, hx, rfl⟩, exact f.unit_le_op_norm x (mem_closed_ball_zero_iff.1 hx) },
+  refine le_antisymm (cSup_le ((nonempty_closed_ball.mpr zero_le_one).image _) hbdd) _,
   rw ←op_nnnorm_eq_Sup_unit_ball,
-  exact cSup_le_cSup ⟨∥f∥₊, hbdd⟩ (hball.image _) (set.image_subset _ hsubset),
+  exact cSup_le_cSup ⟨∥f∥₊, hbdd⟩ ((nonempty_ball.2 zero_lt_one).image _)
+    (set.image_subset _ ball_subset_closed_ball),
 end
 
 lemma op_norm_eq_Sup_closed_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
-  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥) '' {x : E | ∥x∥ ≤ 1}) = ∥f∥ :=
+  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥) '' closed_ball 0 1) = ∥f∥ :=
 by simpa only [nnreal.coe_Sup, set.image_image] using nnreal.coe_eq.2
   f.op_nnnorm_eq_Sup_closed_unit_ball
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -479,7 +479,7 @@ by { lift r to ℝ≥0 using hr₀, exact f.exists_mul_lt_apply_of_lt_op_nnnorm 
 lemma exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
-  (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ∥f∥₊) : ∃ x : E, ∥x∥₊ ≤ 1 ∧ r < ∥f x∥₊ :=
+  (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ∥f∥₊) : ∃ x : E, ∥x∥₊ < 1 ∧ r < ∥f x∥₊ :=
 begin
   obtain ⟨y, hy⟩ := f.exists_mul_lt_apply_of_lt_op_nnnorm hr,
   have hy'' : ∥y∥₊ ≠ 0 := nnnorm_ne_zero_iff.2
@@ -488,7 +488,7 @@ begin
   rw [←inv_inv (∥f y∥₊), nnreal.lt_inv_iff_mul_lt (inv_ne_zero hfy), mul_assoc, mul_comm (∥y∥₊),
     ←mul_assoc, ←nnreal.lt_inv_iff_mul_lt hy''] at hy,
   obtain ⟨k, hk₁, hk₂⟩ := normed_field.exists_lt_nnnorm_lt 𝕜 hy,
-  refine ⟨k • y, (nnnorm_smul k y).symm ▸ (nnreal.le_inv_iff_mul_le hy'').1 hk₂.le, _⟩,
+  refine ⟨k • y, (nnnorm_smul k y).symm ▸ (nnreal.lt_inv_iff_mul_lt hy'').1 hk₂, _⟩,
   have : ∥σ₁₂ k∥₊ = ∥k∥₊ := subtype.ext ring_hom_isometric.is_iso,
   rwa [map_smulₛₗ f, nnnorm_smul, ←nnreal.div_lt_iff hfy, div_eq_mul_inv, this],
 end
@@ -496,7 +496,7 @@ end
 lemma exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
-  (f : E →SL[σ₁₂] F) {r : ℝ} (hr : r < ∥f∥) : ∃ x : E, ∥x∥ ≤ 1 ∧ r < ∥f x∥ :=
+  (f : E →SL[σ₁₂] F) {r : ℝ} (hr : r < ∥f∥) : ∃ x : E, ∥x∥ < 1 ∧ r < ∥f x∥ :=
 begin
   by_cases hr₀ : r < 0,
   { refine ⟨0, by simpa using hr₀⟩, },
@@ -507,11 +507,12 @@ end
 lemma op_nnnorm_eq_Sup_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
-  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥₊) '' {x : E | ∥x∥₊ ≤ 1}) = ∥f∥₊ :=
+  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥₊) '' {x : E | ∥x∥₊ < 1}) = ∥f∥₊ :=
 begin
-  have hball : {x : E | ∥x∥₊ ≤ 1}.nonempty := ⟨0, nnnorm_zero.trans_le zero_le_one⟩,
+  have hball : {x : E | ∥x∥₊ < 1}.nonempty := ⟨0, nnnorm_zero.trans_lt zero_lt_one⟩,
   refine cSup_eq_of_forall_le_of_forall_lt_exists_gt (hball.image _) _ (λ ub hub, _),
-  { rintro - ⟨x, hx, rfl⟩, exact f.unit_le_op_norm x hx },
+  { rintro - ⟨x, hx, rfl⟩,
+    simpa only [nonneg.coe_one, mul_one] using f.le_op_norm_of_le (mem_set_of.mp hx).le },
   { obtain ⟨x, hx, hxf⟩ := f.exists_lt_apply_of_lt_op_nnnorm hub,
     exact ⟨_, ⟨x, hx, rfl⟩, hxf⟩, }
 end
@@ -519,8 +520,29 @@ end
 lemma op_norm_eq_Sup_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
-  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥) '' {x : E | ∥x∥ ≤ 1}) = ∥f∥ :=
+  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥) '' {x : E | ∥x∥ < 1}) = ∥f∥ :=
 by simpa only [nnreal.coe_Sup, set.image_image] using nnreal.coe_eq.2 f.op_nnnorm_eq_Sup_unit_ball
+
+lemma op_nnnorm_eq_Sup_closed_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+  [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
+  {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
+  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥₊) '' {x : E | ∥x∥₊ ≤ 1}) = ∥f∥₊ :=
+begin
+  have hball : {x : E | ∥x∥₊ < 1}.nonempty := ⟨0, nnnorm_zero.trans_lt zero_lt_one⟩,
+  have hbdd : ∀ y ∈ (λ x, ∥f x∥₊) '' {x : E | ∥x∥₊ ≤ 1}, y ≤ ∥f∥₊,
+  { rintro _ ⟨x, hx, rfl⟩, exact f.unit_le_op_norm x hx },
+  have hsubset : {x : E | ∥x∥₊ < 1} ⊆ {x : E | ∥x∥₊ ≤ 1} := λ x hx, le_of_lt hx,
+  refine le_antisymm (cSup_le ((hball.mono hsubset).image _) hbdd) _,
+  rw ←op_nnnorm_eq_Sup_unit_ball,
+  exact cSup_le_cSup ⟨∥f∥₊, hbdd⟩ (hball.image _) (set.image_subset _ hsubset),
+end
+
+lemma op_norm_eq_Sup_closed_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+  [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
+  {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
+  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥) '' {x : E | ∥x∥ ≤ 1}) = ∥f∥ :=
+by simpa only [nnreal.coe_Sup, set.image_image] using nnreal.coe_eq.2
+  f.op_nnnorm_eq_Sup_closed_unit_ball
 
 end Sup
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -463,6 +463,67 @@ lipschitz_with_iff_norm_sub_le.2 $ λ f g, ((f - g).le_op_norm x).trans_eq (mul_
 
 end
 
+section Sup
+
+variables [ring_hom_isometric σ₁₂]
+
+lemma exists_mul_lt_apply_of_lt_op_nnnorm (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ∥f∥₊) :
+  ∃ x, r * ∥x∥₊ < ∥f x∥₊ :=
+by simpa only [not_forall, not_le, set.mem_set_of] using not_mem_of_lt_cInf
+  (nnnorm_def f ▸ hr : r < Inf {c : ℝ≥0 | ∀ x, ∥f x∥₊ ≤ c * ∥x∥₊}) (order_bot.bdd_below _)
+
+lemma exists_mul_lt_of_lt_op_norm (f : E →SL[σ₁₂] F) {r : ℝ} (hr₀ : 0 ≤ r) (hr : r < ∥f∥) :
+  ∃ x, r * ∥x∥ < ∥f x∥ :=
+by { lift r to ℝ≥0 using hr₀, exact f.exists_mul_lt_apply_of_lt_op_nnnorm hr }
+
+lemma exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+  [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
+  {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
+  (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ∥f∥₊) : ∃ x : E, ∥x∥₊ ≤ 1 ∧ r < ∥f x∥₊ :=
+begin
+  obtain ⟨y, hy⟩ := f.exists_mul_lt_apply_of_lt_op_nnnorm hr,
+  have hy'' : ∥y∥₊ ≠ 0 := nnnorm_ne_zero_iff.2
+    (λ heq, by simpa only [heq, nnnorm_zero, map_zero, not_lt_zero'] using hy),
+  have hfy : ∥f y∥₊ ≠ 0 := (zero_le'.trans_lt hy).ne',
+  rw [←inv_inv (∥f y∥₊), nnreal.lt_inv_iff_mul_lt (inv_ne_zero hfy), mul_assoc, mul_comm (∥y∥₊),
+    ←mul_assoc, ←nnreal.lt_inv_iff_mul_lt hy''] at hy,
+  obtain ⟨k, hk₁, hk₂⟩ := normed_field.exists_lt_nnnorm_lt 𝕜 hy,
+  refine ⟨k • y, (nnnorm_smul k y).symm ▸ (nnreal.le_inv_iff_mul_le hy'').1 hk₂.le, _⟩,
+  have : ∥σ₁₂ k∥₊ = ∥k∥₊ := subtype.ext ring_hom_isometric.is_iso,
+  rwa [map_smulₛₗ f, nnnorm_smul, ←nnreal.div_lt_iff hfy, div_eq_mul_inv, this],
+end
+
+lemma exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+  [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
+  {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
+  (f : E →SL[σ₁₂] F) {r : ℝ} (hr : r < ∥f∥) : ∃ x : E, ∥x∥ ≤ 1 ∧ r < ∥f x∥ :=
+begin
+  by_cases hr₀ : r < 0,
+  { refine ⟨0, by simpa using hr₀⟩, },
+  { lift r to ℝ≥0 using not_lt.1 hr₀,
+    exact f.exists_lt_apply_of_lt_op_nnnorm hr, }
+end
+
+lemma op_nnnorm_eq_Sup_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+  [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
+  {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
+  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥₊) '' {x : E | ∥x∥₊ ≤ 1}) = ∥f∥₊ :=
+begin
+  have hball : {x : E | ∥x∥₊ ≤ 1}.nonempty := ⟨0, nnnorm_zero.trans_le zero_le_one⟩,
+  refine cSup_eq_of_forall_le_of_forall_lt_exists_gt (hball.image _) _ (λ ub hub, _),
+  { rintro - ⟨x, hx, rfl⟩, exact f.unit_le_op_norm x hx },
+  { obtain ⟨x, hx, hxf⟩ := f.exists_lt_apply_of_lt_op_nnnorm hub,
+    exact ⟨_, ⟨x, hx, rfl⟩, hxf⟩, }
+end
+
+lemma op_norm_eq_Sup_unit_ball {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+  [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
+  {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
+  (f : E →SL[σ₁₂] F) : Sup ((λ x, ∥f x∥) '' {x : E | ∥x∥ ≤ 1}) = ∥f∥ :=
+by simpa only [nnreal.coe_Sup, set.image_image] using nnreal.coe_eq.2 f.op_nnnorm_eq_Sup_unit_ball
+
+end Sup
+
 section
 
 lemma op_norm_ext [ring_hom_isometric σ₁₃] (f : E →SL[σ₁₂] F) (g : E →SL[σ₁₃] G)


### PR DESCRIPTION
This provides a few results pertaining to the operator norm over a `densely_normed_field`. In particular, if `0 ≤ r < ∥f∥` then there exists some `x` with `∥x∥ ≤ 1` such that `r < ∥f x∥`. Consequently, the operator norm is the supremum of the norm of the image of the unit ball under `f`.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
