### PR TITLE
[Merged by Bors] - feat(analysis/calculus/uniform_limits_deriv): pointwise convergence out of derivative convergence on a preconnected set

### DIFF
--- a/src/analysis/calculus/uniform_limits_deriv.lean
+++ b/src/analysis/calculus/uniform_limits_deriv.lean
@@ -97,23 +97,24 @@ open_locale uniformity filter topological_space
 
 section limits_of_derivatives
 
-variables {ι : Type*} {l : filter ι} [ne_bot l]
-  {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+variables {ι : Type*} {l : filter ι}
+  {E : Type*} [normed_add_comm_group E]
   {𝕜 : Type*} [is_R_or_C 𝕜] [normed_space 𝕜 E]
   {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
-  {f : ι → E → G} {g : E → G} {f' : ι → (E → (E →L[𝕜] G))} {g' : E → (E →L[𝕜] G)}
+  {y : G} {f : ι → E → G} {g : E → G} {f' : ι → (E → (E →L[𝕜] G))} {g' : E → (E →L[𝕜] G)}
   {x : E}
 
 /-- If a sequence of functions real or complex functions are eventually differentiable on a
-neighborhood of `x`, they converge pointwise _at_ `x`, and their derivatives
-converge uniformly in a neighborhood of `x`, then the functions form a uniform Cauchy sequence
-in a neighborhood of `x`. -/
-lemma uniform_cauchy_seq_on_filter_of_tendsto_uniformly_on_filter_fderiv
+neighborhood of `x`, they are Cauchy _at_ `x`, and their derivatives
+are a uniform Cauchy sequence in a neighborhood of `x`, then the functions form a uniform Cauchy
+sequence in a neighborhood of `x`. -/
+lemma uniform_cauchy_seq_on_filter_of_fderiv
   (hf' : uniform_cauchy_seq_on_filter f' l (𝓝 x))
   (hf : ∀ᶠ (n : ι × E) in (l ×ᶠ 𝓝 x), has_fderiv_at (f n.1) (f' n.1 n.2) n.2)
-  (hfg : tendsto (λ n, f n x) l (𝓝 (g x))) :
+  (hfg : cauchy (map (λ (n : ι), f n x) l)) :
   uniform_cauchy_seq_on_filter f l (𝓝 x) :=
 begin
+  letI : normed_space ℝ E, from normed_space.restrict_scalars ℝ 𝕜 _,
   rw seminormed_add_group.uniform_cauchy_seq_on_filter_iff_tendsto_uniformly_on_filter_zero at
     hf' ⊢,
 
@@ -154,7 +155,7 @@ begin
       (convex_ball x r) (metric.mem_ball_self hr) hy, },
   { -- This is just `hfg` run through `eventually_prod_iff`
     refine metric.tendsto_uniformly_on_filter_iff.mpr (λ ε hε, _),
-    obtain ⟨t, ht, ht'⟩ := (metric.cauchy_iff.mp hfg.cauchy_map).2 ε hε,
+    obtain ⟨t, ht, ht'⟩ := (metric.cauchy_iff.mp hfg).2 ε hε,
     exact eventually_prod_iff.mpr
     ⟨ (λ (n : ι × ι), (f n.1 x ∈ t) ∧ (f n.2 x ∈ t)),
       eventually_prod_iff.mpr ⟨_, ht, _, ht, (λ n hn n' hn', ⟨hn, hn'⟩)⟩,
@@ -165,23 +166,26 @@ end
 
 /-- A variant of the second fundamental theorem of calculus (FTC-2): If a sequence of functions
 between real or complex normed spaces are differentiable on a ball centered at `x`, they
-converge pointwise _at_ `x`, and their derivatives converge uniformly on the ball, then the
+form a Cauchy sequence _at_ `x`, and their derivatives are Cauchy uniformly on the ball, then the
 functions form a uniform Cauchy sequence on the ball.
 
 NOTE: The fact that we work on a ball is typically all that is necessary to work with power series
 and Dirichlet series (our primary use case). However, this can be generalized by replacing the ball
 with any connected, bounded, open set and replacing uniform convergence with local uniform
-convergence.
+convergence. See `cauchy_map_of_uniform_cauchy_seq_on_fderiv`.
 -/
-lemma uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_fderiv
-  {r : ℝ} (hr : 0 < r)
-  (hf' : uniform_cauchy_seq_on f' l (metric.ball x r))
+lemma uniform_cauchy_seq_on_ball_of_fderiv
+  {r : ℝ} (hf' : uniform_cauchy_seq_on f' l (metric.ball x r))
   (hf : ∀ n : ι, ∀ y : E, y ∈ metric.ball x r → has_fderiv_at (f n) (f' n y) y)
-  (hfg : tendsto (λ n, f n x) l (𝓝 (g x))) :
+  (hfg : cauchy (map (λ (n : ι), f n x) l)) :
   uniform_cauchy_seq_on f l (metric.ball x r) :=
 begin
+  letI : normed_space ℝ E, from normed_space.restrict_scalars ℝ 𝕜 _,
+  haveI : ne_bot l, from (cauchy_map_iff.1 hfg).1,
+  rcases le_or_lt r 0 with hr|hr,
+  { simp only [metric.ball_eq_empty.2 hr, uniform_cauchy_seq_on, set.mem_empty_iff_false,
+      is_empty.forall_iff, eventually_const, implies_true_iff] },
   rw seminormed_add_group.uniform_cauchy_seq_on_iff_tendsto_uniformly_on_zero at hf' ⊢,
-
   suffices : tendsto_uniformly_on
     (λ (n : ι × ι) (z : E), f n.1 z - f n.2 z - (f n.1 x - f n.2 x)) 0
       (l ×ᶠ l) (metric.ball x r) ∧
@@ -213,12 +217,47 @@ begin
     exact this.trans hq, },
   { -- This is just `hfg` run through `eventually_prod_iff`
     refine metric.tendsto_uniformly_on_iff.mpr (λ ε hε, _),
-    obtain ⟨t, ht, ht'⟩ := (metric.cauchy_iff.mp hfg.cauchy_map).2 ε hε,
+    obtain ⟨t, ht, ht'⟩ := (metric.cauchy_iff.mp hfg).2 ε hε,
     rw eventually_prod_iff,
     refine ⟨(λ n, f n x ∈ t), ht, (λ n, f n x ∈ t), ht, _⟩,
     intros n hn n' hn' z hz,
     rw [dist_eq_norm, pi.zero_apply, zero_sub, norm_neg, ←dist_eq_norm],
     exact (ht' _ hn _ hn'), },
+end
+
+/-- If a sequence of functions between real or complex normed spaces are differentiable on a
+preconnected open set, they form a Cauchy sequence _at_ `x`, and their derivatives are Cauchy
+uniformly on the set, then the functions form a Cauchy sequence at any point in the set. -/
+lemma cauchy_map_of_uniform_cauchy_seq_on_fderiv
+  {s : set E} (hs : is_open s) (h's : is_preconnected s)
+  (hf' : uniform_cauchy_seq_on f' l s)
+  (hf : ∀ n : ι, ∀ y : E, y ∈ s → has_fderiv_at (f n) (f' n y) y)
+  {x₀ x : E} (hx₀ : x₀ ∈ s) (hx : x ∈ s)
+  (hfg : cauchy (map (λ (n : ι), f n x₀) l)) :
+  cauchy (map (λ (n : ι), f n x) l) :=
+begin
+  haveI : ne_bot l, from (cauchy_map_iff.1 hfg).1,
+  let t := {y | y ∈ s ∧ cauchy (map (λ (n : ι), f n y) l)},
+  suffices H : s ⊆ t, from (H hx).2,
+  have A : ∀ x ε, x ∈ t → metric.ball x ε ⊆ s → metric.ball x ε ⊆ t,
+  from λ x ε xt hx y hy, ⟨hx hy, (uniform_cauchy_seq_on_ball_of_fderiv (hf'.mono hx)
+    (λ n y hy, hf n y (hx hy)) xt.2).cauchy_map hy⟩,
+  have open_t : is_open t,
+  { rw metric.is_open_iff,
+    assume x hx,
+    rcases metric.is_open_iff.1 hs x hx.1 with ⟨ε, εpos, hε⟩,
+    exact ⟨ε, εpos, A x ε hx hε⟩ },
+  have st_nonempty : (s ∩ t).nonempty, from ⟨x₀, hx₀, ⟨hx₀, hfg⟩⟩,
+  suffices H : closure t ∩ s ⊆ t, from h's.subset_of_closure_inter_subset open_t st_nonempty H,
+  rintros x ⟨xt, xs⟩,
+  refine ⟨xs, _⟩,
+  obtain ⟨ε, εpos, hε⟩ : ∃ (ε : ℝ) (H : ε > 0), metric.ball x ε ⊆ s,
+    from metric.is_open_iff.1 hs x xs,
+  obtain ⟨y, yt, hxy⟩ : ∃ (y : E) (yt : y ∈ t), dist x y < ε / 2,
+    from metric.mem_closure_iff.1 xt _ (half_pos εpos),
+  have B : metric.ball y (ε / 2) ⊆ metric.ball x ε,
+  { apply metric.ball_subset_ball', rw dist_comm, linarith },
+  exact (A y (ε / 2) yt (B.trans hε) (metric.mem_ball.2 hxy)).2,
 end
 
 /-- If `f_n → g` pointwise and the derivatives `(f_n)' → h` _uniformly_ converge, then
@@ -233,6 +272,10 @@ lemma difference_quotients_converge_uniformly
     (λ y : E, (∥y - x∥⁻¹ : 𝕜) • (g y - g x))
     l (𝓝 x) :=
 begin
+  letI : normed_space ℝ E, from normed_space.restrict_scalars ℝ 𝕜 _,
+  rcases eq_or_ne l ⊥ with hl|hl,
+  { simp only [hl, tendsto_uniformly_on_filter, bot_prod, eventually_bot, implies_true_iff] },
+  haveI : ne_bot l := ⟨hl⟩,
   refine uniform_cauchy_seq_on_filter.tendsto_uniformly_on_filter_of_tendsto _
     ((hfg.and (eventually_const.mpr hfg.self_of_nhds)).mono (λ y hy, (hy.1.sub hy.2).const_smul _)),
   rw seminormed_add_group.uniform_cauchy_seq_on_filter_iff_tendsto_uniformly_on_filter_zero,
@@ -275,7 +318,7 @@ In words the assumptions mean the following:
   * `hf`: For all `(y, n)` with `y` sufficiently close to `x` and `n` sufficiently large, `f' n` is
     the derivative of `f n`
   * `hfg`: The `f n` converge pointwise to `g` on a neighborhood of `x` -/
-lemma has_fderiv_at_of_tendsto_uniformly_on_filter
+lemma has_fderiv_at_of_tendsto_uniformly_on_filter [ne_bot l]
   (hf' : tendsto_uniformly_on_filter f' g' l (𝓝 x))
   (hf : ∀ᶠ (n : ι × E) in (l ×ᶠ 𝓝 x), has_fderiv_at (f n.1) (f' n.1 n.2) n.2)
   (hfg : ∀ᶠ y in 𝓝 x, tendsto (λ n, f n y) l (𝓝 (g y))) :
@@ -366,7 +409,7 @@ end
 
 /-- `(d/dx) lim_{n → ∞} f n x = lim_{n → ∞} f' n x` when the `f' n` converge
 _uniformly_ to their limit on an open set containing `x`. -/
-lemma has_fderiv_at_of_tendsto_uniformly_on
+lemma has_fderiv_at_of_tendsto_uniformly_on [ne_bot l]
   {s : set E} (hs : is_open s)
   (hf' : tendsto_uniformly_on f' g' l s)
   (hf : ∀ (n : ι), ∀ (x : E), x ∈ s → has_fderiv_at (f n) (f' n x) x)
@@ -391,7 +434,7 @@ end
 
 /-- `(d/dx) lim_{n → ∞} f n x = lim_{n → ∞} f' n x` when the `f' n` converge
 _uniformly_ to their limit. -/
-lemma has_fderiv_at_of_tendsto_uniformly
+lemma has_fderiv_at_of_tendsto_uniformly [ne_bot l]
   (hf' : tendsto_uniformly f' g' l)
   (hf : ∀ (n : ι), ∀ (x : E), has_fderiv_at (f n) (f' n x) x)
   (hfg : ∀ (x : E), tendsto (λ n, f n x) l (𝓝 (g x))) :
@@ -446,24 +489,21 @@ begin
   exact mul_le_mul hn.le rfl.le (norm_nonneg _) hq.le,
 end
 
-variables [ne_bot l]
-
-lemma uniform_cauchy_seq_on_filter_of_tendsto_uniformly_on_filter_deriv
+lemma uniform_cauchy_seq_on_filter_of_deriv
   (hf' : uniform_cauchy_seq_on_filter f' l (𝓝 x))
   (hf : ∀ᶠ (n : ι × 𝕜) in (l ×ᶠ 𝓝 x), has_deriv_at (f n.1) (f' n.1 n.2) n.2)
-  (hfg : tendsto (λ n, f n x) l (𝓝 (g x))) :
+  (hfg : cauchy (map (λ (n : ι), f n x) l)) :
   uniform_cauchy_seq_on_filter f l (𝓝 x) :=
 begin
   simp_rw has_deriv_at_iff_has_fderiv_at at hf,
-  exact uniform_cauchy_seq_on_filter_of_tendsto_uniformly_on_filter_fderiv
+  exact uniform_cauchy_seq_on_filter_of_fderiv
     hf'.one_smul_right hf hfg,
 end
 
 lemma uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_deriv
-  {r : ℝ} (hr : 0 < r)
-  (hf' : uniform_cauchy_seq_on f' l (metric.ball x r))
+  {r : ℝ} (hf' : uniform_cauchy_seq_on f' l (metric.ball x r))
   (hf : ∀ n : ι, ∀ y : 𝕜, y ∈ metric.ball x r → has_deriv_at (f n) (f' n y) y)
-  (hfg : tendsto (λ n, f n x) l (𝓝 (g x))) :
+  (hfg : cauchy (map (λ (n : ι), f n x) l)) :
   uniform_cauchy_seq_on f l (metric.ball x r) :=
 begin
   simp_rw has_deriv_at_iff_has_fderiv_at at hf,
@@ -472,10 +512,10 @@ begin
     (metric.ball x r),
   { rw uniform_cauchy_seq_on_iff_uniform_cauchy_seq_on_filter,
     exact hf'.one_smul_right, },
-  exact uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_fderiv hr hf' hf hfg,
+  exact uniform_cauchy_seq_on_ball_of_fderiv hf' hf hfg,
 end
 
-lemma has_deriv_at_of_tendsto_uniformly_on_filter
+lemma has_deriv_at_of_tendsto_uniformly_on_filter [ne_bot l]
   (hf' : tendsto_uniformly_on_filter f' g' l (𝓝 x))
   (hf : ∀ᶠ (n : ι × 𝕜) in (l ×ᶠ 𝓝 x), has_deriv_at (f n.1) (f' n.1 n.2) n.2)
   (hfg : ∀ᶠ y in 𝓝 x, tendsto (λ n, f n y) l (𝓝 (g y))) :
@@ -507,7 +547,7 @@ begin
   exact has_fderiv_at_of_tendsto_uniformly_on_filter hf' hf hfg,
 end
 
-lemma has_deriv_at_of_tendsto_uniformly_on
+lemma has_deriv_at_of_tendsto_uniformly_on [ne_bot l]
   {s : set 𝕜} (hs : is_open s)
   (hf' : tendsto_uniformly_on f' g' l s)
   (hf : ∀ (n : ι), ∀ (x : 𝕜), x ∈ s → has_deriv_at (f n) (f' n x) x)
@@ -527,7 +567,7 @@ begin
   exact has_deriv_at_of_tendsto_uniformly_on_filter hf' hf hfg,
 end
 
-lemma has_deriv_at_of_tendsto_uniformly
+lemma has_deriv_at_of_tendsto_uniformly [ne_bot l]
   (hf' : tendsto_uniformly f' g' l)
   (hf : ∀ (n : ι), ∀ (x : 𝕜), has_deriv_at (f n) (f' n x) x)
   (hfg : ∀ (x : 𝕜), tendsto (λ n, f n x) l (𝓝 (g x))) :

--- a/src/analysis/calculus/uniform_limits_deriv.lean
+++ b/src/analysis/calculus/uniform_limits_deriv.lean
@@ -237,7 +237,7 @@ lemma cauchy_map_of_uniform_cauchy_seq_on_fderiv
   cauchy (map (λ n, f n x) l) :=
 begin
   haveI : ne_bot l, from (cauchy_map_iff.1 hfg).1,
-  let t := {y | y ∈ s ∧ cauchy (map (λ (n : ι), f n y) l)},
+  let t := {y | y ∈ s ∧ cauchy (map (λ n, f n y) l)},
   suffices H : s ⊆ t, from (H hx).2,
   have A : ∀ x ε, x ∈ t → metric.ball x ε ⊆ s → metric.ball x ε ⊆ t,
   from λ x ε xt hx y hy, ⟨hx hy, (uniform_cauchy_seq_on_ball_of_fderiv (hf'.mono hx)
@@ -492,7 +492,7 @@ end
 lemma uniform_cauchy_seq_on_filter_of_deriv
   (hf' : uniform_cauchy_seq_on_filter f' l (𝓝 x))
   (hf : ∀ᶠ (n : ι × 𝕜) in (l ×ᶠ 𝓝 x), has_deriv_at (f n.1) (f' n.1 n.2) n.2)
-  (hfg : cauchy (map (λ (n : ι), f n x) l)) :
+  (hfg : cauchy (map (λ n, f n x) l)) :
   uniform_cauchy_seq_on_filter f l (𝓝 x) :=
 begin
   simp_rw has_deriv_at_iff_has_fderiv_at at hf,
@@ -503,7 +503,7 @@ end
 lemma uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_deriv
   {r : ℝ} (hf' : uniform_cauchy_seq_on f' l (metric.ball x r))
   (hf : ∀ n : ι, ∀ y : 𝕜, y ∈ metric.ball x r → has_deriv_at (f n) (f' n y) y)
-  (hfg : cauchy (map (λ (n : ι), f n x) l)) :
+  (hfg : cauchy (map (λ n, f n x) l)) :
   uniform_cauchy_seq_on f l (metric.ball x r) :=
 begin
   simp_rw has_deriv_at_iff_has_fderiv_at at hf,

--- a/src/analysis/calculus/uniform_limits_deriv.lean
+++ b/src/analysis/calculus/uniform_limits_deriv.lean
@@ -250,14 +250,13 @@ begin
   have st_nonempty : (s ∩ t).nonempty, from ⟨x₀, hx₀, ⟨hx₀, hfg⟩⟩,
   suffices H : closure t ∩ s ⊆ t, from h's.subset_of_closure_inter_subset open_t st_nonempty H,
   rintros x ⟨xt, xs⟩,
-  refine ⟨xs, _⟩,
   obtain ⟨ε, εpos, hε⟩ : ∃ (ε : ℝ) (H : ε > 0), metric.ball x ε ⊆ s,
     from metric.is_open_iff.1 hs x xs,
   obtain ⟨y, yt, hxy⟩ : ∃ (y : E) (yt : y ∈ t), dist x y < ε / 2,
     from metric.mem_closure_iff.1 xt _ (half_pos εpos),
   have B : metric.ball y (ε / 2) ⊆ metric.ball x ε,
   { apply metric.ball_subset_ball', rw dist_comm, linarith },
-  exact (A y (ε / 2) yt (B.trans hε) (metric.mem_ball.2 hxy)).2,
+  exact A y (ε / 2) yt (B.trans hε) (metric.mem_ball.2 hxy)
 end
 
 /-- If `f_n → g` pointwise and the derivatives `(f_n)' → h` _uniformly_ converge, then

--- a/src/analysis/calculus/uniform_limits_deriv.lean
+++ b/src/analysis/calculus/uniform_limits_deriv.lean
@@ -16,12 +16,12 @@ _uniformly_. The formal statement appears as `has_fderiv_at_of_tendsto_locally_u
 
 ## Main statements
 
-* `uniform_cauchy_seq_on_filter_of_tendsto_uniformly_on_filter_fderiv`: If
+* `uniform_cauchy_seq_on_filter_of_fderiv`: If
     1. `f : ℕ → E → G` is a sequence of functions which have derivatives
        `f' : ℕ → E → (E →L[𝕜] G)` on a neighborhood of `x`,
     2. the functions `f` converge at `x`, and
-    3. the derivatives `f'` converge uniformly on a neighborhood of `x`,
-  then the `f` converge _uniformly_ on a neighborhood of `x`
+    3. the derivatives `f'` form a Cauchy sequence uniformly on a neighborhood of `x`,
+  then the `f` form a Cauchy sequence _uniformly_ on a neighborhood of `x`
 * `has_fderiv_at_of_tendsto_uniformly_on_filter` : Suppose (1), (2), and (3) above are true. Let
   `g` (resp. `g'`) be the limiting function of the `f` (resp. `g'`). Then `f'` is the derivative of
   `g` on a neighborhood of `x`
@@ -500,7 +500,7 @@ begin
     hf'.one_smul_right hf hfg,
 end
 
-lemma uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_deriv
+lemma uniform_cauchy_seq_on_ball_of_deriv
   {r : ℝ} (hf' : uniform_cauchy_seq_on f' l (metric.ball x r))
   (hf : ∀ n : ι, ∀ y : 𝕜, y ∈ metric.ball x r → has_deriv_at (f n) (f' n y) y)
   (hfg : cauchy (map (λ n, f n x) l)) :

--- a/src/analysis/calculus/uniform_limits_deriv.lean
+++ b/src/analysis/calculus/uniform_limits_deriv.lean
@@ -101,7 +101,7 @@ variables {ι : Type*} {l : filter ι}
   {E : Type*} [normed_add_comm_group E]
   {𝕜 : Type*} [is_R_or_C 𝕜] [normed_space 𝕜 E]
   {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
-  {y : G} {f : ι → E → G} {g : E → G} {f' : ι → (E → (E →L[𝕜] G))} {g' : E → (E →L[𝕜] G)}
+  {f : ι → E → G} {g : E → G} {f' : ι → (E → (E →L[𝕜] G))} {g' : E → (E →L[𝕜] G)}
   {x : E}
 
 /-- If a sequence of functions real or complex functions are eventually differentiable on a
@@ -111,7 +111,7 @@ sequence in a neighborhood of `x`. -/
 lemma uniform_cauchy_seq_on_filter_of_fderiv
   (hf' : uniform_cauchy_seq_on_filter f' l (𝓝 x))
   (hf : ∀ᶠ (n : ι × E) in (l ×ᶠ 𝓝 x), has_fderiv_at (f n.1) (f' n.1 n.2) n.2)
-  (hfg : cauchy (map (λ (n : ι), f n x) l)) :
+  (hfg : cauchy (map (λ n, f n x) l)) :
   uniform_cauchy_seq_on_filter f l (𝓝 x) :=
 begin
   letI : normed_space ℝ E, from normed_space.restrict_scalars ℝ 𝕜 _,
@@ -177,7 +177,7 @@ convergence. See `cauchy_map_of_uniform_cauchy_seq_on_fderiv`.
 lemma uniform_cauchy_seq_on_ball_of_fderiv
   {r : ℝ} (hf' : uniform_cauchy_seq_on f' l (metric.ball x r))
   (hf : ∀ n : ι, ∀ y : E, y ∈ metric.ball x r → has_fderiv_at (f n) (f' n y) y)
-  (hfg : cauchy (map (λ (n : ι), f n x) l)) :
+  (hfg : cauchy (map (λ n, f n x) l)) :
   uniform_cauchy_seq_on f l (metric.ball x r) :=
 begin
   letI : normed_space ℝ E, from normed_space.restrict_scalars ℝ 𝕜 _,
@@ -233,8 +233,8 @@ lemma cauchy_map_of_uniform_cauchy_seq_on_fderiv
   (hf' : uniform_cauchy_seq_on f' l s)
   (hf : ∀ n : ι, ∀ y : E, y ∈ s → has_fderiv_at (f n) (f' n y) y)
   {x₀ x : E} (hx₀ : x₀ ∈ s) (hx : x ∈ s)
-  (hfg : cauchy (map (λ (n : ι), f n x₀) l)) :
-  cauchy (map (λ (n : ι), f n x) l) :=
+  (hfg : cauchy (map (λ n, f n x₀) l)) :
+  cauchy (map (λ n, f n x) l) :=
 begin
   haveI : ne_bot l, from (cauchy_map_iff.1 hfg).1,
   let t := {y | y ∈ s ∧ cauchy (map (λ (n : ι), f n y) l)},

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import topology.uniform_space.basic
+import topology.uniform_space.cauchy
 
 /-!
 # Uniform convergence
@@ -569,6 +570,18 @@ begin
   intros u hu,
   have hh : tendsto (λ x : ι, (x, x)) p (p ×ᶠ p), { exact tendsto_diag, },
   exact (hh.prod_map hh).eventually ((h.prod h') u hu),
+end
+
+/-- If a sequence of functions is uniformly Cauchy on a set, then the values at each point form
+a Cauchy sequence. -/
+lemma uniform_cauchy_seq_on.cauchy_map [hp : ne_bot p]
+  (hf : uniform_cauchy_seq_on F p s) (hx : x ∈ s) :
+  cauchy (map (λ i, F i x) p) :=
+begin
+  simp only [cauchy_map_iff, hp, true_and],
+  assume u hu,
+  rw mem_map,
+  filter_upwards [hf u hu] with p hp using hp x hx,
 end
 
 section seq_tendsto


### PR DESCRIPTION
Also cleanup the file `calculus/uniform_limits_deriv` by removing unnecessary typeclass assumptions, fixing lemma names and docstrings, and replacing convergence assumptions by Cauchyness assumption when the limit is not relevant.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
