### PR TITLE
[Merged by Bors] - feat(order/locally_finite): add lemmas expanding `finset.Icc`

### DIFF
--- a/src/data/dfinsupp/interval.lean
+++ b/src/data/dfinsupp/interval.lean
@@ -152,6 +152,8 @@ locally_finite_order.of_Icc (Π₀ i, α i)
 
 variables (f g : Π₀ i, α i)
 
+lemma Icc_eq : Icc f g = (f.support ∪ g.support).dfinsupp (f.range_Icc g) := rfl
+
 lemma card_Icc : (Icc f g).card = ∏ i in f.support ∪ g.support, (Icc (f i) (g i)).card :=
 card_dfinsupp _ _
 

--- a/src/data/finsupp/interval.lean
+++ b/src/data/finsupp/interval.lean
@@ -75,6 +75,8 @@ locally_finite_order.of_Icc (ι →₀ α)
     exact forall_and_distrib,
   end)
 
+lemma Icc_eq : Icc f g = (f.support ∪ g.support).finsupp (f.range_Icc g) := rfl
+
 lemma card_Icc : (Icc f g).card = ∏ i in f.support ∪ g.support, (Icc (f i) (g i)).card :=
 card_finsupp _ _
 

--- a/src/data/pi/interval.lean
+++ b/src/data/pi/interval.lean
@@ -28,6 +28,8 @@ locally_finite_order.of_Icc _
 
 variables (a b : Π i, α i)
 
+lemma Icc_eq : Icc a b = pi_finset (λ i, Icc (a i) (b i)) := rfl
+
 lemma card_Icc : (Icc a b).card = ∏ i, (Icc (a i) (b i)).card := card_pi_finset _
 
 lemma card_Ico : (Ico a b).card = (∏ i, (Icc (a i) (b i)).card) - 1 :=

--- a/src/order/locally_finite.lean
+++ b/src/order/locally_finite.lean
@@ -656,6 +656,8 @@ lemma Iio_of_dual (a : αᵒᵈ) : Iio (of_dual a) = (Ioi a).map of_dual.to_embe
 
 end locally_finite_order_top
 
+namespace prod
+
 instance [locally_finite_order α] [locally_finite_order β]
   [decidable_rel ((≤) : α × β → α × β → Prop)] :
   locally_finite_order (α × β) :=
@@ -674,6 +676,21 @@ instance [locally_finite_order_bot α] [locally_finite_order_bot β]
   locally_finite_order_bot (α × β) :=
 locally_finite_order_bot.of_Iic' (α × β)
   (λ a, Iic a.fst ×ˢ Iic a.snd) (λ a x, by { rw [mem_product, mem_Iic, mem_Iic], refl })
+
+lemma Icc_eq [locally_finite_order α] [locally_finite_order β]
+  [decidable_rel ((≤) : α × β → α × β → Prop)] (p q : α × β) :
+  finset.Icc p q = finset.Icc p.1 q.1 ×ˢ finset.Icc p.2 q.2 := rfl
+
+@[simp] lemma Icc_mk_mk [locally_finite_order α] [locally_finite_order β]
+  [decidable_rel ((≤) : α × β → α × β → Prop)] (a₁ a₂ : α) (b₁ b₂ : β) :
+  finset.Icc (a₁, b₁) (a₂, b₂) = finset.Icc a₁ a₂ ×ˢ finset.Icc b₁ b₂ := rfl
+
+lemma card_Icc [locally_finite_order α] [locally_finite_order β]
+  [decidable_rel ((≤) : α × β → α × β → Prop)] (p q : α × β) :
+  (finset.Icc p q).card = (finset.Icc p.1 q.1).card * (finset.Icc p.2 q.2).card :=
+finset.card_product _ _
+
+end prod
 
 end preorder
 


### PR DESCRIPTION
This avoids the need to unfold `finset.Icc` to access the component-wise definitions.

I only really needed this for `prod`, but added a handful of lemmas elsewhere too.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
