### PR TITLE
[Merged by Bors] - doc(overview,undergrad): refer to `affine_span` not `span_points`

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -386,7 +386,7 @@ Geometry:
     affine function: 'affine_map'
     affine subspace: 'affine_subspace'
     barycenter: 'finset.affine_combination'
-    affine span: 'span_points'
+    affine span: 'affine_span'
     Euclidean affine space: 'normed_add_torsor'
     angle: ' inner_product_geometry.angle'
 

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -244,7 +244,7 @@ Affine and Euclidean Geometry:
     affine function: 'affine_map'
     affine subspace: 'affine_subspace'
     barycenter: 'finset.affine_combination'
-    affine span: 'span_points'
+    affine span: 'affine_span'
     equations of affine subspace: ''
     affine groups: 'affine_equiv.group'
     affine property: 'https://en.wikipedia.org/wiki/Affine_transformation#Properties'


### PR DESCRIPTION
As explained in the `linear_algebra.affine_space.affine_subspace` module doc string, `affine_span` is preferred over `span_points` for most purposes, so refer to `affine_span` not `span_points` in overview.yaml and undergrad.yaml.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
