### PR TITLE
[Merged by Bors] - feat(data/nat/gcd/basic): add `nat.dvd_mul` and `dvd_mul`

### DIFF
--- a/src/algebra/gcd_monoid/basic.lean
+++ b/src/algebra/gcd_monoid/basic.lean
@@ -414,6 +414,9 @@ by { rw mul_comm at H ⊢, exact dvd_gcd_mul_of_dvd_mul H }
 
 /-- Represent a divisor of `m * n` as a product of a divisor of `m` and a divisor of `n`.
 
+In other words, the nonzero elements of a `gcd_monoid` form a decomposition monoid
+(more widely known as a pre-Schreier domain in the context of rings).
+
 Note: In general, this representation is highly non-unique.
 
 See `nat.prod_dvd_and_dvd_of_dvd_prod` for a constructive version on `ℕ`.  -/

--- a/src/algebra/gcd_monoid/basic.lean
+++ b/src/algebra/gcd_monoid/basic.lean
@@ -414,17 +414,19 @@ by { rw mul_comm at H ⊢, exact dvd_gcd_mul_of_dvd_mul H }
 
 /-- Represent a divisor of `m * n` as a product of a divisor of `m` and a divisor of `n`.
 
- Note: In general, this representation is highly non-unique. -/
+Note: In general, this representation is highly non-unique.
+
+See `nat.prod_dvd_and_dvd_of_dvd_prod` for a constructive version on `ℕ`.  -/
 lemma exists_dvd_and_dvd_of_dvd_mul [gcd_monoid α] {m n k : α} (H : k ∣ m * n) :
-  ∃ d₁ (hd₁ : d₁ ∣ m) d₂ (hd₂ : d₂ ∣ n), k = d₁ * d₂ :=
+  ∃ d₁ d₂, d₁ ∣ m ∧ d₂ ∣ n ∧ k = d₁ * d₂ :=
 begin
   by_cases h0 : gcd k m = 0,
   { rw gcd_eq_zero_iff at h0,
     rcases h0 with ⟨rfl, rfl⟩,
-    refine ⟨0, dvd_refl 0, n, dvd_refl n, _⟩,
+    refine ⟨0, n, dvd_refl 0, dvd_refl n, _⟩,
     simp },
   { obtain ⟨a, ha⟩ := gcd_dvd_left k m,
-    refine ⟨gcd k m, gcd_dvd_right _ _, a, _, ha⟩,
+    refine ⟨gcd k m, a, gcd_dvd_right _ _, _, ha⟩,
     suffices h : gcd k m * a ∣ gcd k m * n,
     { cases h with b hb,
       use b,
@@ -434,9 +436,17 @@ begin
     exact dvd_gcd_mul_of_dvd_mul H }
 end
 
+lemma dvd_mul [gcd_monoid α] {k m n : α} :
+  k ∣ (m * n) ↔ ∃ d₁ d₂, d₁ ∣ m ∧ d₂ ∣ n ∧ k = d₁ * d₂ :=
+begin
+  refine ⟨exists_dvd_and_dvd_of_dvd_mul, _⟩,
+  rintro ⟨d₁, d₂, hy, hz, rfl⟩,
+  exact mul_dvd_mul hy hz,
+end
+
 theorem gcd_mul_dvd_mul_gcd [gcd_monoid α] (k m n : α) : gcd k (m * n) ∣ gcd k m * gcd k n :=
 begin
-  obtain ⟨m', hm', n', hn', h⟩ := (exists_dvd_and_dvd_of_dvd_mul $ gcd_dvd_right k (m * n)),
+  obtain ⟨m', n', hm', hn', h⟩ := exists_dvd_and_dvd_of_dvd_mul (gcd_dvd_right k (m * n)),
   replace h : gcd k (m * n) = m' * n' := h,
   rw h,
   have hm'n' : m' * n' ∣ k := h ▸ gcd_dvd_left _ _,
@@ -512,7 +522,7 @@ begin
   { use 1, rw pow_zero at h ⊢, use units.mk_of_mul_eq_one _ _ h,
     rw [units.coe_mk_of_mul_eq_one, one_mul] },
   have hc : c ∣ a * b, { rw h, exact dvd_pow_self _ hk.ne' },
-  obtain ⟨d₁, hd₁, d₂, hd₂, hc⟩ := exists_dvd_and_dvd_of_dvd_mul hc,
+  obtain ⟨d₁, d₂, hd₁, hd₂, hc⟩ := exists_dvd_and_dvd_of_dvd_mul hc,
   use d₁,
   obtain ⟨h0₁, ⟨a', ha'⟩⟩ := pow_dvd_of_mul_eq_pow ha hab h hc hd₁,
   rw [mul_comm] at h hc,

--- a/src/data/nat/gcd/basic.lean
+++ b/src/data/nat/gcd/basic.lean
@@ -8,8 +8,8 @@ import algebra.group_power.order
 /-!
 # Definitions and properties of `nat.gcd`, `nat.lcm`, and `nat.coprime`
 
-Generalizations of these are provided in a later file as `gcd_monoid.gcd`, `gcd_monoid.lcm`, and
-`is_coprime`.
+The more general equivalents of these are provided in a later file as `gcd_monoid.gcd`,
+`gcd_monoid.lcm`, and `is_coprime`.
 
 -/
 

--- a/src/data/nat/gcd/basic.lean
+++ b/src/data/nat/gcd/basic.lean
@@ -8,8 +8,11 @@ import algebra.group_power.order
 /-!
 # Definitions and properties of `nat.gcd`, `nat.lcm`, and `nat.coprime`
 
-The more general equivalents of these are provided in a later file as `gcd_monoid.gcd`,
-`gcd_monoid.lcm`, and `is_coprime`.
+Generalizations of these are provided in a later file as `gcd_monoid.gcd` and
+`gcd_monoid.lcm`.
+
+Note that the global `is_coprime` is not a straightforward generalization of `nat.coprime`, see
+`nat.is_coprime_iff_coprime` for the connection between the two.
 
 -/
 

--- a/src/data/nat/gcd/basic.lean
+++ b/src/data/nat/gcd/basic.lean
@@ -487,27 +487,38 @@ lemma coprime.eq_of_mul_eq_zero {m n : ℕ} (h : m.coprime n) (hmn : m * n = 0) 
 def prod_dvd_and_dvd_of_dvd_prod {m n k : ℕ} (H : k ∣ m * n) :
   { d : {m' // m' ∣ m} × {n' // n' ∣ n} // k = d.1 * d.2 } :=
 begin
-cases h0 : (gcd k m),
-case nat.zero
-{ obtain rfl : k = 0 := eq_zero_of_gcd_eq_zero_left h0,
-  obtain rfl : m = 0 := eq_zero_of_gcd_eq_zero_right h0,
-  exact ⟨⟨⟨0, dvd_refl 0⟩, ⟨n, dvd_refl n⟩⟩, (zero_mul n).symm⟩ },
-case nat.succ : tmp
-{ have hpos : 0 < gcd k m := h0.symm ▸ nat.zero_lt_succ _; clear h0 tmp,
-  have hd : gcd k m * (k / gcd k m) = k := (nat.mul_div_cancel' (gcd_dvd_left k m)),
-  refine ⟨⟨⟨gcd k m,  gcd_dvd_right k m⟩, ⟨k / gcd k m, _⟩⟩, hd.symm⟩,
-  apply dvd_of_mul_dvd_mul_left hpos,
-  rw [hd, ← gcd_mul_right],
-  exact dvd_gcd (dvd_mul_right _ _) H }
+  cases h0 : (gcd k m),
+  case nat.zero
+  { obtain rfl : k = 0 := eq_zero_of_gcd_eq_zero_left h0,
+    obtain rfl : m = 0 := eq_zero_of_gcd_eq_zero_right h0,
+    exact ⟨⟨⟨0, dvd_refl 0⟩, ⟨n, dvd_refl n⟩⟩, (zero_mul n).symm⟩ },
+  case nat.succ : tmp
+  { have hpos : 0 < gcd k m := h0.symm ▸ nat.zero_lt_succ _; clear h0 tmp,
+    have hd : gcd k m * (k / gcd k m) = k := (nat.mul_div_cancel' (gcd_dvd_left k m)),
+    refine ⟨⟨⟨gcd k m,  gcd_dvd_right k m⟩, ⟨k / gcd k m, _⟩⟩, hd.symm⟩,
+    apply dvd_of_mul_dvd_mul_left hpos,
+    rw [hd, ← gcd_mul_right],
+    exact dvd_gcd (dvd_mul_right _ _) H }
+end
+
+lemma dvd_mul {x m n : ℕ} :
+  x ∣ (m * n) ↔ ∃ y z, y ∣ m ∧ z ∣ n ∧ y * z = x :=
+begin
+  split,
+  { intro h,
+    obtain ⟨⟨⟨y, hy⟩, ⟨z, hz⟩⟩, rfl⟩ := prod_dvd_and_dvd_of_dvd_prod h,
+    exact ⟨y, z, hy, hz, rfl⟩, },
+  { rintro ⟨y, z, hy, hz, rfl⟩,
+    exact mul_dvd_mul hy hz },
 end
 
 theorem gcd_mul_dvd_mul_gcd (k m n : ℕ) : gcd k (m * n) ∣ gcd k m * gcd k n :=
 begin
-rcases (prod_dvd_and_dvd_of_dvd_prod $ gcd_dvd_right k (m * n)) with ⟨⟨⟨m', hm'⟩, ⟨n', hn'⟩⟩, h⟩,
-replace h : gcd k (m * n) = m' * n' := h,
-rw h,
-have hm'n' : m' * n' ∣ k := h ▸ gcd_dvd_left _ _,
-apply mul_dvd_mul,
+  rcases (prod_dvd_and_dvd_of_dvd_prod $ gcd_dvd_right k (m * n)) with ⟨⟨⟨m', hm'⟩, ⟨n', hn'⟩⟩, h⟩,
+  replace h : gcd k (m * n) = m' * n' := h,
+  rw h,
+  have hm'n' : m' * n' ∣ k := h ▸ gcd_dvd_left _ _,
+  apply mul_dvd_mul,
   { have hm'k : m' ∣ k := (dvd_mul_right m' n').trans hm'n',
     exact dvd_gcd hm'k hm' },
   { have hn'k : n' ∣ k := (dvd_mul_left n' m').trans hm'n',

--- a/src/data/nat/gcd/basic.lean
+++ b/src/data/nat/gcd/basic.lean
@@ -6,7 +6,10 @@ Authors: Jeremy Avigad, Leonardo de Moura
 import algebra.group_power.order
 
 /-!
-# Definitions and properties of `gcd`, `lcm`, and `coprime`
+# Definitions and properties of `nat.gcd`, `nat.lcm`, and `nat.coprime`
+
+Generalizations of these are provided in a later file as `gcd_monoid.gcd`, `gcd_monoid.lcm`, and
+`is_coprime`.
 
 -/
 
@@ -483,7 +486,10 @@ lemma coprime.eq_of_mul_eq_zero {m n : ℕ} (h : m.coprime n) (hmn : m * n = 0) 
   (λ hm, ⟨hm, n.coprime_zero_left.mp $ hm ▸ h⟩)
   (λ hn, ⟨m.coprime_zero_left.mp $ hn ▸ h.symm, hn⟩)
 
-/-- Represent a divisor of `m * n` as a product of a divisor of `m` and a divisor of `n`. -/
+/-- Represent a divisor of `m * n` as a product of a divisor of `m` and a divisor of `n`.
+
+See `exists_dvd_and_dvd_of_dvd_mul` for the more general but less constructive version for other
+`gcd_monoid`s. -/
 def prod_dvd_and_dvd_of_dvd_prod {m n k : ℕ} (H : k ∣ m * n) :
   { d : {m' // m' ∣ m} × {n' // n' ∣ n} // k = d.1 * d.2 } :=
 begin


### PR DESCRIPTION
This follows trivially from `prod_dvd_and_dvd_of_dvd_prod` and `exists_dvd_and_dvd_of_dvd_mul`, but is more discoverable and easier to use.

Also fixes some bad indentation in the same file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
