### PR TITLE
[Merged by Bors] - chore(data/nat/basic): reorder arguments to `nat.even_odd_rec` to make it work with `induction`

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -733,9 +733,9 @@ extend from `P i` to both `P (2 * i)` and `P (2 * i + 1)`, then we have `P n` fo
 This is nothing more than a wrapper around `nat.binary_rec`, to avoid having to switch to
 dealing with `bit0` and `bit1`. -/
 @[elab_as_eliminator]
-def even_odd_rec (n : ℕ) (P : ℕ → Sort*) (h0 : P 0)
-  (h_even : ∀ i, P i → P (2 * i))
-  (h_odd : ∀ i, P i → P (2 * i + 1)) : P n :=
+def even_odd_rec {P : ℕ → Sort*} (h0 : P 0)
+  (h_even : ∀ n (ih : P n), P (2 * n))
+  (h_odd : ∀ n (ih : P n), P (2 * n + 1)) (n : ℕ) : P n :=
 begin
   refine @binary_rec P h0 (λ b i hi, _) n,
   cases b,
@@ -745,12 +745,12 @@ end
 
 @[simp] lemma even_odd_rec_zero (P : ℕ → Sort*) (h0 : P 0)
   (h_even : ∀ i, P i → P (2 * i)) (h_odd : ∀ i, P i → P (2 * i + 1)) :
-  @even_odd_rec 0 P h0 h_even h_odd = h0 := binary_rec_zero _ _
+  @even_odd_rec _ h0 h_even h_odd 0 = h0 := binary_rec_zero _ _
 
 @[simp] lemma even_odd_rec_even (n : ℕ) (P : ℕ → Sort*) (h0 : P 0)
   (h_even : ∀ i, P i → P (2 * i)) (h_odd : ∀ i, P i → P (2 * i + 1))
   (H : h_even 0 h0 = h0) :
-  @even_odd_rec (2 * n) P h0 h_even h_odd = h_even n (even_odd_rec n P h0 h_even h_odd) :=
+  @even_odd_rec _ h0 h_even h_odd (2 * n) = h_even n (even_odd_rec h0 h_even h_odd n) :=
 begin
   convert binary_rec_eq _ ff n,
   { exact (bit0_eq_two_mul _).symm },
@@ -762,7 +762,7 @@ end
 @[simp] lemma even_odd_rec_odd (n : ℕ) (P : ℕ → Sort*) (h0 : P 0)
   (h_even : ∀ i, P i → P (2 * i)) (h_odd : ∀ i, P i → P (2 * i + 1))
   (H : h_even 0 h0 = h0) :
-  @even_odd_rec (2 * n + 1) P h0 h_even h_odd = h_odd n (even_odd_rec n P h0 h_even h_odd) :=
+  @even_odd_rec _ h0 h_even h_odd (2 * n + 1) = h_odd n (even_odd_rec h0 h_even h_odd n) :=
 begin
   convert binary_rec_eq _ tt n,
   { exact (bit0_eq_two_mul _).symm },


### PR DESCRIPTION
The `induction` tactic needs `n` to come after `p`. At any rate, the convention is to take `n` last for `*_rec` and first for `*_rec_on`.

With this change, `induction n using nat.even_odd_rec` both works and introduces hypotheses with sensible names.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
