### PR TITLE
feat(data/finsupp): generalise support in finsupp

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -729,8 +729,8 @@ by { ext, refl }
 begin
   rcases eq_or_ne m 0 with rfl | hm,
   { simp only [single_zero, comap_domain_zero] },
-  { rw [eq_single_iff, comap_domain_apply, comap_domain_support, ← finset.coe_subset, coe_preimage,
-      support_single_ne_zero _ hm, coe_singleton, coe_singleton, single_eq_same],
+  { rw [eq_single_iff, comap_domain_apply, support_def, comap_domain_support, ← finset.coe_subset,
+      coe_preimage, support_single_ne_zero _ hm, coe_singleton, coe_singleton, single_eq_same],
     rw [support_single_ne_zero _ hm, coe_singleton] at hif,
     exact ⟨λ x hx, hif hx rfl hx, rfl⟩ }
 end
@@ -1571,7 +1571,7 @@ begin
   rw [split_support, mem_image, ne.def, ← support_eq_empty, ← ne.def,
     ← finset.nonempty_iff_ne_empty, split, comap_domain, finset.nonempty],
   simp only [exists_prop, finset.mem_preimage, exists_and_distrib_right, exists_eq_right,
-    mem_support_iff, sigma.exists, ne.def]
+    mem_support_iff, sigma.exists, ne.def, coe_mk],
 end
 
 /-- Given `l`, a finitely supported function from the sigma type `Σ i, αs i` to `β` and

--- a/src/data/finsupp/defs.lean
+++ b/src/data/finsupp/defs.lean
@@ -84,21 +84,73 @@ open_locale classical big_operators
 
 variables {α β γ ι M M' N P G H R S : Type*}
 
-/-- `finsupp α M`, denoted `α →₀ M`, is the type of functions `f : α → M` such that
-  `f x = 0` for all but finitely many `x`. -/
-structure finsupp (α : Type*) (M : Type*) [has_zero M] :=
+/-- `finsupp' α M v` is the type of functions `f : α → M` such that
+  `f x = v` for all but finitely many `x`. -/
+structure finsupp' (α : Type*) (M : Type*) (v : M) :=
 (support            : finset α)
 (to_fun             : α → M)
-(mem_support_to_fun : ∀a, a ∈ support ↔ to_fun a ≠ 0)
+(mem_support_to_fun : ∀a, a ∈ support ↔ to_fun a ≠ v)
+
+/-- `finsupp α M`, denoted `α →₀ M`, is the type of functions `f : α → M` such that
+  `f x = 0` for all but finitely many `x`. -/
+def finsupp (α : Type*) (M : Type*) [has_zero M] :=
+finsupp' α M 0
 
 infixr ` →₀ `:25 := finsupp
 
+namespace finsupp'
+
+/-! ### Basic declarations about `finsupp'` -/
+
+section basic
+variables {v : M}
+
+instance fun_like : fun_like (finsupp' α M v) α (λ _, M) := ⟨to_fun, begin
+  rintro ⟨s, f, hf⟩ ⟨t, g, hg⟩ (rfl : f = g),
+  congr',
+  ext a,
+  exact (hf _).trans (hg _).symm,
+end⟩
+
+/-- Helper instance for when there are too many metavariables to apply `fun_like.has_coe_to_fun`
+directly. -/
+instance : has_coe_to_fun (finsupp' α M v) (λ _, α → M) := fun_like.has_coe_to_fun
+
+@[ext] lemma ext {f g : finsupp' α M v} (h : ∀ a, f a = g a) : f = g := fun_like.ext _ _ h
+
+@[simp] lemma coe_mk (f : α → M) (s : finset α) (h : ∀ a, a ∈ s ↔ f a ≠ v) :
+  ⇑(⟨s, f, h⟩ : finsupp' α M v) = f := rfl
+
+instance : inhabited (finsupp' α M v) := ⟨⟨∅, λ _, v, λ _, ⟨false.elim, λ H, H rfl⟩⟩⟩
+
+@[simp] lemma mem_support_iff {f : finsupp' α M v} : ∀{a:α}, a ∈ f.support ↔ f a ≠ v :=
+f.mem_support_to_fun
+
+lemma not_mem_support_iff {f : finsupp' α M v} {a} : a ∉ f.support ↔ f a = v :=
+not_iff_comm.1 mem_support_iff.symm
+
+end basic
+
+end finsupp'
+
 namespace finsupp
+
+open finsupp'
 
 /-! ### Basic declarations about `finsupp` -/
 
 section basic
 variable [has_zero M]
+
+/-! We expose fields of `finsupp'` in a more convenient way for the `finsupp` API. -/
+
+abbreviation to_fun : (α →₀ M) → α → M := finsupp'.to_fun
+abbreviation support : (α →₀ M) → finset α := finsupp'.support
+abbreviation mem_support_to_fun : ∀ (f : α →₀ M), ∀a, a ∈ f.support ↔ f.to_fun a ≠ 0 :=
+finsupp'.mem_support_to_fun
+
+lemma to_fun_def (f : α →₀ M) : f.to_fun = finsupp'.to_fun f := rfl
+lemma support_def (f : α →₀ M) : f.support = finsupp'.support f := rfl
 
 instance fun_like : fun_like (α →₀ M) α (λ _, M) := ⟨to_fun, begin
   rintro ⟨s, f, hf⟩ ⟨t, g, hg⟩ (rfl : f = g),
@@ -123,6 +175,9 @@ lemma congr_fun {f g : α →₀ M} (h : f = g) (a : α) : f a = g a := fun_like
 
 @[simp] lemma coe_mk (f : α → M) (s : finset α) (h : ∀ a, a ∈ s ↔ f a ≠ 0) :
   ⇑(⟨s, f, h⟩ : α →₀ M) = f := rfl
+
+@[simp] lemma to_fun_mk (f : α → M) (s : finset α) (h : ∀ a, a ∈ s ↔ f a ≠ 0) :
+  to_fun (⟨s, f, h⟩ : finsupp' α M 0) = f := rfl
 
 instance : has_zero (α →₀ M) := ⟨⟨∅, 0, λ _, ⟨false.elim, λ H, H rfl⟩⟩⟩
 

--- a/src/data/finsupp/defs.lean
+++ b/src/data/finsupp/defs.lean
@@ -144,9 +144,11 @@ variable [has_zero M]
 
 /-! We expose fields of `finsupp'` in a more convenient way for the `finsupp` API. -/
 
+/-- Coerces a finitely supported function into the function itself. -/
 abbreviation to_fun : (α →₀ M) → α → M := finsupp'.to_fun
+/-- The finite set of values on which this function takes nonzero values. -/
 abbreviation support : (α →₀ M) → finset α := finsupp'.support
-abbreviation mem_support_to_fun : ∀ (f : α →₀ M), ∀a, a ∈ f.support ↔ f.to_fun a ≠ 0 :=
+lemma mem_support_to_fun : ∀ (f : α →₀ M), ∀a, a ∈ f.support ↔ f.to_fun a ≠ 0 :=
 finsupp'.mem_support_to_fun
 
 lemma to_fun_def (f : α →₀ M) : f.to_fun = finsupp'.to_fun f := rfl

--- a/src/data/finsupp/fin.lean
+++ b/src/data/finsupp/fin.lean
@@ -53,7 +53,7 @@ begin
   simp only [finsupp.cons, fin.cons, finsupp.tail, fin.tail],
   ext,
   simp only [equiv_fun_on_fintype_symm_apply_to_fun, equiv.inv_fun_as_coe,
-    finsupp.coe_mk, fin.cases_succ, equiv_fun_on_fintype],
+    finsupp.to_fun_mk, fin.cases_succ, equiv_fun_on_fintype],
   refl,
 end
 

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -289,7 +289,7 @@ variables (σ) (R)
 /-- The constant multivariate formal power series.-/
 def C : R →+* mv_power_series σ R :=
 { map_one' := rfl,
-  map_mul' := λ a b, (monomial_mul_monomial 0 0 a b).symm,
+  map_mul' := λ a b, by simpa only [zero_add] using (monomial_mul_monomial (0 : σ →₀ ℕ) 0 a b).symm,
   map_zero' := (monomial R (0 : _)).map_zero,
   .. monomial R (0 : σ →₀ ℕ) }
 


### PR DESCRIPTION
Add a structure `finsupp'` which behaves like `finsupp`, except that the `0` is replaced by an arbitrary object `v : M`.

---

Follows from the discussion in [this zulip chat](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Finsupp.20generalisations). This allows generalisation of `finsupp` to, for example, finitely supported functions to an `option M` type.

## Naming and file structure

I'm not convinced that `finsupp'` is an appropriate name for this data structure (but I'm committing as a proof of concept), and I also don't think that my new code is really in the right place. If this PR is accepted, I'm hoping to follow it up with a number of other PRs to transport some of the `finsupp` API into this more general form, keeping the old lemmas accessible under their original names and API. This would mean that there would be a lot of `finsupp'` API, and it probably shouldn't be in a `finsupp` file.

## Merging with `dfinsupp`

Eric Wieser has [this branch](https://github.com/leanprover-community/mathlib/tree/eric-wieser/finsupp-is-dfinsupp) where he turned `finsupp` into a special case of `dfinsupp`. It's possible that if we want to go down that route, it might better to do his refactor first, and then generalise `dfinsupp` into a hypothetical `dfinsupp'`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
