### PR TITLE
[Merged by Bors] - doc(ring_theory/valuation/valuation_ring): Value "group" is a group with zero

### DIFF
--- a/src/ring_theory/valuation/valuation_ring.lean
+++ b/src/ring_theory/valuation/valuation_ring.lean
@@ -29,7 +29,6 @@ We also provide the equivalence of the following notions for a domain `R` in `va
 3. "divides" is a total relation on the elements of `R`.
 4. "contains" is a total relation on the ideals of `R`.
 5. `R` is a local bezout domain.
-value_group
 -/
 
 universes u v w

--- a/src/ring_theory/valuation/valuation_ring.lean
+++ b/src/ring_theory/valuation/valuation_ring.lean
@@ -29,6 +29,7 @@ We also provide the equivalence of the following notions for a domain `R` in `va
 3. "divides" is a total relation on the elements of `R`.
 4. "contains" is a total relation on the ideals of `R`.
 5. `R` is a local bezout domain.
+
 -/
 
 universes u v w

--- a/src/ring_theory/valuation/valuation_ring.lean
+++ b/src/ring_theory/valuation/valuation_ring.lean
@@ -29,7 +29,7 @@ We also provide the equivalence of the following notions for a domain `R` in `va
 3. "divides" is a total relation on the elements of `R`.
 4. "contains" is a total relation on the ideals of `R`.
 5. `R` is a local bezout domain.
-
+value_group
 -/
 
 universes u v w
@@ -45,7 +45,7 @@ section
 variables (A : Type u) [comm_ring A]
 variables (K : Type v) [field K] [algebra A K]
 
-/-- The value group of the valuation ring `A`. -/
+/-- The value group of the valuation ring `A`. Note: this is actually a group with zero. -/
 def value_group : Type v := quotient (mul_action.orbit_rel Aˣ K)
 
 instance : inhabited (value_group A K) := ⟨quotient.mk' 0⟩


### PR DESCRIPTION
I trust that Adam is using the correct naming conventions to be found in the literature, but I think it's worth clarifying that `valuation_ring.value_group` is not actually a group, it's a group with zero. See the `valuation_ring.value_group.linear_ordered_comm_group_with_zero` at https://github.com/leanprover-community/mathlib/blob/3248c5207364d38c1e2e6a29588ffd77b1906710/src/ring_theory/valuation/valuation_ring.lean#L120

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
