### PR TITLE
[Merged by Bors] - refactor(topology/bases): removing/adding the empty set from/to a basis

### DIFF
--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -63,28 +63,47 @@ structure is_topological_basis (s : set (set α)) : Prop :=
 (sUnion_eq : (⋃₀ s) = univ)
 (eq_generate_from : t = generate_from s)
 
+lemma is_topological_basis.insert_empty {s : set (set α)} (h : is_topological_basis s) :
+  is_topological_basis (insert ∅ s) :=
+begin
+  refine ⟨_, by rw [sUnion_insert, empty_union, h.sUnion_eq], _⟩,
+  { rintro t₁ (rfl|h₁) t₂ (rfl|h₂) x ⟨hx₁, hx₂⟩, {cases hx₁}, {cases hx₁}, {cases hx₂},
+    obtain ⟨t₃, h₃, hs⟩ := h.exists_subset_inter _ h₁ _ h₂ x ⟨hx₁, hx₂⟩,
+    exact ⟨t₃, or.inr h₃, hs⟩ },
+  { rw h.eq_generate_from,
+    refine le_antisymm (le_generate_from $ λ t, _) (generate_from_mono $ subset_insert ∅ s),
+    rintro (rfl|ht), { convert is_open_empty }, { exact generate_open.basic t ht } },
+end
+
+lemma is_topological_basis.diff_empty {s : set (set α)} (h : is_topological_basis s) :
+  is_topological_basis (s \ {∅}) :=
+begin
+  refine ⟨_, by rw [sUnion_diff_singleton_empty, h.sUnion_eq], _⟩,
+  { rintro t₁ ⟨h₁, -⟩ t₂ ⟨h₂, -⟩ x hx,
+    obtain ⟨t₃, h₃, hs⟩ := h.exists_subset_inter _ h₁ _ h₂ x hx,
+    exact ⟨t₃, ⟨h₃, ne_empty_iff_nonempty.2 ⟨x, hs.1⟩⟩, hs⟩ },
+  { rw h.eq_generate_from,
+    refine le_antisymm (generate_from_mono $ diff_subset s _) (le_generate_from $ λ t ht, _),
+    obtain rfl|he := eq_or_ne t ∅, { convert is_open_empty },
+    exact generate_open.basic t ⟨ht, he⟩ },
+end
+
 /-- If a family of sets `s` generates the topology, then nonempty intersections of finite
 subcollections of `s` form a topological basis. -/
 lemma is_topological_basis_of_subbasis {s : set (set α)} (hs : t = generate_from s) :
-  is_topological_basis ((λ f, ⋂₀ f) '' {f : set (set α) | f.finite ∧ f ⊆ s ∧ (⋂₀ f).nonempty}) :=
+  is_topological_basis ((λ f, ⋂₀ f) '' {f : set (set α) | f.finite ∧ f ⊆ s}) :=
 begin
   refine ⟨_, _, _⟩,
-  { rintro _ ⟨t₁, ⟨hft₁, ht₁b, ht₁⟩, rfl⟩ _ ⟨t₂, ⟨hft₂, ht₂b, ht₂⟩, rfl⟩ x h,
+  { rintro _ ⟨t₁, ⟨hft₁, ht₁b⟩, rfl⟩ _ ⟨t₂, ⟨hft₂, ht₂b⟩, rfl⟩ x h,
     have : ⋂₀ (t₁ ∪ t₂) = ⋂₀ t₁ ∩ ⋂₀ t₂ := sInter_union t₁ t₂,
-    exact ⟨_, ⟨t₁ ∪ t₂, ⟨hft₁.union hft₂, union_subset ht₁b ht₂b, this.symm ▸ ⟨x, h⟩⟩, this⟩, h,
-      subset.rfl⟩ },
+    exact ⟨_, ⟨t₁ ∪ t₂, ⟨hft₁.union hft₂, union_subset ht₁b ht₂b⟩, this⟩, h, subset.rfl⟩ },
   { rw [sUnion_image, Union₂_eq_univ_iff],
-    intro x, have : x ∈ ⋂₀ ∅, { rw sInter_empty, exact mem_univ x },
-    exact ⟨∅, ⟨finite_empty, empty_subset _, x, this⟩, this⟩ },
-  { rw hs,
-    apply le_antisymm; apply le_generate_from,
-    { rintro _ ⟨t, ⟨hft, htb, ht⟩, rfl⟩,
-      exact @is_open_sInter _ (generate_from s) _ hft (λ s hs, generate_open.basic _ $ htb hs) },
-    { intros t ht,
-      rcases t.eq_empty_or_nonempty with rfl|hne, { apply @is_open_empty _ _ },
-      rw ← sInter_singleton t at hne ⊢,
-      exact generate_open.basic _ ⟨{t}, ⟨finite_singleton t, singleton_subset_iff.2 ht, hne⟩,
-        rfl⟩ } }
+    exact λ x, ⟨∅, ⟨finite_empty, empty_subset _⟩, sInter_empty.substr $ mem_univ x⟩ },
+  { refine hs.trans (le_antisymm (le_generate_from _) $ generate_from_mono $ λ t ht, _),
+    { rintro _ ⟨t, ⟨hft, htb⟩, rfl⟩,
+      apply is_open_sInter, exacts [hft, λ s hs, generate_open.basic _ $ htb hs] },
+    { rw ← sInter_singleton t,
+      exact ⟨{t}, ⟨finite_singleton t, singleton_subset_iff.2 ht⟩, rfl⟩ } },
 end
 
 /-- If a family of open sets `s` is such that every open neighbourhood contains some
@@ -564,14 +583,12 @@ protected lemma is_topological_basis.second_countable_topology
 variable (α)
 
 lemma exists_countable_basis [second_countable_topology α] :
-  ∃b:set (set α), b.countable ∧ ∅ ∉ b ∧ is_topological_basis b :=
-let ⟨b, hb₁, hb₂⟩ := second_countable_topology.is_open_generated_countable α in
-let b' := (λs, ⋂₀ s) '' {s:set (set α) | s.finite ∧ s ⊆ b ∧ (⋂₀ s).nonempty} in
-⟨b',
-  ((countable_set_of_finite_subset hb₁).mono
-    (by { simp only [← and_assoc], apply inter_subset_left })).image _,
-  assume ⟨s, ⟨_, _, hn⟩, hp⟩, absurd hn (not_nonempty_iff_eq_empty.2 hp),
-  is_topological_basis_of_subbasis hb₂⟩
+  ∃ b : set (set α), b.countable ∧ ∅ ∉ b ∧ is_topological_basis b :=
+begin
+  obtain ⟨b, hb₁, hb₂⟩ := second_countable_topology.is_open_generated_countable α,
+  refine ⟨_, _, not_mem_diff_of_mem _, (is_topological_basis_of_subbasis hb₂).diff_empty⟩,
+  exacts [((countable_set_of_finite_subset hb₁).image _).mono (diff_subset _ _), rfl],
+end
 
 /-- A countable topological basis of `α`. -/
 def countable_basis [second_countable_topology α] : set (set α) :=

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -88,7 +88,7 @@ begin
     exact generate_open.basic t ⟨ht, he⟩ },
 end
 
-/-- If a family of sets `s` generates the topology, then nonempty intersections of finite
+/-- If a family of sets `s` generates the topology, then intersections of finite
 subcollections of `s` form a topological basis. -/
 lemma is_topological_basis_of_subbasis {s : set (set α)} (hs : t = generate_from s) :
   is_topological_basis ((λ f, ⋂₀ f) '' {f : set (set α) | f.finite ∧ f ⊆ s}) :=

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -93,17 +93,15 @@ subcollections of `s` form a topological basis. -/
 lemma is_topological_basis_of_subbasis {s : set (set α)} (hs : t = generate_from s) :
   is_topological_basis ((λ f, ⋂₀ f) '' {f : set (set α) | f.finite ∧ f ⊆ s}) :=
 begin
-  refine ⟨_, _, _⟩,
+  refine ⟨_, _, hs.trans (le_antisymm (le_generate_from _) $ generate_from_mono $ λ t ht, _)⟩,
   { rintro _ ⟨t₁, ⟨hft₁, ht₁b⟩, rfl⟩ _ ⟨t₂, ⟨hft₂, ht₂b⟩, rfl⟩ x h,
-    have : ⋂₀ (t₁ ∪ t₂) = ⋂₀ t₁ ∩ ⋂₀ t₂ := sInter_union t₁ t₂,
-    exact ⟨_, ⟨t₁ ∪ t₂, ⟨hft₁.union hft₂, union_subset ht₁b ht₂b⟩, this⟩, h, subset.rfl⟩ },
+    exact ⟨_, ⟨_, ⟨hft₁.union hft₂, union_subset ht₁b ht₂b⟩, sInter_union t₁ t₂⟩, h, subset.rfl⟩ },
   { rw [sUnion_image, Union₂_eq_univ_iff],
     exact λ x, ⟨∅, ⟨finite_empty, empty_subset _⟩, sInter_empty.substr $ mem_univ x⟩ },
-  { refine hs.trans (le_antisymm (le_generate_from _) $ generate_from_mono $ λ t ht, _),
-    { rintro _ ⟨t, ⟨hft, htb⟩, rfl⟩,
-      apply is_open_sInter, exacts [hft, λ s hs, generate_open.basic _ $ htb hs] },
-    { rw ← sInter_singleton t,
-      exact ⟨{t}, ⟨finite_singleton t, singleton_subset_iff.2 ht⟩, rfl⟩ } },
+  { rintro _ ⟨t, ⟨hft, htb⟩, rfl⟩, apply is_open_sInter,
+    exacts [hft, λ s hs, generate_open.basic _ $ htb hs] },
+  { rw ← sInter_singleton t,
+    exact ⟨{t}, ⟨finite_singleton t, singleton_subset_iff.2 ht⟩, rfl⟩ },
 end
 
 /-- If a family of open sets `s` is such that every open neighbourhood contains some


### PR DESCRIPTION
+ Add lemmas `is_topological_basis.insert/diff_empty` that allows adding the empty set to a basis and removing the empty set from a basis.

+ Remove `(⋂₀ f).nonempty` from `is_topological_basis_of_subbasis` and golf the proof. This condition is unnatural and was only used to exclude the empty set in [topological_space.second_countable_topology.to_separable_space](https://leanprover-community.github.io/mathlib_docs/topology/bases.html#topological_space.second_countable_topology.to_separable_space), because we want to choose a point from each set in the basis. As a result, the proof `exists_countable_basis` needs a slight modification.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
