### PR TITLE
feat(tactic/abel): separate out abel_nf

### DIFF
--- a/src/algebra/module/injective.lean
+++ b/src/algebra/module/injective.lean
@@ -325,7 +325,7 @@ def extension_of_max_adjoin (h : module.Baer R Q) (y : N) :
           ↑((extension_of_max_adjoin.fst i a) + (extension_of_max_adjoin.fst i b)) +
           (extension_of_max_adjoin.snd i a + extension_of_max_adjoin.snd i b) • y,
         { rw [extension_of_max_adjoin.eqn, extension_of_max_adjoin.eqn, add_smul],
-          abel, },
+          abel_nf, },
         rw [extension_of_max_adjoin.extension_to_fun_wd i f h (a + b) _ _ eq1,
           linear_pmap.map_add, map_add],
         unfold extension_of_max_adjoin.extension_to_fun,

--- a/src/algebra/star/chsh.lean
+++ b/src/algebra/star/chsh.lean
@@ -198,7 +198,7 @@ begin
     -- move Aᵢ to the left of Bᵢ
     simp only [←T.A₀B₀_commutes, ←T.A₀B₁_commutes, ←T.A₁B₀_commutes, ←T.A₁B₁_commutes],
     -- collect terms, simplify coefficients, and collect terms again:
-    abel,
+    abel_nf,
     -- all terms coincide, but the last one. Simplify all other terms
     simp only [M],
     simp only [neg_mul, int.cast_bit0, one_mul, mul_inv_cancel_of_invertible,

--- a/src/analysis/calculus/fderiv_symmetric.lean
+++ b/src/analysis/calculus/fderiv_symmetric.lean
@@ -319,7 +319,7 @@ begin
   simp only [continuous_linear_map.map_add, continuous_linear_map.map_smul, smul_add, smul_smul,
     continuous_linear_map.add_apply, pi.smul_apply, continuous_linear_map.coe_smul', C] at this,
   rw ← sub_eq_zero at this,
-  abel at this,
+  abel_nf at this,
   simp only [one_zsmul, neg_smul, sub_eq_zero, mul_comm, ← sub_eq_add_neg] at this,
   apply smul_right_injective F _ this,
   simp [(tpos v).ne', (tpos w).ne']

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -602,7 +602,7 @@ begin
   have hg : ∀ x ∈ s, has_fderiv_within_at g (f' x - φ) s x :=
     λ x xs, (hf x xs).sub φ.has_fderiv_within_at,
   calc ∥f y - f x - φ (y - x)∥ = ∥f y - f x - (φ y - φ x)∥ : by simp
-  ... = ∥(f y - φ y) - (f x - φ x)∥ : by abel
+  ... = ∥(f y - φ y) - (f x - φ x)∥ : by abel_nf
   ... = ∥g y - g x∥ : by simp
   ... ≤ C * ∥y - x∥ : convex.norm_image_sub_le_of_norm_has_fderiv_within_le hg bound hs xs ys,
 end

--- a/src/analysis/normed/group/hom_completion.lean
+++ b/src/analysis/normed/group/hom_completion.lean
@@ -225,7 +225,7 @@ begin
       rw normed_add_group_hom.comp_range,
       apply add_subgroup.mem_map_of_mem,
       simp only [incl_range, mem_ker] },
-    { calc ∥hatg - (g - g')∥ = ∥hatg - g + g'∥ : by abel
+    { calc ∥hatg - (g - g')∥ = ∥hatg - g + g'∥ : by abel_nf
       ... ≤ ∥hatg - g∥ + ∥(g' : completion G)∥ : norm_add_le _ _
       ... < δ + C'*∥f∥*∥hatg - g∥ : by linarith
       ... ≤ δ + C'*∥f∥*δ : add_le_add_left (mul_le_mul_of_nonneg_left hg.le hCf) δ

--- a/src/group_theory/specific_groups/quaternion.lean
+++ b/src/group_theory/specific_groups/quaternion.lean
@@ -89,7 +89,7 @@ instance : group (quaternion_group n) :=
     begin
       rintros (i | i) (j | j) (k | k);
       simp only [mul];
-      abel,
+      abel_nf,
       simp only [neg_mul, one_mul, int.cast_one, zsmul_eq_mul, int.cast_neg,
                  add_right_inj],
       calc -(n : zmod (2 * n)) = 0 - n : by rw zero_sub

--- a/src/ring_theory/ore_localization/basic.lean
+++ b/src/ring_theory/ore_localization/basic.lean
@@ -446,7 +446,7 @@ begin
   symmetry, rw ore_div_eq_iff,
   use sc * sd, use rc * sd,
   split; simp only [submonoid.coe_mul],
-  { noncomm_ring, assoc_rw [hd, hc], noncomm_ring },
+  { simp only [add_mul], assoc_rw [hd, hc], noncomm_ring },
   { assoc_rewrite [hc], noncomm_ring }
 end
 

--- a/src/ring_theory/ore_localization/basic.lean
+++ b/src/ring_theory/ore_localization/basic.lean
@@ -530,7 +530,7 @@ begin
   rcases ore_div_add_char' r₂ r₃ s₂ s₃ with ⟨rb, sb, hb, hb'⟩, rw hb', clear hb',
   rcases ore_div_add_char' (r₁ * sa + r₂ * ra) r₃ (s₁ * sa) s₃ with ⟨rc, sc, hc, q⟩, rw q, clear q,
   rcases ore_div_add_char' r₁ (r₂ * sb + r₃ * rb) s₁ (s₂ * sb) with ⟨rd, sd, hd, q⟩, rw q, clear q,
-  noncomm_ring, rw add_comm (r₂ * _),
+  noncomm_ring_nf, rw add_comm (r₂ * _),
   repeat { rw ←add_ore_div },
   congr' 1,
   { rcases ore_condition (sd : R) (sa * sc) with ⟨re, se, he⟩,

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -422,7 +422,7 @@ match loc with
 | _ := failed
 end <|>
 do abel_nf red SOP loc,
-   fail "Try this: abel_nf"
+   trace "Try this: abel_nf"
 
 
 add_tactic_doc

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -422,7 +422,7 @@ match loc with
 | _ := failed
 end <|>
 do abel_nf red SOP loc,
-   trace "Try this: abel_nf"
+   fail "Try this: abel_nf"
 
 
 add_tactic_doc

--- a/src/tactic/noncomm_ring.lean
+++ b/src/tactic/noncomm_ring.lean
@@ -8,15 +8,11 @@ import tactic.abel
 namespace tactic
 namespace interactive
 
-/-- A tactic for simplifying identities in not-necessarily-commutative rings.
-
-An example:
-```lean
-example {R : Type*} [ring R] (a b c : R) : a * (b + c + c - b) = 2*a*c :=
-by noncomm_ring
-```
+/--
+Try to simplify expressions in a not-necessarily-commutative ring.
+This does not achieve a normal form for such expressions.
 -/
-meta def noncomm_ring :=
+meta def noncomm_ring_simp :=
 `[simp only [-- Expand everything out.
              add_mul, mul_add, sub_eq_add_neg,
              -- Right associate all products.
@@ -28,8 +24,42 @@ meta def noncomm_ring :=
              -- Pull `zsmul n` out the front so `abel` can see them.
              mul_smul_comm, smul_mul_assoc,
              -- Pull out negations.
-             neg_mul, mul_neg] {fail_if_unchanged := ff};
-  abel]
+             neg_mul, mul_neg] {fail_if_unchanged := ff}]
+
+/--
+A tactic for solving identities in not-necessarily-commutative rings.
+It is not a complete decision procedure.
+
+An example:
+```lean
+example {R : Type*} [ring R] (a b c : R) : a * (b + c + c - b) = 2*a*c :=
+by noncomm_ring
+```
+-/
+meta def noncomm_ring1 :=
+noncomm_ring_simp >> (done <|> `[abel1])
+
+/--
+A tactic for simplifying expressions in not-necessarily-commutative rings.
+Unlike `ring_nf`, there is not a normal form for expressions,
+so it may fail to solve some identities.
+
+An example:
+```lean
+example {R : Type*} [ring R] (a b c : R) : a * (b + c + c - b) = 2*a*c :=
+by noncomm_ring
+```
+-/
+meta def noncomm_ring_nf :=
+noncomm_ring_simp >> (done <|> `[abel_nf])
+
+/--
+A tactic for solving identities and simplifying expressions in not-necessarily-commutative rings.
+Unlike `ring`, there is not a normal form for expressions,
+and in particular not all identites can be solved.
+-/
+meta def noncomm_ring :=
+noncomm_ring_simp >> (done <|> `[abel1] <|> (`[abel_nf] >> trace "Try this: noncomm_ring_nf"))
 
 add_tactic_doc
 { name       := "noncomm_ring",

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -15,6 +15,6 @@ example [add_comm_group α] (n : ℕ) (a : α) : 0 + n • a = n • a := by abe
 def id' (x : α) := x
 example [add_comm_group α] : a + b - b - id' a = 0 :=
 begin
-  success_if_fail { abel; done },
-  abel!
+  success_if_fail { abel_nf; done },
+  abel_nf!,
 end


### PR DESCRIPTION
This makes `abel` behave in a parallel fashion to `ring`.

`abel1` and `abel_nf` are the basic functions, which respectively solve equations and rewrite into normal form.

Then `abel` is just a wrapper, which tries `abel1`, and if that fails tries `abel_nf`. If `abel_nf` succeeds, it prints a `Try this: abel_nf` message.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
