### PR TITLE
[Merged by Bors] - chore: update scripts/port_status for more flexible tagging

### DIFF
--- a/scripts/port_status.py
+++ b/scripts/port_status.py
@@ -46,10 +46,10 @@ allDone = dict()
 parentsDone = dict()
 for node in graph.nodes:
     ancestors = nx.ancestors(graph, node)
-    if all(data[imported] == 'Yes' for imported in ancestors) and data[node] == 'No':
+    if all(data[imported].startswith('Yes') for imported in ancestors) and data[node].startswith('No'):
         allDone[node] = len(nx.descendants(graph, node))
     else:
-        if all(data[imported] == 'Yes' for imported in graph.predecessors(node)) and data[node] == 'No':
+        if all(data[imported].startswith('Yes') for imported in graph.predecessors(node)) and data[node].startswith('No'):
             parentsDone[node] = len(nx.descendants(graph, node))
 
 print('# The following files have all dependencies ported already, and should be ready to port:')

--- a/scripts/port_status.py
+++ b/scripts/port_status.py
@@ -13,6 +13,15 @@ def mk_label(path: Path) -> str:
     rel = path.relative_to(Path('src'))
     return str(rel.with_suffix('')).replace(os.sep, '.')
 
+def stripPrefix(tag : str) -> str:
+    if tag.startswith('No: '):
+        return tag[4:]
+    else:
+        if tag.startswith('No'):
+            return tag[2:].lstrip()
+        else:
+            return tag
+
 graph = nx.DiGraph()
 
 for path in Path('src').glob('**/*.lean'):
@@ -47,19 +56,22 @@ parentsDone = dict()
 for node in graph.nodes:
     ancestors = nx.ancestors(graph, node)
     if all(data[imported].startswith('Yes') for imported in ancestors) and data[node].startswith('No'):
-        allDone[node] = len(nx.descendants(graph, node))
+        allDone[node] = (len(nx.descendants(graph, node)), stripPrefix(data[node]))
     else:
         if all(data[imported].startswith('Yes') for imported in graph.predecessors(node)) and data[node].startswith('No'):
-            parentsDone[node] = len(nx.descendants(graph, node))
+            parentsDone[node] = (len(nx.descendants(graph, node)), stripPrefix(data[node]))
 
 print('# The following files have all dependencies ported already, and should be ready to port:')
 print('# Earlier items in the list are required in more places in mathlib.')
-allDone = dict(sorted(allDone.items(), key=lambda item: -item[1]))
-for k in allDone:
-  print(k)
+allDone = dict(sorted(allDone.items(), key=lambda item: -item[1][0]))
+for k, v in allDone.items():
+    if v[1] == "":
+        print(k)
+    else:
+        print(k + "    -- " + v[1])
 
 print()
 print('# The following files have their immediate dependencies ported already, and may be ready to port:')
-parentsDone = dict(sorted(parentsDone.items(), key=lambda item: -item[1]))
+parentsDone = dict(sorted(parentsDone.items(), key=lambda item: -item[1][0]))
 for k in parentsDone:
   print(k)


### PR DESCRIPTION
In https://github.com/leanprover-community/mathlib/wiki/mathlib4-port-status we would like to be able to write more complicated statuses, like
* `Yes mathlib4#999 1234abcd` to track commit information about the port
* `No blocked by ring tactic`
* `No PR'd as ...`

This update to the script checks if the status starts with `Yes` or `No` to determine status.

Further, when reporting good candidates for porting, it includes the comment after `No` if present.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
