### PR TITLE
[Merged by Bors] - feat(data/set/intervals/basic): Injectivity of half-infinite intervals

### DIFF
--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -25,13 +25,11 @@ for some statements it should be `linear_order` or `densely_ordered`).
 TODO: This is just the beginning; a lot of rules are missing
 -/
 
+open function order_dual (to_dual of_dual)
+
 variables {α β : Type*}
 
 namespace set
-
-open set
-open order_dual (to_dual of_dual)
-
 section preorder
 variables [preorder α] {a a₁ a₂ b b₁ b₂ c x : α}
 
@@ -549,13 +547,11 @@ eq_singleton_iff_unique_mem.2 ⟨left_mem_Ici, λ b, h.eq_of_ge⟩
 
 lemma _root_.is_min.Iic_eq (h : is_min a) : Iic a = {a} := h.to_dual.Ici_eq
 
-lemma Ici_injective : function.injective (Ici : α → set α) :=
-λ a b h, le_antisymm (h.symm.subset le_rfl) (h.subset le_rfl)
+lemma Ici_injective : injective (Ici : α → set α) := λ a b, eq_of_forall_ge_iff ∘ set.ext_iff.1
+lemma Iic_injective : injective (Iic : α → set α) := λ a b, eq_of_forall_le_iff ∘ set.ext_iff.1
 
-lemma Iic_injective : function.injective (Iic : α → set α) := @Ici_injective αᵒᵈ _
-
-lemma Ici_eq_Ici_iff : Ici a = Ici b ↔ a = b := Ici_injective.eq_iff
-lemma Iic_eq_Iic_iff : Iic a = Iic b ↔ a = b := @Ici_eq_Ici_iff αᵒᵈ _ _ _
+lemma Ici_inj : Ici a = Ici b ↔ a = b := Ici_injective.eq_iff
+lemma Iic_inj : Iic a = Iic b ↔ a = b := Iic_injective.eq_iff
 
 end partial_order
 
@@ -651,6 +647,12 @@ by rw [diff_eq, compl_Iio, inter_comm, Ici_inter_Iic]
 
 @[simp] lemma Iio_diff_Iio : Iio b \ Iio a = Ico a b :=
 by rw [diff_eq, compl_Iio, inter_comm, Ici_inter_Iio]
+
+lemma Ioi_injective : injective (Ioi : α → set α) := λ a b, eq_of_forall_gt_iff ∘ set.ext_iff.1
+lemma Iio_injective : injective (Iio : α → set α) := λ a b, eq_of_forall_lt_iff ∘ set.ext_iff.1
+
+lemma Ioi_inj : Ioi a = Ioi b ↔ a = b := Ioi_injective.eq_iff
+lemma Iio_inj : Iio a = Iio b ↔ a = b := Iio_injective.eq_iff
 
 lemma Ico_subset_Ico_iff (h₁ : a₁ < b₁) :
   Ico a₁ b₁ ⊆ Ico a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ ≤ b₂ :=

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -549,17 +549,17 @@ eq_singleton_iff_unique_mem.2 ⟨left_mem_Ici, λ b, h.eq_of_ge⟩
 
 lemma _root_.is_min.Iic_eq (h : is_min a) : Iic a = {a} := h.to_dual.Ici_eq
 
-lemma Ici_eq_Ici_iff : Ici a = Ici b ↔ a = b :=
+lemma Iic_injective : function.injective (Ici : α → set α) :=
 begin
+  intros a b,
+  rw [subset_antisymm_iff, le_antisymm_iff],
+  intro h,
   split,
-  { intro h,
-    rw le_antisymm_iff,
-    rw subset.antisymm_iff at h,
-    split,
-    { rw ← Ici_subset_Ici, exact h.2, },
-    { rw ← Ici_subset_Ici, exact h.1, } },
-  { apply congr_arg, }
+  { rw ← Ici_subset_Ici, exact h.2, },
+  { rw ← Ici_subset_Ici, exact h.1, },
 end
+
+lemma Ici_eq_Ici_iff (a b : α) : Ici a = Ici b ↔ a = b := Iic_injective.eq_iff
 
 lemma Iic_eq_Iic_iff : Iic a = Iic b ↔ a = b :=
 begin

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -549,6 +549,30 @@ eq_singleton_iff_unique_mem.2 ⟨left_mem_Ici, λ b, h.eq_of_ge⟩
 
 lemma _root_.is_min.Iic_eq (h : is_min a) : Iic a = {a} := h.to_dual.Ici_eq
 
+lemma Ici_eq_Ici_iff : Ici a = Ici b ↔ a = b :=
+begin
+  split,
+  { intro h,
+    rw le_antisymm_iff,
+    rw subset.antisymm_iff at h,
+    split,
+    { rw ← Ici_subset_Ici, exact h.2, },
+    { rw ← Ici_subset_Ici, exact h.1, } },
+  { apply congr_arg, }
+end
+
+lemma Iic_eq_Iic_iff : Iic a = Iic b ↔ a = b :=
+begin
+  split,
+  { intro h,
+    rw le_antisymm_iff,
+    rw subset.antisymm_iff at h,
+    split,
+    { rw ← Iic_subset_Iic, exact h.1, },
+    { rw ← Iic_subset_Iic, exact h.2, } },
+  { apply congr_arg, }
+end
+
 end partial_order
 
 section order_top

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -550,21 +550,12 @@ eq_singleton_iff_unique_mem.2 ⟨left_mem_Ici, λ b, h.eq_of_ge⟩
 lemma _root_.is_min.Iic_eq (h : is_min a) : Iic a = {a} := h.to_dual.Ici_eq
 
 lemma Ici_injective : function.injective (Ici : α → set α) :=
-begin
-  intros a b,
-  rw [subset_antisymm_iff, le_antisymm_iff],
-  intro h,
-  split,
-  { rw ← Ici_subset_Ici, exact h.2, },
-  { rw ← Ici_subset_Ici, exact h.1, },
-end
+λ a b h, le_antisymm (h.symm.subset le_rfl) (h.subset le_rfl)
 
-lemma Ici_eq_Ici_iff (a b : α) : Ici a = Ici b ↔ a = b := Ici_injective.eq_iff
+lemma Iic_injective : function.injective (Iic : α → set α) := @Ici_injective αᵒᵈ _
 
-lemma Iic_injective : function.injective (Iic : α → set α) := by convert @Ici_injective αᵒᵈ _
-
-lemma Iic_eq_Iic_iff : Iic a = Iic b ↔ a = b :=
-Ici_eq_Ici_iff (to_dual a) (to_dual b)
+lemma Ici_eq_Ici_iff : Ici a = Ici b ↔ a = b := Ici_injective.eq_iff
+lemma Iic_eq_Iic_iff : Iic a = Iic b ↔ a = b := @Ici_eq_Ici_iff αᵒᵈ _ _ _
 
 end partial_order
 

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -561,6 +561,8 @@ end
 
 lemma Ici_eq_Ici_iff (a b : α) : Ici a = Ici b ↔ a = b := Ici_injective.eq_iff
 
+lemma Iic_injective : function.injective (Iic : α → set α) := by convert @Ici_injective αᵒᵈ _
+
 lemma Iic_eq_Iic_iff : Iic a = Iic b ↔ a = b :=
 Ici_eq_Ici_iff (to_dual a) (to_dual b)
 

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -549,7 +549,7 @@ eq_singleton_iff_unique_mem.2 ⟨left_mem_Ici, λ b, h.eq_of_ge⟩
 
 lemma _root_.is_min.Iic_eq (h : is_min a) : Iic a = {a} := h.to_dual.Ici_eq
 
-lemma Iic_injective : function.injective (Ici : α → set α) :=
+lemma Ici_injective : function.injective (Ici : α → set α) :=
 begin
   intros a b,
   rw [subset_antisymm_iff, le_antisymm_iff],
@@ -559,19 +559,10 @@ begin
   { rw ← Ici_subset_Ici, exact h.1, },
 end
 
-lemma Ici_eq_Ici_iff (a b : α) : Ici a = Ici b ↔ a = b := Iic_injective.eq_iff
+lemma Ici_eq_Ici_iff (a b : α) : Ici a = Ici b ↔ a = b := Ici_injective.eq_iff
 
 lemma Iic_eq_Iic_iff : Iic a = Iic b ↔ a = b :=
-begin
-  split,
-  { intro h,
-    rw le_antisymm_iff,
-    rw subset.antisymm_iff at h,
-    split,
-    { rw ← Iic_subset_Iic, exact h.1, },
-    { rw ← Iic_subset_Iic, exact h.2, } },
-  { apply congr_arg, }
-end
+Ici_eq_Ici_iff (to_dual a) (to_dual b)
 
 end partial_order
 

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -330,6 +330,12 @@ lemma eq_of_forall_ge_iff [partial_order α] {a b : α}
   (H : ∀ c, a ≤ c ↔ b ≤ c) : a = b :=
 ((H _).2 le_rfl).antisymm ((H _).1 le_rfl)
 
+lemma eq_of_forall_lt_iff [linear_order α] {a b : α} (h : ∀ c, c < a ↔ c < b) : a = b :=
+(le_of_forall_lt $ λ _, (h _).1).antisymm $ le_of_forall_lt $ λ _, (h _).2
+
+lemma eq_of_forall_gt_iff [linear_order α] {a b : α} (h : ∀ c, a < c ↔ b < c) : a = b :=
+(le_of_forall_lt' $ λ _, (h _).2).antisymm $ le_of_forall_lt' $ λ _, (h _).1
+
 /-- A symmetric relation implies two values are equal, when it implies they're less-equal.  -/
 lemma rel_imp_eq_of_rel_imp_le [partial_order β] (r : α → α → Prop) [is_symm α r] {f : α → β}
   (h : ∀ a b, r a b → f a ≤ f b) {a b : α} : r a b → f a = f b :=


### PR DESCRIPTION
Adds lemma `set.Ici_eq_Ici_iff`, required by #17037. For completeness, the equivalent result for `Iic` is also included.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
