### PR TITLE
[Merged by Bors] - feat(geometry/euclidean/angle/oriented): more sign lemmas

### DIFF
--- a/src/geometry/euclidean/angle/oriented/affine.lean
+++ b/src/geometry/euclidean/angle/oriented/affine.lean
@@ -196,6 +196,18 @@ lemma angle_eq_iff_oangle_eq_of_sign_eq {p₁ p₂ p₃ p₄ p₅ p₆ : P} (hp�
 (o).angle_eq_iff_oangle_eq_of_sign_eq (vsub_ne_zero.2 hp₁) (vsub_ne_zero.2 hp₃)
                                       (vsub_ne_zero.2 hp₄) (vsub_ne_zero.2 hp₆) hs
 
+/-- The oriented angle between three points equals the unoriented angle if the sign is
+positive. -/
+lemma oangle_eq_angle_of_sign_eq_one {p₁ p₂ p₃ : P} (h : (∡ p₁ p₂ p₃).sign = 1) :
+  ∡ p₁ p₂ p₃ = ∠ p₁ p₂ p₃ :=
+(o).oangle_eq_angle_of_sign_eq_one h
+
+/-- The oriented angle between three points equals minus the unoriented angle if the sign is
+negative. -/
+lemma oangle_eq_angle_of_sign_eq_neg_one {p₁ p₂ p₃ : P} (h : (∡ p₁ p₂ p₃).sign = -1) :
+  ∡ p₁ p₂ p₃ = -∠ p₁ p₂ p₃ :=
+(o).oangle_eq_angle_of_sign_eq_neg_one h
+
 /-- The unoriented angle at `p` between two points not equal to `p` is zero if and only if the
 unoriented angle is zero. -/
 lemma oangle_eq_zero_iff_angle_eq_zero {p p₁ p₂ : P} (hp₁ : p₁ ≠ p) (hp₂ : p₂ ≠ p) :

--- a/src/geometry/euclidean/angle/oriented/affine.lean
+++ b/src/geometry/euclidean/angle/oriented/affine.lean
@@ -204,9 +204,9 @@ lemma oangle_eq_angle_of_sign_eq_one {p₁ p₂ p₃ : P} (h : (∡ p₁ p₂ p�
 
 /-- The oriented angle between three points equals minus the unoriented angle if the sign is
 negative. -/
-lemma oangle_eq_angle_of_sign_eq_neg_one {p₁ p₂ p₃ : P} (h : (∡ p₁ p₂ p₃).sign = -1) :
+lemma oangle_eq_neg_angle_of_sign_eq_neg_one {p₁ p₂ p₃ : P} (h : (∡ p₁ p₂ p₃).sign = -1) :
   ∡ p₁ p₂ p₃ = -∠ p₁ p₂ p₃ :=
-(o).oangle_eq_angle_of_sign_eq_neg_one h
+(o).oangle_eq_neg_angle_of_sign_eq_neg_one h
 
 /-- The unoriented angle at `p` between two points not equal to `p` is zero if and only if the
 unoriented angle is zero. -/

--- a/src/geometry/euclidean/angle/oriented/basic.lean
+++ b/src/geometry/euclidean/angle/oriented/basic.lean
@@ -945,6 +945,33 @@ begin
   rw [o.angle_eq_abs_oangle_to_real hw hx, o.angle_eq_abs_oangle_to_real hy hz, h]
 end
 
+/-- The oriented angle between two vectors equals the unoriented angle if the sign is positive. -/
+lemma oangle_eq_angle_of_sign_eq_one {x y : V} (h : (o.oangle x y).sign = 1) :
+  o.oangle x y = inner_product_geometry.angle x y :=
+begin
+  by_cases hx : x = 0, { exfalso, simpa [hx] using h },
+  by_cases hy : y = 0, { exfalso, simpa [hy] using h },
+  refine (o.oangle_eq_angle_or_eq_neg_angle hx hy).resolve_right _,
+  intro hxy,
+  rw [hxy, real.angle.sign_neg, neg_eq_iff_neg_eq, eq_comm, ←sign_type.neg_iff, ←not_le] at h,
+  exact h (real.angle.sign_coe_nonneg_of_nonneg_of_le_pi (inner_product_geometry.angle_nonneg _ _)
+                                                         (inner_product_geometry.angle_le_pi _ _))
+end
+
+/-- The oriented angle between two vectors equals minus the unoriented angle if the sign is
+negative. -/
+lemma oangle_eq_angle_of_sign_eq_neg_one {x y : V} (h : (o.oangle x y).sign = -1) :
+  o.oangle x y = -inner_product_geometry.angle x y :=
+begin
+  by_cases hx : x = 0, { exfalso, simpa [hx] using h },
+  by_cases hy : y = 0, { exfalso, simpa [hy] using h },
+  refine (o.oangle_eq_angle_or_eq_neg_angle hx hy).resolve_left _,
+  intro hxy,
+  rw [hxy, ←sign_type.neg_iff, ←not_le] at h,
+  exact h (real.angle.sign_coe_nonneg_of_nonneg_of_le_pi (inner_product_geometry.angle_nonneg _ _)
+                                                         (inner_product_geometry.angle_le_pi _ _))
+end
+
 /-- The oriented angle between two nonzero vectors is zero if and only if the unoriented angle
 is zero. -/
 lemma oangle_eq_zero_iff_angle_eq_zero {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) :
@@ -1091,6 +1118,64 @@ not change the sign of the angle. -/
 @[simp] lemma oangle_sign_sub_smul_left (x y : V) (r : ℝ) :
   (o.oangle (x - r • y) y).sign = (o.oangle x y).sign :=
 by rw [sub_eq_add_neg, ←neg_smul, oangle_sign_add_smul_left]
+
+/-- Adding the first vector passed to `oangle` to the second vector does not change the sign of
+the angle. -/
+@[simp] lemma oangle_sign_add_right (x y : V) : (o.oangle x (x + y)).sign = (o.oangle x y).sign :=
+by rw [←o.oangle_sign_smul_add_right x y 1, one_smul]
+
+/-- Adding the second vector passed to `oangle` to the first vector does not change the sign of
+the angle. -/
+@[simp] lemma oangle_sign_add_left (x y : V) : (o.oangle (x + y) y).sign = (o.oangle x y).sign :=
+by rw [←o.oangle_sign_add_smul_left x y 1, one_smul]
+
+/-- Subtracting the first vector passed to `oangle` from the second vector does not change the
+sign of the angle. -/
+@[simp] lemma oangle_sign_sub_right (x y : V) :
+  (o.oangle x (y - x)).sign = (o.oangle x y).sign :=
+by rw [←o.oangle_sign_sub_smul_right x y 1, one_smul]
+
+/-- Subtracting the second vector passed to `oangle` from the first vector does not change the
+sign of the angle. -/
+@[simp] lemma oangle_sign_sub_left (x y : V) :
+  (o.oangle (x - y) y).sign = (o.oangle x y).sign :=
+by rw [←o.oangle_sign_sub_smul_left x y 1, one_smul]
+
+/-- Subtracting the second vector passed to `oangle` from a multiple of the first vector negates
+the sign of the angle. -/
+@[simp] lemma oangle_sign_smul_sub_right (x y : V) (r : ℝ) :
+  (o.oangle x (r • x - y)).sign = -(o.oangle x y).sign :=
+by rw [←oangle_sign_neg_right, sub_eq_add_neg, oangle_sign_smul_add_right]
+
+/-- Subtracting the first vector passed to `oangle` from a multiple of the second vector negates
+the sign of the angle. -/
+@[simp] lemma oangle_sign_smul_sub_left (x y : V) (r : ℝ) :
+  (o.oangle (r • y - x) y).sign = -(o.oangle x y).sign :=
+by rw [←oangle_sign_neg_left, sub_eq_neg_add, oangle_sign_add_smul_left]
+
+/-- Subtracting the second vector passed to `oangle` from the first vector negates the sign of
+the angle. -/
+lemma oangle_sign_sub_right_eq_neg (x y : V) :
+  (o.oangle x (x - y)).sign = -(o.oangle x y).sign :=
+by rw [←o.oangle_sign_smul_sub_right x y 1, one_smul]
+
+/-- Subtracting the first vector passed to `oangle` from the second vector negates the sign of
+the angle. -/
+lemma oangle_sign_sub_left_eq_neg (x y : V) :
+  (o.oangle (y - x) y).sign = -(o.oangle x y).sign :=
+by rw [←o.oangle_sign_smul_sub_left x y 1, one_smul]
+
+/-- Subtracting the first vector passed to `oangle` from the second vector then swapping the
+vectors does not change the sign of the angle. -/
+@[simp] lemma oangle_sign_sub_right_swap (x y : V) :
+  (o.oangle y (y - x)).sign = (o.oangle x y).sign :=
+by rw [oangle_sign_sub_right_eq_neg, o.oangle_rev y x, real.angle.sign_neg]
+
+/-- Subtracting the second vector passed to `oangle` from the first vector then swapping the
+vectors does not change the sign of the angle. -/
+@[simp] lemma oangle_sign_sub_left_swap (x y : V) :
+  (o.oangle (x - y) x).sign = (o.oangle x y).sign :=
+by rw [oangle_sign_sub_left_eq_neg, o.oangle_rev y x, real.angle.sign_neg]
 
 /-- The sign of the angle between a vector, and a linear combination of that vector with a second
 vector, is the sign of the factor by which the second vector is multiplied in that combination

--- a/src/geometry/euclidean/angle/oriented/basic.lean
+++ b/src/geometry/euclidean/angle/oriented/basic.lean
@@ -960,7 +960,7 @@ end
 
 /-- The oriented angle between two vectors equals minus the unoriented angle if the sign is
 negative. -/
-lemma oangle_eq_angle_of_sign_eq_neg_one {x y : V} (h : (o.oangle x y).sign = -1) :
+lemma oangle_eq_neg_angle_of_sign_eq_neg_one {x y : V} (h : (o.oangle x y).sign = -1) :
   o.oangle x y = -inner_product_geometry.angle x y :=
 begin
   by_cases hx : x = 0, { exfalso, simpa [hx] using h },


### PR DESCRIPTION
Add more lemmas about signs of oriented angles: relation to unoriented angles when the sign is given as 1 or as -1, plus a series of (mostly `@[simp]`) lemmas for signs of angles between linear combinations of vectors, that follow readily from the existing lemmas for such combinations but avoid the need for manipulation using `one_smul` and similar at the site of use.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
