### PR TITLE
feat(ring_theory/ideal/local_ring): add `local_ring.residue_field.map_id_apply` & `local_ring.residue_field.map_comp_apply` & ​`local_ring.residue_field.map_equiv`

### DIFF
--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -371,6 +371,28 @@ lemma map_comp (f : T →+* R) (g : R →+* S) [is_local_ring_hom f] [is_local_r
   (local_ring.residue_field.map g).comp (local_ring.residue_field.map f) :=
 ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
 
+open ring_equiv semiring
+
+@[simp]lemma map_id_apply {x : residue_field R} : map (ring_hom.id R) x = x :=
+by simp only [map_id, ring_hom.id_apply]
+
+@[simp]lemma map_comp_apply (f : R →+* S) (g : S →+* T) (x : residue_field R)
+[is_local_ring_hom f] [is_local_ring_hom g] :
+map (g.comp f) x = (map g) ((map f) x) :=
+by simp only [map_comp, ring_hom.comp_apply]
+
+noncomputable theory
+
+-- This approach avoids the `of_hom_inv` approach
+def map_equiv (f : R ≃+* S):
+ (local_ring.residue_field R) ≃+* (local_ring.residue_field S) :=
+{ to_fun := map (f : R →+* S),
+  inv_fun := map (f.symm : S →+* R),
+  left_inv := λ x, by simp only [← map_comp_apply, symm_comp, map_id, ring_hom.id_apply],
+  right_inv := λ x, by simp only [← map_comp_apply, comp_symm, map_id, ring_hom.id_apply],
+  map_mul' := ring_hom.map_mul _,
+  map_add' := ring_hom.map_add _ }
+
 end residue_field
 
 lemma ker_eq_maximal_ideal [field K] (φ : R →+* K) (hφ : function.surjective φ) :


### PR DESCRIPTION
Two lemmata and one definition required for the study of inertia group.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
 - [x] depends on: #17045

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
