### PR TITLE
[Merged by Bors] - feat(ring_theory): induction and multiplicativity via prime factorization

### DIFF
--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -985,7 +985,7 @@ begin
   { simpa using h1 is_unit_one },
   rw finset.prod_insert hpf',
   exact hcp
-    (prime_pow_coprime_prod_of_coprime_insert _ i p hpf' is_prime is_coprime)
+    (prime_pow_coprime_prod_of_coprime_insert i p hpf' is_prime is_coprime)
     (hpr (i p) (is_prime _ (finset.mem_insert_self _ _)))
     (ih (λ q hq, is_prime _ (finset.mem_insert_of_mem hq))
     (λ q hq q' hq', is_coprime _ (finset.mem_insert_of_mem hq) _ (finset.mem_insert_of_mem hq')))
@@ -1013,7 +1013,7 @@ begin
   refine induction_on_prime_power _ _ _ _ @h1 @hpr @hcp;
     simp only [multiset.mem_to_finset],
   { apply prime_of_normalized_factor },
-  { apply normalized_factors_coprime },
+  { apply normalized_factors_eq_of_dvd },
 end
 
 /-- If `f` maps `p ^ i` to `(f p) ^ i` for primes `p`, and `f`
@@ -1032,7 +1032,7 @@ begin
   { simpa using h1 is_unit_one },
   have hpr_p := is_prime _ (finset.mem_insert_self _ _),
   have hpr_s : ∀ p ∈ s, prime p := λ p hp, is_prime _ (finset.mem_insert_of_mem hp),
-  have hcp_p := λ i, (prime_pow_coprime_prod_of_coprime_insert _ i p hps is_prime is_coprime),
+  have hcp_p := λ i, (prime_pow_coprime_prod_of_coprime_insert i p hps is_prime is_coprime),
   have hcp_s : ∀ (p q ∈ s), p ∣ q → p = q := λ p hp q hq, is_coprime p
     (finset.mem_insert_of_mem hp) q
     (finset.mem_insert_of_mem hq),

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -545,7 +545,7 @@ begin
   rwa [← normalize_normalized_factor p p_mem, normalize_eq_normalize_iff, dvd_dvd_iff_associated]
 end
 
-lemma normalized_factors_coprime (a : α) : ∀ (p q ∈ normalized_factors a), p ∣ q → p = q :=
+lemma normalized_factors_eq_of_dvd (a : α) : ∀ (p q ∈ normalized_factors a), p ∣ q → p = q :=
 begin
   intros p hp q hq hdvd,
   convert normalize_eq_normalize hdvd

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -545,6 +545,15 @@ begin
   rwa [← normalize_normalized_factor p p_mem, normalize_eq_normalize_iff, dvd_dvd_iff_associated]
 end
 
+lemma normalized_factors_coprime (a : α) : ∀ (p q ∈ normalized_factors a), p ∣ q → p = q :=
+begin
+  intros p hp q hq hdvd,
+  convert normalize_eq_normalize hdvd
+    (((prime_of_normalized_factor _ hp).irreducible).dvd_symm
+      ((prime_of_normalized_factor _ hq).irreducible) hdvd);
+    apply (normalize_normalized_factor _ _).symm; assumption
+end
+
 lemma exists_mem_normalized_factors_of_dvd {a p : α} (ha0 : a ≠ 0) (hp : irreducible p) : p ∣ a →
   ∃ q ∈ normalized_factors a, p ~ᵤ q :=
 λ ⟨b, hb⟩,
@@ -933,8 +942,159 @@ end
 
 end multiplicity
 
-end unique_factorization_monoid
+section multiplicative
 
+variables [cancel_comm_monoid_with_zero α] [unique_factorization_monoid α]
+variables {β : Type*} [cancel_comm_monoid_with_zero β]
+
+open_locale big_operators
+
+lemma prime_pow_coprime_prod_of_coprime_insert [decidable_eq α] (s : finset α) (i : α → ℕ) (p : α)
+  (hps : p ∉ s) (is_prime : ∀ q ∈ insert p s, prime q)
+  (is_coprime : ∀ (q q' ∈ insert p s), q ∣ q' → q = q') :
+  ∀ (q : α), q ∣ p ^ i p → q ∣ ∏ p' in s, p' ^ i p' → is_unit q :=
+begin
+  have hp := is_prime _ (finset.mem_insert_self _ _),
+  refine λ _, no_factors_of_no_prime_factors (pow_ne_zero _ hp.ne_zero) _,
+  intros d hdp hdprod hd,
+  apply hps,
+  replace hdp := hd.dvd_of_dvd_pow hdp,
+  obtain ⟨q, q_mem', hdq⟩ := hd.exists_mem_multiset_dvd hdprod,
+  obtain ⟨q, q_mem, rfl⟩ := multiset.mem_map.mp q_mem',
+  replace hdq := hd.dvd_of_dvd_pow hdq,
+  have : p ∣ q := dvd_trans
+    (hd.irreducible.dvd_symm hp.irreducible hdp)
+    hdq,
+  convert q_mem,
+  exact is_coprime _  (finset.mem_insert_self p s) _ (finset.mem_insert_of_mem q_mem) this,
+end
+
+/-- If `P` holds for units and powers of primes,
+and `P x ∧ P y` for coprime `x, y` implies `P (x * y)`,
+then `P` holds on a product of powers of distinct primes. -/
+@[elab_as_eliminator]
+theorem induction_on_prime_power
+  {P : α → Prop} (s : finset α) (i : α → ℕ)
+  (is_prime : ∀ p ∈ s, prime p) (is_coprime : ∀ p q ∈ s, p ∣ q → p = q)
+  (h1 : ∀ {x}, is_unit x → P x) (hpr : ∀ {p} (i : ℕ), prime p → P (p ^ i))
+  (hcp : ∀ {x y}, (∀ p, p ∣ x → p ∣ y → is_unit p) → P x → P y → P (x * y)) :
+  P (∏ p in s, p ^ (i p)) :=
+begin
+  letI := classical.dec_eq α,
+  induction s using finset.induction_on with p f' hpf' ih,
+  { simpa using h1 is_unit_one },
+  rw finset.prod_insert hpf',
+  exact hcp
+    (prime_pow_coprime_prod_of_coprime_insert _ i p hpf' is_prime is_coprime)
+    (hpr (i p) (is_prime _ (finset.mem_insert_self _ _)))
+    (ih (λ q hq, is_prime _ (finset.mem_insert_of_mem hq))
+    (λ q hq q' hq', is_coprime _ (finset.mem_insert_of_mem hq) _ (finset.mem_insert_of_mem hq')))
+end
+
+/-- If `P` holds for `0`, units and powers of primes,
+and `P x ∧ P y` for coprime `x, y` implies `P (x * y)`,
+then `P` holds on all `a : α`. -/
+@[elab_as_eliminator]
+theorem induction_on_coprime
+  {P : α → Prop} (a : α) (h0 : P 0) (h1 : ∀ {x}, is_unit x → P x)
+  (hpr : ∀ {p} (i : ℕ), prime p → P (p ^ i))
+  (hcp : ∀ {x y}, (∀ p, p ∣ x → p ∣ y → is_unit p) → P x → P y → P (x * y)) :
+  P a :=
+begin
+  letI := classical.dec_eq α,
+  have P_of_associated : ∀ {x y}, associated x y → P x → P y,
+  { rintros x y ⟨u, rfl⟩ hx,
+    exact hcp (λ p _ hpx, is_unit_of_dvd_unit hpx u.is_unit) hx (h1 u.is_unit) },
+  by_cases ha0 : a = 0, { rwa ha0 },
+  haveI : nontrivial α := ⟨⟨_, _, ha0⟩⟩,
+  letI : normalization_monoid α := unique_factorization_monoid.normalization_monoid,
+  refine P_of_associated (normalized_factors_prod ha0) _,
+  rw [← (normalized_factors a).map_id, finset.prod_multiset_map_count],
+  refine induction_on_prime_power _ _ _ _ @h1 @hpr @hcp;
+    simp only [multiset.mem_to_finset],
+  { apply prime_of_normalized_factor },
+  { apply normalized_factors_coprime },
+end
+
+/-- If `f` maps `p ^ i` to `(f p) ^ i` for primes `p`, and `f`
+is multiplicative on coprime elements, then `f` is multiplicative on all products of primes. -/
+@[elab_as_eliminator]
+theorem multiplicative_prime_power
+  {f : α → β} (s : finset α) (i j : α → ℕ)
+  (is_prime : ∀ p ∈ s, prime p) (is_coprime : ∀ p q ∈ s, p ∣ q → p = q)
+  (h1 : ∀ {x y}, is_unit y → f (x * y) = f x * f y)
+  (hpr : ∀ {p} (i : ℕ), prime p → f (p ^ i) = (f p) ^ i)
+  (hcp : ∀ {x y}, (∀ p, p ∣ x → p ∣ y → is_unit p) → f (x * y) = f x * f y) :
+  f (∏ p in s, p ^ (i p + j p)) = f (∏ p in s, p ^ i p) * f (∏ p in s, p ^ j p) :=
+begin
+  letI := classical.dec_eq α,
+  induction s using finset.induction_on with p s hps ih,
+  { simpa using h1 is_unit_one },
+  have hpr_p := is_prime _ (finset.mem_insert_self _ _),
+  have hpr_s : ∀ p ∈ s, prime p := λ p hp, is_prime _ (finset.mem_insert_of_mem hp),
+  have hcp_p := λ i, (prime_pow_coprime_prod_of_coprime_insert _ i p hps is_prime is_coprime),
+  have hcp_s : ∀ (p q ∈ s), p ∣ q → p = q := λ p hp q hq, is_coprime p
+    (finset.mem_insert_of_mem hp) q
+    (finset.mem_insert_of_mem hq),
+  rw [finset.prod_insert hps, finset.prod_insert hps, finset.prod_insert hps,
+      hcp (hcp_p _), hpr _ hpr_p, hcp (hcp_p _), hpr _ hpr_p, hcp (hcp_p _), hpr _ hpr_p,
+      ih hpr_s hcp_s,
+      pow_add, mul_assoc, mul_left_comm (f p ^ j p), mul_assoc],
+end
+
+/-- If `f` maps `p ^ i` to `(f p) ^ i` for primes `p`, and `f`
+is multiplicative on coprime elements, then `f` is multiplicative everywhere. -/
+theorem multiplicative_of_coprime
+  (f : α → β) (a b : α) (h0 : f 0 = 0) (h1 : ∀ {x y}, is_unit y → f (x * y) = f x * f y)
+  (hpr : ∀ {p} (i : ℕ), prime p → f (p ^ i) = (f p) ^ i)
+  (hcp : ∀ {x y}, (∀ p, p ∣ x → p ∣ y → is_unit p) → f (x * y) = f x * f y) :
+  f (a * b) = f a * f b :=
+begin
+  letI := classical.dec_eq α,
+  by_cases ha0 : a = 0, { rw [ha0, zero_mul, h0, zero_mul] },
+  by_cases hb0 : b = 0, { rw [hb0, mul_zero, h0, mul_zero] },
+  by_cases hf1 : f 1 = 0,
+  { calc f (a * b) = f ((a * b) * 1) : by rw mul_one
+               ... = 0 : by simp only [h1 is_unit_one, hf1, mul_zero]
+               ... = f a * f (b * 1) : by simp only [h1 is_unit_one, hf1, mul_zero]
+               ... = f a * f b : by rw mul_one },
+  have h1' : f 1 = 1 := (mul_left_inj' hf1).mp (by rw [← h1 is_unit_one, one_mul, one_mul]),
+  haveI : nontrivial α := ⟨⟨_, _, ha0⟩⟩,
+  letI : normalization_monoid α := unique_factorization_monoid.normalization_monoid,
+  suffices : f (∏ p in (normalized_factors a).to_finset ∪ (normalized_factors b).to_finset,
+        p ^ ((normalized_factors a).count p + (normalized_factors b).count p))
+    = f (∏ p in (normalized_factors a).to_finset ∪ (normalized_factors b).to_finset,
+        p ^ (normalized_factors a).count p) *
+      f (∏ (p : α) in (normalized_factors a).to_finset ∪ (normalized_factors b).to_finset,
+        p ^ (normalized_factors b).count p),
+  { obtain ⟨ua, a_eq⟩ := normalized_factors_prod ha0,
+    obtain ⟨ub, b_eq⟩ := normalized_factors_prod hb0,
+    rw [← a_eq, ← b_eq, mul_right_comm _ ↑ua, h1 ua.is_unit, h1 ub.is_unit, h1 ua.is_unit,
+        ← mul_assoc, h1 ub.is_unit, mul_right_comm _ (f ua), ← mul_assoc],
+    congr,
+    rw [← (normalized_factors a).map_id, ← (normalized_factors b).map_id,
+        finset.prod_multiset_map_count, finset.prod_multiset_map_count,
+        finset.prod_subset (finset.subset_union_left _ (normalized_factors b).to_finset),
+        finset.prod_subset (finset.subset_union_right _ (normalized_factors b).to_finset),
+        ← finset.prod_mul_distrib],
+    simp_rw [id.def, ← pow_add, this],
+    all_goals { simp only [multiset.mem_to_finset] },
+    { intros p hpab hpb, simp [hpb] },
+    { intros p hpab hpa, simp [hpa] } },
+  refine multiplicative_prime_power _ _ _ _ _ @h1 @hpr @hcp,
+  all_goals { simp only [multiset.mem_to_finset, finset.mem_union] },
+  { rintros p (hpa | hpb); apply prime_of_normalized_factor; assumption },
+  { rintro p (hp | hp) q (hq | hq) hdvd;
+      rw [← normalize_normalized_factor _ hp, ← normalize_normalized_factor _ hq];
+      exact normalize_eq_normalize hdvd
+        ((prime_of_normalized_factor _ hp).irreducible.dvd_symm
+          (prime_of_normalized_factor _ hq).irreducible
+          hdvd) },
+end
+
+end multiplicative
+
+end unique_factorization_monoid
 
 namespace associates
 open unique_factorization_monoid associated multiset

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -949,7 +949,7 @@ variables {β : Type*} [cancel_comm_monoid_with_zero β]
 
 open_locale big_operators
 
-lemma prime_pow_coprime_prod_of_coprime_insert [decidable_eq α] (s : finset α) (i : α → ℕ) (p : α)
+lemma prime_pow_coprime_prod_of_coprime_insert [decidable_eq α] {s : finset α} (i : α → ℕ) (p : α)
   (hps : p ∉ s) (is_prime : ∀ q ∈ insert p s, prime q)
   (is_coprime : ∀ (q q' ∈ insert p s), q ∣ q' → q = q') :
   ∀ (q : α), q ∣ p ^ i p → q ∣ ∏ p' in s, p' ^ i p' → is_unit q :=


### PR DESCRIPTION
Two pairs of lemmas for unique factorization domains, where we can show that a property holds on all elements, or a function is multiplicative, by showing this works on base cases, products of coprime elements and powers of prime elements.

We will use the last result to show the ideal norm is a multiplicative map.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
