### PR TITLE
[Merged by Bors] - feat(geometry/euclidean/angle/oriented/basic): `rotation_rotation`

### DIFF
--- a/src/geometry/euclidean/angle/oriented/basic.lean
+++ b/src/geometry/euclidean/angle/oriented/basic.lean
@@ -553,10 +553,9 @@ begin
 end
 
 /-- Rotating twice is equivalent to rotating by the sum of the angles. -/
-@[simp] lemma rotation_trans (θ₁ θ₂ : real.angle) :
-  (o.rotation θ₁).trans (o.rotation θ₂) = o.rotation (θ₂ + θ₁) :=
+@[simp] lemma rotation_rotation (θ₁ θ₂ : real.angle) (x : V) :
+  o.rotation θ₁ (o.rotation θ₂ x) = o.rotation (θ₁ + θ₂) x :=
 begin
-  ext x,
   simp only [o.rotation_apply, ←mul_smul, real.angle.cos_add, real.angle.sin_add, add_smul,
     sub_smul, linear_isometry_equiv.trans_apply, smul_add, linear_isometry_equiv.map_add,
     linear_isometry_equiv.map_smul, right_angle_rotation_right_angle_rotation, smul_neg],
@@ -565,9 +564,9 @@ begin
 end
 
 /-- Rotating twice is equivalent to rotating by the sum of the angles. -/
-@[simp] lemma rotation_apply_apply (θ₁ θ₂ : real.angle) (x : V) :
-  o.rotation θ₁ (o.rotation θ₂ x) = o.rotation (θ₁ + θ₂) x :=
-by rw [←rotation_trans, linear_isometry_equiv.trans_apply]
+@[simp] lemma rotation_trans (θ₁ θ₂ : real.angle) :
+  (o.rotation θ₁).trans (o.rotation θ₂) = o.rotation (θ₂ + θ₁) :=
+linear_isometry_equiv.ext $ λ _, by rw [←rotation_rotation, linear_isometry_equiv.trans_apply]
 
 /-- Rotating the first of two vectors by `θ` scales their Kahler form by `cos θ - sin θ * I`. -/
 @[simp] lemma kahler_rotation_left (x y : V) (θ : real.angle) :

--- a/src/geometry/euclidean/angle/oriented/basic.lean
+++ b/src/geometry/euclidean/angle/oriented/basic.lean
@@ -564,6 +564,11 @@ begin
   abel,
 end
 
+/-- Rotating twice is equivalent to rotating by the sum of the angles. -/
+@[simp] lemma rotation_apply_apply (θ₁ θ₂ : real.angle) (x : V) :
+  o.rotation θ₁ (o.rotation θ₂ x) = o.rotation (θ₁ + θ₂) x :=
+by rw [←rotation_trans, linear_isometry_equiv.trans_apply]
+
 /-- Rotating the first of two vectors by `θ` scales their Kahler form by `cos θ - sin θ * I`. -/
 @[simp] lemma kahler_rotation_left (x y : V) (θ : real.angle) :
   o.kahler (o.rotation θ x) y = conj (θ.exp_map_circle : ℂ) * o.kahler x y :=


### PR DESCRIPTION
Add another version of the lemma that rotating twice is equivalent to rotating by the sum of the angles, but for applying `rotation` twice to a vector rather than combining the isometries with `trans`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
