### PR TITLE
[Merged by Bors] - feat(ring_theory/discrete_valuation_ring): add not_is_field

### DIFF
--- a/src/number_theory/padics/padic_integers.lean
+++ b/src/number_theory/padics/padic_integers.lean
@@ -529,7 +529,7 @@ instance : is_adic_complete (maximal_ideal ℤ_[p]) ℤ_[p] :=
         refine this.trans (max_le_iff.mpr ⟨hx, hi.le⟩) } }
   end }
 
-  /-- `ℤ_[p]` with its usual ring structure is not a field. -/
+/-- `ℤ_[p]` with its usual ring structure is not a field. -/
 lemma not_is_field : ¬ is_field ℤ_[p] :=
 begin
   rw ring.not_is_field_iff_exists_prime,

--- a/src/number_theory/padics/padic_integers.lean
+++ b/src/number_theory/padics/padic_integers.lean
@@ -529,14 +529,6 @@ instance : is_adic_complete (maximal_ideal ℤ_[p]) ℤ_[p] :=
         refine this.trans (max_le_iff.mpr ⟨hx, hi.le⟩) } }
   end }
 
-/-- `ℤ_[p]` with its usual ring structure is not a field. -/
-lemma not_is_field : ¬ is_field ℤ_[p] :=
-begin
-  rw ring.not_is_field_iff_exists_prime,
-  exact ⟨local_ring.maximal_ideal ℤ_[p], discrete_valuation_ring.not_a_field ℤ_[p],
-     ideal.is_maximal.is_prime' (maximal_ideal ℤ_[p])⟩,
-end
-
 end dvr
 
 end padic_int

--- a/src/number_theory/padics/padic_integers.lean
+++ b/src/number_theory/padics/padic_integers.lean
@@ -529,6 +529,14 @@ instance : is_adic_complete (maximal_ideal ℤ_[p]) ℤ_[p] :=
         refine this.trans (max_le_iff.mpr ⟨hx, hi.le⟩) } }
   end }
 
+  /-- `ℤ_[p]` with its usual ring structure is not a field. -/
+lemma not_is_field : ¬ is_field ℤ_[p] :=
+begin
+  rw ring.not_is_field_iff_exists_prime,
+  exact ⟨local_ring.maximal_ideal ℤ_[p], discrete_valuation_ring.not_a_field ℤ_[p],
+     ideal.is_maximal.is_prime' (maximal_ideal ℤ_[p])⟩,
+end
+
 end dvr
 
 end padic_int

--- a/src/ring_theory/discrete_valuation_ring.lean
+++ b/src/ring_theory/discrete_valuation_ring.lean
@@ -62,11 +62,7 @@ lemma not_a_field : maximal_ideal R ≠ ⊥ := not_a_field'
 
 /-- A discrete valuation `R` is not a field. -/
 lemma not_is_field : ¬ is_field R :=
-begin
-  rw ring.not_is_field_iff_exists_prime,
-  exact ⟨local_ring.maximal_ideal R, discrete_valuation_ring.not_a_field R,
-     ideal.is_maximal.is_prime' (maximal_ideal R)⟩,
-end
+ring.not_is_field_iff_exists_prime.mpr ⟨_, not_a_field R, is_maximal.is_prime' (maximal_ideal R)⟩
 
 variable {R}
 

--- a/src/ring_theory/discrete_valuation_ring.lean
+++ b/src/ring_theory/discrete_valuation_ring.lean
@@ -60,7 +60,7 @@ variables (R : Type u) [comm_ring R] [is_domain R] [discrete_valuation_ring R]
 
 lemma not_a_field : maximal_ideal R ≠ ⊥ := not_a_field'
 
-/-- A discrete valuation `R` is not a field. -/
+/-- A discrete valuation ring `R` is not a field. -/
 lemma not_is_field : ¬ is_field R :=
 ring.not_is_field_iff_exists_prime.mpr ⟨_, not_a_field R, is_maximal.is_prime' (maximal_ideal R)⟩
 

--- a/src/ring_theory/discrete_valuation_ring.lean
+++ b/src/ring_theory/discrete_valuation_ring.lean
@@ -60,6 +60,14 @@ variables (R : Type u) [comm_ring R] [is_domain R] [discrete_valuation_ring R]
 
 lemma not_a_field : maximal_ideal R ≠ ⊥ := not_a_field'
 
+/-- A discrete valuation `R` is not a field. -/
+lemma not_is_field : ¬ is_field R :=
+begin
+  rw ring.not_is_field_iff_exists_prime,
+  exact ⟨local_ring.maximal_ideal R, discrete_valuation_ring.not_a_field R,
+     ideal.is_maximal.is_prime' (maximal_ideal R)⟩,
+end
+
 variable {R}
 
 open principal_ideal_ring


### PR DESCRIPTION
A discrete valuation ring is not a field.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
