### PR TITLE
[Merged by Bors] - feat(ring_theory): specialize Chinese Remainder Theorem to two ideals

### DIFF
--- a/src/algebra/ring/fin.lean
+++ b/src/algebra/ring/fin.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2022 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+import algebra.ring.pi
+import algebra.ring.prod
+import logic.equiv.fin
+
+/-!
+# Rings and `fin`
+
+This file collects some basic results involving rings and the `fin` type
+
+## Main results
+
+ * `ring_equiv.fin_two`: The product over `fin 2` of some rings is the cartesian product
+
+-/
+
+/-- The product over `fin 2` of some rings is just the cartesian product of these rings. -/
+@[simps]
+def ring_equiv.pi_fin_two (R : fin 2 → Type*) [Π i, semiring (R i)] :
+  (Π (i : fin 2), R i) ≃+* R 0 × R 1 :=
+{ to_fun := pi_fin_two_equiv R,
+  map_add' := λ a b, rfl,
+  map_mul' := λ a b, rfl,
+  .. pi_fin_two_equiv R }

--- a/src/ring_theory/dedekind_domain/ideal.lean
+++ b/src/ring_theory/dedekind_domain/ideal.lean
@@ -1264,6 +1264,14 @@ is_dedekind_domain.quotient_equiv_pi_of_prod_eq _ _ _
     λ P, ideal.quotient.mk _ x :=
 rfl
 
+/-- **Chinese remainder theorem**, specialized to two ideals. -/
+noncomputable def ideal.quotient_mul_equiv_quotient_prod (I J : ideal R)
+  (coprime : I ⊔ J = ⊤) :
+  (R ⧸ (I * J)) ≃+* (R ⧸ I) × R ⧸ J :=
+ring_equiv.trans
+  (ideal.quot_equiv_of_eq (inf_eq_mul_of_coprime coprime).symm)
+  (ideal.quotient_inf_equiv_quotient_prod I J coprime)
+
 end dedekind_domain
 
 end chinese_remainder

--- a/src/ring_theory/ideal/quotient.lean
+++ b/src/ring_theory/ideal/quotient.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Chris Hughes, Mario Carneiro, Anne Baanen
 -/
+import algebra.ring.fin
 import linear_algebra.quotient
 import ring_theory.ideal.basic
 import tactic.fin_cases
@@ -411,15 +412,6 @@ noncomputable def quotient_inf_ring_equiv_pi_quotient [finite ι] (f : ι → id
 
 end chinese_remainder
 
-/-- The product over `fin 2` of some rings is just the cartesian product of these rings. -/
-@[simps]
-def _root_.ring_equiv.fin_two (R : fin 2 → Type*) [Π i, semiring (R i)] :
-  (Π (i : fin 2), R i) ≃+* R 0 × R 1 :=
-{ to_fun := pi_fin_two_equiv R,
-  map_add' := λ a b, rfl,
-  map_mul' := λ a b, rfl,
-  .. pi_fin_two_equiv R }
-
 /-- **Chinese remainder theorem**, specialized to two ideals. -/
 noncomputable def quotient_inf_equiv_quotient_prod (I J : ideal R)
   (coprime : I ⊔ J = ⊤) :
@@ -430,7 +422,7 @@ by { intros i j h,
   fin_cases i; fin_cases j; try { contradiction }; simpa [f, sup_comm] using coprime },
 (ideal.quot_equiv_of_eq (by simp [infi, inf_comm])).trans $
 (ideal.quotient_inf_ring_equiv_pi_quotient f hf).trans $
-ring_equiv.fin_two (λ i, R ⧸ f i)
+ring_equiv.pi_fin_two (λ i, R ⧸ f i)
 
 @[simp] lemma quotient_inf_equiv_quotient_prod_fst (I J : ideal R) (coprime : I ⊔ J = ⊤)
   (x : R ⧸ (I ⊓ J)) : (quotient_inf_equiv_quotient_prod I J coprime x).fst =

--- a/src/ring_theory/ideal/quotient.lean
+++ b/src/ring_theory/ideal/quotient.lean
@@ -432,4 +432,26 @@ by { intros i j h,
 (ideal.quotient_inf_ring_equiv_pi_quotient f hf).trans $
 ring_equiv.fin_two (λ i, R ⧸ f i)
 
+@[simp] lemma quotient_inf_equiv_quotient_prod_fst (I J : ideal R) (coprime : I ⊔ J = ⊤)
+  (x : R ⧸ (I ⊓ J)) : (quotient_inf_equiv_quotient_prod I J coprime x).fst =
+  ideal.quotient.factor (I ⊓ J) I inf_le_left x :=
+quot.induction_on x (λ x, rfl)
+
+@[simp] lemma quotient_inf_equiv_quotient_prod_snd (I J : ideal R) (coprime : I ⊔ J = ⊤)
+  (x : R ⧸ (I ⊓ J)) : (quotient_inf_equiv_quotient_prod I J coprime x).snd =
+  ideal.quotient.factor (I ⊓ J) J inf_le_right x :=
+quot.induction_on x (λ x, rfl)
+
+@[simp] lemma fst_comp_quotient_inf_equiv_quotient_prod (I J : ideal R) (coprime : I ⊔ J = ⊤) :
+  (ring_hom.fst _ _).comp
+    (quotient_inf_equiv_quotient_prod I J coprime : R ⧸ I ⊓ J →+* (R ⧸ I) × R ⧸ J) =
+  ideal.quotient.factor (I ⊓ J) I inf_le_left :=
+by ext; refl
+
+@[simp] lemma snd_comp_quotient_inf_equiv_quotient_prod (I J : ideal R) (coprime : I ⊔ J = ⊤) :
+  (ring_hom.snd _ _).comp
+    (quotient_inf_equiv_quotient_prod I J coprime : R ⧸ I ⊓ J →+* (R ⧸ I) × R ⧸ J) =
+  ideal.quotient.factor (I ⊓ J) J inf_le_right :=
+by ext; refl
+
 end ideal

--- a/src/ring_theory/ideal/quotient.lean
+++ b/src/ring_theory/ideal/quotient.lean
@@ -413,7 +413,7 @@ end chinese_remainder
 
 /-- The product over `fin 2` of some rings is just the cartesian product of these rings. -/
 @[simps]
-def ring_equiv.fin_two (R : fin 2 → Type*) [Π i, semiring (R i)] :
+def _root_.ring_equiv.fin_two (R : fin 2 → Type*) [Π i, semiring (R i)] :
   (Π (i : fin 2), R i) ≃+* R 0 × R 1 :=
 { to_fun := pi_fin_two_equiv R,
   map_add' := λ a b, rfl,
@@ -421,7 +421,7 @@ def ring_equiv.fin_two (R : fin 2 → Type*) [Π i, semiring (R i)] :
   .. pi_fin_two_equiv R }
 
 /-- **Chinese remainder theorem**, specialized to two ideals. -/
-noncomputable def ideal.quotient_inf_equiv_quotient_prod (I J : ideal R)
+noncomputable def quotient_inf_equiv_quotient_prod (I J : ideal R)
   (coprime : I ⊔ J = ⊤) :
   (R ⧸ (I ⊓ J)) ≃+* (R ⧸ I) × R ⧸ J :=
 let f : fin 2 → ideal R := ![I, J] in

--- a/src/ring_theory/ideal/quotient.lean
+++ b/src/ring_theory/ideal/quotient.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau, Chris Hughes, Mario Carneiro, Anne Baanen
 -/
 import linear_algebra.quotient
 import ring_theory.ideal.basic
+import tactic.fin_cases
 /-!
 # Ideal quotients
 
@@ -409,5 +410,26 @@ noncomputable def quotient_inf_ring_equiv_pi_quotient [finite ι] (f : ι → id
   .. quotient_inf_to_pi_quotient f }
 
 end chinese_remainder
+
+/-- The product over `fin 2` of some rings is just the cartesian product of these rings. -/
+@[simps]
+def ring_equiv.fin_two (R : fin 2 → Type*) [Π i, semiring (R i)] :
+  (Π (i : fin 2), R i) ≃+* R 0 × R 1 :=
+{ to_fun := pi_fin_two_equiv R,
+  map_add' := λ a b, rfl,
+  map_mul' := λ a b, rfl,
+  .. pi_fin_two_equiv R }
+
+/-- **Chinese remainder theorem**, specialized to two ideals. -/
+noncomputable def ideal.quotient_inf_equiv_quotient_prod (I J : ideal R)
+  (coprime : I ⊔ J = ⊤) :
+  (R ⧸ (I ⊓ J)) ≃+* (R ⧸ I) × R ⧸ J :=
+let f : fin 2 → ideal R := ![I, J] in
+have hf : ∀ (i j : fin 2), i ≠ j → f i ⊔ f j = ⊤,
+by { intros i j h,
+  fin_cases i; fin_cases j; try { contradiction }; simpa [f, sup_comm] using coprime },
+(ideal.quot_equiv_of_eq (by simp [infi, inf_comm])).trans $
+(ideal.quotient_inf_ring_equiv_pi_quotient f hf).trans $
+ring_equiv.fin_two (λ i, R ⧸ f i)
 
 end ideal


### PR DESCRIPTION
The current arbitrarily-indexed version of CRT is surprisingly hard to apply to `R / (I ⊓ J)` inline, so here it is extracted into its own theorem.

I added an import of the `fin_cases` tactic to `ring_theory.ideal.quotient`; I believe this is lightweight enough and certainly it wouldn't cause a big jump in the amount of transitive imports.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

 - [x] depends on: #17100

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
