### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal): define `submodule.card_quot`

### DIFF
--- a/src/ring_theory/ideal/norm.lean
+++ b/src/ring_theory/ideal/norm.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2022 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen, Alex J. Best
+-/
+
+import linear_algebra.isomorphisms
+import ring_theory.dedekind_domain.ideal
+
+/-!
+# Ideal norms
+This file will define the absolute ideal norm `ideal.abs_norm (I : ideal R) : ℕ` as the cardinality of
+the quotient `R ⧸ I` (setting it to 0 if the cardinality is infinite).
+
+## Main definitions
+ * `submodule.card_quot (S : submodule R M)`: the cardinality of the quotient `M ⧸ S`, in `ℕ`.
+   This maps `⊥` to `0` and `⊤` to `1`.
+
+## TODO
+ * `ideal.abs_norm (I : ideal R)`: the absolute ideal norm, defined as
+   the cardinality of the quotient `R ⧸ I`, as a bundled monoid-with-zero homomorphism.
+   (In an upcoming PR!)
+
+ * Define the relative norm.
+
+-/
+
+open_locale big_operators
+
+namespace submodule
+
+variables {R M : Type*} [ring R] [add_comm_group M] [module R M]
+
+section
+
+open_locale classical
+
+/-- The cardinality of `(M ⧸ S)`, if `(M ⧸ S)` is finite, and `0` otherwise.
+This is used to define the absolute ideal norm `ideal.abs_norm`.
+-/
+noncomputable def card_quot (S : submodule R M) : ℕ :=
+if h : nonempty (fintype (M ⧸ S)) then @fintype.card _ h.some else 0
+
+@[simp] lemma card_quot_apply (S : submodule R M) [h : fintype (M ⧸ S)] :
+  card_quot S = fintype.card (M ⧸ S) :=
+by convert dif_pos (nonempty.intro h) -- `convert` deals with the different `fintype` instances
+
+@[simp] lemma card_quot_bot [infinite M] : card_quot (⊥ : submodule R M) = 0 :=
+dif_neg (by simp; apply_instance)
+
+@[simp] lemma card_quot_top : card_quot (⊤ : submodule R M) = 1 :=
+calc card_quot ⊤ = fintype.card (M ⧸ ⊤) : card_quot_apply _
+... = fintype.card punit : fintype.card_eq.mpr ⟨equiv_of_subsingleton_of_subsingleton 0 0⟩
+... = 1 : fintype.card_punit
+
+@[simp] lemma card_quot_eq_one_iff {P : submodule R M} : card_quot P = 1 ↔ P = ⊤ :=
+begin
+  unfold card_quot,
+  split_ifs,
+  { rw [fintype.card_eq_one_iff_nonempty_unique, submodule.unique_quotient_iff_eq_top] },
+  { simp only [zero_ne_one, false_iff],
+    rintro rfl,
+    have : nonempty (fintype (M ⧸ ⊤)) := ⟨@quotient_top.fintype R M _ _ _⟩,
+    contradiction }
+end
+
+end
+
+end submodule

--- a/src/ring_theory/ideal/norm.lean
+++ b/src/ring_theory/ideal/norm.lean
@@ -9,8 +9,8 @@ import ring_theory.dedekind_domain.ideal
 
 /-!
 # Ideal norms
-This file will define the absolute ideal norm `ideal.abs_norm (I : ideal R) : ℕ` as the cardinality of
-the quotient `R ⧸ I` (setting it to 0 if the cardinality is infinite).
+This file will define the absolute ideal norm `ideal.abs_norm (I : ideal R) : ℕ` as the cardinality
+of the quotient `R ⧸ I` (setting it to 0 if the cardinality is infinite).
 
 ## Main definitions
  * `submodule.card_quot (S : submodule R M)`: the cardinality of the quotient `M ⧸ S`, in `ℕ`.

--- a/src/ring_theory/ideal/norm.lean
+++ b/src/ring_theory/ideal/norm.lean
@@ -43,11 +43,15 @@ add_subgroup.index S.to_add_subgroup
   card_quot S = fintype.card (M ⧸ S) :=
 add_subgroup.index_eq_card _
 
+variables (R M)
+
 @[simp] lemma card_quot_bot [infinite M] : card_quot (⊥ : submodule R M) = 0 :=
 add_subgroup.index_bot.trans nat.card_eq_zero_of_infinite
 
 @[simp] lemma card_quot_top : card_quot (⊤ : submodule R M) = 1 :=
 add_subgroup.index_top
+
+variables {R M}
 
 @[simp] lemma card_quot_eq_one_iff {P : submodule R M} : card_quot P = 1 ↔ P = ⊤ :=
 add_subgroup.index_eq_one.trans (by simp [set_like.ext_iff])

--- a/src/ring_theory/ideal/norm.lean
+++ b/src/ring_theory/ideal/norm.lean
@@ -33,36 +33,24 @@ variables {R M : Type*} [ring R] [add_comm_group M] [module R M]
 
 section
 
-open_locale classical
-
 /-- The cardinality of `(M ⧸ S)`, if `(M ⧸ S)` is finite, and `0` otherwise.
 This is used to define the absolute ideal norm `ideal.abs_norm`.
 -/
 noncomputable def card_quot (S : submodule R M) : ℕ :=
-if h : nonempty (fintype (M ⧸ S)) then @fintype.card _ h.some else 0
+add_subgroup.index S.to_add_subgroup
 
-@[simp] lemma card_quot_apply (S : submodule R M) [h : fintype (M ⧸ S)] :
+@[simp] lemma card_quot_apply (S : submodule R M) [fintype (M ⧸ S)] :
   card_quot S = fintype.card (M ⧸ S) :=
-by convert dif_pos (nonempty.intro h) -- `convert` deals with the different `fintype` instances
+add_subgroup.index_eq_card _
 
 @[simp] lemma card_quot_bot [infinite M] : card_quot (⊥ : submodule R M) = 0 :=
-dif_neg (by simp; apply_instance)
+add_subgroup.index_bot.trans nat.card_eq_zero_of_infinite
 
 @[simp] lemma card_quot_top : card_quot (⊤ : submodule R M) = 1 :=
-calc card_quot ⊤ = fintype.card (M ⧸ ⊤) : card_quot_apply _
-... = fintype.card punit : fintype.card_eq.mpr ⟨equiv_of_subsingleton_of_subsingleton 0 0⟩
-... = 1 : fintype.card_punit
+add_subgroup.index_top
 
 @[simp] lemma card_quot_eq_one_iff {P : submodule R M} : card_quot P = 1 ↔ P = ⊤ :=
-begin
-  unfold card_quot,
-  split_ifs,
-  { rw [fintype.card_eq_one_iff_nonempty_unique, submodule.unique_quotient_iff_eq_top] },
-  { simp only [zero_ne_one, false_iff],
-    rintro rfl,
-    have : nonempty (fintype (M ⧸ ⊤)) := ⟨@quotient_top.fintype R M _ _ _⟩,
-    contradiction }
-end
+add_subgroup.index_eq_one.trans (by simp [set_like.ext_iff])
 
 end
 


### PR DESCRIPTION
This is the first step towards defining the absolute ideal norm: a definition of the cardinality of the quotient.

Once I've got a few more lemmas PR'd, we can show multiplicativity of `submodule.card_quot` restricted to ideals of a Dedekind domain, and bundle it into a `monoid_with_zero` hom.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

 - [x] depends on: #17084

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
