### PR TITLE
test(scripts/lint_style): add comma linter

### DIFF
--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -330,7 +330,7 @@ def comma_followed_by_whitespace_check(lines, path):
     errors = []
     for line_nr, line in skip_comments(enumerate(lines, 1)):
         for i, char in enumerate(line):
-            if char == "," and not (line[i+1] == "\n" or line[i+1] == " "):
+            if char == "," and not (line[i+1] in " \'\"\n"):
                 errors += [(ERR_COM, line_nr, path)]
     return errors
 


### PR DESCRIPTION

This PR adds a linter that detects commas not immediately followed by whitespace. This is not explicitly described by the style guide, but it seems to be used pretty consistently throughout mathlib, and I think it makes code more readable and parseable. Let met know if there are any problems with this idea/feel free to discuss it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
