### PR TITLE
[Merged by Bors] - feat(number_theory/divisors): more thoroughly link `divisors_antidiagonal` and `divisors`

### DIFF
--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -228,7 +228,7 @@ end
 
 @[simp] lemma image_fst_divisors_antidiagonal :
   (divisors_antidiagonal n).image prod.fst = divisors n :=
-by { ext, simp [has_dvd.dvd, eq_comm] }
+by { ext, simp [has_dvd.dvd, @eq_comm _ n (_ * _)] }
 
 @[simp] lemma image_snd_divisors_antidiagonal :
   (divisors_antidiagonal n).image prod.snd = divisors n :=

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -226,8 +226,46 @@ begin
     simp [h] }
 end
 
+@[simp] lemma image_fst_divisors_antidiagonal :
+  (divisors_antidiagonal n).image prod.fst = divisors n :=
+by { ext, simp [has_dvd.dvd, eq_comm] }
+
+@[simp] lemma image_snd_divisors_antidiagonal :
+  (divisors_antidiagonal n).image prod.snd = divisors n :=
+begin
+  rw [←map_swap_divisors_antidiagonal, map_eq_image, image_image],
+  exact image_fst_divisors_antidiagonal
+end
+
+lemma map_div_right_divisors :
+  n.divisors.map ⟨λ d, (d, n/d), λ p₁ p₂, congr_arg prod.fst⟩ = n.divisors_antidiagonal :=
+begin
+  obtain rfl | hn := decidable.eq_or_ne n 0,
+  { simp },
+  ext ⟨d, nd⟩,
+  simp only [and_true, finset.mem_map, exists_eq_left, ne.def, hn, not_false_iff,
+    mem_divisors_antidiagonal, function.embedding.coe_fn_mk, mem_divisors],
+  split,
+  { rintro ⟨a, ⟨k, rfl⟩, h⟩,
+    obtain ⟨rfl, rfl⟩ := prod.mk.inj_iff.1 h,
+    have := (mul_ne_zero_iff.1 hn).1,
+    rw nat.mul_div_cancel_left _ (zero_lt_iff.mpr this), },
+  { rintro rfl,
+    refine ⟨d, dvd_mul_right _ _, _⟩,
+    have := (mul_ne_zero_iff.1 hn).1,
+    rw nat.mul_div_cancel_left _ (zero_lt_iff.mpr this) }
+end
+
+lemma map_div_left_divisors :
+  n.divisors.map ⟨λ d, (n/d, d), λ p₁ p₂, congr_arg prod.snd⟩ = n.divisors_antidiagonal :=
+begin
+  apply finset.map_injective ⟨prod.swap, prod.swap_right_inverse.injective⟩,
+  rw [map_swap_divisors_antidiagonal, ←map_div_right_divisors, finset.map_map],
+  refl,
+end
+
 lemma sum_divisors_eq_sum_proper_divisors_add_self :
-∑ i in divisors n, i = ∑ i in proper_divisors n, i + n :=
+  ∑ i in divisors n, i = ∑ i in proper_divisors n, i + n :=
 begin
   cases n,
   { simp },
@@ -382,25 +420,8 @@ by simp [h, divisors_prime_pow]
 lemma prod_divisors_antidiagonal {M : Type*} [comm_monoid M] (f : ℕ → ℕ → M) {n : ℕ} :
   ∏ i in n.divisors_antidiagonal, f i.1 i.2 = ∏ i in n.divisors, f i (n / i) :=
 begin
-  refine prod_bij (λ i _, i.1) _ _ _ _,
-  { intro i,
-    apply fst_mem_divisors_of_mem_antidiagonal },
-  { rintro ⟨i, j⟩ hij,
-    simp only [mem_divisors_antidiagonal, ne.def] at hij,
-    rw [←hij.1, nat.mul_div_cancel_left],
-    apply nat.pos_of_ne_zero,
-    rintro rfl,
-    simp only [zero_mul] at hij,
-    apply hij.2 hij.1.symm },
-  { simp only [and_imp, prod.forall, mem_divisors_antidiagonal, ne.def],
-    rintro i₁ j₁ ⟨i₂, j₂⟩ h - (rfl : i₂ * j₂ = _) h₁ (rfl : _ = i₂),
-    simp only [nat.mul_eq_zero, not_or_distrib, ←ne.def] at h₁,
-    rw mul_right_inj' h₁.1 at h,
-    simp [h] },
-  simp only [and_imp, exists_prop, mem_divisors_antidiagonal, exists_and_distrib_right, ne.def,
-    exists_eq_right', mem_divisors, prod.exists],
-  rintro _ ⟨k, rfl⟩ hn,
-  exact ⟨⟨k, rfl⟩, hn⟩,
+  rw [←map_div_right_divisors, finset.prod_map],
+  refl,
 end
 
 @[to_additive]


### PR DESCRIPTION
The lemmas in this file seemed to jump to proving statements about products over sets rather than first proving equalities of the sets themselves. This adds those skipped lemmas (from scratch) and golfs the derived results.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
