### PR TITLE
[Merged by Bors] - chore(analysis/complex/basic): golf some proofs

### DIFF
--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -242,9 +242,7 @@ conjugation. -/
 lemma ring_hom_eq_id_or_conj_of_continuous {f : ℂ →+* ℂ} (hf : continuous f) :
   f = ring_hom.id ℂ ∨ f = conj :=
 begin
-  refine (real_alg_hom_eq_id_or_conj $ alg_hom.mk' f $ λ x z, congr_fun _ x).imp (λ h, _) (λ h, _),
-  { refine rat.dense_embedding_coe_real.dense.equalizer (by continuity) (by continuity) _,
-    ext1, simp only [real_smul, function.comp_app, map_rat_cast, of_real_rat_cast, map_mul], },
+  refine (real_alg_hom_eq_id_or_conj $ alg_hom.mk' f $ map_real_smul f hf).imp (λ h, _) (λ h, _),
   all_goals { convert congr_arg alg_hom.to_ring_hom h, ext1, refl, },
 end
 
@@ -266,6 +264,16 @@ def of_real_li : ℝ →ₗᵢ[ℝ] ℂ := ⟨of_real_am.to_linear_map, norm_rea
 lemma isometry_of_real : isometry (coe : ℝ → ℂ) := of_real_li.isometry
 
 @[continuity] lemma continuous_of_real : continuous (coe : ℝ → ℂ) := of_real_li.continuous
+
+/-- The only continuous ring homomorphism from `ℝ` to `ℂ` is the identity. -/
+lemma ring_hom_eq_of_real_of_continuous {f : ℝ →+* ℂ} (h : continuous f) :
+  f = complex.of_real :=
+begin
+  refine fun_like.coe_injective _,
+  refine rat.dense_embedding_coe_real.dense.equalizer h continuous_of_real _,
+  ext1,
+  simp only [function.comp_app, map_rat_cast, of_real_rat_cast],
+end
 
 /-- Continuous linear map version of the canonical embedding of `ℝ` in `ℂ`. -/
 def of_real_clm : ℝ →L[ℝ] ℂ := of_real_li.to_continuous_linear_map

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -269,11 +269,10 @@ lemma isometry_of_real : isometry (coe : ℝ → ℂ) := of_real_li.isometry
 lemma ring_hom_eq_of_real_of_continuous {f : ℝ →+* ℂ} (h : continuous f) :
   f = complex.of_real :=
 begin
-  refine fun_like.coe_injective _,
-  refine rat.dense_embedding_coe_real.dense.equalizer h continuous_of_real _,
-  ext1,
-  simp only [function.comp_app, map_rat_cast, of_real_rat_cast],
-end
+  convert congr_arg alg_hom.to_ring_hom
+    (subsingleton.elim (alg_hom.mk' f $ map_real_smul f h) $ algebra.of_id ℝ ℂ),
+  ext1, refl,
+end 
 
 /-- Continuous linear map version of the canonical embedding of `ℝ` in `ℂ`. -/
 def of_real_clm : ℝ →L[ℝ] ℂ := of_real_li.to_continuous_linear_map

--- a/src/topology/instances/real_vector_space.lean
+++ b/src/topology/instances/real_vector_space.lean
@@ -18,10 +18,8 @@ variables {E : Type*} [add_comm_group E] [module ℝ E] [topological_space E]
   [has_continuous_smul ℝ E] {F : Type*} [add_comm_group F] [module ℝ F]
   [topological_space F] [has_continuous_smul ℝ F] [t2_space F]
 
-namespace add_monoid_hom
-
 /-- A continuous additive map between two vector spaces over `ℝ` is `ℝ`-linear. -/
-lemma map_real_smul (f : E →+ F) (hf : continuous f) (c : ℝ) (x : E) :
+lemma map_real_smul {G} [add_monoid_hom_class G E F] (f : G) (hf : continuous f) (c : ℝ) (x : E) :
   f (c • x) = c • f x :=
 suffices (λ c : ℝ, f (c • x)) = λ c : ℝ, c • f x, from _root_.congr_fun this c,
 rat.dense_embedding_coe_real.dense.equalizer
@@ -29,10 +27,12 @@ rat.dense_embedding_coe_real.dense.equalizer
   (continuous_id.smul continuous_const)
   (funext $ λ r, map_rat_cast_smul f ℝ ℝ r x)
 
+namespace add_monoid_hom
+
 /-- Reinterpret a continuous additive homomorphism between two real vector spaces
 as a continuous real-linear map. -/
 def to_real_linear_map (f : E →+ F) (hf : continuous f) : E →L[ℝ] F :=
-⟨{ to_fun := f, map_add' := f.map_add, map_smul' := f.map_real_smul hf }, hf⟩
+⟨{ to_fun := f, map_add' := f.map_add, map_smul' := map_real_smul f hf }, hf⟩
 
 @[simp] lemma coe_to_real_linear_map (f : E →+ F) (hf : continuous f) :
   ⇑(f.to_real_linear_map hf) = f := rfl
@@ -53,4 +53,4 @@ topological `ℝ`-algebra `A` (e.g. `A = ℂ`) and any topological group that is
 instance real.is_scalar_tower [t2_space E] {A : Type*} [topological_space A]
   [ring A] [algebra ℝ A] [module A E] [has_continuous_smul ℝ A]
   [has_continuous_smul A E] : is_scalar_tower ℝ A E :=
-⟨λ r x y, ((smul_add_hom A E).flip y).map_real_smul (continuous_id.smul continuous_const) r x⟩
+⟨λ r x y, map_real_smul ((smul_add_hom A E).flip y) (continuous_id.smul continuous_const) r x⟩


### PR DESCRIPTION
This also generalizes `add_monoid_hom.map_real_smul` to `add_monoid_hom_class` and removes the namespace to match `map_rat_smul`.

The `ring_hom_eq_of_real_of_continuous` lemma is new, but a trivial consequence of existing lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
