### PR TITLE
[Merged by Bors] - feat(algebra/algebra/spectrum): add a few basic lemmas for convenience

### DIFF
--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -3,10 +3,10 @@ Copyright (c) 2021 Jireh Loreaux. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
-import tactic.noncomm_ring
-import field_theory.is_alg_closed.basic
 import algebra.star.pointwise
 import algebra.star.subalgebra
+import field_theory.is_alg_closed.basic
+import tactic.noncomm_ring
 /-!
 # Spectrum of an element in an algebra
 This file develops the basic theory of the spectrum of an element of an algebra.

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -6,6 +6,7 @@ Authors: Jireh Loreaux
 import tactic.noncomm_ring
 import field_theory.is_alg_closed.basic
 import algebra.star.pointwise
+import algebra.star.subalgebra
 /-!
 # Spectrum of an element in an algebra
 This file develops the basic theory of the spectrum of an element of an algebra.
@@ -38,6 +39,7 @@ This theory will serve as the foundation for spectral theory in Banach algebras.
 -/
 
 open set
+open_locale pointwise
 
 universes u v
 
@@ -101,6 +103,16 @@ iff.rfl
 lemma not_mem_iff {r : R} {a : A} :
   r ∉ σ a ↔ is_unit (↑ₐr - a) :=
 by { apply not_iff_not.mp, simp [set.not_not_mem, mem_iff] }
+
+variables (R)
+
+lemma zero_mem_iff {a : A} : (0 : R) ∈ σ a ↔ ¬is_unit a :=
+by rw [mem_iff, map_zero, zero_sub, is_unit.neg_iff]
+
+lemma zero_not_mem_iff {a : A} : (0 : R) ∉ σ a ↔ is_unit a :=
+by rw [zero_mem_iff, not_not]
+
+variables {R}
 
 lemma mem_resolvent_set_of_left_right_inverse {r : R} {a b c : A}
   (h₁ : (↑ₐr - a) * b = 1) (h₂ : c * (↑ₐr - a) = 1) :
@@ -167,37 +179,24 @@ end
 
 lemma inv_mem_iff {r : Rˣ} {a : Aˣ} :
   (r : R) ∈ σ (a : A) ↔ (↑r⁻¹ : R) ∈ σ (↑a⁻¹ : A) :=
-begin
-  simp only [mem_iff, not_iff_not, ←mem_resolvent_set_iff],
-  exact ⟨λ h, inv_mem_resolvent_set h, λ h, by simpa using inv_mem_resolvent_set h⟩,
-end
+not_iff_not.2 $ ⟨inv_mem_resolvent_set, inv_mem_resolvent_set⟩
 
 lemma zero_mem_resolvent_set_of_unit (a : Aˣ) : 0 ∈ resolvent_set R (a : A) :=
-by { rw [mem_resolvent_set_iff, is_unit.sub_iff], simp }
+by simpa only [mem_resolvent_set_iff, ←not_mem_iff, zero_not_mem_iff] using a.is_unit
 
 lemma ne_zero_of_mem_of_unit {a : Aˣ} {r : R} (hr : r ∈ σ (a : A)) : r ≠ 0 :=
 λ hn, (hn ▸ hr) (zero_mem_resolvent_set_of_unit a)
 
 lemma add_mem_iff {a : A} {r s : R} :
-  r ∈ σ a ↔ r + s ∈ σ (↑ₐs + a) :=
-begin
-  apply not_iff_not.mpr,
-  simp only [mem_resolvent_set_iff],
-  have h_eq : ↑ₐ(r + s) - (↑ₐs + a) = ↑ₐr - a,
-    { simp, noncomm_ring },
-  rw h_eq,
-end
+  r + s ∈ spectrum R a ↔ r ∈ spectrum R (- algebra_map R A s + a) :=
+by simp only [mem_iff, sub_neg_eq_add, ←sub_sub, map_add]
 
 lemma smul_mem_smul_iff {a : A} {s : R} {r : Rˣ} :
   r • s ∈ σ (r • a) ↔ s ∈ σ a :=
-begin
-  apply not_iff_not.mpr,
-  simp only [mem_resolvent_set_iff, algebra.algebra_map_eq_smul_one],
-  have h_eq : (r • s) • (1 : A) = r • s • 1, by simp,
-  rw [h_eq, ←smul_sub, is_unit_smul_iff],
-end
+by simp only [mem_iff, not_iff_not, algebra.algebra_map_eq_smul_one, smul_assoc, ←smul_sub,
+  is_unit_smul_iff]
 
-open_locale pointwise polynomial
+open_locale polynomial
 
 theorem unit_smul_eq_smul (a : A) (r : Rˣ) :
   σ (r • a) = r • σ a :=
@@ -215,33 +214,22 @@ end
 theorem unit_mem_mul_iff_mem_swap_mul {a b : A} {r : Rˣ} :
   ↑r ∈ σ (a * b) ↔ ↑r ∈ σ (b * a) :=
 begin
-  apply not_iff_not.mpr,
-  simp only [mem_resolvent_set_iff, algebra.algebra_map_eq_smul_one],
-  have coe_smul_eq : ↑r • 1 = r • (1 : A), from rfl,
-  rw coe_smul_eq,
-  simp only [is_unit.smul_sub_iff_sub_inv_smul],
-  have right_inv_of_swap : ∀ {x y z : A} (h : (1 - x * y) * z = 1),
-    (1 - y * x) * (1 + y * z * x) = 1, from λ x y z h,
-      calc (1 - y * x) * (1 + y * z * x) = 1 - y * x + y * ((1 - x * y) * z) * x : by noncomm_ring
-      ...                                = 1                                     : by simp [h],
-  have left_inv_of_swap : ∀ {x y z : A} (h : z * (1 - x * y) = 1),
-    (1 + y * z * x) * (1 - y * x) = 1, from λ x y z h,
-      calc (1 + y * z * x) * (1 - y * x) = 1 - y * x + y * (z * (1 - x * y)) * x : by noncomm_ring
-      ...                                = 1                                     : by simp [h],
-  have is_unit_one_sub_mul_of_swap : ∀ {x y : A} (h : is_unit (1 - x * y)),
-    is_unit (1 - y * x), from λ x y h, by
-      { let h₁ := right_inv_of_swap h.unit.val_inv,
-        let h₂ := left_inv_of_swap h.unit.inv_val,
-        exact ⟨⟨1 - y * x, 1 + y * h.unit.inv * x, h₁, h₂⟩, rfl⟩, },
-  have is_unit_one_sub_mul_iff_swap : ∀ {x y : A},
-    is_unit (1 - x * y) ↔ is_unit (1 - y * x), by
-      { intros, split, repeat {apply is_unit_one_sub_mul_of_swap}, },
-  rw [←smul_mul_assoc, ←mul_smul_comm r⁻¹ b a, is_unit_one_sub_mul_iff_swap],
+  have h₁ : ∀ x y : A, is_unit (1 - x * y) → is_unit (1 - y * x),
+  { refine λ x y h, ⟨⟨1 - y * x, 1 + y * h.unit.inv * x, _, _⟩, rfl⟩,
+    calc (1 - y * x) * (1 + y * (is_unit.unit h).inv * x)
+        = (1 - y * x) + y * ((1 - x * y) * h.unit.inv) * x : by noncomm_ring
+    ... = 1 : by simp only [units.inv_eq_coe_inv, is_unit.mul_coe_inv, mul_one, sub_add_cancel],
+    calc (1 + y * (is_unit.unit h).inv * x) * (1 - y * x)
+        = (1 - y * x) + y * (h.unit.inv * (1 - x * y)) * x : by noncomm_ring
+    ... = 1 : by simp only [units.inv_eq_coe_inv, is_unit.coe_inv_mul, mul_one, sub_add_cancel]},
+  simpa only [mem_iff, not_iff_not, algebra.algebra_map_eq_smul_one, ←units.smul_def,
+    is_unit.smul_sub_iff_sub_inv_smul, ←smul_mul_assoc, ←mul_smul_comm r⁻¹ b a]
+    using iff.intro (h₁ (r⁻¹ • a) b) (h₁ b (r⁻¹ • a)),
 end
 
 theorem preimage_units_mul_eq_swap_mul {a b : A} :
   (coe : Rˣ → R) ⁻¹' σ (a * b) = coe ⁻¹'  σ (b * a) :=
-by { ext, exact unit_mem_mul_iff_mem_swap_mul, }
+set.ext $ λ _, unit_mem_mul_iff_mem_swap_mul
 
 section star
 
@@ -250,8 +238,8 @@ variables [has_involutive_star R] [star_ring A] [star_module R A]
 lemma star_mem_resolvent_set_iff {r : R} {a : A} :
   star r ∈ resolvent_set R a ↔ r ∈ resolvent_set R (star a) :=
 by refine ⟨λ h, _, λ h, _⟩;
-   simpa only [mem_resolvent_set_iff, algebra.algebra_map_eq_smul_one, star_sub, star_smul,
-     star_star, star_one] using is_unit.star h
+  simpa only [mem_resolvent_set_iff, algebra.algebra_map_eq_smul_one, star_sub, star_smul,
+    star_star, star_one] using is_unit.star h
 
 protected lemma map_star (a : A) : σ (star a) = star (σ a) :=
 by { ext, simpa only [set.mem_star, mem_iff, not_iff_not] using star_mem_resolvent_set_iff.symm }
@@ -268,10 +256,32 @@ variables [comm_ring R] [ring A] [algebra R A]
 local notation `σ` := spectrum R
 local notation `↑ₐ` := algebra_map R A
 
-theorem left_add_coset_eq (a : A) (r : R) :
-  left_add_coset r (σ a) = σ (↑ₐr + a) :=
-by { ext, rw [mem_left_add_coset_iff, neg_add_eq_sub, add_mem_iff],
-     nth_rewrite 1 ←sub_add_cancel x r, }
+-- it would be nice to state this for `subalgebra_class`, but we don't have such a thing yet
+lemma subset_subalgebra {S : subalgebra R A} (a : S) : spectrum R (a : A) ⊆ spectrum R a :=
+compl_subset_compl.2 (λ _, is_unit.map S.val)
+
+-- this is why it would be nice if `subset_subalgebra` was registered for `subalgebra_class`.
+lemma subset_star_subalgebra [star_ring R] [star_ring A] [star_module R A] {S : star_subalgebra R A}
+  (a : S) : spectrum R (a : A) ⊆ spectrum R a :=
+compl_subset_compl.2 (λ _, is_unit.map S.subtype)
+
+lemma singleton_add_eq (a : A) (r : R) : {r} + (σ a) = σ (↑ₐr + a) :=
+ext $ λ x,
+  by rw [singleton_add, image_add_left, mem_preimage, add_comm, add_mem_iff, map_neg, neg_neg]
+
+lemma add_singleton_eq (a : A) (r : R) : (σ a) + {r} = σ (a + ↑ₐr) :=
+add_comm {r} (σ a) ▸ add_comm (algebra_map R A r) a ▸ singleton_add_eq a r
+
+lemma neg_eq (a : A) : -(σ a) = σ (-a) :=
+set.ext $ λ x, by simp only [mem_neg, mem_iff, map_neg, ←neg_add', is_unit.neg_iff, sub_neg_eq_add]
+
+lemma singleton_sub_eq (a : A) (r : R) :
+  {r} - (σ a) = σ (↑ₐr - a) :=
+by rw [sub_eq_add_neg, neg_eq, singleton_add_eq, sub_eq_add_neg]
+
+lemma sub_singleton_eq (a : A) (r : R) :
+  (σ a) - {r} = σ (a - ↑ₐr) :=
+by simpa only [neg_sub, neg_eq] using congr_arg has_neg.neg (singleton_sub_eq a r)
 
 open polynomial
 
@@ -309,22 +319,11 @@ begin
 end
 
 @[simp] theorem scalar_eq [nontrivial A] (k : 𝕜) : σ (↑ₐk) = {k} :=
-begin
-  have coset_eq : left_add_coset k {0} = {k}, by
-    { ext, split,
-      { intro hx, simp [left_add_coset] at hx, exact hx, },
-      { intro hx, simp at hx, exact ⟨0, ⟨set.mem_singleton 0, by simp [hx]⟩⟩, }, },
-  calc σ (↑ₐk) = σ (↑ₐk + 0)                  : by simp
-    ...        = left_add_coset k (σ (0 : A)) : by rw ←left_add_coset_eq
-    ...        = left_add_coset k {0}         : by rw zero_eq
-    ...        = {k}                          : coset_eq,
-end
+by rw [←add_zero (↑ₐk), ←singleton_add_eq, zero_eq, set.singleton_add_singleton, add_zero]
 
 @[simp] lemma one_eq [nontrivial A] : σ (1 : A) = {1} :=
-calc σ (1 : A) = σ (↑ₐ1) : by simp [algebra.algebra_map_eq_smul_one]
+calc σ (1 : A) = σ (↑ₐ1) : by rw [algebra.algebra_map_eq_smul_one, one_smul]
   ...          = {1}     : scalar_eq 1
-
-open_locale pointwise
 
 /-- the assumption `(σ a).nonempty` is necessary and cannot be removed without
     further conditions on the algebra `A` and scalar field `𝕜`. -/
@@ -403,15 +402,32 @@ begin
 end
 
 /-- In this version of the spectral mapping theorem, we assume the spectrum
-is nonempty instead of assuming the degree of the polynomial is positive. Note: the
-assumption `[nontrivial A]` is necessary for the same reason as in `spectrum.zero_eq`. -/
-theorem map_polynomial_aeval_of_nonempty [is_alg_closed 𝕜] [nontrivial A] (a : A) (p : 𝕜[X])
+is nonempty instead of assuming the degree of the polynomial is positive. -/
+theorem map_polynomial_aeval_of_nonempty [is_alg_closed 𝕜] (a : A) (p : 𝕜[X])
   (hnon : (σ a).nonempty) : σ (aeval a p) = (λ k, eval k p) '' (σ a) :=
 begin
+  nontriviality A,
   refine or.elim (le_or_gt (degree p) 0) (λ h, _) (map_polynomial_aeval_of_degree_pos a p),
   { rw eq_C_of_degree_le_zero h,
     simp only [set.image_congr, eval_C, aeval_C, scalar_eq, set.nonempty.image_const hnon] },
 end
+
+/-- A specialization of `spectrum.subset_polynomial_aeval` to monic monomials for convenience. -/
+lemma pow_image_subset (a : A) (n : ℕ) : (λ x, x ^ n) '' (σ a) ⊆ σ (a ^ n) :=
+by simpa only [eval_pow, eval_X, aeval_X_pow] using subset_polynomial_aeval a (X ^ n : 𝕜[X])
+
+/-- A specialization of `spectrum.map_polynomial_aeval_of_nonempty` to monic monomials for
+convenience. -/
+lemma map_pow_of_pos [is_alg_closed 𝕜] (a : A) {n : ℕ} (hn : 0 < n) :
+  σ (a ^ n) = (λ x, x ^ n) '' (σ a) :=
+by simpa only [aeval_X_pow, eval_pow, eval_X] using
+  map_polynomial_aeval_of_degree_pos a (X ^ n : 𝕜[X]) (by { rw_mod_cast degree_X_pow, exact hn })
+
+/-- A specialization of `spectrum.map_polynomial_aeval_of_nonempty` to monic monomials for
+convenience. -/
+lemma map_pow_of_nonempty [is_alg_closed 𝕜] {a : A} (ha : (σ a).nonempty) (n : ℕ) :
+  σ (a ^ n) = (λ x, x ^ n) '' (σ a) :=
+by simpa only [aeval_X_pow, eval_pow, eval_X] using map_polynomial_aeval_of_nonempty a (X ^ n) ha
 
 variable (𝕜)
 /--

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -188,8 +188,12 @@ lemma ne_zero_of_mem_of_unit {a : Aˣ} {r : R} (hr : r ∈ σ (a : A)) : r ≠ 0
 λ hn, (hn ▸ hr) (zero_mem_resolvent_set_of_unit a)
 
 lemma add_mem_iff {a : A} {r s : R} :
-  r + s ∈ spectrum R a ↔ r ∈ spectrum R (- algebra_map R A s + a) :=
+  r + s ∈ σ a ↔ r ∈ σ (-↑ₐs + a) :=
 by simp only [mem_iff, sub_neg_eq_add, ←sub_sub, map_add]
+
+lemma add_mem_add_iff {a : A} {r s : R} :
+  r + s ∈ σ (↑ₐs + a) ↔ r ∈ σ a  :=
+by rw [add_mem_iff, neg_add_cancel_left]
 
 lemma smul_mem_smul_iff {a : A} {s : R} {r : Rˣ} :
   r • s ∈ σ (r • a) ↔ s ∈ σ a :=
@@ -271,6 +275,9 @@ ext $ λ x,
 
 lemma add_singleton_eq (a : A) (r : R) : (σ a) + {r} = σ (a + ↑ₐr) :=
 add_comm {r} (σ a) ▸ add_comm (algebra_map R A r) a ▸ singleton_add_eq a r
+
+lemma vadd_eq (a : A) (r : R) : r +ᵥ (σ a) = σ (↑ₐr + a) :=
+(singleton_add).symm.trans $ singleton_add_eq a r
 
 lemma neg_eq (a : A) : -(σ a) = σ (-a) :=
 set.ext $ λ x, by simp only [mem_neg, mem_iff, map_neg, ←neg_add', is_unit.neg_iff, sub_neg_eq_add]

--- a/src/algebra/star/subalgebra.lean
+++ b/src/algebra/star/subalgebra.lean
@@ -52,6 +52,10 @@ instance : subsemiring_class (star_subalgebra R A) A :=
   one_mem := one_mem',
   zero_mem := zero_mem' }
 
+instance {R A} [comm_ring R] [star_ring R] [ring A] [star_ring A] [algebra R A] [star_module R A] :
+  subring_class (star_subalgebra R A) A :=
+{ neg_mem := λ s a ha, show -a ∈ s.to_subalgebra, from neg_mem ha }
+
 -- this uses the `has_star` instance `s` inherits from `star_mem_class (star_subalgebra R A) A`
 instance (s : star_subalgebra R A) : star_ring s :=
 { star := star,


### PR DESCRIPTION
This adds a few basic lemmas concerning the spectrum of an element which are particularly convenient and were missing. In addiiton, we golf a few existing declarations and otherwise try to clean up the file a bit.

---

Note: this does not exactly depend on #17136, but both PRs add the same `subring_class` instance for `star_subalgebra`. Consequently, whichever PR is going to be merged second should merge master before going on the queue. Both of these are my PRs, so I will keep track of this.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
