### PR TITLE
[Merged by Bors] - feat(ring_theory/ideal/local_ring): add lemmas about and bundled versions of `local_ring.residue_field.map`

### DIFF
--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -375,25 +375,32 @@ section
 
 open ring_equiv local_ring
 
-@[simp]lemma map_id_apply {x : residue_field R} : map (ring_hom.id R) x = x :=
+@[simp]
+lemma map_id_apply {x : residue_field R} : map (ring_hom.id R) x = x :=
 by simp only [map_id, ring_hom.id_apply]
 
-@[simp]lemma map_comp_apply (f : R →+* S) (g : S →+* T) (x : residue_field R)
+@[simp]
+lemma map_map (f : R →+* S) (g : S →+* T) (x : residue_field R)
 [is_local_ring_hom f] [is_local_ring_hom g] :
-map (g.comp f) x = (map g) ((map f) x) :=
+  map (g.comp f) x = map g (map f x) :=
 by simp only [map_comp, ring_hom.comp_apply]
 
 noncomputable theory
 
 /-- A ring isomorphism defines an isomorphism of residue fields -/
+@[simps apply]
 def map_equiv (f : R ≃+* S):
- (local_ring.residue_field R) ≃+* (local_ring.residue_field S) :=
+  local_ring.residue_field R ≃+* local_ring.residue_field S :=
 { to_fun := map (f : R →+* S),
   inv_fun := map (f.symm : S →+* R),
-  left_inv := λ x, by simp only [← map_comp_apply, symm_comp, map_id, ring_hom.id_apply],
-  right_inv := λ x, by simp only [← map_comp_apply, comp_symm, map_id, ring_hom.id_apply],
+  left_inv := λ x, by simp only [← map_map, symm_comp, map_id, ring_hom.id_apply],
+  right_inv := λ x, by simp only [← map_map, comp_symm, map_id, ring_hom.id_apply],
   map_mul' := ring_hom.map_mul _,
   map_add' := ring_hom.map_add _ }
+
+@[simp]
+lemma map_equiv.symm (f : R ≃+* S):
+  (map_equiv f).symm = map_equiv f.symm := ext $ λ x, rfl
 
 end
 

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -406,7 +406,6 @@ noncomputable def map_aut:
 { to_fun := map_equiv,
   map_mul' := begin
   intros φ ψ,
-  ext,
   exact map_comp (φ : R →+* R) (ψ : R →+* R),
   end,
   map_one' := begin

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -383,11 +383,9 @@ by simp only [map_id, ring_hom.id_apply]
   map g (map f x) = map (g.comp f) x :=
 by simp only [map_comp, ring_hom.comp_apply]
 
-noncomputable theory
-
 /-- A ring isomorphism defines an isomorphism of residue fields -/
 @[simps apply]
-def map_equiv (f : R ≃+* S):
+noncomputable def map_equiv (f : R ≃+* S):
   local_ring.residue_field R ≃+* local_ring.residue_field S :=
 { to_fun := map (f : R →+* S),
   inv_fun := map (f.symm : S →+* R),
@@ -402,19 +400,19 @@ lemma map_equiv.symm (f : R ≃+* S):
 
 /-- The group homomorphism from `ring_aut R` to `ring_aut k` where `k`
 is the residue field of `R`. -/
-def map_aut:
+@[simps]
+noncomputable def map_aut:
   ring_aut R →* ring_aut (local_ring.residue_field R):=
 { to_fun := map_equiv,
   map_mul' := begin
   intros φ ψ,
   ext,
-  exact map_map (φ : R →+* R) (ψ : R →+* R) x,
+  exact map_comp (φ : R →+* R) (ψ : R →+* R),
   end,
   map_one' := begin
   ext,
   apply local_ring.residue_field.map_id_apply,
-  end
-  }
+  end }
 
 end
 

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -407,7 +407,7 @@ noncomputable def map_aut:
   map_mul' := begin
   intros φ ψ,
   ext,
-  simp only [map_equiv_apply, ← map_comp (φ : R →+* R) (ψ : R →+* R), ring_hom.id_apply, map_mul'],
+  exact (map_map (ψ : R →+* R) (φ : R →+* R) x).symm,
   end,
   map_one' := begin
   ext,

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -385,7 +385,7 @@ by simp only [map_comp, ring_hom.comp_apply]
 
 /-- A ring isomorphism defines an isomorphism of residue fields -/
 @[simps apply]
-noncomputable def map_equiv (f : R ≃+* S):
+noncomputable def map_equiv (f : R ≃+* S) :
   local_ring.residue_field R ≃+* local_ring.residue_field S :=
 { to_fun := map (f : R →+* S),
   inv_fun := map (f.symm : S →+* R),
@@ -395,32 +395,31 @@ noncomputable def map_equiv (f : R ≃+* S):
   map_add' := ring_hom.map_add _ }
 
 @[simp]
-lemma map_equiv.symm (f : R ≃+* S):
+lemma map_equiv.symm (f : R ≃+* S) :
   (map_equiv f).symm = map_equiv f.symm := ext $ λ x, rfl
 
 @[simp]
-lemma map_equiv_trans: ∀ (x y : ring_aut R),
-  map_equiv (x * y) = map_equiv x * map_equiv y :=
+lemma map_equiv_trans (e₁ : R ≃+* S) (e₂ : S ≃+* T) :
+  map_equiv (e₁.trans e₂) = (map_equiv e₁).trans (map_equiv e₂) :=
 begin
-  rintros φ ψ,
-  ext,
-  exact (map_map (ψ : R →+* R) (φ : R →+* R) x).symm,
+ ext,
+ simp only [coe_ring_hom_trans, map_equiv_apply, ring_equiv.coe_trans, function.comp_app, map_map],
 end
 
 @[simp]
-lemma map_equiv_refl : map_equiv (1 : ring_aut R) = 1 :=
+lemma map_equiv_refl : map_equiv (ring_equiv.refl R) = ring_equiv.refl _ :=
 begin
-ext,
-apply local_ring.residue_field.map_id_apply,
+ ext,
+ apply local_ring.residue_field.map_id_apply,
 end
 
 /-- The group homomorphism from `ring_aut R` to `ring_aut k` where `k`
 is the residue field of `R`. -/
 @[simps]
-noncomputable def map_aut:
-  ring_aut R →* ring_aut (local_ring.residue_field R):=
+noncomputable def map_aut :
+  ring_aut R →* ring_aut (local_ring.residue_field R) :=
 { to_fun := map_equiv,
-  map_mul' := map_equiv_trans,
+  map_mul' := λ e₁ e₂, by apply map_equiv_trans,
   map_one' := map_equiv_refl }
 
 end

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -371,58 +371,40 @@ lemma map_comp (f : T →+* R) (g : R →+* S) [is_local_ring_hom f] [is_local_r
   (local_ring.residue_field.map g).comp (local_ring.residue_field.map f) :=
 ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
 
-section
-
-open ring_equiv local_ring
-
-@[simp] lemma map_id_apply {x : residue_field R} : map (ring_hom.id R) x = x :=
-by simp only [map_id, ring_hom.id_apply]
+lemma map_id_apply (x : residue_field R) : map (ring_hom.id R) x = x :=
+fun_like.congr_fun map_id x
 
 @[simp] lemma map_map (f : R →+* S) (g : S →+* T) (x : residue_field R)
-[is_local_ring_hom f] [is_local_ring_hom g] :
+  [is_local_ring_hom f] [is_local_ring_hom g] :
   map g (map f x) = map (g.comp f) x :=
-by simp only [map_comp, ring_hom.comp_apply]
+fun_like.congr_fun (map_comp f g).symm x
 
-/-- A ring isomorphism defines an isomorphism of residue fields -/
+/-- A ring isomorphism defines an isomorphism of residue fields. -/
 @[simps apply]
 noncomputable def map_equiv (f : R ≃+* S) :
   local_ring.residue_field R ≃+* local_ring.residue_field S :=
 { to_fun := map (f : R →+* S),
   inv_fun := map (f.symm : S →+* R),
-  left_inv := λ x, by simp only [map_map, symm_comp, map_id, ring_hom.id_apply],
-  right_inv := λ x, by simp only [map_map, comp_symm, map_id, ring_hom.id_apply],
+  left_inv := λ x, by simp only [map_map, ring_equiv.symm_comp, map_id, ring_hom.id_apply],
+  right_inv := λ x, by simp only [map_map, ring_equiv.comp_symm, map_id, ring_hom.id_apply],
   map_mul' := ring_hom.map_mul _,
   map_add' := ring_hom.map_add _ }
 
-@[simp]
-lemma map_equiv.symm (f : R ≃+* S) :
-  (map_equiv f).symm = map_equiv f.symm := ext $ λ x, rfl
+@[simp] lemma map_equiv.symm (f : R ≃+* S) : (map_equiv f).symm = map_equiv f.symm := rfl
 
-@[simp]
-lemma map_equiv_trans (e₁ : R ≃+* S) (e₂ : S ≃+* T) :
+@[simp] lemma map_equiv_trans (e₁ : R ≃+* S) (e₂ : S ≃+* T) :
   map_equiv (e₁.trans e₂) = (map_equiv e₁).trans (map_equiv e₂) :=
-begin
- ext,
- simp only [coe_ring_hom_trans, map_equiv_apply, ring_equiv.coe_trans, function.comp_app, map_map],
-end
+ring_equiv.to_ring_hom_injective $ map_comp (e₁ : R →+* S) (e₂ : S →+* T)
 
-@[simp]
-lemma map_equiv_refl : map_equiv (ring_equiv.refl R) = ring_equiv.refl _ :=
-begin
- ext,
- apply local_ring.residue_field.map_id_apply,
-end
+@[simp] lemma map_equiv_refl : map_equiv (ring_equiv.refl R) = ring_equiv.refl _ :=
+ring_equiv.to_ring_hom_injective map_id
 
 /-- The group homomorphism from `ring_aut R` to `ring_aut k` where `k`
 is the residue field of `R`. -/
-@[simps]
-noncomputable def map_aut :
-  ring_aut R →* ring_aut (local_ring.residue_field R) :=
+@[simps] noncomputable def map_aut : ring_aut R →* ring_aut (local_ring.residue_field R) :=
 { to_fun := map_equiv,
-  map_mul' := λ e₁ e₂, by apply map_equiv_trans,
+  map_mul' := λ e₁ e₂, map_equiv_trans e₂ e₁,
   map_one' := map_equiv_refl }
-
-end
 
 end residue_field
 

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -406,7 +406,8 @@ noncomputable def map_aut:
 { to_fun := map_equiv,
   map_mul' := begin
   intros φ ψ,
-  exact map_comp (φ : R →+* R) (ψ : R →+* R),
+  ext,
+  simp only [map_equiv_apply, ← map_comp (φ : R →+* R) (ψ : R →+* R), ring_hom.id_apply, map_mul'],
   end,
   map_one' := begin
   ext,

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -361,7 +361,7 @@ end
 
 /-- Applying `residue_field.map` to the identity ring homomorphism gives the identity
 ring homomorphism. -/
-lemma map_id :
+@[simp] lemma map_id :
   local_ring.residue_field.map (ring_hom.id R) = ring_hom.id (local_ring.residue_field R) :=
 ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
 
@@ -375,12 +375,10 @@ section
 
 open ring_equiv local_ring
 
-@[simp]
-lemma map_id_apply {x : residue_field R} : map (ring_hom.id R) x = x :=
+@[simp] lemma map_id_apply {x : residue_field R} : map (ring_hom.id R) x = x :=
 by simp only [map_id, ring_hom.id_apply]
 
-@[simp]
-lemma map_map (f : R →+* S) (g : S →+* T) (x : residue_field R)
+@[simp] lemma map_map (f : R →+* S) (g : S →+* T) (x : residue_field R)
 [is_local_ring_hom f] [is_local_ring_hom g] :
   map (g.comp f) x = map g (map f x) :=
 by simp only [map_comp, ring_hom.comp_apply]

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -371,6 +371,31 @@ lemma map_comp (f : T →+* R) (g : R →+* S) [is_local_ring_hom f] [is_local_r
   (local_ring.residue_field.map g).comp (local_ring.residue_field.map f) :=
 ideal.quotient.ring_hom_ext $ ring_hom.ext $ λx, rfl
 
+section
+
+open ring_equiv local_ring
+
+@[simp]lemma map_id_apply {x : residue_field R} : map (ring_hom.id R) x = x :=
+by simp only [map_id, ring_hom.id_apply]
+
+@[simp]lemma map_comp_apply (f : R →+* S) (g : S →+* T) (x : residue_field R)
+[is_local_ring_hom f] [is_local_ring_hom g] :
+map (g.comp f) x = (map g) ((map f) x) :=
+by simp only [map_comp, ring_hom.comp_apply]
+
+noncomputable theory
+
+def map_equiv (f : R ≃+* S):
+ (local_ring.residue_field R) ≃+* (local_ring.residue_field S) :=
+{ to_fun := map (f : R →+* S),
+  inv_fun := map (f.symm : S →+* R),
+  left_inv := λ x, by simp only [← map_comp_apply, symm_comp, map_id, ring_hom.id_apply],
+  right_inv := λ x, by simp only [← map_comp_apply, comp_symm, map_id, ring_hom.id_apply],
+  map_mul' := ring_hom.map_mul _,
+  map_add' := ring_hom.map_add _ }
+
+end
+
 end residue_field
 
 lemma ker_eq_maximal_ideal [field K] (φ : R →+* K) (hφ : function.surjective φ) :

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -391,14 +391,30 @@ def map_equiv (f : R ≃+* S):
   local_ring.residue_field R ≃+* local_ring.residue_field S :=
 { to_fun := map (f : R →+* S),
   inv_fun := map (f.symm : S →+* R),
-  left_inv := λ x, by simp only [← map_map, symm_comp, map_id, ring_hom.id_apply],
-  right_inv := λ x, by simp only [← map_map, comp_symm, map_id, ring_hom.id_apply],
+  left_inv := λ x, by simp only [map_map, symm_comp, map_id, ring_hom.id_apply],
+  right_inv := λ x, by simp only [map_map, comp_symm, map_id, ring_hom.id_apply],
   map_mul' := ring_hom.map_mul _,
   map_add' := ring_hom.map_add _ }
 
 @[simp]
 lemma map_equiv.symm (f : R ≃+* S):
   (map_equiv f).symm = map_equiv f.symm := ext $ λ x, rfl
+
+/-- The group homomorphism from `ring_aut R` to `ring_aut k` where `k`
+is the residue field of `R`. -/
+def map_aut:
+  ring_aut R →* ring_aut (local_ring.residue_field R):=
+{ to_fun := map_equiv,
+  map_mul' := begin
+  intros φ ψ,
+  ext,
+  exact map_map (φ : R →+* R) (ψ : R →+* R) x,
+  end,
+  map_one' := begin
+  ext,
+  apply local_ring.residue_field.map_id_apply,
+  end
+  }
 
 end
 

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -385,6 +385,7 @@ by simp only [map_comp, ring_hom.comp_apply]
 
 noncomputable theory
 
+/-- A ring isomorphism defines an isomorphism of residue fields -/
 def map_equiv (f : R ≃+* S):
  (local_ring.residue_field R) ≃+* (local_ring.residue_field S) :=
 { to_fun := map (f : R →+* S),

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -380,7 +380,7 @@ by simp only [map_id, ring_hom.id_apply]
 
 @[simp] lemma map_map (f : R →+* S) (g : S →+* T) (x : residue_field R)
 [is_local_ring_hom f] [is_local_ring_hom g] :
-  map (g.comp f) x = map g (map f x) :=
+  map g (map f x) = map (g.comp f) x :=
 by simp only [map_comp, ring_hom.comp_apply]
 
 noncomputable theory

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -398,21 +398,30 @@ noncomputable def map_equiv (f : R ≃+* S):
 lemma map_equiv.symm (f : R ≃+* S):
   (map_equiv f).symm = map_equiv f.symm := ext $ λ x, rfl
 
+@[simp]
+lemma map_equiv_trans: ∀ (x y : ring_aut R),
+  map_equiv (x * y) = map_equiv x * map_equiv y :=
+begin
+  rintros φ ψ,
+  ext,
+  exact (map_map (ψ : R →+* R) (φ : R →+* R) x).symm,
+end
+
+@[simp]
+lemma map_equiv_refl : map_equiv (1 : ring_aut R) = 1 :=
+begin
+ext,
+apply local_ring.residue_field.map_id_apply,
+end
+
 /-- The group homomorphism from `ring_aut R` to `ring_aut k` where `k`
 is the residue field of `R`. -/
 @[simps]
 noncomputable def map_aut:
   ring_aut R →* ring_aut (local_ring.residue_field R):=
 { to_fun := map_equiv,
-  map_mul' := begin
-  intros φ ψ,
-  ext,
-  exact (map_map (ψ : R →+* R) (φ : R →+* R) x).symm,
-  end,
-  map_one' := begin
-  ext,
-  apply local_ring.residue_field.map_id_apply,
-  end }
+  map_mul' := map_equiv_trans,
+  map_one' := map_equiv_refl }
 
 end
 


### PR DESCRIPTION
Add `local_ring.residue_field.map_id_apply` & `local_ring.residue_field.map_comp_apply` & ​`local_ring.residue_field.map_equiv`.

Some more lemmata needed for the definition of inertia group.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
