### PR TITLE
[Merged by Bors] - feat(group_theory/p_group): If `p ∤ n`, then the `n`th power map is a bijection

### DIFF
--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -91,7 +91,7 @@ hG.of_surjective (quotient_group.mk' H) quotient.surjective_quotient_mk'
 lemma of_equiv {H : Type*} [group H] (ϕ : G ≃* H) : is_p_group p H :=
 hG.of_surjective ϕ.to_monoid_hom ϕ.surjective
 
-lemma pow_bijective' {n : ℕ} (hn : nat.coprime p n) : function.bijective ((^ n) : G → G) :=
+lemma pow_bijective' {n : ℕ} (hn : p.coprime n) : function.bijective ((^ n) : G → G) :=
 begin
   have : ∀ g : G, (nat.card (subgroup.zpowers g)).coprime n := λ g, let ⟨k, hk⟩ := hG g in
   order_eq_card_zpowers' g ▸ (hn.pow_left k).coprime_dvd_left (order_of_dvd_of_pow_eq_one hk),

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -20,6 +20,29 @@ then the number of fixed points of the action is congruent mod `p` to the cardin
 It also contains proofs of some corollaries of this lemma about existence of fixed points.
 -/
 
+namespace nat
+
+lemma xgcd_one_left {s t r' s' t'} : xgcd_aux 1 s t r' s' t' = (1, s, t) :=
+by simp only [xgcd_aux, mod_one]
+
+@[simp] theorem gcd_a_one_left {s : ℕ} : gcd_a 1 s = 1 :=
+by rw [gcd_a, xgcd, xgcd_one_left]
+
+@[simp] theorem gcd_b_one_left {s : ℕ} : gcd_b 1 s = 0 :=
+by rw [gcd_b, xgcd, xgcd_one_left]
+
+@[simp] theorem gcd_a_one_right : ∀ {s : ℕ}, s ≠ 1 → gcd_a s 1 = 0
+| 0       := λ h, gcd_a_zero_left
+| 1       := λ h, (h rfl).elim
+| (s + 2) := λ h, by simp only [gcd_a, xgcd, xgcd_aux, one_mod, mod_one]; refl
+
+@[simp] theorem gcd_b_one_right : ∀ {s : ℕ}, s ≠ 1 → gcd_b s 1 = 1
+| 0       := λ h, gcd_b_zero_left
+| 1       := λ h, (h rfl).elim
+| (s + 2) := λ h, by simp only [gcd_b, xgcd, xgcd_aux, one_mod, mod_one]; refl
+
+end nat
+
 open_locale big_operators
 
 open fintype mul_action
@@ -91,23 +114,39 @@ hG.of_surjective (quotient_group.mk' H) quotient.surjective_quotient_mk'
 lemma of_equiv {H : Type*} [group H] (ϕ : G ≃* H) : is_p_group p H :=
 hG.of_surjective ϕ.to_monoid_hom ϕ.surjective
 
-lemma pow_bijective' {n : ℕ} (hn : p.coprime n) : function.bijective ((^ n) : G → G) :=
-begin
-  have : ∀ g : G, (nat.card (subgroup.zpowers g)).coprime n := λ g, let ⟨k, hk⟩ := hG g in
-  order_eq_card_zpowers' g ▸ (hn.pow_left k).coprime_dvd_left (order_of_dvd_of_pow_eq_one hk),
-  refine function.bijective_iff_has_inverse.mpr
-    ⟨λ g, (pow_coprime (this g)).symm ⟨g, subgroup.mem_zpowers g⟩, _, _⟩,
-  { refine λ g, subtype.ext_iff.mp ((pow_coprime (this (g ^ n))).left_inv ⟨g, _⟩),
-    exact ⟨_, subtype.ext_iff.mp ((pow_coprime (this g)).left_inv ⟨g, subgroup.mem_zpowers g⟩)⟩ },
-  { exact λ g, subtype.ext_iff.mp ((pow_coprime (this g)).right_inv ⟨g, subgroup.mem_zpowers g⟩) },
-end
+lemma order_of_coprime {n : ℕ} (hn : p.coprime n) (g : G) : (order_of g).coprime n :=
+let ⟨k, hk⟩ := hG g in (hn.pow_left k).coprime_dvd_left (order_of_dvd_of_pow_eq_one hk)
+
+noncomputable def pow_equiv' {n : ℕ} (hn : p.coprime n) : G ≃ G :=
+{ to_fun := (^ n),
+  inv_fun := λ g, g ^ ((order_of g).gcd_b n),
+  left_inv := λ g, by
+  { simp only,
+    by_cases hp : p = 0,
+    { rw [hp, nat.coprime_zero_left] at hn,
+      rw [hn, pow_one],
+      by_cases hg : order_of g = 1,
+      { rwa [hg, nat.gcd_b_one_left, zpow_zero, eq_comm, ←order_of_eq_one_iff] },
+      { rw [nat.gcd_b_one_right hg, zpow_one] } },
+    replace hp := (is_of_fin_order_iff_pow_eq_one g).mpr
+      (let ⟨n, hn'⟩ := hG g in ⟨p ^ n, pow_pos (nat.pos_of_ne_zero hp) n, hn'⟩),
+    have gcd_eq_one : (order_of g).gcd n = 1 := order_of_coprime hG hn g,
+    rw [order_of_pow'' g n hp, gcd_eq_one, nat.div_one],
+    have key := congr_arg ((^) g) ((order_of g).gcd_eq_gcd_ab n),
+    rwa [zpow_add, zpow_mul, zpow_mul, zpow_coe_nat, zpow_coe_nat, zpow_coe_nat,
+      pow_order_of_eq_one, one_zpow, one_mul, gcd_eq_one, pow_one, eq_comm] at key },
+  right_inv := λ g, by
+  { have gcd_eq_one : (order_of g).gcd n = 1 := order_of_coprime hG hn g,
+    have key := congr_arg ((^) g) ((order_of g).gcd_eq_gcd_ab n),
+    rwa [zpow_add, zpow_mul, zpow_mul', zpow_coe_nat, zpow_coe_nat, zpow_coe_nat,
+      pow_order_of_eq_one, one_zpow, one_mul, gcd_eq_one, pow_one, eq_comm] at key } }
 
 variables [hp : fact p.prime]
 
 include hp
 
-lemma pow_bijective {n : ℕ} (hn : ¬ p ∣ n) : function.bijective ((^ n) : G → G) :=
-hG.pow_bijective' (hp.out.coprime_iff_not_dvd.mpr hn)
+noncomputable def pow_equiv {n : ℕ} (hn : ¬ p ∣ n) : G ≃ G :=
+pow_equiv' hG (hp.out.coprime_iff_not_dvd.mpr hn)
 
 lemma index (H : subgroup G) [finite (G ⧸ H)] :
   ∃ n : ℕ, H.index = p ^ n :=

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -119,11 +119,11 @@ include hp
 noncomputable def pow_equiv {n : ℕ} (hn : ¬ p ∣ n) : G ≃ G :=
 pow_equiv' hG (hp.out.coprime_iff_not_dvd.mpr hn)
 
-@[simp] lemma pow_equiv_apply {n : ℕ} (hn : p.coprime n) (g : G) : hG.pow_equiv' hn g = g ^ n :=
+@[simp] lemma pow_equiv_apply {n : ℕ} (hn : ¬ p ∣ n) (g : G) : hG.pow_equiv hn g = g ^ n :=
 hG.pow_equiv'_apply _ g
 
-@[simp] lemma pow_equiv_symm_apply {n : ℕ} (hn : p.coprime n) (g : G) :
-  (hG.pow_equiv' hn).symm g = g ^ (order_of g).gcd_b n :=
+@[simp] lemma pow_equiv_symm_apply {n : ℕ} (hn : ¬ p ∣ n) (g : G) :
+  (hG.pow_equiv hn).symm g = g ^ (order_of g).gcd_b n :=
 hG.pow_equiv'_symm_apply _ g
 
 lemma index (H : subgroup G) [finite (G ⧸ H)] :

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -91,9 +91,23 @@ hG.of_surjective (quotient_group.mk' H) quotient.surjective_quotient_mk'
 lemma of_equiv {H : Type*} [group H] (ϕ : G ≃* H) : is_p_group p H :=
 hG.of_surjective ϕ.to_monoid_hom ϕ.surjective
 
+lemma pow_bijective' {n : ℕ} (hn : nat.coprime p n) : function.bijective ((^ n) : G → G) :=
+begin
+  have : ∀ g : G, (nat.card (subgroup.zpowers g)).coprime n := λ g, let ⟨k, hk⟩ := hG g in
+  order_eq_card_zpowers' g ▸ (hn.pow_left k).coprime_dvd_left (order_of_dvd_of_pow_eq_one hk),
+  refine function.bijective_iff_has_inverse.mpr
+    ⟨λ g, (pow_coprime (this g)).symm ⟨g, subgroup.mem_zpowers g⟩, _, _⟩,
+  { refine λ g, subtype.ext_iff.mp ((pow_coprime (this (g ^ n))).left_inv ⟨g, _⟩),
+    exact ⟨_, subtype.ext_iff.mp ((pow_coprime (this g)).left_inv ⟨g, subgroup.mem_zpowers g⟩)⟩ },
+  { exact λ g, subtype.ext_iff.mp ((pow_coprime (this g)).right_inv ⟨g, subgroup.mem_zpowers g⟩) },
+end
+
 variables [hp : fact p.prime]
 
 include hp
+
+lemma pow_bijective {n : ℕ} (hn : ¬ p ∣ n) : function.bijective ((^ n) : G → G) :=
+hG.pow_bijective' (hp.out.coprime_iff_not_dvd.mpr hn)
 
 lemma index (H : subgroup G) [finite (G ⧸ H)] :
   ∃ n : ℕ, H.index = p ^ n :=

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -95,7 +95,7 @@ lemma order_of_coprime {n : ℕ} (hn : p.coprime n) (g : G) : (order_of g).copri
 let ⟨k, hk⟩ := hG g in (hn.pow_left k).coprime_dvd_left (order_of_dvd_of_pow_eq_one hk)
 
 /-- If `gcd(p,n) = 1`, then the `n`th power map is a bijection. -/
-noncomputable def pow_equiv' {n : ℕ} (hn : p.coprime n) : G ≃ G :=
+noncomputable def pow_equiv {n : ℕ} (hn : p.coprime n) : G ≃ G :=
 let h : ∀ g : G, (nat.card (subgroup.zpowers g)).coprime n :=
   λ g, order_eq_card_zpowers' g ▸ hG.order_of_coprime hn g in
 { to_fun := (^ n),
@@ -104,11 +104,11 @@ let h : ∀ g : G, (nat.card (subgroup.zpowers g)).coprime n :=
     ⟨g, _, subtype.ext_iff.1 $ (pow_coprime (h g)).left_inv ⟨g, subgroup.mem_zpowers g⟩⟩,
   right_inv := λ g, subtype.ext_iff.1 $ (pow_coprime (h g)).right_inv ⟨g, subgroup.mem_zpowers g⟩ }
 
-@[simp] lemma pow_equiv'_apply {n : ℕ} (hn : p.coprime n) (g : G) : hG.pow_equiv' hn g = g ^ n :=
+@[simp] lemma pow_equiv_apply {n : ℕ} (hn : p.coprime n) (g : G) : hG.pow_equiv hn g = g ^ n :=
 rfl
 
-@[simp] lemma pow_equiv'_symm_apply {n : ℕ} (hn : p.coprime n) (g : G) :
-  (hG.pow_equiv' hn).symm g = g ^ (order_of g).gcd_b n :=
+@[simp] lemma pow_equiv_symm_apply {n : ℕ} (hn : p.coprime n) (g : G) :
+  (hG.pow_equiv hn).symm g = g ^ (order_of g).gcd_b n :=
 by rw order_eq_card_zpowers'; refl
 
 variables [hp : fact p.prime]
@@ -116,15 +116,8 @@ variables [hp : fact p.prime]
 include hp
 
 /-- If `p ∤ n`, then the `n`th power map is a bijection. -/
-noncomputable def pow_equiv {n : ℕ} (hn : ¬ p ∣ n) : G ≃ G :=
-pow_equiv' hG (hp.out.coprime_iff_not_dvd.mpr hn)
-
-@[simp] lemma pow_equiv_apply {n : ℕ} (hn : ¬ p ∣ n) (g : G) : hG.pow_equiv hn g = g ^ n :=
-hG.pow_equiv'_apply _ g
-
-@[simp] lemma pow_equiv_symm_apply {n : ℕ} (hn : ¬ p ∣ n) (g : G) :
-  (hG.pow_equiv hn).symm g = g ^ (order_of g).gcd_b n :=
-hG.pow_equiv'_symm_apply _ g
+@[reducible] noncomputable def pow_equiv' {n : ℕ} (hn : ¬ p ∣ n) : G ≃ G :=
+pow_equiv hG (hp.out.coprime_iff_not_dvd.mpr hn)
 
 lemma index (H : subgroup G) [finite (G ⧸ H)] :
   ∃ n : ℕ, H.index = p ^ n :=

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -97,12 +97,19 @@ let ⟨k, hk⟩ := hG g in (hn.pow_left k).coprime_dvd_left (order_of_dvd_of_pow
 /-- If `gcd(p,n) = 1`, then the `n`th power map is a bijection. -/
 noncomputable def pow_equiv' {n : ℕ} (hn : p.coprime n) : G ≃ G :=
 let h : ∀ g : G, (nat.card (subgroup.zpowers g)).coprime n :=
-λ g, order_eq_card_zpowers' g ▸ hG.order_of_coprime hn g in
+  λ g, order_eq_card_zpowers' g ▸ hG.order_of_coprime hn g in
 { to_fun := (^ n),
   inv_fun := λ g, (pow_coprime (h g)).symm ⟨g, subgroup.mem_zpowers g⟩,
   left_inv := λ g, subtype.ext_iff.1 $ (pow_coprime (h (g ^ n))).left_inv
     ⟨g, _, subtype.ext_iff.1 $ (pow_coprime (h g)).left_inv ⟨g, subgroup.mem_zpowers g⟩⟩,
   right_inv := λ g, subtype.ext_iff.1 $ (pow_coprime (h g)).right_inv ⟨g, subgroup.mem_zpowers g⟩ }
+
+@[simp] lemma pow_equiv'_apply {n : ℕ} (hn : p.coprime n) (g : G) : hG.pow_equiv' hn g = g ^ n :=
+rfl
+
+@[simp] lemma pow_equiv'_symm_apply {n : ℕ} (hn : p.coprime n) (g : G) :
+  (hG.pow_equiv' hn).symm g = g ^ (order_of g).gcd_b n :=
+by rw order_eq_card_zpowers'; refl
 
 variables [hp : fact p.prime]
 
@@ -111,6 +118,13 @@ include hp
 /-- If `p ∤ n`, then the `n`th power map is a bijection. -/
 noncomputable def pow_equiv {n : ℕ} (hn : ¬ p ∣ n) : G ≃ G :=
 pow_equiv' hG (hp.out.coprime_iff_not_dvd.mpr hn)
+
+@[simp] lemma pow_equiv_apply {n : ℕ} (hn : p.coprime n) (g : G) : hG.pow_equiv' hn g = g ^ n :=
+hG.pow_equiv'_apply _ g
+
+@[simp] lemma pow_equiv_symm_apply {n : ℕ} (hn : p.coprime n) (g : G) :
+  (hG.pow_equiv' hn).symm g = g ^ (order_of g).gcd_b n :=
+hG.pow_equiv'_symm_apply _ g
 
 lemma index (H : subgroup G) [finite (G ⧸ H)] :
   ∃ n : ℕ, H.index = p ^ n :=

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -94,6 +94,7 @@ hG.of_surjective ϕ.to_monoid_hom ϕ.surjective
 lemma order_of_coprime {n : ℕ} (hn : p.coprime n) (g : G) : (order_of g).coprime n :=
 let ⟨k, hk⟩ := hG g in (hn.pow_left k).coprime_dvd_left (order_of_dvd_of_pow_eq_one hk)
 
+/-- If `gcd(p,n) = 1`, then the `n`th power map is a bijection. -/
 noncomputable def pow_equiv' {n : ℕ} (hn : p.coprime n) : G ≃ G :=
 let h : ∀ g : G, (nat.card (subgroup.zpowers g)).coprime n :=
 λ g, order_eq_card_zpowers' g ▸ hG.order_of_coprime hn g in
@@ -107,6 +108,7 @@ variables [hp : fact p.prime]
 
 include hp
 
+/-- If `p ∤ n`, then the `n`th power map is a bijection. -/
 noncomputable def pow_equiv {n : ℕ} (hn : ¬ p ∣ n) : G ≃ G :=
 pow_equiv' hG (hp.out.coprime_iff_not_dvd.mpr hn)
 


### PR DESCRIPTION
This PR proves that if `p ∤ n`, then the `n`th power map is a bijection.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
