### PR TITLE
[Merged by Bors] - feat(topology/metric_space/hausdorff_distance): The diameter of a thickening

### DIFF
--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -1068,7 +1068,7 @@ begin
   obtain ⟨y', hy', hyy'⟩ := hy,
   refine (edist_triangle_right _ _ _).trans ((add_le_add hxx'.le $ (edist_triangle _ _ _).trans $
     add_le_add hyy'.le $ edist_le_diam_of_mem hy' hx').trans_eq _),
-  -- Now we're done, but `ring` won't do it :(
+  -- Now we're done, but `ring` won't do it because we're on `ennreal` :(
   rw [←add_assoc, ←two_mul, mul_add,
     ennreal.mul_div_cancel' ennreal.two_ne_zero ennreal.two_ne_top],
   abel,

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -1077,18 +1077,30 @@ end
 lemma ediam_thickening_le (ε : ℝ≥0) : emetric.diam (thickening ε s) ≤ emetric.diam s + 2 * ε :=
 (emetric.diam_mono $ thickening_subset_cthickening _ _).trans $ ediam_cthickening_le _
 
-lemma diam_cthickening_le {α : Type*} [pseudo_metric_space α] {s : set α} (hε : 0 ≤ ε)
-  (hs : bounded s) : diam (cthickening ε s) ≤ diam s + 2 * ε :=
+lemma diam_cthickening_le {α : Type*} [pseudo_metric_space α] (s : set α) (hε : 0 ≤ ε) :
+  diam (cthickening ε s) ≤ diam s + 2 * ε :=
 begin
-  have : (2 : ℝ≥0∞) * @coe ℝ≥0 _ _ ⟨ε, hε⟩ ≠ ⊤ := by simp,
-  refine (ennreal.to_real_mono (ennreal.add_ne_top.2 ⟨hs.ediam_ne_top, this⟩) $
-    ediam_cthickening_le ⟨ε, hε⟩).trans_eq _,
-  simp [ennreal.to_real_add hs.ediam_ne_top this, diam],
+  by_cases hs : bounded (cthickening ε s),
+  { replace hs := hs.mono (self_subset_cthickening _),
+    have : (2 : ℝ≥0∞) * @coe ℝ≥0 _ _ ⟨ε, hε⟩ ≠ ⊤ := by simp,
+    refine (ennreal.to_real_mono (ennreal.add_ne_top.2 ⟨hs.ediam_ne_top, this⟩) $
+      ediam_cthickening_le ⟨ε, hε⟩).trans_eq _,
+    simp [ennreal.to_real_add hs.ediam_ne_top this, diam] },
+  { rw diam_eq_zero_of_unbounded hs,
+    positivity }
 end
 
-lemma diam_thickening_le {α : Type*} [pseudo_metric_space α] {s : set α} (hε : 0 ≤ ε)
-  (hs : bounded s) : diam (thickening ε s) ≤ diam s + 2 * ε :=
-(diam_mono (thickening_subset_cthickening _ _) hs.cthickening).trans $ diam_cthickening_le hε hs
+lemma diam_thickening_le {α : Type*} [pseudo_metric_space α] (s : set α) (hε : 0 ≤ ε) :
+  diam (thickening ε s) ≤ diam s + 2 * ε :=
+begin
+  by_cases hs : bounded s,
+  { exact (diam_mono (thickening_subset_cthickening _ _) hs.cthickening).trans
+      (diam_cthickening_le _ hε) },
+  obtain rfl | hε := hε.eq_or_lt,
+  { simp [thickening_of_nonpos, diam_nonneg] },
+  { rw diam_eq_zero_of_unbounded (mt (bounded.mono $ self_subset_thickening hε _) hs),
+    positivity }
+end
 
 @[simp] lemma thickening_closure : thickening δ (closure s) = thickening δ s :=
 by simp_rw [thickening, inf_edist_closure]

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -1054,6 +1054,42 @@ by simp_rw [cthickening, inf_edist_union, inf_eq_min, min_le_iff, set_of_or]
   thickening δ (⋃ i, f i) = ⋃ i, thickening δ (f i) :=
 by simp_rw [thickening, inf_edist_Union, infi_lt_iff, set_of_exists]
 
+lemma ediam_cthickening_le (ε : ℝ≥0) : emetric.diam (cthickening ε s) ≤ emetric.diam s + 2 * ε :=
+begin
+  refine diam_le (λ x hx y hy, ennreal.le_of_forall_pos_le_add $ λ δ hδ _, _),
+  rw [mem_cthickening_iff, ennreal.of_real_coe_nnreal] at hx hy,
+  have hε : (ε : ℝ≥0∞) < ε + ↑(δ / 2) :=
+    ennreal.coe_lt_coe.2 (lt_add_of_pos_right _ $ half_pos hδ),
+  rw [ennreal.coe_div two_ne_zero, ennreal.coe_two] at hε,
+  replace hx := hx.trans_lt hε,
+  replace hy := hy.trans_lt hε,
+  rw inf_edist_lt_iff at hx hy,
+  obtain ⟨x', hx', hxx'⟩ := hx,
+  obtain ⟨y', hy', hyy'⟩ := hy,
+  refine (edist_triangle_right _ _ _).trans ((add_le_add hxx'.le $ (edist_triangle _ _ _).trans $
+    add_le_add hyy'.le $ edist_le_diam_of_mem hy' hx').trans_eq _),
+  -- Now we're done, but `ring` won't do it :(
+  rw [←add_assoc, ←two_mul, mul_add,
+    ennreal.mul_div_cancel' ennreal.two_ne_zero ennreal.two_ne_top],
+  abel,
+end
+
+lemma ediam_thickening_le (ε : ℝ≥0) : emetric.diam (thickening ε s) ≤ emetric.diam s + 2 * ε :=
+(emetric.diam_mono $ thickening_subset_cthickening _ _).trans $ ediam_cthickening_le _
+
+lemma diam_cthickening_le {α : Type*} [pseudo_metric_space α] {s : set α} (hε : 0 ≤ ε)
+  (hs : bounded s) : diam (cthickening ε s) ≤ diam s + 2 * ε :=
+begin
+  have : (2 : ℝ≥0∞) * @coe ℝ≥0 _ _ ⟨ε, hε⟩ ≠ ⊤ := by simp,
+  refine (ennreal.to_real_mono (ennreal.add_ne_top.2 ⟨hs.ediam_ne_top, this⟩) $
+    ediam_cthickening_le ⟨ε, hε⟩).trans_eq _,
+  simp [ennreal.to_real_add hs.ediam_ne_top this, diam],
+end
+
+lemma diam_thickening_le {α : Type*} [pseudo_metric_space α] {s : set α} (hε : 0 ≤ ε)
+  (hs : bounded s) : diam (thickening ε s) ≤ diam s + 2 * ε :=
+(diam_mono (thickening_subset_cthickening _ _) hs.cthickening).trans $ diam_cthickening_le hε hs
+
 @[simp] lemma thickening_closure : thickening δ (closure s) = thickening δ s :=
 by simp_rw [thickening, inf_edist_closure]
 


### PR DESCRIPTION
The diameter of the `ε`-thickening of `s` is at most the diameter of `s` + `2ε`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
