### PR TITLE
[Merged by Bors] - chore(algebra/*): mark frozen files that have been ported to mathlib4

### DIFF
--- a/src/algebra/abs.lean
+++ b/src/algebra/abs.lean
@@ -7,6 +7,10 @@ Authors: Christopher Hoskin
 /-!
 # Absolute value
 
+> THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
+> https://github.com/leanprover-community/mathlib4/pull/477
+> No changes accepted without a corresponding PR to mathlib4.
+
 This file defines a notational class `has_abs` which adds the unary operator `abs` and the notation
 `|.|`. The concept of an absolute value occurs in lattice ordered groups and in GL and GM spaces.
 

--- a/src/algebra/abs.lean
+++ b/src/algebra/abs.lean
@@ -7,9 +7,9 @@ Authors: Christopher Hoskin
 /-!
 # Absolute value
 
-> THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
+> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
 > https://github.com/leanprover-community/mathlib4/pull/477
-> No changes accepted without a corresponding PR to mathlib4.
+> Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines a notational class `has_abs` which adds the unary operator `abs` and the notation
 `|.|`. The concept of an absolute value occurs in lattice ordered groups and in GL and GM spaces.

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -14,7 +14,7 @@ import order.monotone
 
 > THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
 > https://github.com/leanprover-community/mathlib4/pull/467
-> No changes accepted with corresponding PRs to mathlib4.
+> No changes accepted without a corresponding PR to mathlib4.
 
 This file contains general lemmas and instances to work with the interactions between a relation and
 an action on a Type.

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -12,9 +12,9 @@ import order.monotone
 
 # Covariants and contravariants
 
-> THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
+> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
 > https://github.com/leanprover-community/mathlib4/pull/467
-> No changes accepted without a corresponding PR to mathlib4.
+> Any changes to this file require a corresponding PR to mathlib4.
 
 This file contains general lemmas and instances to work with the interactions between a relation and
 an action on a Type.

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -12,6 +12,10 @@ import order.monotone
 
 # Covariants and contravariants
 
+> THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
+> https://github.com/leanprover-community/mathlib4/pull/467
+> No changes accepted with corresponding PRs to mathlib4.
+
 This file contains general lemmas and instances to work with the interactions between a relation and
 an action on a Type.
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -9,6 +9,10 @@ import algebra.group.defs
 /-!
 # Basic lemmas about semigroups, monoids, and groups
 
+> THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
+> https://github.com/leanprover-community/mathlib4/pull/457
+> No changes accepted with corresponding PRs to mathlib4.
+
 This file lists various basic lemmas about semigroups, monoids, and groups. Most proofs are
 one-liners from the corresponding axioms. For the definitions of semigroups, monoids and groups, see
 `algebra/group/defs.lean`.

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -9,9 +9,9 @@ import algebra.group.defs
 /-!
 # Basic lemmas about semigroups, monoids, and groups
 
-> THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
+> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
 > https://github.com/leanprover-community/mathlib4/pull/457
-> No changes accepted without a corresponding PR to mathlib4.
+> Any changes to this file require a corresponding PR to mathlib4.
 
 This file lists various basic lemmas about semigroups, monoids, and groups. Most proofs are
 one-liners from the corresponding axioms. For the definitions of semigroups, monoids and groups, see

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -11,7 +11,7 @@ import algebra.group.defs
 
 > THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
 > https://github.com/leanprover-community/mathlib4/pull/457
-> No changes accepted with corresponding PRs to mathlib4.
+> No changes accepted without a corresponding PR to mathlib4.
 
 This file lists various basic lemmas about semigroups, monoids, and groups. Most proofs are
 one-liners from the corresponding axioms. For the definitions of semigroups, monoids and groups, see

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -11,7 +11,7 @@ import tactic.basic
 
 > THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
 > https://github.com/leanprover-community/mathlib4/pull/457
-> No changes accepted with corresponding PRs to mathlib4.
+> No changes accepted without a corresponding PR to mathlib4.
 
 In this file we define typeclasses for algebraic structures with one binary operation.
 The classes are named `(add_)?(comm_)?(semigroup|monoid|group)`, where `add_` means that

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -9,9 +9,9 @@ import tactic.basic
 /-!
 # Typeclasses for (semi)groups and monoids
 
-> THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
+> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
 > https://github.com/leanprover-community/mathlib4/pull/457
-> No changes accepted without a corresponding PR to mathlib4.
+> Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define typeclasses for algebraic structures with one binary operation.
 The classes are named `(add_)?(comm_)?(semigroup|monoid|group)`, where `add_` means that

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -9,6 +9,10 @@ import tactic.basic
 /-!
 # Typeclasses for (semi)groups and monoids
 
+> THIS FILE IS FROZEN, AS IT HAS BEEN PORTED TO MATHLIB4
+> https://github.com/leanprover-community/mathlib4/pull/457
+> No changes accepted with corresponding PRs to mathlib4.
+
 In this file we define typeclasses for algebraic structures with one binary operation.
 The classes are named `(add_)?(comm_)?(semigroup|monoid|group)`, where `add_` means that
 the class uses additive notation and `comm_` means that the class assumes that the binary

--- a/src/logic/relator.lean
+++ b/src/logic/relator.lean
@@ -2,11 +2,18 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
-
-Relator for functions, pairs, sums, and lists.
 -/
 
 import logic.basic
+
+/-!
+# Relator for functions, pairs, sums, and lists.
+
+> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
+> https://github.com/leanprover-community/mathlib4/pull/385
+> Any changes to this file require a corresponding PR to mathlib4.
+
+-/
 
 namespace relator
 universes u₁ u₂ v₁ v₂


### PR DESCRIPTION
This is chiefly a proposal that we get started marking files as frozen, and a proposal for a specific format.

Once we settle on what gets written here, we should add some CI that adds a special label to any PR modifying a frozen file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
