### PR TITLE
[Merged by Bors] - refactor(data/fintype/basic): simplify the defeq of `sum.fintype`

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -349,17 +349,14 @@ lemma prod_sdiff [decidable_eq α] (h : s₁ ⊆ s₂) :
 by rw [←prod_union sdiff_disjoint, sdiff_union_of_subset h]
 
 @[simp, to_additive]
-lemma prod_sum_elim [decidable_eq (α ⊕ γ)]
-  (s : finset α) (t : finset γ) (f : α → β) (g : γ → β) :
-  ∏ x in s.map function.embedding.inl ∪ t.map function.embedding.inr, sum.elim f g x =
+lemma prod_sum_elim (s : finset α) (t : finset γ) (f : α → β) (g : γ → β) :
+  ∏ x in (s.map function.embedding.inl).disj_union (t.map function.embedding.inr)
+     (λ x, by { simp_rw mem_map, rintro ⟨a, _, rfl⟩ ⟨b, _, ⟨⟩⟩ }), sum.elim f g x =
     (∏ x in s, f x) * (∏ x in t, g x) :=
 begin
-  rw [prod_union, prod_map, prod_map],
-  { simp only [sum.elim_inl, function.embedding.inl_apply, function.embedding.inr_apply,
-      sum.elim_inr] },
-  { simp only [disjoint_left, finset.mem_map, finset.mem_map],
-    rintros _ ⟨i, hi, rfl⟩ ⟨j, hj, H⟩,
-    cases H }
+  rw [prod_disj_union, prod_map, prod_map],
+  simp only [sum.elim_inl, function.embedding.inl_apply, function.embedding.inr_apply,
+      sum.elim_inr],
 end
 
 @[simp, to_additive]
@@ -367,19 +364,8 @@ lemma prod_on_sum [fintype α] [fintype γ] (f : α ⊕ γ → β) :
   ∏ (x : α ⊕ γ), f x  =
     (∏ (x : α), f (sum.inl x)) * (∏ (x : γ), f (sum.inr x)) :=
 begin
-  haveI := classical.dec_eq (α ⊕ γ),
   convert prod_sum_elim univ univ (λ x, f (sum.inl x)) (λ x, f (sum.inr x)),
-  { ext a,
-    split,
-    { intro x,
-      cases a,
-      { simp only [mem_union, mem_map, mem_univ, function.embedding.inl_apply, or_false,
-          exists_true_left, exists_apply_eq_apply, function.embedding.inr_apply, exists_false], },
-      { simp only [mem_union, mem_map, mem_univ, function.embedding.inl_apply, false_or,
-          exists_true_left, exists_false, function.embedding.inr_apply,
-          exists_apply_eq_apply], }, },
-    { simp only [mem_univ, implies_true_iff], }, },
-  { simp only [sum.elim_comp_inl_inr], },
+  exact (sum.elim_comp_inl_inr _).symm,
 end
 
 @[to_additive]

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -361,12 +361,6 @@ lemma prod_sum_elim (s : finset α) (t : finset γ) (f : α → β) (g : γ → 
   ∏ x in s.disj_sum t, sum.elim f g x = (∏ x in s, f x) * (∏ x in t, g x) :=
 by simp
 
-@[simp, to_additive]
-lemma prod_on_sum [fintype α] [fintype γ] (f : α ⊕ γ → β) :
-  ∏ x : α ⊕ γ, f x  =
-    (∏ x : α, f (sum.inl x)) * (∏ x : γ, f (sum.inr x)) :=
-prod_disj_sum _ _ _
-
 @[to_additive]
 lemma prod_bUnion [decidable_eq α] {s : finset γ} {t : γ → finset α}
   (hs : set.pairwise_disjoint ↑s t) :

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -351,8 +351,8 @@ by rw [←prod_union sdiff_disjoint, sdiff_union_of_subset h]
 @[simp, to_additive]
 lemma prod_sum_elim (s : finset α) (t : finset γ) (f : α → β) (g : γ → β) :
   ∏ x in (s.map function.embedding.inl).disj_union (t.map function.embedding.inr)
-     finset.disjoint_map_inl_map_inr, sum.elim f g x =
-    (∏ x in s, f x) * (∏ x in t, g x) :=
+    (finset.disjoint_map_inl_map_inr _ _), sum.elim f g x =
+      (∏ x in s, f x) * (∏ x in t, g x) :=
 begin
   rw [prod_disj_union, prod_map, prod_map],
   simp only [sum.elim_inl, function.embedding.inl_apply, function.embedding.inr_apply,

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -349,24 +349,23 @@ lemma prod_sdiff [decidable_eq α] (h : s₁ ⊆ s₂) :
 by rw [←prod_union sdiff_disjoint, sdiff_union_of_subset h]
 
 @[simp, to_additive]
-lemma prod_sum_elim (s : finset α) (t : finset γ) (f : α → β) (g : γ → β) :
-  ∏ x in (s.map function.embedding.inl).disj_union (t.map function.embedding.inr)
-    (finset.disjoint_map_inl_map_inr _ _), sum.elim f g x =
-      (∏ x in s, f x) * (∏ x in t, g x) :=
+lemma prod_disj_sum (s : finset α) (t : finset γ) (f : α ⊕ γ → β) :
+  ∏ x in s.disj_sum t, f x = (∏ x in s, f (sum.inl x)) * (∏ x in t, f (sum.inr x)) :=
 begin
-  rw [prod_disj_union, prod_map, prod_map],
-  simp only [sum.elim_inl, function.embedding.inl_apply, function.embedding.inr_apply,
-      sum.elim_inr],
+  rw [←map_inl_disj_union_map_inr, prod_disj_union, prod_map, prod_map],
+  refl,
 end
+
+@[to_additive]
+lemma prod_sum_elim (s : finset α) (t : finset γ) (f : α → β) (g : γ → β) :
+  ∏ x in s.disj_sum t, sum.elim f g x = (∏ x in s, f x) * (∏ x in t, g x) :=
+by simp
 
 @[simp, to_additive]
 lemma prod_on_sum [fintype α] [fintype γ] (f : α ⊕ γ → β) :
-  ∏ (x : α ⊕ γ), f x  =
-    (∏ (x : α), f (sum.inl x)) * (∏ (x : γ), f (sum.inr x)) :=
-begin
-  convert prod_sum_elim univ univ (λ x, f (sum.inl x)) (λ x, f (sum.inr x)),
-  exact (sum.elim_comp_inl_inr _).symm,
-end
+  ∏ x : α ⊕ γ, f x  =
+    (∏ x : α, f (sum.inl x)) * (∏ x : γ, f (sum.inr x)) :=
+prod_disj_sum _ _ _
 
 @[to_additive]
 lemma prod_bUnion [decidable_eq α] {s : finset γ} {t : γ → finset α}

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -351,7 +351,7 @@ by rw [←prod_union sdiff_disjoint, sdiff_union_of_subset h]
 @[simp, to_additive]
 lemma prod_sum_elim (s : finset α) (t : finset γ) (f : α → β) (g : γ → β) :
   ∏ x in (s.map function.embedding.inl).disj_union (t.map function.embedding.inr)
-     (λ x, by { simp_rw mem_map, rintro ⟨a, _, rfl⟩ ⟨b, _, ⟨⟩⟩ }), sum.elim f g x =
+     finset.disjoint_map_inl_map_inr, sum.elim f g x =
     (∏ x in s, f x) * (∏ x in t, g x) :=
 begin
   rw [prod_disj_union, prod_map, prod_map],

--- a/src/algebra/big_operators/fin.lean
+++ b/src/algebra/big_operators/fin.lean
@@ -146,7 +146,7 @@ begin
   rw fintype.prod_equiv fin_sum_fin_equiv.symm f (λ i, f (fin_sum_fin_equiv.to_fun i)), swap,
   { intro x,
     simp only [equiv.to_fun_as_coe, equiv.apply_symm_apply], },
-  apply prod_on_sum,
+  apply fintype.prod_sum_type,
 end
 
 @[to_additive]

--- a/src/analysis/convex/combination.lean
+++ b/src/analysis/convex/combination.lean
@@ -73,10 +73,7 @@ lemma finset.center_mass_segment'
   (s : finset ι) (t : finset ι') (ws : ι → R) (zs : ι → E) (wt : ι' → R) (zt : ι' → E)
   (hws : ∑ i in s, ws i = 1) (hwt : ∑ i in t, wt i = 1) (a b : R) (hab : a + b = 1) :
   a • s.center_mass ws zs + b • t.center_mass wt zt =
-    ((s.map embedding.inl).disj_union (t.map embedding.inr) $
-      finset.disjoint_map_inl_map_inr _ _).center_mass
-        (sum.elim (λ i, a * ws i) (λ j, b * wt j))
-        (sum.elim zs zt) :=
+    (s.disj_sum t).center_mass (sum.elim (λ i, a * ws i) (λ j, b * wt j)) (sum.elim zs zt) :=
 begin
   rw [s.center_mass_eq_of_sum_1 _ hws, t.center_mass_eq_of_sum_1 _ hwt,
     smul_sum, smul_sum, ← finset.sum_sum_elim, finset.center_mass_eq_of_sum_1],
@@ -288,13 +285,13 @@ begin
     rw [finset.center_mass_segment' _ _ _ _ _ _ hwx₁ hwy₁ _ _ hab],
     refine ⟨_, _, _, _, _, _, _, rfl⟩,
     { rintros i hi,
-      rw [finset.mem_disj_union, finset.mem_map, finset.mem_map] at hi,
+      rw [finset.mem_disj_sum] at hi,
       rcases hi with ⟨j, hj, rfl⟩|⟨j, hj, rfl⟩;
         simp only [sum.elim_inl, sum.elim_inr];
         apply_rules [mul_nonneg, hwx₀, hwy₀] },
-    { simp [finset.sum_sum_elim, finset.mul_sum.symm, *, -finset.disj_union_eq_union], },
+    { simp [finset.sum_sum_elim, finset.mul_sum.symm, *], },
     { intros i hi,
-      rw [finset.mem_disj_union, finset.mem_map, finset.mem_map] at hi,
+      rw [finset.mem_disj_sum] at hi,
       rcases hi with ⟨j, hj, rfl⟩|⟨j, hj, rfl⟩; apply_rules [hzx, hzy] } },
   { rintros _ ⟨ι, t, w, z, hw₀, hw₁, hz, rfl⟩,
     exact t.center_mass_mem_convex_hull hw₀ (hw₁.symm ▸ zero_lt_one) hz }

--- a/src/analysis/convex/combination.lean
+++ b/src/analysis/convex/combination.lean
@@ -73,9 +73,10 @@ lemma finset.center_mass_segment'
   (s : finset ι) (t : finset ι') (ws : ι → R) (zs : ι → E) (wt : ι' → R) (zt : ι' → E)
   (hws : ∑ i in s, ws i = 1) (hwt : ∑ i in t, wt i = 1) (a b : R) (hab : a + b = 1) :
   a • s.center_mass ws zs + b • t.center_mass wt zt =
-    (s.map embedding.inl ∪ t.map embedding.inr).center_mass
-      (sum.elim (λ i, a * ws i) (λ j, b * wt j))
-      (sum.elim zs zt) :=
+    ((s.map embedding.inl).disj_union (t.map embedding.inr) $
+      λ x, by { simp_rw mem_map, rintro ⟨a, _, rfl⟩ ⟨b, _, ⟨⟩⟩ }).center_mass
+        (sum.elim (λ i, a * ws i) (λ j, b * wt j))
+        (sum.elim zs zt) :=
 begin
   rw [s.center_mass_eq_of_sum_1 _ hws, t.center_mass_eq_of_sum_1 _ hwt,
     smul_sum, smul_sum, ← finset.sum_sum_elim, finset.center_mass_eq_of_sum_1],
@@ -287,13 +288,13 @@ begin
     rw [finset.center_mass_segment' _ _ _ _ _ _ hwx₁ hwy₁ _ _ hab],
     refine ⟨_, _, _, _, _, _, _, rfl⟩,
     { rintros i hi,
-      rw [finset.mem_union, finset.mem_map, finset.mem_map] at hi,
+      rw [finset.mem_disj_union, finset.mem_map, finset.mem_map] at hi,
       rcases hi with ⟨j, hj, rfl⟩|⟨j, hj, rfl⟩;
         simp only [sum.elim_inl, sum.elim_inr];
         apply_rules [mul_nonneg, hwx₀, hwy₀] },
-    { simp [finset.sum_sum_elim, finset.mul_sum.symm, *] },
+    { simp [finset.sum_sum_elim, finset.mul_sum.symm, *, -finset.disj_union_eq_union], },
     { intros i hi,
-      rw [finset.mem_union, finset.mem_map, finset.mem_map] at hi,
+      rw [finset.mem_disj_union, finset.mem_map, finset.mem_map] at hi,
       rcases hi with ⟨j, hj, rfl⟩|⟨j, hj, rfl⟩; apply_rules [hzx, hzy] } },
   { rintros _ ⟨ι, t, w, z, hw₀, hw₁, hz, rfl⟩,
     exact t.center_mass_mem_convex_hull hw₀ (hw₁.symm ▸ zero_lt_one) hz }

--- a/src/analysis/convex/combination.lean
+++ b/src/analysis/convex/combination.lean
@@ -74,7 +74,7 @@ lemma finset.center_mass_segment'
   (hws : ∑ i in s, ws i = 1) (hwt : ∑ i in t, wt i = 1) (a b : R) (hab : a + b = 1) :
   a • s.center_mass ws zs + b • t.center_mass wt zt =
     ((s.map embedding.inl).disj_union (t.map embedding.inr) $
-      λ x, by { simp_rw mem_map, rintro ⟨a, _, rfl⟩ ⟨b, _, ⟨⟩⟩ }).center_mass
+      finset.disjoint_map_inl_map_inr _ _).center_mass
         (sum.elim (λ i, a * ws i) (λ j, b * wt j))
         (sum.elim zs zt) :=
 begin

--- a/src/data/finset/sum.lean
+++ b/src/data/finset/sum.lean
@@ -34,6 +34,16 @@ val_inj.1 $ multiset.disj_sum_zero _
 
 @[simp] lemma card_disj_sum : (s.disj_sum t).card = s.card + t.card := multiset.card_disj_sum _ _
 
+/-- Note that this is not stated with `disjoint` so that it can be used with `finset.disj_union`. -/
+lemma disjoint_map_inl_map_inr {α β : Type*} (s : finset α) (t : finset β) (a : α ⊕ β) :
+  a ∈ (s.map embedding.inl : finset (α ⊕ β)) → a ∉ (t.map embedding.inr : finset (α ⊕ β)) :=
+by { simp_rw mem_map, rintro ⟨a, _, rfl⟩ ⟨b, _, ⟨⟩⟩ }
+
+@[simp]
+lemma map_inl_disj_union_map_inr :
+  (s.map embedding.inl).disj_union (t.map embedding.inr) (disjoint_map_inl_map_inr _ _) =
+    s.disj_sum t := rfl
+
 variables {s t} {s₁ s₂ : finset α} {t₁ t₂ : finset β} {a : α} {b : β} {x : α ⊕ β}
 
 lemma mem_disj_sum : x ∈ s.disj_sum t ↔ (∃ a, a ∈ s ∧ inl a = x) ∨ ∃ b, b ∈ t ∧ inr b = x :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -975,20 +975,19 @@ instance (α : Type*) [fintype α] : fintype (lex α) := ‹fintype α›
 @[simp] lemma fintype.card_lex (α : Type*) [fintype α] :
   fintype.card (lex α) = fintype.card α := rfl
 
+/-- Note that this is not stated with `disjoint` so that it can be used with `finset.disj_union`. -/
+lemma finset.disjoint_map_inl_map_inr {α β : Type*} [fintype α] [fintype β] (a : α ⊕ β) :
+  a ∈ (univ.map embedding.inl : finset (α ⊕ β)) → a ∉ (univ.map embedding.inr : finset (α ⊕ β)) :=
+by { simp_rw mem_map, rintro ⟨a, _, rfl⟩ ⟨b, _, ⟨⟩⟩ }
 
 instance (α : Type u) (β : Type v) [fintype α] [fintype β] : fintype (α ⊕ β) :=
-{ elems :=
-    ((univ : finset α).map embedding.inl).disj_union ((univ : finset β).map embedding.inr) $ λ a,
-      by { simp_rw mem_map, rintro ⟨a, _, rfl⟩ ⟨b, _, ⟨⟩⟩ },
-  complete := λ x, begin
-    rw mem_disj_union,
-    cases x; simp,
-  end }
+{ elems := finset.disj_union _ _ finset.disjoint_map_inl_map_inr,
+  complete := by rintro (_ | _); simp }
 
 lemma univ_sum_type {α β : Type*} [fintype α] [fintype β] :
   (univ : finset (α ⊕ β)) =
-    ((univ : finset α).map embedding.inl).disj_union ((univ : finset β).map embedding.inr) (λ a,
-      by { simp_rw mem_map, rintro ⟨a, _, rfl⟩ ⟨b, _, ⟨⟩⟩ }) :=
+    ((univ : finset α).map embedding.inl).disj_union ((univ : finset β).map embedding.inr)
+      finset.disjoint_map_inl_map_inr :=
 rfl
 
 /-- Given that `α ⊕ β` is a fintype, `α` is also a fintype. This is non-computable as it uses

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -980,8 +980,8 @@ instance (α : Type u) (β : Type v) [fintype α] [fintype β] : fintype (α ⊕
 { elems := univ.disj_sum univ,
   complete := by rintro (_ | _); simp }
 
-lemma univ_sum_type {α β : Type*} [fintype α] [fintype β] :
-  (univ : finset (α ⊕ β)) = univ.disj_sum univ :=
+@[simp] lemma finset.univ_disj_sum_univ {α β : Type*} [fintype α] [fintype β] :
+  univ.disj_sum univ = (univ : finset (α ⊕ β)) :=
 rfl
 
 /-- Given that `α ⊕ β` is a fintype, `α` is also a fintype. This is non-computable as it uses

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -10,6 +10,7 @@ import data.finset.pi
 import data.finset.powerset
 import data.finset.prod
 import data.finset.sigma
+import data.finset.sum
 import data.finite.defs
 import data.list.nodup_equiv_fin
 import data.sym.basic
@@ -975,20 +976,12 @@ instance (α : Type*) [fintype α] : fintype (lex α) := ‹fintype α›
 @[simp] lemma fintype.card_lex (α : Type*) [fintype α] :
   fintype.card (lex α) = fintype.card α := rfl
 
-/-- Note that this is not stated with `disjoint` so that it can be used with `finset.disj_union`. -/
-lemma finset.disjoint_map_inl_map_inr {α β : Type*} [fintype α] [fintype β]
-  (s : finset α) (t : finset β) (a : α ⊕ β) :
-  a ∈ (s.map embedding.inl : finset (α ⊕ β)) → a ∉ (t.map embedding.inr : finset (α ⊕ β)) :=
-by { simp_rw mem_map, rintro ⟨a, _, rfl⟩ ⟨b, _, ⟨⟩⟩ }
-
 instance (α : Type u) (β : Type v) [fintype α] [fintype β] : fintype (α ⊕ β) :=
-{ elems := finset.disj_union _ _ (finset.disjoint_map_inl_map_inr univ univ),
+{ elems := univ.disj_sum univ,
   complete := by rintro (_ | _); simp }
 
 lemma univ_sum_type {α β : Type*} [fintype α] [fintype β] :
-  (univ : finset (α ⊕ β)) =
-    ((univ : finset α).map embedding.inl).disj_union ((univ : finset β).map embedding.inr)
-      (finset.disjoint_map_inl_map_inr _ _) :=
+  (univ : finset (α ⊕ β)) = univ.disj_sum univ :=
 rfl
 
 /-- Given that `α ⊕ β` is a fintype, `α` is also a fintype. This is non-computable as it uses
@@ -1003,11 +996,7 @@ fintype.of_injective (sum.inr : β → α ⊕ β) sum.inr_injective
 
 @[simp] theorem fintype.card_sum [fintype α] [fintype β] :
   fintype.card (α ⊕ β) = fintype.card α + fintype.card β :=
-begin
-  refine (card_disj_union _ _ _).trans _,
-  rw [card_map, card_map],
-  refl,
-end
+card_disj_sum _ _
 
 /-- If the subtype of all-but-one elements is a `fintype` then the type itself is a `fintype`. -/
 def fintype_of_fintype_ne (a : α) (h : fintype {b // b ≠ a}) : fintype α :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -976,18 +976,19 @@ instance (α : Type*) [fintype α] : fintype (lex α) := ‹fintype α›
   fintype.card (lex α) = fintype.card α := rfl
 
 /-- Note that this is not stated with `disjoint` so that it can be used with `finset.disj_union`. -/
-lemma finset.disjoint_map_inl_map_inr {α β : Type*} [fintype α] [fintype β] (a : α ⊕ β) :
-  a ∈ (univ.map embedding.inl : finset (α ⊕ β)) → a ∉ (univ.map embedding.inr : finset (α ⊕ β)) :=
+lemma finset.disjoint_map_inl_map_inr {α β : Type*} [fintype α] [fintype β]
+  (s : finset α) (t : finset β) (a : α ⊕ β) :
+  a ∈ (s.map embedding.inl : finset (α ⊕ β)) → a ∉ (t.map embedding.inr : finset (α ⊕ β)) :=
 by { simp_rw mem_map, rintro ⟨a, _, rfl⟩ ⟨b, _, ⟨⟩⟩ }
 
 instance (α : Type u) (β : Type v) [fintype α] [fintype β] : fintype (α ⊕ β) :=
-{ elems := finset.disj_union _ _ finset.disjoint_map_inl_map_inr,
+{ elems := finset.disj_union _ _ (finset.disjoint_map_inl_map_inr univ univ),
   complete := by rintro (_ | _); simp }
 
 lemma univ_sum_type {α β : Type*} [fintype α] [fintype β] :
   (univ : finset (α ⊕ β)) =
     ((univ : finset α).map embedding.inl).disj_union ((univ : finset β).map embedding.inr)
-      finset.disjoint_map_inl_map_inr :=
+      (finset.disjoint_map_inl_map_inr _ _) :=
 rfl
 
 /-- Given that `α ⊕ β` is a fintype, `α` is also a fintype. This is non-computable as it uses

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -243,7 +243,7 @@ lemma fintype.prod_sum_elim (f : α₁ → M) (g : α₂ → M) :
   (∏ x, sum.elim f g x) = (∏ a₁, f a₁) * (∏ a₂, g a₂) :=
 prod_disj_sum _ _ _
 
-@[to_additive]
+@[simp, to_additive]
 lemma fintype.prod_sum_type (f : α₁ ⊕ α₂ → M) :
   (∏ x, f x) = (∏ a₁, f (sum.inl a₁)) * (∏ a₂, f (sum.inr a₂)) :=
 prod_disj_sum _ _ _

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -241,7 +241,7 @@ variables {α₁ : Type*} {α₂ : Type*} {M : Type*} [fintype α₁] [fintype �
 @[to_additive]
 lemma fintype.prod_sum_elim (f : α₁ → M) (g : α₂ → M) :
   (∏ x, sum.elim f g x) = (∏ a₁, f a₁) * (∏ a₂, g a₂) :=
-by { classical, rw [univ_sum_type, prod_sum_elim] }
+by { classical, rw [←univ_disj_sum_univ, prod_sum_elim] }
 
 @[to_additive]
 lemma fintype.prod_sum_type (f : α₁ ⊕ α₂ → M) :

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -241,11 +241,11 @@ variables {α₁ : Type*} {α₂ : Type*} {M : Type*} [fintype α₁] [fintype �
 @[to_additive]
 lemma fintype.prod_sum_elim (f : α₁ → M) (g : α₂ → M) :
   (∏ x, sum.elim f g x) = (∏ a₁, f a₁) * (∏ a₂, g a₂) :=
-by { classical, rw [←univ_disj_sum_univ, prod_sum_elim] }
+prod_disj_sum _ _ _
 
 @[to_additive]
 lemma fintype.prod_sum_type (f : α₁ ⊕ α₂ → M) :
   (∏ x, f x) = (∏ a₁, f (sum.inl a₁)) * (∏ a₂, f (sum.inr a₂)) :=
-by simp only [← fintype.prod_sum_elim, sum.elim_comp_inl_inr]
+prod_disj_sum _ _ _
 
 end


### PR DESCRIPTION
Using `finset.disj_sum` instead of `finset.union` removes a handful of proof obligations, and makes some results defeq.

This removes the generalization on `univ_sum_type` that includes handling `fintype.subsingleton`, as it probably isn't useful; but the new version holds without decidable equality.

This removes `finset.prod_on_sum` which is a duplicate of `fintype.prod_sum_type`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
