### PR TITLE
[Merged by Bors] - fix(geometry/euclidean/angle/unoriented/right_angle): lemma naming consistency

### DIFF
--- a/src/geometry/euclidean/angle/unoriented/right_angle.lean
+++ b/src/geometry/euclidean/angle/unoriented/right_angle.lean
@@ -486,7 +486,7 @@ begin
 end
 
 /-- The tangent of an angle in a right-angled triangle as a ratio of sides. -/
-lemma tan_angle_eq_of_angle_eq_pi_div_two {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = π / 2) :
+lemma tan_angle_of_angle_eq_pi_div_two {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = π / 2) :
   real.tan (∠ p₂ p₃ p₁) = dist p₁ p₂ / dist p₃ p₂ :=
 begin
   rw [angle, ←inner_eq_zero_iff_angle_eq_pi_div_two, real_inner_comm, ←neg_eq_zero,


### PR DESCRIPTION
Adjust the name of one lemma for `tan` to be consistent with the names of corresponding `sin` and `cos` lemmas.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
