### PR TITLE
[Merged by Bors] - feat(geometry/euclidean/angle/oriented/affine): signs of angles and sides of subspaces

### DIFF
--- a/src/geometry/euclidean/angle/oriented/affine.lean
+++ b/src/geometry/euclidean/angle/oriented/affine.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
+import analysis.convex.side
 import geometry.euclidean.angle.oriented.basic
 import geometry.euclidean.angle.unoriented.affine
 
@@ -495,5 +496,48 @@ fourth point between the second and third or first and third points have the sam
 lemma _root_.sbtw.oangle_sign_eq_right {p₁ p₂ p₃ : P} (p₄ : P) (h : sbtw ℝ p₁ p₂ p₃) :
   (∡ p₂ p₄ p₃).sign = (∡ p₁ p₄ p₃).sign :=
 h.wbtw.oangle_sign_eq_of_ne_right _ h.ne_right
+
+/-- Given two points in an affine subspace, the angles between those two points at two other
+points on the same side of that subspace have the same sign. -/
+lemma _root_.affine_subspace.s_same_side.oangle_sign_eq {s : affine_subspace ℝ P}
+  {p₁ p₂ p₃ p₄ : P} (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) (hp₃p₄ : s.s_same_side p₃ p₄) :
+  (∡ p₁ p₄ p₂).sign = (∡ p₁ p₃ p₂).sign :=
+begin
+  by_cases h : p₁ = p₂, { simp [h] },
+  let sp : set (P × P × P) := (λ p : P, (p₁, p, p₂)) '' {p | s.s_same_side p₃ p},
+  have hc : is_connected sp := (is_connected_set_of_s_same_side hp₃p₄.2.1 hp₃p₄.nonempty).image
+    _ (continuous_const.prod_mk (continuous.prod.mk_left _)).continuous_on,
+  have hf : continuous_on (λ p : P × P × P, ∡ p.1 p.2.1 p.2.2) sp,
+  { refine continuous_at.continuous_on (λ p hp, continuous_at_oangle _ _),
+    all_goals { simp_rw [sp, set.mem_image, set.mem_set_of] at hp,
+                obtain ⟨p', hp', rfl⟩ := hp,
+                dsimp only,
+                rintro rfl },
+    { exact hp'.2.2 hp₁ },
+    { exact hp'.2.2 hp₂ } },
+  have hsp : ∀ p : P × P × P, p ∈ sp → ∡ p.1 p.2.1 p.2.2 ≠ 0 ∧ ∡ p.1 p.2.1 p.2.2 ≠ π,
+  { intros p hp,
+    simp_rw [sp, set.mem_image, set.mem_set_of] at hp,
+    obtain ⟨p', hp', rfl⟩ := hp,
+    dsimp only,
+    rw [oangle_ne_zero_and_ne_pi_iff_affine_independent],
+    exact affine_independent_of_ne_of_mem_of_not_mem_of_mem h hp₁ hp'.2.2 hp₂ },
+  have hp₃ : (p₁, p₃, p₂) ∈ sp :=
+    set.mem_image_of_mem _ (s_same_side_self_iff.2 ⟨hp₃p₄.nonempty, hp₃p₄.2.1⟩),
+  have hp₄ : (p₁, p₄, p₂) ∈ sp := set.mem_image_of_mem _ hp₃p₄,
+  convert real.angle.sign_eq_of_continuous_on hc hf hsp hp₃ hp₄
+end
+
+/-- Given two points in an affine subspace, the angles between those two points at two other
+points on opposite sides of that subspace have opposite signs. -/
+lemma _root_.affine_subspace.s_opp_side.oangle_sign_eq_neg {s : affine_subspace ℝ P}
+  {p₁ p₂ p₃ p₄ : P} (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) (hp₃p₄ : s.s_opp_side p₃ p₄) :
+  (∡ p₁ p₄ p₂).sign = -(∡ p₁ p₃ p₂).sign :=
+begin
+  have hp₁p₃ : p₁ ≠ p₃, { rintro rfl, exact hp₃p₄.left_not_mem hp₁ },
+  rw [←(hp₃p₄.symm.trans (s_opp_side_point_reflection hp₁ hp₃p₄.left_not_mem)).oangle_sign_eq
+          hp₁ hp₂, ←oangle_rotate_sign p₁, ←oangle_rotate_sign p₁, oangle_swap₁₃_sign,
+      (sbtw_point_reflection_of_ne ℝ hp₁p₃).symm.oangle_sign_eq _],
+end
 
 end euclidean_geometry


### PR DESCRIPTION
Add lemmas about the signs of angles, at points on the same / opposite side of an affine subspace (typically a line), between two points in that subspace.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
