### PR TITLE
[Merged by Bors] - docs(data/set/pointwise)/big_operators): Correct copyright

### DIFF
--- a/src/data/set/pointwise/big_operators.lean
+++ b/src/data/set/pointwise/big_operators.lean
@@ -1,10 +1,10 @@
 /-
-Copyright (c) 2019 Johan Commelin. All rights reserved.
+Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johan Commelin, Floris van Doorn
+Authors: Eric Wieser
 -/
-import data.set.pointwise.basic
 import algebra.big_operators.basic
+import data.set.pointwise.basic
 
 /-!
 # Results about pointwise operations on sets and big operators.


### PR DESCRIPTION
All this material comes from #8220 and #14928.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Scott blindly copied the copyright from `data.set.pointwise` in #16950.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
