### PR TITLE
[Merged by Bors] - chore(algebra/squarefree): rename `squarefree_of_dvd_of_squarefree` for dot notation

### DIFF
--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -92,7 +92,7 @@ squarefree_of_dvd_of_squarefree (gcd_dvd_right _ _) hb
 
 lemma squarefree.gcd_left {a : α} (b : α) (ha : squarefree a) :
   squarefree (gcd a b) :=
-squarefree_of_dvd_of_squarefree (gcd_dvd_left _ _) hb
+squarefree_of_dvd_of_squarefree (gcd_dvd_left _ _) ha
 
 end squarefree_gcd_of_squarefree
 

--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -82,6 +82,20 @@ lemma squarefree_of_dvd_of_squarefree [comm_monoid R]
   squarefree x :=
 λ a h, hsq _ (h.trans hdvd)
 
+section squarefree_gcd_of_squarefree
+
+variables {α : Type*} [cancel_comm_monoid_with_zero α] [gcd_monoid α]
+
+lemma squarefree_gcd_of_squarefree_right (a : α) {b : α} (hb : squarefree b) :
+  squarefree (gcd a b) :=
+λ x hx, hb x $ hx.trans $ gcd_dvd_right _ _
+
+lemma squarefree_gcd_of_squarefree_left {a : α} (b : α) (ha : squarefree a) :
+  squarefree (gcd a b) :=
+λ x hx, ha x $ hx.trans $ gcd_dvd_left _ _
+
+end squarefree_gcd_of_squarefree
+
 namespace multiplicity
 
 section comm_monoid

--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -86,13 +86,13 @@ section squarefree_gcd_of_squarefree
 
 variables {α : Type*} [cancel_comm_monoid_with_zero α] [gcd_monoid α]
 
-lemma squarefree_gcd_of_squarefree_right (a : α) {b : α} (hb : squarefree b) :
+lemma squarefree.gcd_right (a : α) {b : α} (hb : squarefree b) :
   squarefree (gcd a b) :=
-λ x hx, hb x $ hx.trans $ gcd_dvd_right _ _
+squarefree_of_dvd_of_squarefree (gcd_dvd_right _ _) hb
 
-lemma squarefree_gcd_of_squarefree_left {a : α} (b : α) (ha : squarefree a) :
+lemma squarefree.gcd_left {a : α} (b : α) (ha : squarefree a) :
   squarefree (gcd a b) :=
-λ x hx, ha x $ hx.trans $ gcd_dvd_left _ _
+squarefree_of_dvd_of_squarefree (gcd_dvd_left _ _) hb
 
 end squarefree_gcd_of_squarefree
 

--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -77,7 +77,7 @@ lemma squarefree.of_mul_left [comm_monoid R] {m n : R} (hmn : squarefree (m * n)
 lemma squarefree.of_mul_right [comm_monoid R] {m n : R} (hmn : squarefree (m * n)) : squarefree n :=
 (λ p hp, hmn p (dvd_mul_of_dvd_right hp m))
 
-lemma squarefree_of_dvd_of_squarefree [comm_monoid R]
+lemma squarefree.squarefree_of_dvd [comm_monoid R]
   {x y : R} (hdvd : x ∣ y) (hsq : squarefree y) :
   squarefree x :=
 λ a h, hsq _ (h.trans hdvd)
@@ -88,11 +88,11 @@ variables {α : Type*} [cancel_comm_monoid_with_zero α] [gcd_monoid α]
 
 lemma squarefree.gcd_right (a : α) {b : α} (hb : squarefree b) :
   squarefree (gcd a b) :=
-squarefree_of_dvd_of_squarefree (gcd_dvd_right _ _) hb
+hb.squarefree_of_dvd (gcd_dvd_right _ _)
 
 lemma squarefree.gcd_left {a : α} (b : α) (ha : squarefree a) :
   squarefree (gcd a b) :=
-squarefree_of_dvd_of_squarefree (gcd_dvd_left _ _) ha
+ha.squarefree_of_dvd (gcd_dvd_left _ _)
 
 end squarefree_gcd_of_squarefree
 

--- a/src/data/nat/squarefree.lean
+++ b/src/data/nat/squarefree.lean
@@ -84,7 +84,7 @@ begin
   refine ⟨λ h, _, by { rintro ⟨hn, rfl⟩, simpa }⟩,
   rcases eq_or_ne n 0 with rfl | hn₀,
   { simpa [zero_pow hk.bot_lt] using h },
-  refine ⟨squarefree_of_dvd_of_squarefree (dvd_pow_self _ hk) h, by_contradiction $ λ h₁, _⟩,
+  refine ⟨h.squarefree_of_dvd (dvd_pow_self _ hk), by_contradiction $ λ h₁, _⟩,
   have : 2 ≤ k := k.two_le_iff.mpr ⟨hk, h₁⟩,
   apply hn (nat.is_unit_iff.1 (h _ _)),
   rw ←sq,


### PR DESCRIPTION
As suggested in #16999, this name is quite long and should get dot notation. I'm not totally convinced by the name but can't come up with a better one myself at the moment.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

 - [x] depends on: #16999 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
