### PR TITLE
[Merged by Bors] - feat(linear_algebra): membership of a submodule given a basis of the submodule

### DIFF
--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -153,20 +153,6 @@ begin
   rwa [←hlm, repr_total, ←finsupp.mem_supported R l]
 end
 
-/-- If the submodule `P` has a basis, `x ∈ P` iff it is a linear combination of basis vectors. -/
-lemma mem_submodule_iff {P : submodule R M} (b : basis ι R P) {x : M} :
-  x ∈ P ↔ ∃ (c : ι →₀ R), x = finsupp.sum c (λ i x, x • b i) :=
-begin
-  split,
-  { intro hx, use b.repr ⟨x, hx⟩,
-    calc P.subtype ⟨x, hx⟩
-        = P.subtype (b.repr.symm (b.repr ⟨x, hx⟩)) : by rw linear_equiv.symm_apply_apply
-    ... = (b.repr ⟨x, hx⟩).sum (λ i x, x • P.subtype (b i)) : _,
-    rw [basis.repr_symm_apply, P.subtype.map_finsupp_total, finsupp.total_apply] },
-  { rintros ⟨c, rfl⟩,
-    exact P.sum_mem (λ i _, P.smul_mem _ (b i).2) },
-end
-
 end repr
 
 section coord
@@ -482,6 +468,15 @@ begin
   obtain ⟨x, y, ne⟩ : ∃ (x y : M), x ≠ y := nontrivial.exists_pair_ne,
   obtain ⟨i, _⟩ := not_forall.mp (mt b.ext_elem ne),
   exact ⟨i⟩
+end
+
+/-- If the submodule `P` has a basis, `x ∈ P` iff it is a linear combination of basis vectors. -/
+lemma mem_submodule_iff {P : submodule R M} (b : basis ι R P) {x : M} :
+  x ∈ P ↔ ∃ (c : ι →₀ R), x = finsupp.sum c (λ i x, x • b i) :=
+begin
+  conv_lhs { rw [← P.range_subtype, ← submodule.map_top, ← b.span_eq, submodule.map_span,
+    ← set.range_comp, ← finsupp.range_total] },
+  simpa only [@eq_comm _ x],
 end
 
 section constr

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -824,7 +824,7 @@ by simp [b.constr_apply, b.equiv_fun_apply, finsupp.sum_fintype]
 
 /-- If the submodule `P` has a finite basis,
 `x ∈ P` iff it is a linear combination of basis vectors. -/
-lemma basis.mem_submodule_iff' [fintype ι] {P : submodule R M} (b : basis ι R P) {x : M} :
+lemma basis.mem_submodule_iff' {P : submodule R M} (b : basis ι R P) {x : M} :
   x ∈ P ↔ ∃ (c : ι → R), x = ∑ i, c i • b i :=
 b.mem_submodule_iff.trans $ finsupp.equiv_fun_on_fintype.exists_congr_left.trans $ exists_congr $
 λ c, by simp [finsupp.sum_fintype]

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1519,6 +1519,20 @@ lemma associates.mk_ne_zero' {R : Type*} [comm_semiring R] {r : R} :
   (associates.mk (ideal.span {r} : ideal R)) ≠ 0 ↔ (r ≠ 0):=
 by rw [associates.mk_ne_zero, ideal.zero_eq_bot, ne.def, ideal.span_singleton_eq_bot]
 
+/-- If `I : ideal S` has a basis over `R`,
+`x ∈ I` iff it is a linear combination of basis vectors. -/
+lemma basis.mem_ideal_iff {ι R S : Type*} [comm_ring R] [comm_ring S] [algebra R S]
+  {I : ideal S} (b : basis ι R I) {x : S} :
+  x ∈ I ↔ ∃ (c : ι →₀ R), x = finsupp.sum c (λ i x, x • b i) :=
+(b.map ((I.restrict_scalars_equiv R _ _).restrict_scalars R).symm).mem_submodule_iff
+
+/-- If `I : ideal S` has a finite basis over `R`,
+`x ∈ I` iff it is a linear combination of basis vectors. -/
+lemma basis.mem_ideal_iff' {ι R S : Type*} [fintype ι] [comm_ring R] [comm_ring S] [algebra R S]
+  {I : ideal S} (b : basis ι R I) {x : S} :
+  x ∈ I ↔ ∃ (c : ι → R), x = ∑ i, c i • b i :=
+(b.map ((I.restrict_scalars_equiv R _ _).restrict_scalars R).symm).mem_submodule_iff'
+
 namespace ring_hom
 
 variables {R : Type u} {S : Type v} {T : Type v}


### PR DESCRIPTION
A selection of little lemmas on module bases needed for the absolute ideal norm. 

`basis.mem_submodule_iff` states: `x` is an element of a submodule `P` with basis iff `x` is a linear combination of basis vectors. We include the infinite and finite cases, and specialization to ideals.

`basis.repr_sum_self` states that a linear combination of basis vectors has coordinates exactly given by the coefficient of the combination. This can almost already be done by `simp` except relating the finite sum to `finsupp.total`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
