### PR TITLE
chore(category_theory/*): remove transitive imports

### DIFF
--- a/src/category_theory/Fintype.lean
+++ b/src/category_theory/Fintype.lean
@@ -4,11 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Adam Topaz
 -/
 
-import category_theory.concrete_category.basic
-import category_theory.full_subcategory
-import category_theory.skeletal
 import category_theory.elementwise
-import data.fin.basic
 import data.fintype.basic
 
 /-!

--- a/src/category_theory/abelian/exact.lean
+++ b/src/category_theory/abelian/exact.lean
@@ -3,14 +3,9 @@ Copyright (c) 2020 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Adam Topaz, Johan Commelin, Jakob von Raumer
 -/
-import category_theory.abelian.opposite
-import category_theory.limits.constructions.finite_products_of_binary_products
-import category_theory.limits.preserves.shapes.zero
-import category_theory.limits.preserves.shapes.kernels
 import category_theory.preadditive.left_exact
 import category_theory.adjunction.limits
 import algebra.homology.exact
-import tactic.tfae
 
 /-!
 # Exact sequences in abelian categories

--- a/src/category_theory/abelian/ext.lean
+++ b/src/category_theory/abelian/ext.lean
@@ -3,11 +3,8 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Adam Topaz
 -/
-import algebra.category.Group.basic
-import algebra.category.Module.abelian
 import category_theory.functor.left_derived
 import category_theory.linear.yoneda
-import category_theory.abelian.opposite
 import category_theory.abelian.projective
 
 /-!

--- a/src/category_theory/abelian/generator.lean
+++ b/src/category_theory/abelian/generator.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
 import category_theory.abelian.subobject
-import category_theory.limits.essentially_small
 import category_theory.preadditive.injective
 import category_theory.preadditive.generator
 

--- a/src/category_theory/abelian/homology.lean
+++ b/src/category_theory/abelian/homology.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
-import category_theory.abelian.exact
 import category_theory.abelian.pseudoelements
 
 /-!

--- a/src/category_theory/abelian/injective.lean
+++ b/src/category_theory/abelian/injective.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer
 -/
 
-import category_theory.abelian.exact
 import category_theory.preadditive.injective
-import category_theory.preadditive.yoneda
 
 /-!
 # Injective objects in abelian categories

--- a/src/category_theory/abelian/injective_resolution.lean
+++ b/src/category_theory/abelian/injective_resolution.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang, Scott Morrison
 -/
 import category_theory.preadditive.injective_resolution
-import category_theory.abelian.exact
 import algebra.homology.homotopy_category
 
 /-!

--- a/src/category_theory/abelian/left_derived.lean
+++ b/src/category_theory/abelian/left_derived.lean
@@ -7,7 +7,6 @@ Authors: Riccardo Brasca, Adam Topaz
 import category_theory.abelian.homology
 import category_theory.functor.left_derived
 import category_theory.abelian.projective
-import category_theory.limits.constructions.epi_mono
 
 /-!
 # Zeroth left derived functors

--- a/src/category_theory/abelian/non_preadditive.lean
+++ b/src/category_theory/abelian/non_preadditive.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
-import category_theory.limits.shapes.finite_products
-import category_theory.limits.shapes.kernels
 import category_theory.limits.shapes.normal_mono.equalizers
 import category_theory.abelian.images
 import category_theory.preadditive

--- a/src/category_theory/abelian/opposite.lean
+++ b/src/category_theory/abelian/opposite.lean
@@ -6,7 +6,6 @@ Authors: Scott Morrison
 import category_theory.abelian.basic
 import category_theory.preadditive.opposite
 import category_theory.limits.opposites
-import category_theory.limits.constructions.limits_of_products_and_equalizers
 
 /-!
 # The opposite of an abelian category is abelian.

--- a/src/category_theory/abelian/projective.lean
+++ b/src/category_theory/abelian/projective.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Scott Morrison, Jakob von Raumer
 -/
-import category_theory.abelian.exact
 import category_theory.preadditive.projective_resolution
 
 /-!

--- a/src/category_theory/abelian/pseudoelements.lean
+++ b/src/category_theory/abelian/pseudoelements.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
-import category_theory.abelian.exact
-import category_theory.over
 import algebra.category.Module.abelian
 
 /-!

--- a/src/category_theory/abelian/right_derived.lean
+++ b/src/category_theory/abelian/right_derived.lean
@@ -4,10 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang, Scott Morrison
 -/
 import category_theory.abelian.injective_resolution
-import algebra.homology.additive
-import category_theory.limits.constructions.epi_mono
 import category_theory.abelian.homology
-import category_theory.abelian.exact
 
 /-!
 # Right-derived functors

--- a/src/category_theory/adjunction/comma.lean
+++ b/src/category_theory/adjunction/comma.lean
@@ -3,8 +3,6 @@ Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.adjunction.basic
-import category_theory.punit
 import category_theory.structured_arrow
 
 /-!

--- a/src/category_theory/adjunction/evaluation.lean
+++ b/src/category_theory/adjunction/evaluation.lean
@@ -5,7 +5,6 @@ Authors: Adam Topaz
 -/
 
 import category_theory.limits.shapes.products
-import category_theory.functor.epi_mono
 
 /-!
 

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.adjunction.basic
 import category_theory.conj
 import category_theory.yoneda
 

--- a/src/category_theory/adjunction/lifting.lean
+++ b/src/category_theory/adjunction/lifting.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.limits.shapes.equalizers
-import category_theory.limits.shapes.reflexive
 import category_theory.monad.adjunction
 import category_theory.monad.coequalizer
 

--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Reid Barton. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Johan Commelin
 -/
-import category_theory.adjunction.basic
 import category_theory.limits.creates
 
 /-!

--- a/src/category_theory/adjunction/opposites.lean
+++ b/src/category_theory/adjunction/opposites.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Thomas Read, Andrew Yang
 -/
 
-import category_theory.adjunction.basic
 import category_theory.yoneda
-import category_theory.opposites
 
 /-!
 # Opposite adjunctions

--- a/src/category_theory/adjunction/over.lean
+++ b/src/category_theory/adjunction/over.lean
@@ -3,9 +3,7 @@ Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.limits.shapes.binary_products
 import category_theory.monad.products
-import category_theory.over
 
 /-!
 # Adjunctions related to the over category

--- a/src/category_theory/adjunction/reflective.lean
+++ b/src/category_theory/adjunction/reflective.lean
@@ -5,7 +5,6 @@ Authors: Bhavik Mehta
 -/
 import category_theory.adjunction.fully_faithful
 import category_theory.functor.reflects_isomorphisms
-import category_theory.epi_mono
 
 /-!
 # Reflective functors

--- a/src/category_theory/adjunction/whiskering.lean
+++ b/src/category_theory/adjunction/whiskering.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
 import category_theory.adjunction
-import category_theory.whiskering
 
 /-!
 

--- a/src/category_theory/bicategory/coherence.lean
+++ b/src/category_theory/bicategory/coherence.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yuma Mizuno, Junyan Xu
 -/
 import category_theory.path_category
-import category_theory.functor.fully_faithful
 import category_theory.bicategory.free
 import category_theory.bicategory.locally_discrete
 /-!

--- a/src/category_theory/category/Cat/limit.lean
+++ b/src/category_theory/category/Cat/limit.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.category.Cat
 import category_theory.limits.types
 import category_theory.limits.preserves.basic
 

--- a/src/category_theory/category/Groupoid.lean
+++ b/src/category_theory/category/Groupoid.lean
@@ -5,8 +5,6 @@ Authors: Yury Kudryashov
 -/
 import category_theory.single_obj
 import category_theory.limits.shapes.products
-import category_theory.pi.basic
-import category_theory.limits.is_limit
 
 /-!
 # Category of groupoids

--- a/src/category_theory/category/Quiv.lean
+++ b/src/category_theory/category/Quiv.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.adjunction.basic
 import category_theory.category.Cat
 import category_theory.path_category
 

--- a/src/category_theory/category/basic.lean
+++ b/src/category_theory/category/basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison, Johannes Hölzl, Reid Barton
 -/
 import combinatorics.quiver.basic
-import tactic.basic
 
 /-!
 # Categories

--- a/src/category_theory/category/ulift.lean
+++ b/src/category_theory/category/ulift.lean
@@ -3,8 +3,6 @@ Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
-import category_theory.category.basic
-import category_theory.equivalence
 import category_theory.eq_to_hom
 
 /-!

--- a/src/category_theory/closed/cartesian.lean
+++ b/src/category_theory/closed/cartesian.lean
@@ -4,12 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Edward Ayers, Thomas Read
 -/
 
-import category_theory.epi_mono
 import category_theory.limits.shapes.finite_products
 import category_theory.monoidal.of_has_finite_products
 import category_theory.limits.preserves.shapes.binary_products
-import category_theory.adjunction.limits
-import category_theory.adjunction.mates
 import category_theory.closed.monoidal
 
 /-!

--- a/src/category_theory/closed/functor.lean
+++ b/src/category_theory/closed/functor.lean
@@ -5,7 +5,6 @@ Authors: Bhavik Mehta
 -/
 
 import category_theory.closed.cartesian
-import category_theory.limits.preserves.shapes.binary_products
 import category_theory.adjunction.fully_faithful
 
 /-!

--- a/src/category_theory/closed/ideal.lean
+++ b/src/category_theory/closed/ideal.lean
@@ -3,11 +3,8 @@ Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.limits.preserves.shapes.binary_products
 import category_theory.limits.constructions.finite_products_of_binary_products
 import category_theory.monad.limits
-import category_theory.adjunction.fully_faithful
-import category_theory.adjunction.reflective
 import category_theory.closed.cartesian
 import category_theory.subterminal
 

--- a/src/category_theory/closed/types.lean
+++ b/src/category_theory/closed/types.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.limits.presheaf
 import category_theory.limits.preserves.functor_category
 import category_theory.limits.shapes.types
 import category_theory.closed.cartesian

--- a/src/category_theory/closed/zero.lean
+++ b/src/category_theory/closed/zero.lean
@@ -6,8 +6,6 @@ Authors: Bhavik Mehta
 
 import category_theory.closed.cartesian
 import category_theory.limits.shapes.zero_morphisms
-import category_theory.punit
-import category_theory.conj
 
 /-!
 # A cartesian closed category with zero object is trivial

--- a/src/category_theory/comma.lean
+++ b/src/category_theory/comma.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Johan Commelin, Bhavik Mehta
 -/
-import category_theory.isomorphism
-import category_theory.functor.category
 import category_theory.eq_to_hom
 
 /-!

--- a/src/category_theory/concrete_category/basic.lean
+++ b/src/category_theory/concrete_category/basic.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Johannes Hölzl, Reid Barton, Sean Leather, Yury Kudryashov
 -/
-import category_theory.types
-import category_theory.functor.epi_mono
 import category_theory.limits.constructions.epi_mono
 
 /-!

--- a/src/category_theory/concrete_category/bundled_hom.lean
+++ b/src/category_theory/concrete_category/bundled_hom.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Yury Kudryashov
 -/
 import category_theory.concrete_category.basic
-import category_theory.concrete_category.bundled
 
 /-!
 # Category instances for algebraic structures that use bundled homs.

--- a/src/category_theory/concrete_category/elementwise.lean
+++ b/src/category_theory/concrete_category/elementwise.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
 import tactic.elementwise
-import category_theory.limits.has_limits
 import category_theory.limits.shapes.kernels
 
 /-!

--- a/src/category_theory/concrete_category/reflects_isomorphisms.lean
+++ b/src/category_theory/concrete_category/reflects_isomorphisms.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.concrete_category.basic
-import category_theory.functor.reflects_isomorphisms
 
 /-!
 A `forget₂ C D` forgetful functor between concrete categories `C` and `D`

--- a/src/category_theory/connected_components.lean
+++ b/src/category_theory/connected_components.lean
@@ -3,11 +3,8 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import data.list.chain
-import category_theory.punit
 import category_theory.is_connected
 import category_theory.sigma.basic
-import category_theory.full_subcategory
 
 /-!
 # Connected components of a category

--- a/src/category_theory/core.lean
+++ b/src/category_theory/core.lean
@@ -3,9 +3,6 @@ Copyright (c) 2019 Scott Morrison All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import control.equiv_functor
-import category_theory.groupoid
-import category_theory.whiskering
 import category_theory.types
 
 /-!

--- a/src/category_theory/differential_object.lean
+++ b/src/category_theory/differential_object.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import data.int.basic
 import category_theory.shift
 import category_theory.concrete_category.basic
 

--- a/src/category_theory/elements.lean
+++ b/src/category_theory/elements.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.structured_arrow
-import category_theory.groupoid
-import category_theory.punit
 
 /-!
 # The category of elements

--- a/src/category_theory/endofunctor/algebra.lean
+++ b/src/category_theory/endofunctor/algebra.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Bhavik Mehta, Johan Commelin, Reid Barton, Rob Lewis, Joseph Hua
 -/
 import category_theory.limits.final
-import category_theory.functor.reflects_isomorphisms
 
 /-!
 

--- a/src/category_theory/endomorphism.lean
+++ b/src/category_theory/endomorphism.lean
@@ -3,10 +3,7 @@ Copyright (c) 2019 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Scott Morrison, Simon Hudon
 -/
-import algebra.hom.equiv
 import category_theory.groupoid
-import category_theory.opposites
-import group_theory.group_action.defs
 
 /-!
 # Endomorphisms

--- a/src/category_theory/epi_mono.lean
+++ b/src/category_theory/epi_mono.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Scott Morrison
 -/
 import category_theory.adjunction.basic
-import category_theory.opposites
 import category_theory.groupoid
 
 /-!

--- a/src/category_theory/equivalence.lean
+++ b/src/category_theory/equivalence.lean
@@ -3,8 +3,6 @@ Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tim Baumann, Stephen Morgan, Scott Morrison, Floris van Doorn
 -/
-import category_theory.functor.fully_faithful
-import category_theory.full_subcategory
 import category_theory.whiskering
 import category_theory.essential_image
 import tactic.slice

--- a/src/category_theory/essential_image.lean
+++ b/src/category_theory/essential_image.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.natural_isomorphism
 import category_theory.full_subcategory
 import data.set.basic
 

--- a/src/category_theory/filtered.lean
+++ b/src/category_theory/filtered.lean
@@ -5,10 +5,7 @@ Authors: Reid Barton, Scott Morrison
 -/
 import category_theory.fin_category
 import category_theory.limits.cones
-import category_theory.adjunction.basic
 import category_theory.category.preorder
-import category_theory.category.ulift
-import order.bounded_order
 
 /-!
 # Filtered categories

--- a/src/category_theory/fin_category.lean
+++ b/src/category_theory/fin_category.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison
 -/
 import data.fintype.basic
 import category_theory.discrete_category
-import category_theory.opposites
 import category_theory.category.ulift
 
 /-!

--- a/src/category_theory/functor/basic.lean
+++ b/src/category_theory/functor/basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tim Baumann, Stephen Morgan, Scott Morrison
 -/
 import tactic.reassoc_axiom
-import category_theory.category.basic
 
 /-!
 # Functors

--- a/src/category_theory/functor/epi_mono.lean
+++ b/src/category_theory/functor/epi_mono.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
-import category_theory.epi_mono
 import category_theory.limits.shapes.strong_epi
 import category_theory.lifting_properties.adjunction
 

--- a/src/category_theory/functor/flat.lean
+++ b/src/category_theory/functor/flat.lean
@@ -4,12 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
 import category_theory.limits.filtered_colimit_commutes_finite_limit
-import category_theory.limits.preserves.functor_category
 import category_theory.limits.preserves.shapes.equalizers
 import category_theory.limits.bicones
 import category_theory.limits.comma
-import category_theory.limits.preserves.finite
-import category_theory.limits.shapes.finite_limits
 
 /-!
 # Representably flat functors

--- a/src/category_theory/functor/hom.lean
+++ b/src/category_theory/functor/hom.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Reid Barton. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Scott Morrison
 -/
-import category_theory.products.basic
 import category_theory.types
 
 /-!

--- a/src/category_theory/functor/reflects_isomorphisms.lean
+++ b/src/category_theory/functor/reflects_isomorphisms.lean
@@ -3,9 +3,7 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.balanced
 import category_theory.functor.epi_mono
-import category_theory.functor.fully_faithful
 
 /-!
 # Functors which reflect isomorphisms

--- a/src/category_theory/generator.lean
+++ b/src/category_theory/generator.lean
@@ -3,12 +3,9 @@ Copyright (c) 2022 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
-import category_theory.balanced
 import category_theory.limits.essentially_small
 import category_theory.limits.opposites
-import category_theory.limits.shapes.zero_morphisms
 import category_theory.subobject.lattice
-import category_theory.subobject.well_powered
 import data.set.opposite
 
 /-!

--- a/src/category_theory/glue_data.lean
+++ b/src/category_theory/glue_data.lean
@@ -3,9 +3,7 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import tactic.elementwise
 import category_theory.limits.shapes.multiequalizer
-import category_theory.limits.constructions.epi_mono
 import category_theory.limits.preserves.limits
 import category_theory.limits.shapes.types
 

--- a/src/category_theory/graded_object.lean
+++ b/src/category_theory/graded_object.lean
@@ -3,9 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import data.int.basic
-import algebra.group_power.lemmas
-import category_theory.pi.basic
 import category_theory.shift
 import category_theory.concrete_category.basic
 

--- a/src/category_theory/grothendieck.lean
+++ b/src/category_theory/grothendieck.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.category.Cat
 import category_theory.elements
 
 /-!

--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -3,10 +3,8 @@ Copyright (c) 2018 Reid Barton All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Scott Morrison, David Wärn
 -/
-import category_theory.full_subcategory
 import category_theory.products.basic
 import category_theory.pi.basic
-import category_theory.category.basic
 import tactic.nth_rewrite
 import combinatorics.quiver.connected_component
 

--- a/src/category_theory/groupoid/free_groupoid.lean
+++ b/src/category_theory/groupoid/free_groupoid.lean
@@ -3,13 +3,10 @@ Copyright (c) 2022 Rémi Bottinelli. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémi Bottinelli
 -/
-import category_theory.category.basic
-import category_theory.functor.basic
 import category_theory.groupoid
 import logic.relation
 import tactic.nth_rewrite
 import category_theory.path_category
-import category_theory.quotient
 
 /-!
 # Free groupoid on a quiver

--- a/src/category_theory/idempotents/functor_extension.lean
+++ b/src/category_theory/idempotents/functor_extension.lean
@@ -5,7 +5,6 @@ Authors: Joël Riou
 -/
 
 import category_theory.idempotents.karoubi
-import category_theory.natural_isomorphism
 
 /-!
 # Extension of functors to the idempotent completion

--- a/src/category_theory/idempotents/karoubi.lean
+++ b/src/category_theory/idempotents/karoubi.lean
@@ -6,7 +6,6 @@ Authors: Joël Riou
 
 import category_theory.idempotents.basic
 import category_theory.preadditive.additive_functor
-import category_theory.equivalence
 
 /-!
 # The Karoubi envelope of a category

--- a/src/category_theory/isomorphism_classes.lean
+++ b/src/category_theory/isomorphism_classes.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import category_theory.category.Cat
-import category_theory.groupoid
-import category_theory.types
 
 /-!
 # Objects of a category up to an isomorphism

--- a/src/category_theory/limits/bicones.lean
+++ b/src/category_theory/limits/bicones.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import category_theory.limits.cones
 import category_theory.structured_arrow
 import category_theory.fin_category
 

--- a/src/category_theory/limits/colimit_limit.lean
+++ b/src/category_theory/limits/colimit_limit.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.limits.types
-import category_theory.functor.currying
 import category_theory.limits.functor_category
 
 /-!

--- a/src/category_theory/limits/comma.lean
+++ b/src/category_theory/limits/comma.lean
@@ -3,13 +3,11 @@ Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.arrow
 import category_theory.limits.constructions.epi_mono
 import category_theory.limits.creates
 import category_theory.limits.preserves.finite
 import category_theory.limits.shapes.finite_limits
 import category_theory.limits.unit
-import category_theory.structured_arrow
 
 /-!
 # Limits and colimits in comma categories

--- a/src/category_theory/limits/concrete_category.lean
+++ b/src/category_theory/limits/concrete_category.lean
@@ -3,9 +3,7 @@ Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Adam Topaz
 -/
-import category_theory.limits.preserves.basic
 import category_theory.limits.types
-import category_theory.limits.shapes.wide_pullbacks
 import category_theory.limits.shapes.multiequalizer
 import category_theory.concrete_category.elementwise
 

--- a/src/category_theory/limits/cone_category.lean
+++ b/src/category_theory/limits/cone_category.lean
@@ -5,7 +5,6 @@ Authors: Andrew Yang
 -/
 import category_theory.adjunction.comma
 import category_theory.limits.preserves.shapes.terminal
-import category_theory.structured_arrow
 import category_theory.limits.shapes.equivalence
 
 /-!

--- a/src/category_theory/limits/cones.lean
+++ b/src/category_theory/limits/cones.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison, Floris van Doorn
 -/
-import category_theory.functor.const
 import category_theory.discrete_category
 import category_theory.yoneda
 import category_theory.functor.reflects_isomorphisms

--- a/src/category_theory/limits/constructions/binary_products.lean
+++ b/src/category_theory/limits/constructions/binary_products.lean
@@ -3,9 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Andrew Yang
 -/
-import category_theory.limits.shapes.terminal
-import category_theory.limits.shapes.pullbacks
-import category_theory.limits.shapes.binary_products
 import category_theory.limits.preserves.shapes.pullbacks
 import category_theory.limits.preserves.shapes.terminal
 

--- a/src/category_theory/limits/constructions/epi_mono.lean
+++ b/src/category_theory/limits/constructions/epi_mono.lean
@@ -3,8 +3,6 @@ Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.limits.shapes.pullbacks
-import category_theory.limits.shapes.binary_products
 import category_theory.limits.preserves.shapes.pullbacks
 
 /-!

--- a/src/category_theory/limits/constructions/equalizers.lean
+++ b/src/category_theory/limits/constructions/equalizers.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Andrew Yang
 -/
 import category_theory.limits.shapes.equalizers
-import category_theory.limits.shapes.binary_products
-import category_theory.limits.shapes.pullbacks
 import category_theory.limits.preserves.shapes.pullbacks
 import category_theory.limits.preserves.shapes.binary_products
 

--- a/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
+++ b/src/category_theory/limits/constructions/finite_products_of_binary_products.lean
@@ -5,9 +5,7 @@ Authors: Bhavik Mehta
 -/
 import category_theory.limits.preserves.shapes.binary_products
 import category_theory.limits.preserves.shapes.products
-import category_theory.limits.shapes.binary_products
 import category_theory.limits.shapes.finite_products
-import category_theory.pempty
 import logic.equiv.fin
 
 /-!

--- a/src/category_theory/limits/constructions/limits_of_products_and_equalizers.lean
+++ b/src/category_theory/limits/constructions/limits_of_products_and_equalizers.lean
@@ -3,9 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Scott Morrison
 -/
-import category_theory.limits.shapes.equalizers
-import category_theory.limits.shapes.finite_products
-import category_theory.limits.preserves.shapes.products
 import category_theory.limits.preserves.shapes.equalizers
 import category_theory.limits.preserves.finite
 import category_theory.limits.constructions.finite_products_of_binary_products

--- a/src/category_theory/limits/constructions/over/default.lean
+++ b/src/category_theory/limits/constructions/over/default.lean
@@ -7,7 +7,6 @@ import category_theory.limits.connected
 import category_theory.limits.constructions.over.products
 import category_theory.limits.constructions.over.connected
 import category_theory.limits.constructions.limits_of_products_and_equalizers
-import category_theory.limits.constructions.equalizers
 
 /-!
 # Limits in the over category

--- a/src/category_theory/limits/constructions/over/products.lean
+++ b/src/category_theory/limits/constructions/over/products.lean
@@ -3,9 +3,6 @@ Copyright (c) 2018 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Reid Barton, Bhavik Mehta
 -/
-import category_theory.over
-import category_theory.limits.shapes.pullbacks
-import category_theory.limits.shapes.wide_pullbacks
 import category_theory.limits.shapes.finite_products
 
 /-!

--- a/src/category_theory/limits/constructions/pullbacks.lean
+++ b/src/category_theory/limits/constructions/pullbacks.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
-import category_theory.limits.shapes.binary_products
 import category_theory.limits.shapes.equalizers
 import category_theory.limits.shapes.pullbacks
 

--- a/src/category_theory/limits/constructions/zero_objects.lean
+++ b/src/category_theory/limits/constructions/zero_objects.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.limits.shapes.pullbacks
 import category_theory.limits.shapes.zero_morphisms
 import category_theory.limits.constructions.binary_products
 

--- a/src/category_theory/limits/final.lean
+++ b/src/category_theory/limits/final.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.punit
-import category_theory.structured_arrow
 import category_theory.is_connected
 import category_theory.limits.yoneda
 import category_theory.limits.types

--- a/src/category_theory/limits/fubini.lean
+++ b/src/category_theory/limits/fubini.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.limits.has_limits
-import category_theory.products.basic
-import category_theory.functor.currying
 
 /-!
 # A Fubini theorem for categorical limits

--- a/src/category_theory/limits/is_limit.lean
+++ b/src/category_theory/limits/is_limit.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Mario Carneiro, Scott Morrison, Floris van Doorn
 -/
-import category_theory.adjunction.basic
 import category_theory.limits.cones
 
 /-!

--- a/src/category_theory/limits/kan_extension.lean
+++ b/src/category_theory/limits/kan_extension.lean
@@ -3,8 +3,6 @@ Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Adam Topaz
 -/
-import category_theory.limits.shapes.terminal
-import category_theory.punit
 import category_theory.structured_arrow
 
 /-!

--- a/src/category_theory/limits/lattice.lean
+++ b/src/category_theory/limits/lattice.lean
@@ -3,9 +3,6 @@ Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Justus Springer
 -/
-import order.complete_lattice
-import category_theory.limits.shapes.pullbacks
-import category_theory.category.preorder
 import category_theory.limits.shapes.products
 import category_theory.limits.shapes.finite_limits
 

--- a/src/category_theory/limits/opposites.lean
+++ b/src/category_theory/limits/opposites.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Floris van Doorn
 -/
 import category_theory.limits.filtered
 import category_theory.limits.shapes.finite_products
-import category_theory.discrete_category
 import tactic.equiv_rw
 
 /-!

--- a/src/category_theory/limits/over.lean
+++ b/src/category_theory/limits/over.lean
@@ -3,11 +3,7 @@ Copyright (c) 2018 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Reid Barton, Bhavik Mehta
 -/
-import category_theory.over
 import category_theory.adjunction.opposites
-import category_theory.limits.preserves.basic
-import category_theory.limits.shapes.pullbacks
-import category_theory.limits.creates
 import category_theory.limits.comma
 
 /-!

--- a/src/category_theory/limits/pi.lean
+++ b/src/category_theory/limits/pi.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.pi.basic
 import category_theory.limits.has_limits
 
 /-!

--- a/src/category_theory/limits/preserves/functor_category.lean
+++ b/src/category_theory/limits/preserves/functor_category.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.limits.functor_category
 import category_theory.limits.preserves.shapes.binary_products
 import category_theory.limits.yoneda
 import category_theory.limits.presheaf

--- a/src/category_theory/limits/preserves/shapes/biproducts.lean
+++ b/src/category_theory/limits/preserves/shapes/biproducts.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
 import category_theory.limits.shapes.biproducts
-import category_theory.limits.preserves.shapes.zero
 import category_theory.limits.preserves.shapes.binary_products
 import category_theory.limits.preserves.shapes.products
 

--- a/src/category_theory/limits/preserves/shapes/kernels.lean
+++ b/src/category_theory/limits/preserves/shapes/kernels.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison
 -/
 import category_theory.limits.shapes.kernels
 import category_theory.limits.preserves.shapes.equalizers
-import category_theory.limits.preserves.shapes.zero
 
 /-!
 # Preserving (co)kernels

--- a/src/category_theory/limits/presheaf.lean
+++ b/src/category_theory/limits/presheaf.lean
@@ -8,8 +8,6 @@ import category_theory.adjunction.opposites
 import category_theory.elements
 import category_theory.limits.functor_category
 import category_theory.limits.kan_extension
-import category_theory.limits.preserves.limits
-import category_theory.limits.shapes.terminal
 import category_theory.limits.types
 
 /-!

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -3,9 +3,6 @@ Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Bhavik Mehta
 -/
-import category_theory.limits.shapes.terminal
-import category_theory.discrete_category
-import category_theory.epi_mono
 import category_theory.over
 
 /-!

--- a/src/category_theory/limits/shapes/biproducts.lean
+++ b/src/category_theory/limits/shapes/biproducts.lean
@@ -5,9 +5,7 @@ Authors: Scott Morrison, Jakob von Raumer
 -/
 import algebra.group.ext
 import category_theory.limits.shapes.finite_products
-import category_theory.limits.shapes.binary_products
 import category_theory.preadditive
-import category_theory.limits.shapes.kernels
 
 /-!
 # Biproducts and binary biproducts

--- a/src/category_theory/limits/shapes/comm_sq.lean
+++ b/src/category_theory/limits/shapes/comm_sq.lean
@@ -3,12 +3,8 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Joël Riou
 -/
-import category_theory.comm_sq
 import category_theory.limits.opposites
 import category_theory.limits.shapes.biproducts
-import category_theory.limits.preserves.shapes.pullbacks
-import category_theory.limits.shapes.zero_morphisms
-import category_theory.limits.constructions.binary_products
 import category_theory.limits.constructions.zero_objects
 
 /-!

--- a/src/category_theory/limits/shapes/concrete_category.lean
+++ b/src/category_theory/limits/shapes/concrete_category.lean
@@ -3,8 +3,6 @@ Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.limits.shapes.kernels
-import category_theory.concrete_category.basic
 import category_theory.concrete_category.elementwise
 
 /-!

--- a/src/category_theory/limits/shapes/default.lean
+++ b/src/category_theory/limits/shapes/default.lean
@@ -1,12 +1,1 @@
-import category_theory.limits.shapes.terminal
-import category_theory.limits.shapes.binary_products
-import category_theory.limits.shapes.products
-import category_theory.limits.shapes.finite_products
-import category_theory.limits.shapes.finite_limits
 import category_theory.limits.shapes.biproducts
-import category_theory.limits.shapes.images
-import category_theory.limits.shapes.zero_morphisms
-import category_theory.limits.shapes.kernels
-import category_theory.limits.shapes.equalizers
-import category_theory.limits.shapes.wide_pullbacks
-import category_theory.limits.shapes.pullbacks

--- a/src/category_theory/limits/shapes/diagonal.lean
+++ b/src/category_theory/limits/shapes/diagonal.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import category_theory.limits.shapes.pullbacks
 import category_theory.limits.shapes.kernel_pair
 import category_theory.limits.shapes.comm_sq
 

--- a/src/category_theory/limits/shapes/disjoint_coproduct.lean
+++ b/src/category_theory/limits/shapes/disjoint_coproduct.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.limits.shapes.binary_products
 import category_theory.limits.shapes.pullbacks
 
 /-!

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Markus Himmel
 -/
-import category_theory.epi_mono
 import category_theory.limits.has_limits
 
 /-!

--- a/src/category_theory/limits/shapes/finite_limits.lean
+++ b/src/category_theory/limits/shapes/finite_limits.lean
@@ -4,11 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.fin_category
-import category_theory.limits.shapes.binary_products
 import category_theory.limits.shapes.equalizers
-import category_theory.limits.shapes.wide_pullbacks
 import category_theory.limits.shapes.pullbacks
-import data.fintype.basic
 
 /-!
 # Categories with finite limits.

--- a/src/category_theory/limits/shapes/finite_products.lean
+++ b/src/category_theory/limits/shapes/finite_products.lean
@@ -3,10 +3,8 @@ Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.limits.shapes.binary_products
 import category_theory.limits.shapes.finite_limits
 import category_theory.limits.shapes.products
-import category_theory.limits.shapes.terminal
 
 /-!
 # Categories with finite (co)products

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Markus Himmel
 -/
 import category_theory.limits.shapes.equalizers
 import category_theory.limits.shapes.pullbacks
-import category_theory.limits.shapes.strong_epi
 
 /-!
 # Categorical images

--- a/src/category_theory/limits/shapes/kernel_pair.lean
+++ b/src/category_theory/limits/shapes/kernel_pair.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.limits.shapes.equalizers
-import category_theory.limits.shapes.pullbacks
 import category_theory.limits.shapes.regular_mono
 
 /-!

--- a/src/category_theory/limits/shapes/normal_mono/basic.lean
+++ b/src/category_theory/limits/shapes/normal_mono/basic.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.limits.shapes.regular_mono
 import category_theory.limits.shapes.kernels
-import category_theory.limits.preserves.basic
 
 /-!
 # Definitions and basic properties of normal monomorphisms and epimorphisms.

--- a/src/category_theory/limits/shapes/products.lean
+++ b/src/category_theory/limits/shapes/products.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.limits.has_limits
-import category_theory.discrete_category
 
 /-!
 # Categorical (co)products

--- a/src/category_theory/limits/shapes/reflexive.lean
+++ b/src/category_theory/limits/shapes/reflexive.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.limits.shapes.equalizers
 import category_theory.limits.shapes.kernel_pair
 
 /-!

--- a/src/category_theory/limits/shapes/regular_mono.lean
+++ b/src/category_theory/limits/shapes/regular_mono.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.limits.shapes.pullbacks
-import category_theory.limits.shapes.strong_epi
 import category_theory.limits.shapes.equalizers
 
 /-!

--- a/src/category_theory/limits/shapes/strict_initial.lean
+++ b/src/category_theory/limits/shapes/strict_initial.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 
-import category_theory.limits.shapes.terminal
 import category_theory.limits.shapes.binary_products
-import category_theory.epi_mono
 
 /-!
 # Strict initial objects

--- a/src/category_theory/limits/shapes/terminal.lean
+++ b/src/category_theory/limits/shapes/terminal.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.pempty
 import category_theory.limits.has_limits
-import category_theory.epi_mono
 import category_theory.category.preorder
 
 /-!

--- a/src/category_theory/limits/shapes/types.lean
+++ b/src/category_theory/limits/shapes/types.lean
@@ -5,8 +5,6 @@ Authors: Scott Morrison
 -/
 import category_theory.limits.types
 import category_theory.limits.shapes.products
-import category_theory.limits.shapes.binary_products
-import category_theory.limits.shapes.terminal
 import tactic.elementwise
 
 /-!

--- a/src/category_theory/limits/shapes/wide_equalizers.lean
+++ b/src/category_theory/limits/shapes/wide_equalizers.lean
@@ -3,8 +3,6 @@ Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.epi_mono
-import category_theory.limits.has_limits
 import category_theory.limits.shapes.equalizers
 
 /-!

--- a/src/category_theory/limits/shapes/zero_morphisms.lean
+++ b/src/category_theory/limits/shapes/zero_morphisms.lean
@@ -3,9 +3,6 @@ Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.limits.shapes.products
-import category_theory.limits.shapes.images
-import category_theory.isomorphism_classes
 import category_theory.limits.shapes.zero_objects
 
 /-!

--- a/src/category_theory/limits/shapes/zero_objects.lean
+++ b/src/category_theory/limits/shapes/zero_objects.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Johan Commelin
 -/
 import category_theory.limits.shapes.products
 import category_theory.limits.shapes.images
-import category_theory.isomorphism_classes
 
 /-!
 # Zero objects

--- a/src/category_theory/linear/default.lean
+++ b/src/category_theory/linear/default.lean
@@ -4,9 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.preadditive
-import algebra.module.linear_map
-import algebra.invertible
-import linear_algebra.basic
 import algebra.algebra.basic
 
 /-!

--- a/src/category_theory/linear/yoneda.lean
+++ b/src/category_theory/linear/yoneda.lean
@@ -3,9 +3,7 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import algebra.category.Module.basic
 import category_theory.linear
-import category_theory.preadditive.additive_functor
 import category_theory.preadditive.yoneda
 
 /-!

--- a/src/category_theory/monad/algebra.lean
+++ b/src/category_theory/monad/algebra.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.monad.basic
-import category_theory.adjunction.basic
-import category_theory.functor.epi_mono
 
 /-!
 # Eilenberg-Moore (co)algebras for a (co)monad

--- a/src/category_theory/monad/basic.lean
+++ b/src/category_theory/monad/basic.lean
@@ -3,8 +3,6 @@ Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Bhavik Mehta, Adam Topaz
 -/
-import category_theory.functor.category
-import category_theory.functor.fully_faithful
 import category_theory.functor.reflects_isomorphisms
 
 /-!

--- a/src/category_theory/monad/kleisli.lean
+++ b/src/category_theory/monad/kleisli.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Wojciech Nawrocki, Bhavik Mehta
 -/
 
-import category_theory.adjunction.basic
 import category_theory.monad.basic
 
 /-! # Kleisli category on a (co)monad

--- a/src/category_theory/monad/monadicity.lean
+++ b/src/category_theory/monad/monadicity.lean
@@ -5,7 +5,6 @@ Authors: Bhavik Mehta
 -/
 
 import category_theory.limits.preserves.shapes.equalizers
-import category_theory.limits.shapes.reflexive
 import category_theory.monad.coequalizer
 import category_theory.monad.limits
 

--- a/src/category_theory/monad/products.lean
+++ b/src/category_theory/monad/products.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.over
 import category_theory.monad.algebra
 import category_theory.limits.shapes.binary_products
 

--- a/src/category_theory/monad/types.lean
+++ b/src/category_theory/monad/types.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Bhavik Mehta
 -/
-import category_theory.monad.basic
 import category_theory.monad.kleisli
 import category_theory.category.Kleisli
 import category_theory.types

--- a/src/category_theory/monoidal/CommMon_.lean
+++ b/src/category_theory/monoidal/CommMon_.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.monoidal.braided
 import category_theory.monoidal.Mon_
 
 /-!

--- a/src/category_theory/monoidal/Mon_.lean
+++ b/src/category_theory/monoidal/Mon_.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.monoidal.braided
-import category_theory.monoidal.discrete
-import category_theory.monoidal.coherence_lemmas
 import category_theory.limits.shapes.terminal
 import algebra.punit_instances
 

--- a/src/category_theory/monoidal/braided.lean
+++ b/src/category_theory/monoidal/braided.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.monoidal.coherence_lemmas
-import category_theory.monoidal.natural_transformation
 import category_theory.monoidal.discrete
 
 /-!

--- a/src/category_theory/monoidal/center.lean
+++ b/src/category_theory/monoidal/center.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison
 -/
 import category_theory.monoidal.braided
 import category_theory.functor.reflects_isomorphisms
-import category_theory.monoidal.coherence
 
 /-!
 # Half braidings and the Drinfeld center of a monoidal category

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -5,7 +5,6 @@ Authors: Michael Jendrusch, Scott Morrison, Bhavik Mehta
 -/
 import category_theory.monoidal.category
 import category_theory.adjunction.basic
-import category_theory.products.basic
 
 /-!
 # (Lax) monoidal functors

--- a/src/category_theory/monoidal/functor_category.lean
+++ b/src/category_theory/monoidal/functor_category.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.monoidal.braided
-import category_theory.functor.category
-import category_theory.functor.const
 
 /-!
 # Monoidal structure on `C ⥤ D` when `D` is monoidal.

--- a/src/category_theory/monoidal/natural_transformation.lean
+++ b/src/category_theory/monoidal/natural_transformation.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.monoidal.functor
-import category_theory.full_subcategory
 
 /-!
 # Monoidal natural transformations

--- a/src/category_theory/monoidal/of_chosen_finite_products.lean
+++ b/src/category_theory/monoidal/of_chosen_finite_products.lean
@@ -5,8 +5,6 @@ Authors: Scott Morrison, Simon Hudon
 -/
 import category_theory.monoidal.braided
 import category_theory.limits.shapes.binary_products
-import category_theory.limits.shapes.terminal
-import category_theory.pempty
 
 /-!
 # The monoidal structure on a category with chosen finite products.

--- a/src/category_theory/monoidal/of_has_finite_products.lean
+++ b/src/category_theory/monoidal/of_has_finite_products.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Simon Hudon
 -/
 import category_theory.monoidal.braided
 import category_theory.limits.shapes.binary_products
-import category_theory.limits.shapes.terminal
 
 /-!
 # The natural monoidal structure on any category with finite (co)products.

--- a/src/category_theory/monoidal/skeleton.lean
+++ b/src/category_theory/monoidal/skeleton.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.monoidal.functor
 import category_theory.monoidal.braided
 import category_theory.monoidal.transport
 import category_theory.skeletal

--- a/src/category_theory/morphism_property.lean
+++ b/src/category_theory/morphism_property.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
 import category_theory.limits.shapes.diagonal
-import category_theory.arrow
-import category_theory.limits.shapes.comm_sq
 
 /-!
 # Properties of morphisms

--- a/src/category_theory/natural_isomorphism.lean
+++ b/src/category_theory/natural_isomorphism.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tim Baumann, Stephen Morgan, Scott Morrison, Floris van Doorn
 -/
 import category_theory.functor.category
-import category_theory.isomorphism
 
 /-!
 # Natural isomorphisms

--- a/src/category_theory/noetherian.lean
+++ b/src/category_theory/noetherian.lean
@@ -3,8 +3,6 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.subobject.lattice
-import category_theory.essentially_small
 import category_theory.simple
 
 /-!

--- a/src/category_theory/over.lean
+++ b/src/category_theory/over.lean
@@ -4,9 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Bhavik Mehta
 -/
 import category_theory.structured_arrow
-import category_theory.punit
-import category_theory.functor.reflects_isomorphisms
-import category_theory.functor.epi_mono
 
 /-!
 # Over and under categories

--- a/src/category_theory/path_category.lean
+++ b/src/category_theory/path_category.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.eq_to_hom
 import category_theory.quotient
 import combinatorics.quiver.path
 

--- a/src/category_theory/pi/basic.lean
+++ b/src/category_theory/pi/basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Scott Morrison
 -/
-import category_theory.natural_isomorphism
 import category_theory.eq_to_hom
 
 /-!

--- a/src/category_theory/preadditive/Mat.lean
+++ b/src/category_theory/preadditive/Mat.lean
@@ -3,16 +3,12 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import algebra.big_operators.basic
-import algebra.big_operators.pi
-import category_theory.limits.shapes.biproducts
 import category_theory.preadditive
 import category_theory.preadditive.additive_functor
 import data.matrix.dmatrix
 import data.matrix.basic
 import category_theory.Fintype
 import category_theory.preadditive.single_obj
-import algebra.opposites
 
 /-!
 # Matrices over a category.

--- a/src/category_theory/preadditive/biproducts.lean
+++ b/src/category_theory/preadditive/biproducts.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import tactic.abel
 import category_theory.limits.shapes.biproducts
 import category_theory.limits.preserves.shapes.biproducts
 import category_theory.preadditive

--- a/src/category_theory/preadditive/default.lean
+++ b/src/category_theory/preadditive/default.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Jakob von Raumer
 -/
-import algebra.big_operators.basic
-import algebra.hom.group
 import algebra.module.basic
 import category_theory.endomorphism
 import category_theory.limits.shapes.kernels

--- a/src/category_theory/preadditive/eilenberg_moore.lean
+++ b/src/category_theory/preadditive/eilenberg_moore.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Julian Kuelshammer
 -/
 
-import category_theory.preadditive.default
 import category_theory.monad.algebra
 import category_theory.preadditive.additive_functor
 

--- a/src/category_theory/preadditive/endo_functor.lean
+++ b/src/category_theory/preadditive/endo_functor.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Julian Kuelshammer
 -/
 
-import category_theory.preadditive.default
 import category_theory.endofunctor.algebra
 import category_theory.preadditive.additive_functor
 

--- a/src/category_theory/preadditive/injective.lean
+++ b/src/category_theory/preadditive/injective.lean
@@ -4,10 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang, Kevin Buzzard
 -/
 
-import algebra.homology.exact
-import category_theory.types
 import category_theory.preadditive.projective
-import category_theory.limits.shapes.biproducts
 
 /-!
 # Injective objects and categories with enough injectives

--- a/src/category_theory/preadditive/left_exact.lean
+++ b/src/category_theory/preadditive/left_exact.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Jakob von Raumer
 -/
 import category_theory.abelian.opposite
-import category_theory.limits.constructions.finite_products_of_binary_products
 import category_theory.limits.preserves.shapes.kernels
 
 /-!

--- a/src/category_theory/preadditive/projective.lean
+++ b/src/category_theory/preadditive/projective.lean
@@ -3,11 +3,7 @@ Copyright (c) 2020 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Scott Morrison
 -/
-import algebra.homology.exact
-import category_theory.types
-import category_theory.limits.shapes.biproducts
 import category_theory.preadditive.yoneda
-import algebra.category.Module.epi_mono
 
 /-!
 # Projective objects and categories with enough projectives

--- a/src/category_theory/preadditive/projective_resolution.lean
+++ b/src/category_theory/preadditive/projective_resolution.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.preadditive.projective
-import algebra.homology.single
 import algebra.homology.homotopy_category
 
 /-!

--- a/src/category_theory/preadditive/schur.lean
+++ b/src/category_theory/preadditive/schur.lean
@@ -3,10 +3,8 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Scott Morrison
 -/
-import algebra.group.ext
 import category_theory.simple
 import category_theory.linear
-import category_theory.endomorphism
 import algebra.algebra.spectrum
 
 /-!

--- a/src/category_theory/preadditive/yoneda.lean
+++ b/src/category_theory/preadditive/yoneda.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
 import category_theory.limits.yoneda
-import category_theory.preadditive.opposite
 import algebra.category.Module.abelian
-import algebra.category.Group.preadditive
 
 /-!
 # The Yoneda embedding for preadditive categories

--- a/src/category_theory/quotient.lean
+++ b/src/category_theory/quotient.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 David Wärn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn
 -/
-import category_theory.natural_isomorphism
-import category_theory.equivalence
 import category_theory.eq_to_hom
 
 /-!

--- a/src/category_theory/sigma/basic.lean
+++ b/src/category_theory/sigma/basic.lean
@@ -4,9 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import category_theory.whiskering
-import category_theory.functor.fully_faithful
-import category_theory.natural_isomorphism
-import data.sigma.basic
 
 /-!
 # Disjoint union of categories

--- a/src/category_theory/simple.lean
+++ b/src/category_theory/simple.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Scott Morrison
 -/
-import category_theory.limits.shapes.zero_morphisms
-import category_theory.limits.shapes.kernels
 import category_theory.abelian.basic
 import category_theory.subobject.lattice
 import order.atoms

--- a/src/category_theory/single_obj.lean
+++ b/src/category_theory/single_obj.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import category_theory.endomorphism
-import category_theory.category.Cat
 import algebra.category.Mon.basic
 
 /-!

--- a/src/category_theory/sites/cover_lifting.lean
+++ b/src/category_theory/sites/cover_lifting.lean
@@ -3,8 +3,6 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import category_theory.sites.sheaf
-import category_theory.limits.kan_extension
 import category_theory.sites.cover_preserving
 
 /-!

--- a/src/category_theory/sites/cover_preserving.lean
+++ b/src/category_theory/sites/cover_preserving.lean
@@ -3,9 +3,7 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import category_theory.sites.limits
 import category_theory.functor.flat
-import category_theory.limits.preserves.filtered
 import category_theory.sites.left_exact
 
 /-!

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -3,9 +3,7 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import category_theory.sites.sheaf
 import category_theory.sites.cover_lifting
-import category_theory.adjunction.fully_faithful
 
 /-!
 # Dense subsites

--- a/src/category_theory/sites/grothendieck.lean
+++ b/src/category_theory/sites/grothendieck.lean
@@ -5,9 +5,7 @@ Authors: Bhavik Mehta, E. W. Ayers
 -/
 
 import category_theory.sites.sieves
-import category_theory.limits.shapes.pullbacks
 import category_theory.limits.shapes.multiequalizer
-import category_theory.category.preorder
 import order.copy
 
 /-!

--- a/src/category_theory/sites/left_exact.lean
+++ b/src/category_theory/sites/left_exact.lean
@@ -3,9 +3,7 @@ Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
-import category_theory.sites.sheafification
 import category_theory.sites.limits
-import category_theory.limits.functor_category
 import category_theory.limits.filtered_colimit_commutes_finite_limit
 
 /-!

--- a/src/category_theory/sites/limits.lean
+++ b/src/category_theory/sites/limits.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
-import category_theory.limits.creates
 import category_theory.sites.sheafification
 
 /-!

--- a/src/category_theory/sites/sheaf_of_types.lean
+++ b/src/category_theory/sites/sheaf_of_types.lean
@@ -6,7 +6,6 @@ Authors: Bhavik Mehta
 
 import category_theory.sites.pretopology
 import category_theory.limits.shapes.types
-import category_theory.full_subcategory
 
 /-!
 # Sheaves of types on a Grothendieck topology

--- a/src/category_theory/sites/sieves.lean
+++ b/src/category_theory/sites/sieves.lean
@@ -4,11 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, E. W. Ayers
 -/
 
-import order.complete_lattice
-import category_theory.over
-import category_theory.yoneda
 import category_theory.limits.shapes.pullbacks
-import data.set.lattice
 
 /-!
 # Theory of sieves

--- a/src/category_theory/sites/spaces.lean
+++ b/src/category_theory/sites/spaces.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.sites.grothendieck
 import category_theory.sites.pretopology
 import category_theory.limits.lattice
 import topology.sets.opens

--- a/src/category_theory/sites/subsheaf.lean
+++ b/src/category_theory/sites/subsheaf.lean
@@ -5,7 +5,6 @@ Authors: Andrew Yang
 -/
 import category_theory.elementwise
 import category_theory.sites.compatible_sheafification
-import category_theory.limits.constructions.epi_mono
 import category_theory.adjunction.evaluation
 
 /-!

--- a/src/category_theory/sites/surjective.lean
+++ b/src/category_theory/sites/surjective.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
 import category_theory.sites.subsheaf
-import category_theory.adjunction.evaluation
 
 /-!
 

--- a/src/category_theory/structured_arrow.lean
+++ b/src/category_theory/structured_arrow.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz, Scott Morrison
 -/
 import category_theory.punit
-import category_theory.comma
 import category_theory.limits.shapes.terminal
 import category_theory.essentially_small
 

--- a/src/category_theory/subobject/basic.lean
+++ b/src/category_theory/subobject/basic.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Scott Morrison
 -/
 import category_theory.subobject.mono_over
-import category_theory.skeletal
 import tactic.elementwise
-import tactic.apply_fun
 
 /-!
 # Subobjects

--- a/src/category_theory/subobject/default.lean
+++ b/src/category_theory/subobject/default.lean
@@ -1,5 +1,1 @@
-import category_theory.subobject.mono_over
-import category_theory.subobject.basic
-import category_theory.subobject.factor_thru
-import category_theory.subobject.well_powered
 import category_theory.subobject.lattice

--- a/src/category_theory/subobject/mono_over.lean
+++ b/src/category_theory/subobject/mono_over.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Scott Morrison
 -/
-import category_theory.functor.currying
 import category_theory.limits.over
 import category_theory.limits.shapes.images
 import category_theory.adjunction.reflective

--- a/src/category_theory/subobject/types.lean
+++ b/src/category_theory/subobject/types.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.subobject.well_powered
-import category_theory.types
 
 /-!
 # `Type u` is well-powered

--- a/src/category_theory/subobject/well_powered.lean
+++ b/src/category_theory/subobject/well_powered.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import category_theory.subobject.basic
-import category_theory.essentially_small
 
 /-!
 # Well-powered categories

--- a/src/category_theory/subterminal.lean
+++ b/src/category_theory/subterminal.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import category_theory.limits.shapes.binary_products
-import category_theory.limits.shapes.terminal
 import category_theory.subobject.mono_over
 
 /-!

--- a/src/category_theory/thin.lean
+++ b/src/category_theory/thin.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.functor.category
-import category_theory.isomorphism
 
 /-!
 # Thin categories

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Luke Kershaw. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Luke Kershaw
 -/
-import data.int.basic
 import category_theory.shift
 
 /-!

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -3,8 +3,6 @@ Copyright (c) 2021 Luke Kershaw. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Luke Kershaw
 -/
-import category_theory.preadditive.additive_functor
-import category_theory.shift
 import category_theory.triangulated.rotate
 
 /-!

--- a/src/category_theory/whiskering.lean
+++ b/src/category_theory/whiskering.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import category_theory.isomorphism
-import category_theory.functor.category
 import category_theory.functor.fully_faithful
 
 /-!

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison
 -/
 import category_theory.functor.hom
 import category_theory.functor.currying
-import category_theory.products.basic
 
 /-!
 # The Yoneda embedding


### PR DESCRIPTION
This is everything that `leanproject reduce-imports` suggests, inside `category_theory/`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
