### PR TITLE
[Merged by Bors] - refactor(analysis/special_functions/trigonometric/inverse): `cos_arcsin`, `sin_arccos` degenerate cases

### DIFF
--- a/src/analysis/special_functions/complex/arg.lean
+++ b/src/analysis/special_functions/complex/arg.lean
@@ -46,17 +46,13 @@ begin
     exact div_le_one_of_le x.abs_im_le_abs (abs.nonneg x) },
   rw abs_le at him,
   rw arg, split_ifs with h₁ h₂ h₂,
-  { rw [real.cos_arcsin]; field_simp [real.sqrt_sq, habs.le, *] },
+  { rw [real.cos_arcsin], field_simp [real.sqrt_sq, habs.le, *] },
   { rw [real.cos_add_pi, real.cos_arcsin],
-    { field_simp [real.sqrt_div (sq_nonneg _), real.sqrt_sq_eq_abs,
-        _root_.abs_of_neg (not_le.1 h₁), *] },
-    { simpa [neg_div] using him.2 },
-    { simpa [neg_div, neg_le] using him.1 } },
+    field_simp [real.sqrt_div (sq_nonneg _), real.sqrt_sq_eq_abs,
+      _root_.abs_of_neg (not_le.1 h₁), *] },
   { rw [real.cos_sub_pi, real.cos_arcsin],
-    { field_simp [real.sqrt_div (sq_nonneg _), real.sqrt_sq_eq_abs,
-        _root_.abs_of_neg (not_le.1 h₁), *] },
-    { simpa [neg_div] using him.2 },
-    { simpa [neg_div, neg_le] using him.1 } }
+    field_simp [real.sqrt_div (sq_nonneg _), real.sqrt_sq_eq_abs,
+      _root_.abs_of_neg (not_le.1 h₁), *] }
 end
 
 @[simp] lemma abs_mul_exp_arg_mul_I (x : ℂ) : ↑(abs x) * exp (arg x * I) = x :=

--- a/src/analysis/special_functions/trigonometric/inverse.lean
+++ b/src/analysis/special_functions/trigonometric/inverse.lean
@@ -224,6 +224,7 @@ lemma maps_to_sin_Ioo : maps_to sin (Ioo (-(π / 2)) (π / 2)) (Ioo (-1) 1) :=
 lemma cos_arcsin_nonneg (x : ℝ) : 0 ≤ cos (arcsin x) :=
 cos_nonneg_of_mem_Icc ⟨neg_pi_div_two_le_arcsin _, arcsin_le_pi_div_two _⟩
 
+-- The junk values for `arcsin` and `sqrt` make this true even outside `[-1, 1]`.
 lemma cos_arcsin (x : ℝ) : cos (arcsin x) = sqrt (1 - x ^ 2) :=
 begin
   by_cases hx₁ : -1 ≤ x, swap,
@@ -241,7 +242,7 @@ begin
 end
 
 /-- Inverse of the `cos` function, returns values in the range `0 ≤ arccos x` and `arccos x ≤ π`.
-  If the argument is not between `-1` and `1` it defaults to `π / 2` -/
+  It defaults to `π` on `(-∞, -1)` and to `0` to `(1, ∞)`. -/
 @[pp_nodot] noncomputable def arccos (x : ℝ) : ℝ :=
 π / 2 - arcsin x
 
@@ -295,6 +296,7 @@ by rw [arccos, arcsin_of_one_le hx, sub_self]
 lemma arccos_of_le_neg_one {x : ℝ} (hx : x ≤ -1) : arccos x = π :=
 by rw [arccos, arcsin_of_le_neg_one hx, sub_neg_eq_add, add_halves']
 
+-- The junk values for `arccos` and `sqrt` make this true even outside `[-1, 1]`.
 lemma sin_arccos (x : ℝ) : sin (arccos x) = sqrt (1 - x ^ 2) :=
 begin
   by_cases hx₁ : -1 ≤ x, swap,

--- a/src/analysis/special_functions/trigonometric/inverse.lean
+++ b/src/analysis/special_functions/trigonometric/inverse.lean
@@ -224,9 +224,17 @@ lemma maps_to_sin_Ioo : maps_to sin (Ioo (-(π / 2)) (π / 2)) (Ioo (-1) 1) :=
 lemma cos_arcsin_nonneg (x : ℝ) : 0 ≤ cos (arcsin x) :=
 cos_nonneg_of_mem_Icc ⟨neg_pi_div_two_le_arcsin _, arcsin_le_pi_div_two _⟩
 
-lemma cos_arcsin {x : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) : cos (arcsin x) = sqrt (1 - x ^ 2) :=
-have sin (arcsin x) ^ 2 + cos (arcsin x) ^ 2 = 1 := sin_sq_add_cos_sq (arcsin x),
+lemma cos_arcsin (x : ℝ) : cos (arcsin x) = sqrt (1 - x ^ 2) :=
 begin
+  by_cases hx₁ : -1 ≤ x, swap,
+  { rw not_le at hx₁,
+    rw [arcsin_of_le_neg_one hx₁.le, cos_neg, cos_pi_div_two, sqrt_eq_zero_of_nonpos],
+    nlinarith },
+  by_cases hx₂ : x ≤ 1, swap,
+  { rw not_le at hx₂,
+    rw [arcsin_of_one_le hx₂.le, cos_pi_div_two, sqrt_eq_zero_of_nonpos],
+    nlinarith },
+  have : sin (arcsin x) ^ 2 + cos (arcsin x) ^ 2 = 1 := sin_sq_add_cos_sq (arcsin x),
   rw [← eq_sub_iff_add_eq', ← sqrt_inj (sq_nonneg _) (sub_nonneg.2 (sin_sq_le_one (arcsin x))),
     sq, sqrt_mul_self (cos_arcsin_nonneg _)] at this,
   rw [this, sin_arcsin hx₁ hx₂],
@@ -281,8 +289,24 @@ by rw [arccos, sub_eq_iff_eq_add, ← sub_eq_iff_eq_add', div_two_sub_self, neg_
 lemma arccos_neg (x : ℝ) : arccos (-x) = π - arccos x :=
 by rw [← add_halves π, arccos, arcsin_neg, arccos, add_sub_assoc, sub_sub_self, sub_neg_eq_add]
 
-lemma sin_arccos {x : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) : sin (arccos x) = sqrt (1 - x ^ 2) :=
-by rw [arccos_eq_pi_div_two_sub_arcsin, sin_pi_div_two_sub, cos_arcsin hx₁ hx₂]
+lemma arccos_of_one_le {x : ℝ} (hx : 1 ≤ x) : arccos x = 0 :=
+by rw [arccos, arcsin_of_one_le hx, sub_self]
+
+lemma arccos_of_le_neg_one {x : ℝ} (hx : x ≤ -1) : arccos x = π :=
+by rw [arccos, arcsin_of_le_neg_one hx, sub_neg_eq_add, add_halves']
+
+lemma sin_arccos (x : ℝ) : sin (arccos x) = sqrt (1 - x ^ 2) :=
+begin
+  by_cases hx₁ : -1 ≤ x, swap,
+  { rw not_le at hx₁,
+    rw [arccos_of_le_neg_one hx₁.le, sin_pi, sqrt_eq_zero_of_nonpos],
+    nlinarith },
+  by_cases hx₂ : x ≤ 1, swap,
+  { rw not_le at hx₂,
+    rw [arccos_of_one_le hx₂.le, sin_zero, sqrt_eq_zero_of_nonpos],
+    nlinarith },
+  rw [arccos_eq_pi_div_two_sub_arcsin, sin_pi_div_two_sub, cos_arcsin]
+end
 
 @[simp] lemma arccos_le_pi_div_two {x} : arccos x ≤ π / 2 ↔ 0 ≤ x := by simp [arccos]
 

--- a/src/analysis/special_functions/trigonometric/inverse_deriv.lean
+++ b/src/analysis/special_functions/trigonometric/inverse_deriv.lean
@@ -34,7 +34,7 @@ begin
       cont_diff_at_const.congr_of_eventually_eq this⟩ },
   cases h₂.lt_or_lt with h₂ h₂,
   { have : 0 < sqrt (1 - x ^ 2) := sqrt_pos.2 (by nlinarith [h₁, h₂]),
-    simp only [← cos_arcsin h₁.le h₂.le, one_div] at this ⊢,
+    simp only [← cos_arcsin, one_div] at this ⊢,
     exact ⟨sin_local_homeomorph.has_strict_deriv_at_symm ⟨h₁, h₂⟩ this.ne'
       (has_strict_deriv_at_sin _),
       sin_local_homeomorph.cont_diff_at_symm_deriv this.ne' ⟨h₁, h₂⟩

--- a/src/geometry/euclidean/angle/unoriented/basic.lean
+++ b/src/geometry/euclidean/angle/unoriented/basic.lean
@@ -179,8 +179,7 @@ lemma sin_angle_mul_norm_mul_norm (x y : V) : real.sin (angle x y) * (∥x∥ * 
     real.sqrt (inner x x * inner y y - inner x y * inner x y) :=
 begin
   unfold angle,
-  rw [real.sin_arccos (abs_le.mp (abs_real_inner_div_norm_mul_norm_le_one x y)).1
-                      (abs_le.mp (abs_real_inner_div_norm_mul_norm_le_one x y)).2,
+  rw [real.sin_arccos,
       ←real.sqrt_mul_self (mul_nonneg (norm_nonneg x) (norm_nonneg y)),
       ←real.sqrt_mul' _ (mul_self_nonneg _), sq,
       real.sqrt_mul_self (mul_nonneg (norm_nonneg x) (norm_nonneg y)),


### PR DESCRIPTION
The definitions of `arcsin`, `arccos` and `sqrt` in degenerate cases mean that the lemmas `cos_arcsin` and `sin_arccos` are actually true for all real arguments (including those outside the interval from -1 to 1), without needing any inequality hypotheses.  Remove those inequality hypotheses from the lemmas, so simplifying use of those lemmas elsewhere.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
