### PR TITLE
[Merged by Bors] - chore(algebra/group/*): attribute copyright properly, correct instance names

### DIFF
--- a/src/algebra/group/commutator.lean
+++ b/src/algebra/group/commutator.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Copyright (c) 2022 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad, Leonardo de Moura, Simon Hudon, Mario Carneiro
+Authors: Thomas Browning
 -/
 
 import algebra.group.defs

--- a/src/algebra/group/order_synonym.lean
+++ b/src/algebra/group/order_synonym.lean
@@ -1,26 +1,31 @@
 /-
-Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Copyright (c) 2021 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad, Leonardo de Moura, Simon Hudon, Mario Carneiro
+Authors: Yury Kudryashov, Yaël Dillies
 -/
 
 import algebra.group.defs
 import order.synonym
 
-/-! # Group structure on the type synonyms -/
+/-!
+# Group structure on the order type synonyms
+
+Transfer algebraic instances from `α` to `αᵒᵈ` and `lex α`.
+-/
+
+open order_dual
 
 variables {α β : Type*}
 
-/-! ### order_dual -/
-
-open order_dual
+/-! ### `order_dual` -/
 
 @[to_additive] instance [h : has_one α] : has_one αᵒᵈ := h
 @[to_additive] instance [h : has_mul α] : has_mul αᵒᵈ := h
 @[to_additive] instance [h : has_inv α] : has_inv αᵒᵈ := h
 @[to_additive] instance [h : has_div α] : has_div αᵒᵈ := h
 @[to_additive] instance [h : has_smul α β] : has_smul α βᵒᵈ := h
-@[to_additive] instance order_dual.has_pow [h : has_pow α β] : has_pow αᵒᵈ β := h
+@[to_additive order_dual.has_smul]
+instance order_dual.has_pow [h : has_pow α β] : has_pow αᵒᵈ β := h
 @[to_additive] instance [h : semigroup α] : semigroup αᵒᵈ := h
 @[to_additive] instance [h : comm_semigroup α] : comm_semigroup αᵒᵈ := h
 @[to_additive] instance [h : left_cancel_semigroup α] : left_cancel_semigroup αᵒᵈ := h
@@ -71,7 +76,7 @@ lemma of_dual_pow [has_pow α β] (a : αᵒᵈ) (b : β) : of_dual (a ^ b) = of
 @[to_additive] instance [h : has_inv α] : has_inv (lex α) := h
 @[to_additive] instance [h : has_div α] : has_div (lex α) := h
 @[to_additive] instance [h : has_smul α β] : has_smul α (lex β) := h
-@[to_additive] instance lex.has_pow [h : has_pow α β] : has_pow (lex α) β := h
+@[to_additive lex.has_smul] instance lex.has_pow [h : has_pow α β] : has_pow (lex α) β := h
 @[to_additive] instance [h : semigroup α] : semigroup (lex α) := h
 @[to_additive] instance [h : comm_semigroup α] : comm_semigroup (lex α) := h
 @[to_additive] instance [h : left_cancel_semigroup α] : left_cancel_semigroup (lex α) := h


### PR DESCRIPTION
#16847 copied over the copyright from `algebra.group.basic` without actually attributing things properly.

All the material in `algebra.group.commutator` is from #12309 and the material is mostly from #16122 with some dating back from #8564 

Also fix `order_dual.has_pow` being additivized as `order_dual.has_nsmul` rather than `order_dual.has_smul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
