### PR TITLE
refactor(data/set/lattice): Fix `set_closed` argument implicitness

### DIFF
--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -1824,25 +1824,21 @@ end set
 section sup_closed
 
 /-- A set `s` is sup-closed if for all `x₁, x₂ ∈ s`, `x₁ ⊔ x₂ ∈ s`. -/
-def sup_closed [has_sup α] (s : set α) : Prop := ∀ x1 x2, x1 ∈ s → x2 ∈ s → x1 ⊔ x2 ∈ s
+def sup_closed [has_sup α] (s : set α) : Prop := ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ s → a ⊔ b ∈ s
 
 lemma sup_closed_singleton [semilattice_sup α] (x : α) : sup_closed ({x} : set α) :=
-λ _ _ y1_mem y2_mem, by { rw set.mem_singleton_iff at *, rw [y1_mem, y2_mem, sup_idem], }
+λ a ha b hb, by { rw mem_singleton_iff at *, rw [ha, hb, sup_idem] }
 
 lemma sup_closed.inter [semilattice_sup α] {s t : set α} (hs : sup_closed s)
   (ht : sup_closed t) :
   sup_closed (s ∩ t) :=
-begin
-  intros x y hx hy,
-  rw set.mem_inter_iff at hx hy ⊢,
-  exact ⟨hs x y hx.left hy.left, ht x y hx.right hy.right⟩,
-end
+λ x hx y hy, ⟨hs hx.1 hy.1, ht hx.2 hy.2⟩
 
 lemma sup_closed_of_totally_ordered [semilattice_sup α] (s : set α)
   (hs : ∀ x y : α, x ∈ s → y ∈ s → y ≤ x ∨ x ≤ y) :
   sup_closed s :=
 begin
-  intros x y hxs hys,
+  intros x hxs y hys,
   cases hs x y hxs hys,
   { rwa (sup_eq_left.mpr h), },
   { rwa (sup_eq_right.mpr h), },

--- a/src/measure_theory/pi_system.lean
+++ b/src/measure_theory/pi_system.lean
@@ -347,7 +347,7 @@ begin
   rintros t1 ⟨p1, hp1S, f1, hf1m, ht1_eq⟩ t2 ⟨p2, hp2S, f2, hf2m, ht2_eq⟩ h_nonempty,
   simp_rw [pi_Union_Inter, set.mem_set_of_eq],
   let g := λ n, (ite (n ∈ p1) (f1 n) set.univ) ∩ (ite (n ∈ p2) (f2 n) set.univ),
-  use [p1 ∪ p2, h_sup p1 p2 hp1S hp2S, g],
+  use [p1 ∪ p2, h_sup hp1S hp2S, g],
   have h_inter_eq : t1 ∩ t2 = ⋂ i ∈ p1 ∪ p2, g i,
   { rw [ht1_eq, ht2_eq],
     simp_rw [← set.inf_eq_inter, g],

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -393,7 +393,7 @@ begin
     (generate_from_pi_Union_Inter_subsets m S).symm
     (generate_from_pi_Union_Inter_subsets m T).symm _,
   { refine is_pi_system_pi_Union_Inter _ (λ n, @is_pi_system_measurable_set Ω (m n)) _ _,
-    intros s t hs ht,
+    intros s hs t ht,
     simp only [finset.sup_eq_union, set.mem_set_of_eq, finset.coe_union, set.union_subset_iff],
     exact ⟨hs, ht⟩, },
   { refine is_pi_system_pi_Union_Inter _ (λ n, @is_pi_system_measurable_set Ω (m n)) _ _,

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -389,21 +389,18 @@ lemma indep_supr_of_disjoint [is_probability_measure μ] {m : ι → measurable_
   (h_le : ∀ i, m i ≤ m0) (h_indep : Indep m μ) {S T : set ι} (hST : disjoint S T) :
   indep (⨆ i ∈ S, m i) (⨆ i ∈ T, m i) μ :=
 begin
-  refine indep_sets.indep (supr₂_le (λ i _, h_le i)) (supr₂_le (λ i _, h_le i)) _ _
-    (generate_from_pi_Union_Inter_subsets m S).symm
-    (generate_from_pi_Union_Inter_subsets m T).symm _,
-  { refine is_pi_system_pi_Union_Inter _ (λ n, @is_pi_system_measurable_set Ω (m n)) _ _,
-    intros s hs t ht,
+  classical,
+  have : ∀ S : set ι, sup_closed {t : finset ι | ↑t ⊆ S},
+  { intros S s hs t ht,
     simp only [finset.sup_eq_union, set.mem_set_of_eq, finset.coe_union, set.union_subset_iff],
-    exact ⟨hs, ht⟩, },
-  { refine is_pi_system_pi_Union_Inter _ (λ n, @is_pi_system_measurable_set Ω (m n)) _ _,
-    intros s t hs ht,
-    simp only [finset.sup_eq_union, set.mem_set_of_eq, finset.coe_union, set.union_subset_iff],
-    exact ⟨hs, ht⟩, },
-  { classical,
-    refine indep_sets_pi_Union_Inter_of_disjoint h_indep (λ s t hs ht, _),
-    rw finset.disjoint_iff_ne,
-    exact λ i his j hjt, set.disjoint_iff_forall_ne.mp hST i (hs his) j (ht hjt), },
+    exact ⟨hs, ht⟩ },
+  refine indep_sets.indep (supr₂_le (λ i _, h_le i)) (supr₂_le (λ i _, h_le i))
+    (is_pi_system_pi_Union_Inter _ (λ n, @is_pi_system_measurable_set Ω (m n)) _ $ this _)
+    (is_pi_system_pi_Union_Inter _ (λ n, @is_pi_system_measurable_set Ω (m n)) _ $ this _)
+    (generate_from_pi_Union_Inter_subsets m S).symm (generate_from_pi_Union_Inter_subsets m T).symm
+    (indep_sets_pi_Union_Inter_of_disjoint h_indep $ λ s t hs ht, _),
+  rw finset.disjoint_iff_ne,
+  exact λ i his j hjt, set.disjoint_iff_forall_ne.mp hST i (hs his) j (ht hjt),
 end
 
 lemma indep_supr_of_directed_le {Ω} {m : ι → measurable_space Ω}


### PR DESCRIPTION
Semi-implicit arguments make more sense here, and reordering them too.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Note that this has very little impact, as it's used exactly once.

Also note that this definition is completely misplaced. It has nothing to do with the lattice structure on sets.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
