### PR TITLE
[Merged by Bors] - feat(combinatorics/simple_graph/connectivity): `concat` and `concat_rec`

### DIFF
--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -352,7 +352,7 @@ lemma concat_rec_aux_concat {u v w : V} (p : G.walk u v) (h : G.adj v w) :
 begin
   transitivity concat_rec_aux @Hnil @Hconcat (cons h.symm p.reverse),
   { congr, simp },
-  simp [concat_rec_aux],
+  simp [concat_rec_aux, rec_heq_iff_heq],
 end
 
 /-- Recursor on walks by inducting on `simple_graph.walk.concat`. -/
@@ -370,9 +370,8 @@ begin
   simp only [concat_rec],
   apply eq_of_heq,
   apply rec_heq_of_heq,
-  have := concat_rec_aux_concat @Hnil @Hconcat p h,
-  refine heq.trans this _,
-  congr; simp,
+  refine heq.trans (concat_rec_aux_concat @Hnil @Hconcat p h) _,
+  congr; simp [heq_rec_iff_heq],
 end
 
 end concat_rec

--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -228,7 +228,7 @@ lemma concat_append {u v w x : V} (p : G.walk u v) (h : G.adj v w) (q : G.walk w
 by rw [concat_eq_append, ← append_assoc, cons_nil_append]
 
 /-- A non-trivial `cons` walk is representable as a `concat` walk. -/
-def exists_cons_eq_concat : Π {u v w : V} (h : G.adj u v) (p : G.walk v w),
+lemma exists_cons_eq_concat : Π {u v w : V} (h : G.adj u v) (p : G.walk v w),
   ∃ (x : V) (q : G.walk u x) (h' : G.adj x w), cons h p = q.concat h'
 | _ _ _ h nil := ⟨_, nil, h, rfl⟩
 | _ _ _ h (cons h' p) :=
@@ -239,7 +239,7 @@ def exists_cons_eq_concat : Π {u v w : V} (h : G.adj u v) (p : G.walk v w),
   end
 
 /-- A non-trivial `concat` walk is representable as a `cons` walk. -/
-def concat_eq_cons : Π {u v w : V} (p : G.walk u v) (h : G.adj v w),
+lemma exists_concat_eq_cons : Π {u v w : V} (p : G.walk u v) (h : G.adj v w),
   ∃ (x : V) (h' : G.adj u x) (q : G.walk x w), p.concat h = cons h' q
 | _ _ _ nil h := ⟨_, h, nil, rfl⟩
 | _ _ _ (cons h' p) h := ⟨_, h', walk.concat p h, concat_cons _ _ _⟩

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -908,6 +908,14 @@ lemma rec_heq_of_heq {β} {C : α → Sort*} {x : C a} {y : β} (eq : a = b) (h 
   @eq.rec α a C x b eq == y :=
 by subst eq; exact h
 
+@[simp] lemma rec_heq_iff_heq {β} {C : α → Sort*} {x : C a} {y : β} {eq : a = b} :
+  @eq.rec α a C x b eq == y ↔ x == y :=
+by subst eq
+
+@[simp] lemma heq_rec_iff_heq {β} {C : α → Sort*} {x : β} {y : C a} {eq : a = b} :
+  x == @eq.rec α a C y b eq ↔ x == y :=
+by subst eq
+
 protected lemma eq.congr {x₁ x₂ y₁ y₂ : α} (h₁ : x₁ = y₁) (h₂ : x₂ = y₂) :
   (x₁ = x₂) ↔ (y₁ = y₂) :=
 by { subst h₁, subst h₂ }

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -904,17 +904,17 @@ lemma heq_of_cast_eq :
 lemma cast_eq_iff_heq {α β : Sort*} {a : α} {a' : β} {e : α = β} : cast e a = a' ↔ a == a' :=
 ⟨heq_of_cast_eq _, λ h, by cases h; refl⟩
 
-lemma rec_heq_of_heq {β} {C : α → Sort*} {x : C a} {y : β} (eq : a = b) (h : x == y) :
-  @eq.rec α a C x b eq == y :=
-by subst eq; exact h
+lemma rec_heq_of_heq {β} {C : α → Sort*} {x : C a} {y : β} (e : a = b) (h : x == y) :
+  @eq.rec α a C x b e == y :=
+by subst e; exact h
 
-lemma rec_heq_iff_heq {β} {C : α → Sort*} {x : C a} {y : β} {eq : a = b} :
-  @eq.rec α a C x b eq == y ↔ x == y :=
-by subst eq
+lemma rec_heq_iff_heq {β} {C : α → Sort*} {x : C a} {y : β} {e : a = b} :
+  @eq.rec α a C x b e == y ↔ x == y :=
+by subst e
 
-lemma heq_rec_iff_heq {β} {C : α → Sort*} {x : β} {y : C a} {eq : a = b} :
-  x == @eq.rec α a C y b eq ↔ x == y :=
-by subst eq
+lemma heq_rec_iff_heq {β} {C : α → Sort*} {x : β} {y : C a} {e : a = b} :
+  x == @eq.rec α a C y b e ↔ x == y :=
+by subst e
 
 protected lemma eq.congr {x₁ x₂ y₁ y₂ : α} (h₁ : x₁ = y₁) (h₂ : x₂ = y₂) :
   (x₁ = x₂) ↔ (y₁ = y₂) :=

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -908,11 +908,11 @@ lemma rec_heq_of_heq {β} {C : α → Sort*} {x : C a} {y : β} (eq : a = b) (h 
   @eq.rec α a C x b eq == y :=
 by subst eq; exact h
 
-@[simp] lemma rec_heq_iff_heq {β} {C : α → Sort*} {x : C a} {y : β} {eq : a = b} :
+lemma rec_heq_iff_heq {β} {C : α → Sort*} {x : C a} {y : β} {eq : a = b} :
   @eq.rec α a C x b eq == y ↔ x == y :=
 by subst eq
 
-@[simp] lemma heq_rec_iff_heq {β} {C : α → Sort*} {x : β} {y : C a} {eq : a = b} :
+lemma heq_rec_iff_heq {β} {C : α → Sort*} {x : β} {y : C a} {eq : a = b} :
   x == @eq.rec α a C y b eq ↔ x == y :=
 by subst eq
 


### PR DESCRIPTION
Adds the alternative constructor for walks along with its recursion principle. (Borrowed from lean2/hott.)

Co-authored-by: Floris van Doorn <fpvdoorn@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
