### PR TITLE
[Merged by Bors] - feat(analysis/calculus/cont_diff): norms of iterated derivatives

### DIFF
--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -783,6 +783,11 @@ lemma iterated_fderiv_within_succ_eq_comp_left {n : ℕ} :
   (continuous_multilinear_curry_left_equiv 𝕜 (λ(i : fin (n + 1)), E) F)
     ∘ (fderiv_within 𝕜 (iterated_fderiv_within 𝕜 n f s) s) := rfl
 
+lemma norm_fderiv_within_iterated_fderiv_within {n : ℕ} :
+  ∥fderiv_within 𝕜 (iterated_fderiv_within 𝕜 n f s) s x∥ =
+  ∥iterated_fderiv_within 𝕜 (n + 1) f s x∥ :=
+by rw [iterated_fderiv_within_succ_eq_comp_left, linear_isometry_equiv.norm_map]
+
 theorem iterated_fderiv_within_succ_apply_right {n : ℕ}
   (hs : unique_diff_on 𝕜 s) (hx : x ∈ s) (m : fin (n + 1) → E) :
   (iterated_fderiv_within 𝕜 (n + 1) f s x : (fin (n + 1) → E) → F) m
@@ -821,6 +826,11 @@ lemma iterated_fderiv_within_succ_eq_comp_right {n : ℕ} (hs : unique_diff_on �
   ((continuous_multilinear_curry_right_equiv' 𝕜 n E F)
     ∘ (iterated_fderiv_within 𝕜 n (λy, fderiv_within 𝕜 f s y) s)) x :=
 by { ext m, rw iterated_fderiv_within_succ_apply_right hs hx, refl }
+
+lemma norm_iterated_fderiv_within_fderiv_within {n : ℕ} (hs : unique_diff_on 𝕜 s) (hx : x ∈ s) :
+  ∥iterated_fderiv_within 𝕜 n (fderiv_within 𝕜 f s) s x∥ =
+  ∥iterated_fderiv_within 𝕜 (n + 1) f s x∥ :=
+by rw [iterated_fderiv_within_succ_eq_comp_right hs hx, linear_isometry_equiv.norm_map]
 
 @[simp] lemma iterated_fderiv_within_one_apply
   (hs : unique_diff_on 𝕜 s) (hx : x ∈ s) (m : (fin 1) → E) :
@@ -1462,6 +1472,10 @@ lemma iterated_fderiv_succ_eq_comp_left {n : ℕ} :
   (continuous_multilinear_curry_left_equiv 𝕜 (λ(i : fin (n + 1)), E) F)
     ∘ (fderiv 𝕜 (iterated_fderiv 𝕜 n f)) := rfl
 
+lemma norm_fderiv_iterated_fderiv {n : ℕ} :
+  ∥fderiv 𝕜 (iterated_fderiv 𝕜 n f) x∥ = ∥iterated_fderiv 𝕜 (n + 1) f x∥ :=
+by rw [iterated_fderiv_succ_eq_comp_left, linear_isometry_equiv.norm_map]
+
 lemma iterated_fderiv_within_univ {n : ℕ} :
   iterated_fderiv_within 𝕜 n f univ = iterated_fderiv 𝕜 n f :=
 begin
@@ -1514,6 +1528,10 @@ lemma iterated_fderiv_succ_eq_comp_right {n : ℕ} :
   ((continuous_multilinear_curry_right_equiv' 𝕜 n E F)
     ∘ (iterated_fderiv 𝕜 n (λy, fderiv 𝕜 f y))) x :=
 by { ext m, rw iterated_fderiv_succ_apply_right, refl }
+
+lemma norm_iterated_fderiv_fderiv {n : ℕ} :
+  ∥iterated_fderiv 𝕜 n (fderiv 𝕜 f) x∥ = ∥iterated_fderiv 𝕜 (n + 1) f x∥ :=
+by rw [iterated_fderiv_succ_eq_comp_right, linear_isometry_equiv.norm_map]
 
 @[simp] lemma iterated_fderiv_one_apply (m : (fin 1) → E) :
   (iterated_fderiv 𝕜 1 f x : ((fin 1) → E) → F) m


### PR DESCRIPTION
This PR adds four lemmas that calculate the norm of the (n+1)st iterated derivative as the left and right composition `iterated_fderiv` and `fderiv` with version for both `iterated_fderiv` and `iterated_fderiv_within`.
While these lemmas are borderline trivial, they are very useful and finding `linear_isometry_equiv.norm_map` might be unintuitive.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
