### PR TITLE
[Merged by Bors] - chore(data/list/count): use + 1 instead of nat.succ

### DIFF
--- a/src/data/list/count.lean
+++ b/src/data/list/count.lean
@@ -112,7 +112,7 @@ lemma count_cons' (a b : α) (l : list α) :
   count a (b :: l) = count a l + (if a = b then 1 else 0) :=
 begin rw count_cons, split_ifs; refl end
 
-@[simp] lemma count_cons_self (a : α) (l : list α) : count a (a::l) = succ (count a l) := if_pos rfl
+@[simp] lemma count_cons_self (a : α) (l : list α) : count a (a::l) = count a l + 1 := if_pos rfl
 
 @[simp, priority 990]
 lemma count_cons_of_ne {a b : α} (h : a ≠ b) (l : list α) : count a (b::l) = count a l := if_neg h

--- a/src/data/list/count.lean
+++ b/src/data/list/count.lean
@@ -197,28 +197,26 @@ begin
   exact countp_mono_left (λ y hyl, congr_arg f),
 end
 
-@[simp] lemma count_erase_self (a : α) :
-  ∀ (s : list α), count a (list.erase s a) = pred (count a s)
+lemma count_erase (a b : α) : ∀ l : list α, count a (l.erase b) = count a l - ite (a = b) 1 0
 | [] := by simp
-| (h :: t) :=
+| (c :: l) :=
 begin
-  rw erase_cons,
-  by_cases p : h = a,
-  { rw [if_pos p, count_cons', if_pos p.symm], simp },
-  { rw [if_neg p, count_cons', count_cons', if_neg (λ x : a = h, p x.symm), count_erase_self],
-    simp }
+  rw [erase_cons],
+  by_cases hc : c = b,
+  { rw [if_pos hc, hc, count_cons', nat.add_sub_cancel] },
+  { rw [if_neg hc, count_cons', count_cons', count_erase],
+    by_cases ha : a = b,
+    { rw [← ha, eq_comm] at hc,
+      rw [if_pos ha, if_neg hc, add_zero, add_zero] },
+    { rw [if_neg ha, tsub_zero, tsub_zero] } }
 end
 
-@[simp] lemma count_erase_of_ne {a b : α} (ab : a ≠ b) :
-  ∀ (s : list α), count a (list.erase s b) = count a s
-| [] := by simp
-| (x :: xs) :=
-begin
-  rw erase_cons,
-  split_ifs with h,
-  { rw [count_cons', h, if_neg ab], simp },
-  { rw [count_cons', count_cons', count_erase_of_ne] }
-end
+@[simp] lemma count_erase_self (a : α) (l : list α) : count a (list.erase l a) = count a l - 1 :=
+by rw [count_erase, if_pos rfl]
+
+@[simp] lemma count_erase_of_ne {a b : α} (ab : a ≠ b) (l : list α) :
+  count a (l.erase b) = count a l :=
+by rw [count_erase, if_neg ab, tsub_zero]
 
 @[to_additive]
 lemma prod_map_eq_pow_single [monoid β] {l : list α} (a : α) (f : α → β)

--- a/src/data/list/lattice.lean
+++ b/src/data/list/lattice.lean
@@ -239,30 +239,25 @@ end
   ∀ {l₁ l₂ : list α}, count a (l₁.bag_inter l₂) = min (count a l₁) (count a l₂)
 | []         l₂         := by simp
 | l₁         []         := by simp
-| (h₁ :: l₁) (h₂ :: l₂) :=
+| (b :: l₁)  l₂         :=
 begin
-  simp only [list.bag_inter, list.mem_cons_iff],
-  by_cases p₁ : h₂ = h₁; by_cases p₂ : h₁ = a,
-  { simp only [p₁, p₂, count_bag_inter, min_succ_succ, erase_cons_head, if_true, mem_cons_iff,
-               count_cons_self, true_or, eq_self_iff_true] },
-  { simp only [p₁, ne.symm p₂, count_bag_inter, count_cons, erase_cons_head, if_true, mem_cons_iff,
-               true_or, eq_self_iff_true, if_false] },
-  { rw p₂ at p₁,
-    by_cases p₃ : a ∈ l₂,
-    { simp only [p₁, ne.symm p₁, p₂, p₃, erase_cons, count_bag_inter, eq.symm (min_succ_succ _ _),
-                 succ_pred_eq_of_pos (count_pos.2 p₃), if_true, mem_cons_iff, false_or,
-                 count_cons_self, eq_self_iff_true, if_false, ne.def, not_false_iff,
-                 count_erase_self, list.count_cons_of_ne] },
-    { simp [ne.symm p₁, p₂, p₃] } },
-  { by_cases p₄ : h₁ ∈ l₂; simp only [ne.symm p₁, ne.symm p₂, p₄, count_bag_inter, if_true,
-      if_false, mem_cons_iff, false_or, eq_self_iff_true, ne.def, not_false_iff,count_erase_of_ne,
-      count_cons_of_ne] }
+  by_cases hb : b ∈ l₂,
+  { rw [cons_bag_inter_of_pos _ hb, count_cons', count_cons', count_bag_inter, count_erase,
+      ← min_add_add_right],
+    by_cases ab : a = b,
+    { rw [if_pos ab, tsub_add_cancel_of_le],
+      rwa [succ_le_iff, count_pos, ab] },
+    { rw [if_neg ab, tsub_zero, add_zero, add_zero] } },
+  { rw [cons_bag_inter_of_neg _ hb, count_bag_inter],
+    by_cases ab : a = b,
+    { rw [← ab] at hb, rw [count_eq_zero.2 hb, min_zero, min_zero] },
+    { rw [count_cons_of_ne ab] } },
 end
 
 lemma bag_inter_sublist_left : ∀ l₁ l₂ : list α, l₁.bag_inter l₂ <+ l₁
-| []        l₂ := by simp [nil_sublist]
+| []        l₂ := by simp
 | (b :: l₁) l₂ := begin
-  by_cases b ∈ l₂; simp [h],
+  by_cases b ∈ l₂; simp only [h, cons_bag_inter_of_pos, cons_bag_inter_of_neg, not_false_iff],
   { exact (bag_inter_sublist_left _ _).cons_cons _ },
   { apply sublist_cons_of_sublist, apply bag_inter_sublist_left }
 end


### PR DESCRIPTION
Also add `list.count_erase` and use `-1` instead of `nat.pred` in `list.count_erase_self`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
