### PR TITLE
[Merged by Bors] - feat(group_theory/free_group): to_additivize where possible

### DIFF
--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -15,17 +15,17 @@ functor from groups to types, see `algebra/category/Group/adjunctions`.
 
 ## Main definitions
 
-* `free_group`: the free group associated to a type `α` defined as the words over `a : α × bool`
-  modulo the relation `a * x * x⁻¹ * b = a * b`.
-* `free_group.mk`: the canonical quotient map `list (α × bool) → free_group α`.
-* `free_group.of`: the canonical injection `α → free_group α`.
-* `free_group.lift f`: the canonical group homomorphism `free_group α →* G`
+* `free_group`/`free_add_group`: the free group (resp. free additive group) associated to a type
+  `α` defined as the words over `a : α × bool` modulo the relation `a * x * x⁻¹ * b = a * b`.
+* `free_group.mk`/`free_add_group.mk`: the canonical quotient map `list (α × bool) → free_group α`.
+* `free_group.of`/`free_add_group.of`: the canonical injection `α → free_group α`.
+* `free_group.lift f`/`free_add_group.lift`: the canonical group homomorphism `free_group α →* G`
   given a group `G` and a function `f : α → G`.
 
 ## Main statements
 
-* `free_group.church_rosser`: The Church-Rosser theorem for word reduction
-  (also known as Newman's diamond lemma).
+* `free_group.church_rosser`/`free_add_group.church_rosser`: The Church-Rosser theorem for word
+  reduction (also known as Newman's diamond lemma).
 * `free_group.free_group_unit_equiv_int`: The free group over the one-point type
   is isomorphic to the integers.
 * The free group construction is an instance of a monad.
@@ -36,6 +36,10 @@ First we introduce the one step reduction relation `free_group.red.step`:
 `w * x * x⁻¹ * v   ~>   w * v`, its reflexive transitive closure `free_group.red.trans`
 and prove that its join is an equivalence relation. Then we introduce `free_group α` as a quotient
 over `free_group.red.step`.
+
+For the additive version we introduce the same relation under a different name so that we can
+distinguish the quotient types more easily.
+
 
 ## Tags
 
@@ -734,7 +738,7 @@ end sum
 
 /-- The bijection between the free group on the empty type, and a type with one element. -/
 @[to_additive
-"The bijection between the addititve free group on the empty type, and a type with one element."]
+"The bijection between the additive free group on the empty type, and a type with one element."]
 def free_group_empty_equiv_unit : free_group empty ≃ unit :=
 { to_fun    := λ _, (),
   inv_fun   := λ _, 1,

--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -52,22 +52,23 @@ local attribute [simp] list.append_eq_has_append
 
 run_cmd to_additive.map_namespace `free_group `free_add_group
 
+/-- Reduction step for the additive free group relation: `w + x + (-x) + v ~> w + v` -/
 inductive free_add_group.red.step : list (α × bool) → list (α × bool) → Prop
 | bnot {L₁ L₂ x b} : free_add_group.red.step (L₁ ++ (x, b) :: (x, bnot b) :: L₂) (L₁ ++ L₂)
 attribute [simp] free_add_group.red.step.bnot
 
+/-- Reduction step for the multiplicative free group relation: `w * x * x⁻¹ * v ~> w * v` -/
 @[to_additive]
 inductive free_group.red.step : list (α × bool) → list (α × bool) → Prop
 | bnot {L₁ L₂ x b} : free_group.red.step (L₁ ++ (x, b) :: (x, bnot b) :: L₂) (L₁ ++ L₂)
 attribute [simp] free_group.red.step.bnot
 
 namespace free_group
-/-- Reduction step: `w * x * x⁻¹ * v ~> w * v` -/
 
 variables {L L₁ L₂ L₃ L₄ : list (α × bool)}
 
 /-- Reflexive-transitive closure of red.step -/
-@[to_additive]
+@[to_additive "Reflexive-transitive closure of red.step"]
 def red : list (α × bool) → list (α × bool) → Prop := refl_trans_gen red.step
 
 @[refl, to_additive] lemma red.refl : red L L := refl_trans_gen.refl
@@ -75,13 +76,16 @@ def red : list (α × bool) → list (α × bool) → Prop := refl_trans_gen red
 
 namespace red
 
-/-- Predicate asserting that word `w₁` can be reduced to `w₂` in one step, i.e. there are words
+/-- Predicate asserting that the word `w₁` can be reduced to `w₂` in one step, i.e. there are words
 `w₃ w₄` and letter `x` such that `w₁ = w₃xx⁻¹w₄` and `w₂ = w₃w₄`  -/
-@[to_additive]
+@[to_additive
+"Predicate asserting that the word `w₁` can be reduced to `w₂` in one step, i.e. there are words
+`w₃ w₄` and letter `x` such that `w₁ = w₃ + x + (-x) + w₄` and `w₂ = w₃w₄`"]
 theorem step.length : ∀ {L₁ L₂ : list (α × bool)}, step L₁ L₂ → L₂.length + 2 = L₁.length
 | _ _ (@red.step.bnot _ L1 L2 x b) := by rw [list.length_append, list.length_append]; refl
 
-@[simp, to_additive] lemma step.bnot_rev {x b} : step (L₁ ++ (x, bnot b) :: (x, b) :: L₂) (L₁ ++ L₂) :=
+@[simp, to_additive]
+lemma step.bnot_rev {x b} : step (L₁ ++ (x, bnot b) :: (x, b) :: L₂) (L₁ ++ L₂) :=
 by cases b; from step.bnot
 
 @[simp, to_additive] lemma step.cons_bnot {x b} : red.step ((x, b) :: (x, bnot b) :: L) L :=
@@ -176,7 +180,10 @@ refl_trans_gen.single
 /-- **Church-Rosser theorem** for word reduction: If `w1 w2 w3` are words such that `w1` reduces
 to `w2` and `w3` respectively, then there is a word `w4` such that `w2` and `w3` reduce to `w4`
 respectively. This is also known as Newman's diamond lemma. -/
-@[to_additive]
+@[to_additive
+"**Church-Rosser theorem** for word reduction: If `w1 w2 w3` are words such that `w1` reduces
+to `w2` and `w3` respectively, then there is a word `w4` such that `w2` and `w3` reduce to `w4`
+respectively. This is also known as Newman's diamond lemma."]
 theorem church_rosser : red L₁ L₂ → red L₁ L₃ → join red L₂ L₃ :=
 relation.church_rosser (assume a b c hab hac,
 match b, c, red.step.diamond hab hac rfl with
@@ -241,18 +248,19 @@ iff.intro
   (assume ⟨L₃, L₄, eq, h₃, h₄⟩, eq.symm ▸ append_append h₃ h₄)
 
 /-- The empty word `[]` only reduces to itself. -/
-@[to_additive]
+@[to_additive "The empty word `[]` only reduces to itself."]
 theorem nil_iff : red [] L ↔ L = [] :=
 refl_trans_gen_iff_eq (assume l, red.not_step_nil)
 
 /-- A letter only reduces to itself. -/
-@[to_additive]
+@[to_additive "A letter only reduces to itself."]
 theorem singleton_iff {x} : red [x] L₁ ↔ L₁ = [x] :=
 refl_trans_gen_iff_eq (assume l, not_step_singleton)
 
 /-- If `x` is a letter and `w` is a word such that `xw` reduces to the empty word, then `w` reduces
 to `x⁻¹` -/
-@[to_additive]
+@[to_additive "If `x` is a letter and `w` is a word such that `x + w` reduces to the empty word,
+then `w` reduces to `-x`."]
 theorem cons_nil_iff_singleton {x b} : red ((x, b) :: L) [] ↔ red L [(x, bnot b)] :=
 iff.intro
   (assume h,
@@ -278,7 +286,9 @@ end
 
 /-- If `x` and `y` are distinct letters and `w₁ w₂` are words such that `xw₁` reduces to `yw₂`, then
 `w₁` reduces to `x⁻¹yw₂`. -/
-@[to_additive]
+@[to_additive
+"If `x` and `y` are distinct letters and `w₁ w₂` are words such that `x + w₁` reduces to `y + w₂`,
+then `w₁` reduces to `-x + y + w₂`."]
 theorem inv_of_red_of_ne {x1 b1 x2 b2}
   (H1 : (x1, b1) ≠ (x2, b2))
   (H2 : red ((x1, b1) :: L₁) ((x2, b2) :: L₂)) :
@@ -304,7 +314,8 @@ theorem step.sublist (H : red.step L₁ L₂) : L₂ <+ L₁ :=
 by cases H; simp; constructor; constructor; refl
 
 /-- If `w₁ w₂` are words such that `w₁` reduces to `w₂`, then `w₂` is a sublist of `w₁`. -/
-@[to_additive]
+@[to_additive "If `w₁ w₂` are words such that `w₁` reduces to `w₂`,
+then `w₂` is a sublist of `w₁`."]
 protected theorem sublist : red L₁ L₂ → L₂ <+ L₁ :=
 refl_trans_gen_of_transitive_reflexive
   (λl, list.sublist.refl l) (λa b c hab hbc, list.sublist.trans hbc hab) (λa b, red.step.sublist)
@@ -370,7 +381,8 @@ end free_group
 
 /-- The free group over a type, i.e. the words formed by the elements of the type and their formal
 inverses, quotient by one step reduction. -/
-@[to_additive]
+@[to_additive "The free additive group over a type, i.e. the words formed by the elements of the
+type and their formal inverses, quotient by one step reduction."]
 def free_group (α : Type u) : Type u :=
 quot $ @free_group.red.step α
 
@@ -379,7 +391,7 @@ namespace free_group
 variables {α} {L L₁ L₂ L₃ L₄ : list (α × bool)}
 
 /-- The canonical map from `list (α × bool)` to the free group on `α`. -/
-@[to_additive]
+@[to_additive "The canonical map from `list (α × bool)` to the free additive group on `α`."]
 def mk (L) : free_group α := quot.mk red.step L
 
 @[simp, to_additive] lemma quot_mk_eq_mk : quot.mk red.step L = mk L := rfl
@@ -412,7 +424,8 @@ instance : has_mul (free_group α) :=
 @[simp, to_additive] lemma mul_mk : mk L₁ * mk L₂ = mk (L₁ ++ L₂) := rfl
 
 /-- Transform a word representing a free group element into a word representing its inverse. --/
-@[to_additive]
+@[to_additive "Transform a word representing a free group element into a word representing its
+negative."]
 def inv_rev (w : list (α × bool)) : list (α × bool) :=
 (list.map (λ (g : α × bool), (g.1, bnot g.2)) w).reverse
 
@@ -448,7 +461,8 @@ lemma red.inv_rev {L₁ L₂ : list (α × bool)} (h : red L₁ L₂) :
   red (inv_rev L₁) (inv_rev L₂) :=
 relation.refl_trans_gen.lift _ (λ a b, red.step.inv_rev) h
 
-@[simp, to_additive] lemma red.step_inv_rev_iff : red.step (inv_rev L₁) (inv_rev L₂) ↔ red.step L₁ L₂ :=
+@[simp, to_additive]
+lemma red.step_inv_rev_iff : red.step (inv_rev L₁) (inv_rev L₂) ↔ red.step L₁ L₂ :=
 ⟨λ h, by simpa only [inv_rev_inv_rev] using h.inv_rev, λ h, h.inv_rev⟩
 
 @[simp, to_additive] lemma red_inv_rev_iff : red (inv_rev L₁) (inv_rev L₂) ↔ red L₁ L₂ :=
@@ -467,7 +481,8 @@ instance : group (free_group α) :=
 
 /-- `of` is the canonical injection from the type to the free group over that type by sending each
 element to the equivalence class of the letter that is the element. -/
-@[to_additive]
+@[to_additive "`of` is the canonical injection from the type to the free group over that type
+by sending each element to the equivalence class of the letter that is the element."]
 def of (x : α) : free_group α :=
 mk [(x, tt)]
 
@@ -476,8 +491,8 @@ theorem red.exact : mk L₁ = mk L₂ ↔ join red L₁ L₂ :=
 calc (mk L₁ = mk L₂) ↔ eqv_gen red.step L₁ L₂ : iff.intro (quot.exact _) quot.eqv_gen_sound
   ... ↔ join red L₁ L₂ : eqv_gen_step_iff_join_red
 
-/-- The canonical injection from the type to the free group is an injection. -/
-@[to_additive]
+/-- The canonical map from the type to the free group is an injection. -/
+@[to_additive "The canonical map from the type to the additive free group is an injection."]
 theorem of_injective : function.injective (@of α) :=
 λ _ _ H, let ⟨L₁, hx, hy⟩ := red.exact.1 H in
   by simp [red.singleton_iff] at hx hy; cc
@@ -487,7 +502,8 @@ section lift
 variables {β : Type v} [group β] (f : α → β) {x y : free_group α}
 
 /-- Given `f : α → β` with `β` a group, the canonical map `list (α × bool) → β` -/
-@[to_additive]
+@[to_additive "Given `f : α → β` with `β` an additive group, the canonical map
+`list (α × bool) → β`"]
 def lift.aux : list (α × bool) → β :=
 λ L, list.prod $ L.map $ λ x, cond x.2 (f x.1) (f x.1)⁻¹
 
@@ -500,7 +516,9 @@ by cases H with _ _ _ b; cases b; simp [lift.aux]
 /-- If `β` is a group, then any function from `α` to `β`
 extends uniquely to a group homomorphism from
 the free group over `α` to `β` -/
-@[to_additive, simps symm_apply]
+@[to_additive "If `β` is an additive group, then any function from `α` to `β`
+extends uniquely to an additive group homomorphism from
+the free additive group over `α` to `β`", simps symm_apply]
 def lift : (α → β) ≃ (free_group α →* β) :=
 { to_fun := λ f,
     monoid_hom.mk' (quot.lift (lift.aux f) $ λ L₁ L₂, red.step.lift) $ begin
@@ -535,7 +553,10 @@ monoid_hom.congr_fun $ (lift.symm_apply_eq).mp (funext hg : g ∘ of = f)
 /-- Two homomorphisms out of a free group are equal if they are equal on generators.
 
 See note [partially-applied ext lemmas]. -/
-@[ext, to_additive]
+@[ext, to_additive
+"Two homomorphisms out of a free additive group are equal if they are equal on generators.
+
+See note [partially-applied ext lemmas]."]
 lemma ext_hom {G : Type*} [group G] (f g : free_group α →* G) (h : ∀ a, f (of a) = g (of a)) :
   f = g :=
 lift.symm.injective $ funext h
@@ -571,8 +592,9 @@ variables {β : Type v} (f : α → β) {x y : free_group α}
 
 /-- Any function from `α` to `β` extends uniquely
 to a group homomorphism from the free group
-ver `α` to the free group over `β`. -/
-@[to_additive]
+over `α` to the free group over `β`. -/
+@[to_additive "Any function from `α` to `β` extends uniquely to an additive group homomorphism
+from the additive free group over `α` to the additive free group over `β`."]
 def map : free_group α →* free_group β :=
 monoid_hom.mk'
   (quot.map (list.map $ λ x, (f x.1, x.2)) $ λ L₁ L₂ H, by cases H; simp)
@@ -614,14 +636,16 @@ eq.symm $ map.unique _ $ λ x, by simp
 The converse can be found in `group_theory.free_abelian_group_finsupp`,
 as `equiv.of_free_group_equiv`
  -/
-@[to_additive, simps apply]
+@[to_additive "Equivalent types give rise to additively equivalent additive free groups.",
+simps apply]
 def free_group_congr {α β} (e : α ≃ β) : free_group α ≃* free_group β :=
 { to_fun := map e, inv_fun := map e.symm,
   left_inv := λ x, by simp [function.comp, map.comp],
   right_inv := λ x, by simp [function.comp, map.comp],
   map_mul' := monoid_hom.map_mul _ }
 
-@[simp, to_additive] lemma free_group_congr_refl : free_group_congr (equiv.refl α) = mul_equiv.refl _ :=
+@[simp, to_additive]
+lemma free_group_congr_refl : free_group_congr (equiv.refl α) = mul_equiv.refl _ :=
 mul_equiv.ext map.id
 
 @[simp, to_additive] lemma free_group_congr_symm {α β} (e : α ≃ β) :
@@ -642,8 +666,11 @@ variables [group α] (x y : free_group α)
 /-- If `α` is a group, then any function from `α` to `α`
 extends uniquely to a homomorphism from the
 free group over `α` to `α`. This is the multiplicative
-version of `sum`. -/
-@[to_additive]
+version of `free_group.sum`. -/
+@[to_additive
+"If `α` is an additive group, then any function from `α` to `α`
+extends uniquely to an additive homomorphism from the
+additive free group over `α` to `α`."]
 def prod : free_group α →* α := lift id
 
 variables {x y}
@@ -706,7 +733,8 @@ prod.of
 end sum
 
 /-- The bijection between the free group on the empty type, and a type with one element. -/
-@[to_additive]
+@[to_additive
+"The bijection between the addititve free group on the empty type, and a type with one element."]
 def free_group_empty_equiv_unit : free_group empty ≃ unit :=
 { to_fun    := λ _, (),
   inv_fun   := λ _, 1,
@@ -752,13 +780,14 @@ protected theorem induction_on
 quot.induction_on z $ λ L, list.rec_on L C1 $ λ ⟨x, b⟩ tl ih,
 bool.rec_on b (Cm _ _ (Ci _ $ Cp x) ih) (Cm _ _ (Cp x) ih)
 
-@[simp, to_additive] lemma map_pure (f : α → β) (x : α) : f <$> (pure x : free_group α) = pure (f x) :=
-map.of
+@[simp, to_additive]
+lemma map_pure (f : α → β) (x : α) : f <$> (pure x : free_group α) = pure (f x) := map.of
 
 @[simp, to_additive] lemma map_one (f : α → β) : f <$> (1 : free_group α) = 1 :=
 (map f).map_one
 
-@[simp, to_additive] lemma map_mul (f : α → β) (x y : free_group α) : f <$> (x * y) = f <$> x * f <$> y :=
+@[simp, to_additive]
+lemma map_mul (f : α → β) (x y : free_group α) : f <$> (x * y) = f <$> x * f <$> y :=
 (map f).map_mul x y
 
 @[simp, to_additive] lemma map_inv (f : α → β) (x : free_group α) : f <$> (x⁻¹) = (f <$> x)⁻¹ :=
@@ -774,7 +803,8 @@ lift.of
   x * y >>= f = (x >>= f) * (y >>= f) :=
 (lift f).map_mul _ _
 
-@[simp, to_additive] lemma inv_bind (f : α → free_group β) (x : free_group α) : x⁻¹ >>= f = (x >>= f)⁻¹ :=
+@[simp, to_additive]
+lemma inv_bind (f : α → free_group β) (x : free_group α) : x⁻¹ >>= f = (x >>= f)⁻¹ :=
 (lift f).map_inv _
 
 @[to_additive]
@@ -798,7 +828,8 @@ variable [decidable_eq α]
 
 /-- The maximal reduction of a word. It is computable
 iff `α` has decidable equality. -/
-@[to_additive]
+@[to_additive "The maximal reduction of a word. It is computable
+iff `α` has decidable equality."]
 def reduce (L : list (α × bool)) : list (α × bool) :=
 list.rec_on L [] $ λ hd1 tl1 ih,
 list.cases_on ih [hd1] $ λ hd2 tl2,
@@ -812,7 +843,9 @@ else hd1 :: hd2 :: tl2
 
 /-- The first theorem that characterises the function
 `reduce`: a word reduces to its maximal reduction. -/
-@[to_additive]
+@[to_additive
+"The first theorem that characterises the function
+`reduce`: a word reduces to its maximal reduction."]
 theorem reduce.red : red L (reduce L) :=
 begin
   induction L with hd1 tl1 ih,
@@ -864,7 +897,9 @@ end
 /-- The second theorem that characterises the
 function `reduce`: the maximal reduction of a word
 only reduces to itself. -/
-@[to_additive]
+@[to_additive "The second theorem that characterises the
+function `reduce`: the maximal reduction of a word
+only reduces to itself."]
 theorem reduce.min (H : red (reduce L₁) L₂) : reduce L₁ = L₂ :=
 begin
   induction H with L1 L' L2 H1 H2 ih,
@@ -876,7 +911,9 @@ end
 /-- `reduce` is idempotent, i.e. the maximal reduction
 of the maximal reduction of a word is the maximal
 reduction of the word. -/
-@[simp, to_additive] theorem reduce.idem : reduce (reduce L) = reduce L :=
+@[simp, to_additive "`reduce` is idempotent, i.e. the maximal reduction
+of the maximal reduction of a word is the maximal
+reduction of the word."] theorem reduce.idem : reduce (reduce L) = reduce L :=
 eq.symm $ reduce.min reduce.red
 
 @[to_additive]
@@ -886,12 +923,14 @@ let ⟨L₃, HR13, HR23⟩ := red.church_rosser reduce.red (reduce.red.head H) i
 
 /-- If a word reduces to another word, then they have
 a common maximal reduction. -/
-@[to_additive]
+@[to_additive "If a word reduces to another word, then they have
+a common maximal reduction."]
 theorem reduce.eq_of_red (H : red L₁ L₂) : reduce L₁ = reduce L₂ :=
 let ⟨L₃, HR13, HR23⟩ := red.church_rosser reduce.red (red.trans H reduce.red) in
 (reduce.min HR13).trans (reduce.min HR23).symm
 
 alias reduce.eq_of_red ← red.reduce_eq
+alias free_add_group.reduce.eq_of_red ← free_add_group.red.reduce_eq
 
 @[to_additive]
 lemma red.reduce_right (h : red L₁ L₂) : red L₁ (reduce L₂) :=
@@ -906,32 +945,41 @@ the free group, then they have a common maximal
 reduction. This is the proof that the function that
 sends an element of the free group to its maximal
 reduction is well-defined. -/
-@[to_additive]
+@[to_additive
+"If two words correspond to the same element in
+the additive free group, then they have a common maximal
+reduction. This is the proof that the function that
+sends an element of the free group to its maximal
+reduction is well-defined."]
 theorem reduce.sound (H : mk L₁ = mk L₂) : reduce L₁ = reduce L₂ :=
 let ⟨L₃, H13, H23⟩ := red.exact.1 H in
 (reduce.eq_of_red H13).trans (reduce.eq_of_red H23).symm
 
 /-- If two words have a common maximal reduction,
 then they correspond to the same element in the free group. -/
-@[to_additive]
+@[to_additive "If two words have a common maximal reduction,
+then they correspond to the same element in the additive free group."]
 theorem reduce.exact (H : reduce L₁ = reduce L₂) : mk L₁ = mk L₂ :=
 red.exact.2 ⟨reduce L₂, H ▸ reduce.red, reduce.red⟩
 
 /-- A word and its maximal reduction correspond to
 the same element of the free group. -/
-@[to_additive]
+@[to_additive "A word and its maximal reduction correspond to
+the same element of the additive free group."]
 theorem reduce.self : mk (reduce L) = mk L :=
 reduce.exact reduce.idem
 
 /-- If words `w₁ w₂` are such that `w₁` reduces to `w₂`,
 then `w₂` reduces to the maximal reduction of `w₁`. -/
-@[to_additive]
+@[to_additive "If words `w₁ w₂` are such that `w₁` reduces to `w₂`,
+then `w₂` reduces to the maximal reduction of `w₁`."]
 theorem reduce.rev (H : red L₁ L₂) : red L₂ (reduce L₁) :=
 (reduce.eq_of_red H).symm ▸ reduce.red
 
 /-- The function that sends an element of the free
 group to its maximal reduction. -/
-@[to_additive]
+@[to_additive "The function that sends an element of the additive free
+group to its maximal reduction."]
 def to_word : free_group α → list (α × bool) :=
 quot.lift reduce $ λ L₁ L₂ H, reduce.step.eq H
 
@@ -974,7 +1022,7 @@ begin
 end
 
 /-- Constructive Church-Rosser theorem (compare `church_rosser`). -/
-@[to_additive]
+@[to_additive "Constructive Church-Rosser theorem (compare `church_rosser`)."]
 def reduce.church_rosser (H12 : red L₁ L₂) (H13 : red L₁ L₃) :
   { L₄ // red L₂ L₄ ∧ red L₃ L₄ } :=
 ⟨reduce L₁, reduce.rev H12, reduce.rev H13⟩
@@ -983,7 +1031,7 @@ def reduce.church_rosser (H12 : red L₁ L₂) (H13 : red L₁ L₃) :
 instance : decidable_eq (free_group α) :=
 to_word_injective.decidable_eq
 
--- TODO @[to_additive]
+-- TODO @[to_additive] doesn't succeed, possibly due to a bug
 instance red.decidable_rel : decidable_rel (@red α)
 | [] []          := is_true red.refl
 | [] (hd2::tl2)  := is_false $ λ H, list.no_confusion (red.nil_iff.1 H)
@@ -1024,7 +1072,7 @@ section metric
 variable [decidable_eq α]
 
 /-- The length of reduced words provides a norm on a free group. --/
-@[to_additive]
+@[to_additive "The length of reduced words provides a norm on an additive free group."]
 def norm (x : free_group α) : ℕ := x.to_word.length
 
 @[simp, to_additive] lemma norm_inv_eq {x : free_group α} : norm x⁻¹ = norm x :=

--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -18,7 +18,7 @@ functor from groups to types, see `algebra/category/Group/adjunctions`.
 * `free_group`: the free group associated to a type `α` defined as the words over `a : α × bool`
   modulo the relation `a * x * x⁻¹ * b = a * b`.
 * `free_group.mk`: the canonical quotient map `list (α × bool) → free_group α`.
-* `free_group.of`: the canoical injection `α → free_group α`.
+* `free_group.of`: the canonical injection `α → free_group α`.
 * `free_group.lift f`: the canonical group homomorphism `free_group α →* G`
   given a group `G` and a function `f : α → G`.
 
@@ -50,45 +50,59 @@ variables {α : Type u}
 
 local attribute [simp] list.append_eq_has_append
 
+run_cmd to_additive.map_namespace `free_group `free_add_group
+
+inductive free_add_group.red.step : list (α × bool) → list (α × bool) → Prop
+| bnot {L₁ L₂ x b} : free_add_group.red.step (L₁ ++ (x, b) :: (x, bnot b) :: L₂) (L₁ ++ L₂)
+attribute [simp] free_add_group.red.step.bnot
+
+@[to_additive]
+inductive free_group.red.step : list (α × bool) → list (α × bool) → Prop
+| bnot {L₁ L₂ x b} : free_group.red.step (L₁ ++ (x, b) :: (x, bnot b) :: L₂) (L₁ ++ L₂)
+attribute [simp] free_group.red.step.bnot
+
 namespace free_group
+/-- Reduction step: `w * x * x⁻¹ * v ~> w * v` -/
+
 variables {L L₁ L₂ L₃ L₄ : list (α × bool)}
 
-/-- Reduction step: `w * x * x⁻¹ * v ~> w * v` -/
-inductive red.step : list (α × bool) → list (α × bool) → Prop
-| bnot {L₁ L₂ x b} : red.step (L₁ ++ (x, b) :: (x, bnot b) :: L₂) (L₁ ++ L₂)
-attribute [simp] red.step.bnot
-
 /-- Reflexive-transitive closure of red.step -/
+@[to_additive]
 def red : list (α × bool) → list (α × bool) → Prop := refl_trans_gen red.step
 
-@[refl] lemma red.refl : red L L := refl_trans_gen.refl
-@[trans] lemma red.trans : red L₁ L₂ → red L₂ L₃ → red L₁ L₃ := refl_trans_gen.trans
+@[refl, to_additive] lemma red.refl : red L L := refl_trans_gen.refl
+@[trans, to_additive] lemma red.trans : red L₁ L₂ → red L₂ L₃ → red L₁ L₃ := refl_trans_gen.trans
 
 namespace red
 
 /-- Predicate asserting that word `w₁` can be reduced to `w₂` in one step, i.e. there are words
 `w₃ w₄` and letter `x` such that `w₁ = w₃xx⁻¹w₄` and `w₂ = w₃w₄`  -/
+@[to_additive]
 theorem step.length : ∀ {L₁ L₂ : list (α × bool)}, step L₁ L₂ → L₂.length + 2 = L₁.length
 | _ _ (@red.step.bnot _ L1 L2 x b) := by rw [list.length_append, list.length_append]; refl
 
-@[simp] lemma step.bnot_rev {x b} : step (L₁ ++ (x, bnot b) :: (x, b) :: L₂) (L₁ ++ L₂) :=
+@[simp, to_additive] lemma step.bnot_rev {x b} : step (L₁ ++ (x, bnot b) :: (x, b) :: L₂) (L₁ ++ L₂) :=
 by cases b; from step.bnot
 
-@[simp] lemma step.cons_bnot {x b} : red.step ((x, b) :: (x, bnot b) :: L) L :=
+@[simp, to_additive] lemma step.cons_bnot {x b} : red.step ((x, b) :: (x, bnot b) :: L) L :=
 @step.bnot _ [] _ _ _
 
-@[simp] lemma step.cons_bnot_rev {x b} : red.step ((x, bnot b) :: (x, b) :: L) L :=
+@[simp, to_additive] lemma step.cons_bnot_rev {x b} : red.step ((x, bnot b) :: (x, b) :: L) L :=
 @red.step.bnot_rev _ [] _ _ _
 
+@[to_additive]
 theorem step.append_left : ∀ {L₁ L₂ L₃ : list (α × bool)}, step L₂ L₃ → step (L₁ ++ L₂) (L₁ ++ L₃)
 | _ _ _ red.step.bnot := by rw [← list.append_assoc, ← list.append_assoc]; constructor
 
+@[to_additive]
 theorem step.cons {x} (H : red.step L₁ L₂) : red.step (x :: L₁) (x :: L₂) :=
 @step.append_left _ [x] _ _ H
 
+@[to_additive]
 theorem step.append_right : ∀ {L₁ L₂ L₃ : list (α × bool)}, step L₁ L₂ → step (L₁ ++ L₃) (L₂ ++ L₃)
 | _ _ _ red.step.bnot := by simp
 
+@[to_additive]
 lemma not_step_nil : ¬ step [] L :=
 begin
   generalize h' : [] = L',
@@ -98,6 +112,7 @@ begin
   contradiction
 end
 
+@[to_additive]
 lemma step.cons_left_iff {a : α} {b : bool} :
   step ((a, b) :: L₁) L₂ ↔ (∃L, step L₁ L ∧ L₂ = (a, b) :: L) ∨ (L₁ = (a, bnot b)::L₂) :=
 begin
@@ -116,17 +131,21 @@ begin
     { exact step.cons_bnot } }
 end
 
+@[to_additive]
 lemma not_step_singleton : ∀ {p : α × bool}, ¬ step [p] L
 | (a, b) := by simp [step.cons_left_iff, not_step_nil]
 
+@[to_additive]
 lemma step.cons_cons_iff : ∀{p : α × bool}, step (p :: L₁) (p :: L₂) ↔ step L₁ L₂ :=
 by simp [step.cons_left_iff, iff_def, or_imp_distrib] {contextual := tt}
 
+@[to_additive]
 lemma step.append_left_iff : ∀L, step (L ++ L₁) (L ++ L₂) ↔ step L₁ L₂
 | [] := by simp
 | (p :: l) := by simp [step.append_left_iff l, step.cons_cons_iff]
 
-private theorem step.diamond_aux : ∀ {L₁ L₂ L₃ L₄ : list (α × bool)} {x1 b1 x2 b2},
+@[to_additive]
+theorem step.diamond_aux : ∀ {L₁ L₂ L₃ L₄ : list (α × bool)} {x1 b1 x2 b2},
   L₁ ++ (x1, b1) :: (x1, bnot b1) :: L₂ = L₃ ++ (x2, b2) :: (x2, bnot b2) :: L₄ →
   L₁ ++ L₂ = L₃ ++ L₄ ∨ ∃ L₅, red.step (L₁ ++ L₂) L₅ ∧ red.step (L₃ ++ L₄) L₅
 | []        _ []        _ _ _ _ _ H := by injections; subst_vars; simp
@@ -144,17 +163,20 @@ private theorem step.diamond_aux : ∀ {L₁ L₂ L₃ L₄ : list (α × bool)}
       ⟨_, step.cons H3, by simpa [H1] using step.cons H4⟩
   end
 
+@[to_additive]
 theorem step.diamond : ∀ {L₁ L₂ L₃ L₄ : list (α × bool)},
   red.step L₁ L₃ → red.step L₂ L₄ → L₁ = L₂ →
   L₃ = L₄ ∨ ∃ L₅, red.step L₃ L₅ ∧ red.step L₄ L₅
 | _ _ _ _ red.step.bnot red.step.bnot H := step.diamond_aux H
 
+@[to_additive]
 lemma step.to_red : step L₁ L₂ → red L₁ L₂ :=
 refl_trans_gen.single
 
 /-- **Church-Rosser theorem** for word reduction: If `w1 w2 w3` are words such that `w1` reduces
 to `w2` and `w3` respectively, then there is a word `w4` such that `w2` and `w3` reduce to `w4`
 respectively. This is also known as Newman's diamond lemma. -/
+@[to_additive]
 theorem church_rosser : red L₁ L₂ → red L₁ L₃ → join red L₂ L₃ :=
 relation.church_rosser (assume a b c hab hac,
 match b, c, red.step.diamond hab hac rfl with
@@ -162,9 +184,11 @@ match b, c, red.step.diamond hab hac rfl with
 | b, c, or.inr ⟨d, hbd, hcd⟩ := ⟨d, refl_gen.single hbd, hcd.to_red⟩
 end)
 
+@[to_additive]
 lemma cons_cons {p} : red L₁ L₂ → red (p :: L₁) (p :: L₂) :=
 refl_trans_gen.lift (list.cons p) (assume a b, step.cons)
 
+@[to_additive]
 lemma cons_cons_iff (p) : red (p :: L₁) (p :: L₂) ↔ red L₁ L₂ :=
 iff.intro
   begin
@@ -184,13 +208,16 @@ iff.intro
   end
   cons_cons
 
+@[to_additive]
 lemma append_append_left_iff : ∀L, red (L ++ L₁) (L ++ L₂) ↔ red L₁ L₂
 | []       := iff.rfl
 | (p :: L) := by simp [append_append_left_iff L, cons_cons_iff]
 
+@[to_additive]
 lemma append_append (h₁ : red L₁ L₃) (h₂ : red L₂ L₄) : red (L₁ ++ L₂) (L₃ ++ L₄) :=
 (h₁.lift (λL, L ++ L₂) (assume a b, step.append_right)).trans ((append_append_left_iff _).2 h₂)
 
+@[to_additive]
 lemma to_append_iff : red L (L₁ ++ L₂) ↔ (∃L₃ L₄, L = L₃ ++ L₄ ∧ red L₃ L₁ ∧ red L₄ L₂) :=
 iff.intro
   begin
@@ -214,15 +241,18 @@ iff.intro
   (assume ⟨L₃, L₄, eq, h₃, h₄⟩, eq.symm ▸ append_append h₃ h₄)
 
 /-- The empty word `[]` only reduces to itself. -/
+@[to_additive]
 theorem nil_iff : red [] L ↔ L = [] :=
 refl_trans_gen_iff_eq (assume l, red.not_step_nil)
 
 /-- A letter only reduces to itself. -/
+@[to_additive]
 theorem singleton_iff {x} : red [x] L₁ ↔ L₁ = [x] :=
 refl_trans_gen_iff_eq (assume l, not_step_singleton)
 
 /-- If `x` is a letter and `w` is a word such that `xw` reduces to the empty word, then `w` reduces
 to `x⁻¹` -/
+@[to_additive]
 theorem cons_nil_iff_singleton {x b} : red ((x, b) :: L) [] ↔ red L [(x, bnot b)] :=
 iff.intro
   (assume h,
@@ -232,6 +262,7 @@ iff.intro
     by rw [singleton_iff] at h₁; subst L'; assumption)
   (assume h, (cons_cons h).tail step.cons_bnot)
 
+@[to_additive]
 theorem red_iff_irreducible {x1 b1 x2 b2} (h : (x1, b1) ≠ (x2, b2)) :
   red [(x1, bnot b1), (x2, b2)] L ↔ L = [(x1, bnot b1), (x2, b2)] :=
 begin
@@ -247,6 +278,7 @@ end
 
 /-- If `x` and `y` are distinct letters and `w₁ w₂` are words such that `xw₁` reduces to `yw₂`, then
 `w₁` reduces to `x⁻¹yw₂`. -/
+@[to_additive]
 theorem inv_of_red_of_ne {x1 b1 x2 b2}
   (H1 : (x1, b1) ≠ (x2, b2))
   (H2 : red ((x1, b1) :: L₁) ((x2, b2) :: L₂)) :
@@ -267,16 +299,20 @@ begin
     rwa [h₁] at h₂ }
 end
 
+@[to_additive]
 theorem step.sublist (H : red.step L₁ L₂) : L₂ <+ L₁ :=
 by cases H; simp; constructor; constructor; refl
 
 /-- If `w₁ w₂` are words such that `w₁` reduces to `w₂`, then `w₂` is a sublist of `w₁`. -/
+@[to_additive]
 protected theorem sublist : red L₁ L₂ → L₂ <+ L₁ :=
 refl_trans_gen_of_transitive_reflexive
   (λl, list.sublist.refl l) (λa b c hab hbc, list.sublist.trans hbc hab) (λa b, red.step.sublist)
 
+@[to_additive]
 theorem length_le (h : red L₁ L₂) : L₂.length ≤ L₁.length := h.sublist.length_le
 
+@[to_additive]
 theorem sizeof_of_step : ∀ {L₁ L₂ : list (α × bool)}, step L₁ L₂ → L₂.sizeof < L₁.sizeof
 | _ _ (@step.bnot _ L1 L2 x b) :=
   begin
@@ -293,6 +329,7 @@ theorem sizeof_of_step : ∀ {L₁ L₂ : list (α × bool)}, step L₁ L₂ →
       exact nat.add_lt_add_left ih _ }
   end
 
+@[to_additive]
 theorem length (h : red L₁ L₂) : ∃ n, L₁.length = L₂.length + 2 * n :=
 begin
   induction h with L₂ L₃ h₁₂ h₂₃ ih,
@@ -302,11 +339,13 @@ begin
     simp [mul_add, eq, (step.length h₂₃).symm, add_assoc] }
 end
 
+@[to_additive]
 theorem antisymm (h₁₂ : red L₁ L₂) (h₂₁ : red L₂ L₁) : L₁ = L₂ :=
 h₂₁.sublist.antisymm h₁₂.sublist
 
 end red
 
+@[to_additive]
 theorem equivalence_join_red : equivalence (join (@red α)) :=
 equivalence_join_refl_trans_gen $ assume a b c hab hac,
 (match b, c, red.step.diamond hab hac rfl with
@@ -314,9 +353,11 @@ equivalence_join_refl_trans_gen $ assume a b c hab hac,
 | b, c, or.inr ⟨d, hbd, hcd⟩ := ⟨d, refl_gen.single hbd, refl_trans_gen.single hcd⟩
 end)
 
+@[to_additive]
 theorem join_red_of_step (h : red.step L₁ L₂) : join red L₁ L₂ :=
 join_of_single reflexive_refl_trans_gen h.to_red
 
+@[to_additive]
 theorem eqv_gen_step_iff_join_red : eqv_gen red.step L₁ L₂ ↔ join red L₁ L₂ :=
 iff.intro
   (assume h,
@@ -329,6 +370,7 @@ end free_group
 
 /-- The free group over a type, i.e. the words formed by the elements of the type and their formal
 inverses, quotient by one step reduction. -/
+@[to_additive]
 def free_group (α : Type u) : Type u :=
 quot $ @free_group.red.step α
 
@@ -337,51 +379,63 @@ namespace free_group
 variables {α} {L L₁ L₂ L₃ L₄ : list (α × bool)}
 
 /-- The canonical map from `list (α × bool)` to the free group on `α`. -/
+@[to_additive]
 def mk (L) : free_group α := quot.mk red.step L
 
-@[simp] lemma quot_mk_eq_mk : quot.mk red.step L = mk L := rfl
+@[simp, to_additive] lemma quot_mk_eq_mk : quot.mk red.step L = mk L := rfl
 
-@[simp] lemma quot_lift_mk (β : Type v) (f : list (α × bool) → β)
+@[simp, to_additive] lemma quot_lift_mk (β : Type v) (f : list (α × bool) → β)
   (H : ∀ L₁ L₂, red.step L₁ L₂ → f L₁ = f L₂) :
 quot.lift f H (mk L) = f L := rfl
 
-@[simp] lemma quot_lift_on_mk (β : Type v) (f : list (α × bool) → β)
+@[simp, to_additive] lemma quot_lift_on_mk (β : Type v) (f : list (α × bool) → β)
   (H : ∀ L₁ L₂, red.step L₁ L₂ → f L₁ = f L₂) :
 quot.lift_on (mk L) f H = f L := rfl
 
-@[simp] lemma quot_map_mk (β : Type v) (f : list (α × bool) → list (β × bool))
+@[simp, to_additive] lemma quot_map_mk (β : Type v) (f : list (α × bool) → list (β × bool))
   (H : (red.step ⇒ red.step) f f) :
 quot.map f H (mk L) = mk (f L) := rfl
 
+@[to_additive]
 instance : has_one (free_group α) := ⟨mk []⟩
+@[to_additive]
 lemma one_eq_mk : (1 : free_group α) = mk [] := rfl
 
+@[to_additive]
 instance : inhabited (free_group α) := ⟨1⟩
 
+@[to_additive]
 instance : has_mul (free_group α) :=
 ⟨λ x y, quot.lift_on x
     (λ L₁, quot.lift_on y (λ L₂, mk $ L₁ ++ L₂) (λ L₂ L₃ H, quot.sound $ red.step.append_left H))
     (λ L₁ L₂ H, quot.induction_on y $ λ L₃, quot.sound $ red.step.append_right H)⟩
-@[simp] lemma mul_mk : mk L₁ * mk L₂ = mk (L₁ ++ L₂) := rfl
+@[simp, to_additive] lemma mul_mk : mk L₁ * mk L₂ = mk (L₁ ++ L₂) := rfl
 
 /-- Transform a word representing a free group element into a word representing its inverse. --/
+@[to_additive]
 def inv_rev (w : list (α × bool)) : list (α × bool) :=
 (list.map (λ (g : α × bool), (g.1, bnot g.2)) w).reverse
 
-@[simp] lemma inv_rev_length : (inv_rev L₁).length = L₁.length := by simp [inv_rev]
-@[simp] lemma inv_rev_inv_rev : (inv_rev (inv_rev L₁) = L₁) := by simp [inv_rev, (∘)]
-@[simp] lemma inv_rev_empty : inv_rev ([] : list (α × bool)) = [] := rfl
+@[simp, to_additive] lemma inv_rev_length : (inv_rev L₁).length = L₁.length := by simp [inv_rev]
+@[simp, to_additive] lemma inv_rev_inv_rev : (inv_rev (inv_rev L₁) = L₁) := by simp [inv_rev, (∘)]
+@[simp, to_additive] lemma inv_rev_empty : inv_rev ([] : list (α × bool)) = [] := rfl
 
+@[to_additive]
 lemma inv_rev_involutive : function.involutive (@inv_rev α) := λ _, inv_rev_inv_rev
+@[to_additive]
 lemma inv_rev_injective : function.injective (@inv_rev α) := inv_rev_involutive.injective
+@[to_additive]
 lemma inv_rev_surjective : function.surjective (@inv_rev α) := inv_rev_involutive.surjective
+@[to_additive]
 lemma inv_rev_bijective : function.bijective (@inv_rev α) := inv_rev_involutive.bijective
 
+@[to_additive]
 instance : has_inv (free_group α) :=
 ⟨quot.map inv_rev (by { intros a b h, cases h, simp [inv_rev], })⟩
 
-@[simp] lemma inv_mk : (mk L)⁻¹ = mk (inv_rev L) := rfl
+@[simp, to_additive] lemma inv_mk : (mk L)⁻¹ = mk (inv_rev L) := rfl
 
+@[to_additive]
 lemma red.step.inv_rev {L₁ L₂ : list (α × bool)} (h : red.step L₁ L₂) :
   red.step (inv_rev L₁) (inv_rev L₂) :=
 begin
@@ -389,16 +443,18 @@ begin
   simp [inv_rev],
 end
 
+@[to_additive]
 lemma red.inv_rev {L₁ L₂ : list (α × bool)} (h : red L₁ L₂) :
   red (inv_rev L₁) (inv_rev L₂) :=
 relation.refl_trans_gen.lift _ (λ a b, red.step.inv_rev) h
 
-@[simp] lemma red.step_inv_rev_iff : red.step (inv_rev L₁) (inv_rev L₂) ↔ red.step L₁ L₂ :=
+@[simp, to_additive] lemma red.step_inv_rev_iff : red.step (inv_rev L₁) (inv_rev L₂) ↔ red.step L₁ L₂ :=
 ⟨λ h, by simpa only [inv_rev_inv_rev] using h.inv_rev, λ h, h.inv_rev⟩
 
-@[simp] lemma red_inv_rev_iff : red (inv_rev L₁) (inv_rev L₂) ↔ red L₁ L₂ :=
+@[simp, to_additive] lemma red_inv_rev_iff : red (inv_rev L₁) (inv_rev L₂) ↔ red L₁ L₂ :=
 ⟨λ h, by simpa only [inv_rev_inv_rev] using h.inv_rev, λ h, h.inv_rev⟩
 
+@[to_additive]
 instance : group (free_group α) :=
 { mul := (*),
   one := 1,
@@ -411,14 +467,17 @@ instance : group (free_group α) :=
 
 /-- `of` is the canonical injection from the type to the free group over that type by sending each
 element to the equivalence class of the letter that is the element. -/
+@[to_additive]
 def of (x : α) : free_group α :=
 mk [(x, tt)]
 
+@[to_additive]
 theorem red.exact : mk L₁ = mk L₂ ↔ join red L₁ L₂ :=
 calc (mk L₁ = mk L₂) ↔ eqv_gen red.step L₁ L₂ : iff.intro (quot.exact _) quot.eqv_gen_sound
   ... ↔ join red L₁ L₂ : eqv_gen_step_iff_join_red
 
 /-- The canonical injection from the type to the free group is an injection. -/
+@[to_additive]
 theorem of_injective : function.injective (@of α) :=
 λ _ _ H, let ⟨L₁, hx, hy⟩ := red.exact.1 H in
   by simp [red.singleton_iff] at hx hy; cc
@@ -428,9 +487,11 @@ section lift
 variables {β : Type v} [group β] (f : α → β) {x y : free_group α}
 
 /-- Given `f : α → β` with `β` a group, the canonical map `list (α × bool) → β` -/
+@[to_additive]
 def lift.aux : list (α × bool) → β :=
 λ L, list.prod $ L.map $ λ x, cond x.2 (f x.1) (f x.1)⁻¹
 
+@[to_additive]
 theorem red.step.lift {f : α → β} (H : red.step L₁ L₂) :
   lift.aux f L₁ = lift.aux f L₂ :=
 by cases H with _ _ _ b; cases b; simp [lift.aux]
@@ -439,7 +500,7 @@ by cases H with _ _ _ b; cases b; simp [lift.aux]
 /-- If `β` is a group, then any function from `α` to `β`
 extends uniquely to a group homomorphism from
 the free group over `α` to `β` -/
-@[simps symm_apply]
+@[to_additive, simps symm_apply]
 def lift : (α → β) ≃ (free_group α →* β) :=
 { to_fun := λ f,
     monoid_hom.mk' (quot.lift (lift.aux f) $ λ L₁ L₂, red.step.lift) $ begin
@@ -459,13 +520,14 @@ def lift : (α → β) ≃ (free_group α →* β) :=
   end }
 variable {f}
 
-@[simp] lemma lift.mk : lift f (mk L) =
+@[simp, to_additive] lemma lift.mk : lift f (mk L) =
   list.prod (L.map $ λ x, cond x.2 (f x.1) (f x.1)⁻¹) :=
 rfl
 
-@[simp] lemma lift.of {x} : lift f (of x) = f x :=
+@[simp, to_additive] lemma lift.of {x} : lift f (of x) = f x :=
 one_mul _
 
+@[to_additive]
 theorem lift.unique (g : free_group α →* β)
   (hg : ∀ x, g (of x) = f x) : ∀{x}, g x = lift f x :=
 monoid_hom.congr_fun $ (lift.symm_apply_eq).mp (funext hg : g ∘ of = f)
@@ -473,14 +535,16 @@ monoid_hom.congr_fun $ (lift.symm_apply_eq).mp (funext hg : g ∘ of = f)
 /-- Two homomorphisms out of a free group are equal if they are equal on generators.
 
 See note [partially-applied ext lemmas]. -/
-@[ext]
+@[ext, to_additive]
 lemma ext_hom {G : Type*} [group G] (f g : free_group α →* G) (h : ∀ a, f (of a) = g (of a)) :
   f = g :=
 lift.symm.injective $ funext h
 
+@[to_additive]
 theorem lift.of_eq (x : free_group α) : lift of x = x :=
 monoid_hom.congr_fun (lift.apply_symm_apply (monoid_hom.id _)) x
 
+@[to_additive]
 theorem lift.range_le {s : subgroup β} (H : set.range f ⊆ s) :
   (lift f).range ≤ s :=
 by rintros _ ⟨⟨L⟩, rfl⟩; exact list.rec_on L s.one_mem
@@ -489,6 +553,7 @@ by rintros _ ⟨⟨L⟩, rfl⟩; exact list.rec_on L s.one_mem
       (s.inv_mem $ H ⟨x, rfl⟩) ih)
     (by simp at ih ⊢; from s.mul_mem (H ⟨x, rfl⟩) ih))
 
+@[to_additive]
 theorem lift.range_eq_closure :
   (lift f).range = subgroup.closure (set.range f) :=
 begin
@@ -507,6 +572,7 @@ variables {β : Type v} (f : α → β) {x y : free_group α}
 /-- Any function from `α` to `β` extends uniquely
 to a group homomorphism from the free group
 ver `α` to the free group over `β`. -/
+@[to_additive]
 def map : free_group α →* free_group β :=
 monoid_hom.mk'
   (quot.map (list.map $ λ x, (f x.1, x.2)) $ λ L₁ L₂ H, by cases H; simp)
@@ -514,20 +580,22 @@ monoid_hom.mk'
 
 variable {f}
 
-@[simp] lemma map.mk : map f (mk L) = mk (L.map (λ x, (f x.1, x.2))) :=
+@[simp, to_additive] lemma map.mk : map f (mk L) = mk (L.map (λ x, (f x.1, x.2))) :=
 rfl
 
-@[simp] lemma map.id (x : free_group α) : map id x = x :=
+@[simp, to_additive] lemma map.id (x : free_group α) : map id x = x :=
 by rcases x with ⟨L⟩; simp [list.map_id']
 
-@[simp] lemma map.id' (x : free_group α) : map (λ z, z) x = x := map.id x
+@[simp, to_additive] lemma map.id' (x : free_group α) : map (λ z, z) x = x := map.id x
 
+@[to_additive]
 theorem map.comp {γ : Type w} (f : α → β) (g : β → γ) (x) :
   map g (map f x) = map (g ∘ f) x :=
 by rcases x with ⟨L⟩; simp
 
-@[simp] lemma map.of {x} : map f (of x) = of (f x) := rfl
+@[simp, to_additive] lemma map.of {x} : map f (of x) = of (f x) := rfl
 
+@[to_additive]
 theorem map.unique (g : free_group α →* free_group β)
   (hg : ∀ x, g (of x) = of (f x)) : ∀{x}, g x = map f x :=
 by rintros ⟨L⟩; exact list.rec_on L g.map_one
@@ -537,6 +605,7 @@ by rintros ⟨L⟩; exact list.rec_on L g.map_one
   (show g (of x * mk t) = map f (of x * mk t),
      by simp [g.map_mul, hg, ih]))
 
+@[to_additive]
 theorem map_eq_lift : map f x = lift (of ∘ f) x :=
 eq.symm $ map.unique _ $ λ x, by simp
 
@@ -545,20 +614,21 @@ eq.symm $ map.unique _ $ λ x, by simp
 The converse can be found in `group_theory.free_abelian_group_finsupp`,
 as `equiv.of_free_group_equiv`
  -/
-@[simps apply]
+@[to_additive, simps apply]
 def free_group_congr {α β} (e : α ≃ β) : free_group α ≃* free_group β :=
 { to_fun := map e, inv_fun := map e.symm,
   left_inv := λ x, by simp [function.comp, map.comp],
   right_inv := λ x, by simp [function.comp, map.comp],
   map_mul' := monoid_hom.map_mul _ }
 
-@[simp] lemma free_group_congr_refl : free_group_congr (equiv.refl α) = mul_equiv.refl _ :=
+@[simp, to_additive] lemma free_group_congr_refl : free_group_congr (equiv.refl α) = mul_equiv.refl _ :=
 mul_equiv.ext map.id
 
-@[simp] lemma free_group_congr_symm {α β} (e : α ≃ β) :
+@[simp, to_additive] lemma free_group_congr_symm {α β} (e : α ≃ β) :
   (free_group_congr e).symm = free_group_congr e.symm :=
 rfl
 
+@[to_additive]
 lemma free_group_congr_trans {α β γ} (e : α ≃ β) (f : β ≃ γ) :
   (free_group_congr e).trans (free_group_congr f) = free_group_congr (e.trans f) :=
 mul_equiv.ext $ map.comp _ _
@@ -573,17 +643,19 @@ variables [group α] (x y : free_group α)
 extends uniquely to a homomorphism from the
 free group over `α` to `α`. This is the multiplicative
 version of `sum`. -/
+@[to_additive]
 def prod : free_group α →* α := lift id
 
 variables {x y}
 
-@[simp] lemma prod_mk :
+@[simp, to_additive] lemma prod_mk :
   prod (mk L) = list.prod (L.map $ λ x, cond x.2 x.1 x.1⁻¹) :=
 rfl
 
-@[simp] lemma prod.of {x : α} : prod (of x) = x :=
+@[simp, to_additive] lemma prod.of {x : α} : prod (of x) = x :=
 lift.of
 
+@[to_additive]
 lemma prod.unique (g : free_group α →* α)
   (hg : ∀ x, g (of x) = x) {x} :
   g x = prod x :=
@@ -591,6 +663,7 @@ lift.unique g hg
 
 end prod
 
+@[to_additive]
 theorem lift_eq_prod_map {β : Type v} [group β] {f : α → β} {x} :
   lift f x = prod (map f x) :=
 begin
@@ -633,6 +706,7 @@ prod.of
 end sum
 
 /-- The bijection between the free group on the empty type, and a type with one element. -/
+@[to_additive]
 def free_group_empty_equiv_unit : free_group empty ≃ unit :=
 { to_fun    := λ _, (),
   inv_fun   := λ _, 1,
@@ -661,12 +735,13 @@ section category
 
 variables {β : Type u}
 
+@[to_additive]
 instance : monad free_group.{u} :=
 { pure := λ α, of,
   map := λ α β f, (map f),
   bind := λ α β x f, lift f x }
 
-@[elab_as_eliminator]
+@[elab_as_eliminator, to_additive]
 protected theorem induction_on
   {C : free_group α → Prop}
   (z : free_group α)
@@ -677,31 +752,32 @@ protected theorem induction_on
 quot.induction_on z $ λ L, list.rec_on L C1 $ λ ⟨x, b⟩ tl ih,
 bool.rec_on b (Cm _ _ (Ci _ $ Cp x) ih) (Cm _ _ (Cp x) ih)
 
-@[simp] lemma map_pure (f : α → β) (x : α) : f <$> (pure x : free_group α) = pure (f x) :=
+@[simp, to_additive] lemma map_pure (f : α → β) (x : α) : f <$> (pure x : free_group α) = pure (f x) :=
 map.of
 
-@[simp] lemma map_one (f : α → β) : f <$> (1 : free_group α) = 1 :=
+@[simp, to_additive] lemma map_one (f : α → β) : f <$> (1 : free_group α) = 1 :=
 (map f).map_one
 
-@[simp] lemma map_mul (f : α → β) (x y : free_group α) : f <$> (x * y) = f <$> x * f <$> y :=
+@[simp, to_additive] lemma map_mul (f : α → β) (x y : free_group α) : f <$> (x * y) = f <$> x * f <$> y :=
 (map f).map_mul x y
 
-@[simp] lemma map_inv (f : α → β) (x : free_group α) : f <$> (x⁻¹) = (f <$> x)⁻¹ :=
+@[simp, to_additive] lemma map_inv (f : α → β) (x : free_group α) : f <$> (x⁻¹) = (f <$> x)⁻¹ :=
 (map f).map_inv x
 
-@[simp] lemma pure_bind (f : α → free_group β) (x) : pure x >>= f = f x :=
+@[simp, to_additive] lemma pure_bind (f : α → free_group β) (x) : pure x >>= f = f x :=
 lift.of
 
-@[simp] lemma one_bind (f : α → free_group β) : 1 >>= f = 1 :=
+@[simp, to_additive] lemma one_bind (f : α → free_group β) : 1 >>= f = 1 :=
 (lift f).map_one
 
-@[simp] lemma mul_bind (f : α → free_group β) (x y : free_group α) :
+@[simp, to_additive] lemma mul_bind (f : α → free_group β) (x y : free_group α) :
   x * y >>= f = (x >>= f) * (y >>= f) :=
 (lift f).map_mul _ _
 
-@[simp] lemma inv_bind (f : α → free_group β) (x : free_group α) : x⁻¹ >>= f = (x >>= f)⁻¹ :=
+@[simp, to_additive] lemma inv_bind (f : α → free_group β) (x : free_group α) : x⁻¹ >>= f = (x >>= f)⁻¹ :=
 (lift f).map_inv _
 
+@[to_additive]
 instance : is_lawful_monad free_group.{u} :=
 { id_map := λ α x, free_group.induction_on x (map_one id) (λ x, map_pure id x)
     (λ x ih, by rw [map_inv, ih]) (λ x y ihx ihy, by rw [map_mul, ihx, ihy]),
@@ -722,19 +798,21 @@ variable [decidable_eq α]
 
 /-- The maximal reduction of a word. It is computable
 iff `α` has decidable equality. -/
+@[to_additive]
 def reduce (L : list (α × bool)) : list (α × bool) :=
 list.rec_on L [] $ λ hd1 tl1 ih,
 list.cases_on ih [hd1] $ λ hd2 tl2,
 if hd1.1 = hd2.1 ∧ hd1.2 = bnot hd2.2 then tl2
 else hd1 :: hd2 :: tl2
 
-@[simp] lemma reduce.cons (x) : reduce (x :: L) =
+@[simp, to_additive] lemma reduce.cons (x) : reduce (x :: L) =
   list.cases_on (reduce L) [x] (λ hd tl,
   if x.1 = hd.1 ∧ x.2 = bnot hd.2 then tl
   else x :: hd :: tl) := rfl
 
 /-- The first theorem that characterises the function
 `reduce`: a word reduces to its maximal reduction. -/
+@[to_additive]
 theorem reduce.red : red L (reduce L) :=
 begin
   induction L with hd1 tl1 ih,
@@ -749,18 +827,17 @@ begin
     case list.nil
     { exact red.cons_cons ih },
     case list.cons
-    { dsimp,
-      by_cases h : hd1.fst = hd2.fst ∧ hd1.snd = bnot (hd2.snd),
-      { rw [if_pos h],
-        transitivity,
+    { dsimp only,
+      split_ifs with h,
+      { transitivity,
         { exact red.cons_cons ih },
         { cases hd1, cases hd2, cases h,
           dsimp at *, subst_vars,
           exact red.step.cons_bnot_rev.to_red } },
-      { rw [if_neg h],
-        exact red.cons_cons ih } } }
+      { exact red.cons_cons ih } } }
 end
 
+@[to_additive]
 theorem reduce.not {p : Prop} :
   ∀ {L₁ L₂ L₃ : list (α × bool)} {x b}, reduce L₁ = L₂ ++ (x, b) :: (x, bnot b) :: L₃ → p
 | [] L2 L3 _ _ := λ h, by cases L2; injections
@@ -772,7 +849,8 @@ theorem reduce.not {p : Prop} :
     simp [-add_comm] at this,
     exact absurd this dec_trivial },
   cases hd with y c,
-  by_cases x = y ∧ b = bnot c; simp [h]; intro H,
+  dsimp only,
+  split_ifs with h; intro H,
   { rw H at r,
     exact @reduce.not L1 ((y,c)::L2) L3 x' b' r },
   rcases L2 with _|⟨a, L2⟩,
@@ -786,6 +864,7 @@ end
 /-- The second theorem that characterises the
 function `reduce`: the maximal reduction of a word
 only reduces to itself. -/
+@[to_additive]
 theorem reduce.min (H : red (reduce L₁) L₂) : reduce L₁ = L₂ :=
 begin
   induction H with L1 L' L2 H1 H2 ih,
@@ -797,24 +876,28 @@ end
 /-- `reduce` is idempotent, i.e. the maximal reduction
 of the maximal reduction of a word is the maximal
 reduction of the word. -/
-@[simp] theorem reduce.idem : reduce (reduce L) = reduce L :=
+@[simp, to_additive] theorem reduce.idem : reduce (reduce L) = reduce L :=
 eq.symm $ reduce.min reduce.red
 
+@[to_additive]
 theorem reduce.step.eq (H : red.step L₁ L₂) : reduce L₁ = reduce L₂ :=
 let ⟨L₃, HR13, HR23⟩ := red.church_rosser reduce.red (reduce.red.head H) in
 (reduce.min HR13).trans (reduce.min HR23).symm
 
 /-- If a word reduces to another word, then they have
 a common maximal reduction. -/
+@[to_additive]
 theorem reduce.eq_of_red (H : red L₁ L₂) : reduce L₁ = reduce L₂ :=
 let ⟨L₃, HR13, HR23⟩ := red.church_rosser reduce.red (red.trans H reduce.red) in
 (reduce.min HR13).trans (reduce.min HR23).symm
 
 alias reduce.eq_of_red ← red.reduce_eq
 
+@[to_additive]
 lemma red.reduce_right (h : red L₁ L₂) : red L₁ (reduce L₂) :=
 reduce.eq_of_red h ▸ reduce.red
 
+@[to_additive]
 lemma red.reduce_left (h : red L₁ L₂) : red L₂ (reduce L₁) :=
 (reduce.eq_of_red h).symm ▸ reduce.red
 
@@ -823,49 +906,57 @@ the free group, then they have a common maximal
 reduction. This is the proof that the function that
 sends an element of the free group to its maximal
 reduction is well-defined. -/
+@[to_additive]
 theorem reduce.sound (H : mk L₁ = mk L₂) : reduce L₁ = reduce L₂ :=
 let ⟨L₃, H13, H23⟩ := red.exact.1 H in
 (reduce.eq_of_red H13).trans (reduce.eq_of_red H23).symm
 
 /-- If two words have a common maximal reduction,
 then they correspond to the same element in the free group. -/
+@[to_additive]
 theorem reduce.exact (H : reduce L₁ = reduce L₂) : mk L₁ = mk L₂ :=
 red.exact.2 ⟨reduce L₂, H ▸ reduce.red, reduce.red⟩
 
 /-- A word and its maximal reduction correspond to
 the same element of the free group. -/
+@[to_additive]
 theorem reduce.self : mk (reduce L) = mk L :=
 reduce.exact reduce.idem
 
 /-- If words `w₁ w₂` are such that `w₁` reduces to `w₂`,
 then `w₂` reduces to the maximal reduction of `w₁`. -/
+@[to_additive]
 theorem reduce.rev (H : red L₁ L₂) : red L₂ (reduce L₁) :=
 (reduce.eq_of_red H).symm ▸ reduce.red
 
 /-- The function that sends an element of the free
 group to its maximal reduction. -/
+@[to_additive]
 def to_word : free_group α → list (α × bool) :=
 quot.lift reduce $ λ L₁ L₂ H, reduce.step.eq H
 
+@[to_additive]
 lemma mk_to_word : ∀{x : free_group α}, mk (to_word x) = x :=
 by rintros ⟨L⟩; exact reduce.self
 
+@[to_additive]
 lemma to_word_injective : function.injective (to_word : free_group α → list (α × bool)) :=
 by rintros ⟨L₁⟩ ⟨L₂⟩; exact reduce.exact
 
-@[simp] lemma to_word_inj {x y : free_group α} : to_word x = to_word y ↔ x = y :=
+@[simp, to_additive] lemma to_word_inj {x y : free_group α} : to_word x = to_word y ↔ x = y :=
 to_word_injective.eq_iff
 
-@[simp] lemma to_word_mk : (mk L₁).to_word = reduce L₁ := rfl
+@[simp, to_additive] lemma to_word_mk : (mk L₁).to_word = reduce L₁ := rfl
 
-@[simp] lemma reduce_to_word : ∀ (x : free_group α), reduce (to_word x) = to_word x :=
+@[simp, to_additive] lemma reduce_to_word : ∀ (x : free_group α), reduce (to_word x) = to_word x :=
 by { rintro ⟨L⟩, exact reduce.idem }
 
-@[simp] lemma to_word_one : (1 : free_group α).to_word = [] := rfl
+@[simp, to_additive] lemma to_word_one : (1 : free_group α).to_word = [] := rfl
 
-@[simp] lemma to_word_eq_nil_iff {x : free_group α} : (x.to_word = []) ↔ (x = 1) :=
+@[simp, to_additive] lemma to_word_eq_nil_iff {x : free_group α} : (x.to_word = []) ↔ (x = 1) :=
 to_word_injective.eq_iff' to_word_one
 
+@[to_additive]
 lemma reduce_inv_rev {w : list (α × bool)} : reduce (inv_rev w) = inv_rev (reduce w) :=
 begin
   apply reduce.min,
@@ -875,6 +966,7 @@ begin
   rwa inv_rev_inv_rev at this
 end
 
+@[to_additive]
 lemma to_word_inv {x : free_group α} : (x⁻¹).to_word = inv_rev x.to_word :=
 begin
   rcases x with ⟨L⟩,
@@ -882,13 +974,16 @@ begin
 end
 
 /-- Constructive Church-Rosser theorem (compare `church_rosser`). -/
+@[to_additive]
 def reduce.church_rosser (H12 : red L₁ L₂) (H13 : red L₁ L₃) :
   { L₄ // red L₂ L₄ ∧ red L₃ L₄ } :=
 ⟨reduce L₁, reduce.rev H12, reduce.rev H13⟩
 
+@[to_additive]
 instance : decidable_eq (free_group α) :=
 to_word_injective.decidable_eq
 
+-- TODO @[to_additive]
 instance red.decidable_rel : decidable_rel (@red α)
 | [] []          := is_true red.refl
 | [] (hd2::tl2)  := is_false $ λ H, list.no_confusion (red.nil_iff.1 H)
@@ -929,18 +1024,21 @@ section metric
 variable [decidable_eq α]
 
 /-- The length of reduced words provides a norm on a free group. --/
+@[to_additive]
 def norm (x : free_group α) : ℕ := x.to_word.length
 
-@[simp] lemma norm_inv_eq {x : free_group α} : norm x⁻¹ = norm x :=
+@[simp, to_additive] lemma norm_inv_eq {x : free_group α} : norm x⁻¹ = norm x :=
 by simp only [norm, to_word_inv, inv_rev_length]
 
-@[simp] lemma norm_eq_zero {x : free_group α} : norm x = 0 ↔ x = 1 :=
+@[simp, to_additive] lemma norm_eq_zero {x : free_group α} : norm x = 0 ↔ x = 1 :=
 by simp only [norm, list.length_eq_zero, to_word_eq_nil_iff]
 
-@[simp] lemma norm_one : norm (1 : free_group α) = 0 := rfl
+@[simp, to_additive] lemma norm_one : norm (1 : free_group α) = 0 := rfl
 
+@[to_additive]
 theorem norm_mk_le : norm (mk L₁) ≤ L₁.length := reduce.red.length_le
 
+@[to_additive]
 lemma norm_mul_le (x y : free_group α) : norm (x * y) ≤ norm x + norm y :=
 calc norm (x * y) = norm (mk (x.to_word ++ y.to_word)) : by rw [← mul_mk, mk_to_word, mk_to_word]
               ... ≤ (x.to_word ++ y.to_word).length    : norm_mk_le


### PR DESCRIPTION
For some applications of #2819 I'd like to have additive versions of some results proved using `free_group`, but unfortunately there is no `free_add_group`, so we rectify this here by to_additivizing the file `free_group.

This is done in a rather clumsy way here, making a separate relation `free_add_group.red` on words (lists of elements x bool), even though it is of course the same relation for additive and multiplicative groups when thought of as a relation on lists, and then using to_additive on everything in the file (even if its the same in both cases).
The reason for this is that having the same relation for the additive and multiplicative version causes both types to be `quot red`, so simp gets all messed up when defining simp lemmas turning elements of that type into `mk blah`.
So, while a more elegant way is probably possible, it seems rather tricky to set up compared to the approach in this PR.

There are a couple of places where `to_additive` doesn't work, either because the situation is too complicated, or a bug in to additive (it seems). For now we just ignore those small sections.

A couple of small proof golfs/typos are also fixed in the file.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
