### PR TITLE
[Merged by Bors] - feat(order/cover): Covering two distinct elements

### DIFF
--- a/src/order/cover.lean
+++ b/src/order/cover.lean
@@ -134,6 +134,24 @@ by rw [← Icc_diff_left, h.Icc_eq, diff_singleton_subset_iff]
 
 end partial_order
 
+
+section semilattice_sup
+variables [semilattice_sup α] {a b c : α}
+
+lemma wcovby.sup_eq (hac : a ⩿ c) (hbc : b ⩿ c) (hab : a ≠ b) : a ⊔ b = c :=
+(sup_le hac.le hbc.le).eq_of_not_lt $ λ h,
+  hab.lt_sup_or_lt_sup.elim (λ h', hac.2 h' h) (λ h', hbc.2 h' h)
+
+end semilattice_sup
+
+section semilattice_inf
+variables [semilattice_inf α] {a b c : α}
+
+lemma wcovby.inf_eq (hca : c ⩿ a) (hcb : c ⩿ b) (hab : a ≠ b) : a ⊓ b = c :=
+(le_inf hca.le hcb.le).eq_of_not_gt $ λ h, hab.inf_lt_or_inf_lt.elim (hca.2 h) (hcb.2 h)
+
+end semilattice_inf
+
 end weakly_covers
 
 section has_lt

--- a/src/order/cover.lean
+++ b/src/order/cover.lean
@@ -134,7 +134,6 @@ by rw [← Icc_diff_left, h.Icc_eq, diff_singleton_subset_iff]
 
 end partial_order
 
-
 section semilattice_sup
 variables [semilattice_sup α] {a b c : α}
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -232,7 +232,7 @@ lemma sup_eq_sup_iff_right : a ⊔ c = b ⊔ c ↔ a ≤ b ⊔ c ∧ b ≤ a ⊔
 ⟨λ h, ⟨h ▸ le_sup_left, h.symm ▸ le_sup_left⟩, λ h, sup_congr_right h.1 h.2⟩
 
 lemma ne.lt_sup_or_lt_sup (hab : a ≠ b) : a < a ⊔ b ∨ b < a ⊔ b :=
-by { rw [left_lt_sup, right_lt_sup], exact hab.symm.not_le_or_not_le }
+hab.symm.not_le_or_not_le.imp left_lt_sup.2 right_lt_sup.2
 
 /-- If `f` is monotone, `g` is antitone, and `f ≤ g`, then for all `a`, `b` we have `f a ≤ g b`. -/
 theorem monotone.forall_le_of_antitone {β : Type*} [preorder β] {f g : α → β}
@@ -388,8 +388,7 @@ lemma inf_eq_inf_iff_left : a ⊓ b = a ⊓ c ↔ a ⊓ c ≤ b ∧ a ⊓ b ≤ 
 lemma inf_eq_inf_iff_right : a ⊓ c = b ⊓ c ↔ b ⊓ c ≤ a ∧ a ⊓ c ≤ b :=
 @sup_eq_sup_iff_right αᵒᵈ _ _ _ _
 
-lemma ne.inf_lt_or_inf_lt (hab : a ≠ b) : a ⊓ b < a ∨ a ⊓ b < b :=
-by { rw [inf_lt_left, inf_lt_right], exact hab.not_le_or_not_le }
+lemma ne.inf_lt_or_inf_lt : a ≠ b → a ⊓ b < a ∨ a ⊓ b < b := @ne.lt_sup_or_lt_sup αᵒᵈ _ _ _
 
 theorem semilattice_inf.ext_inf {α} {A B : semilattice_inf α}
   (H : ∀ x y : α, (by haveI := A; exact x ≤ y) ↔ x ≤ y)

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -231,6 +231,9 @@ lemma sup_eq_sup_iff_left : a ⊔ b = a ⊔ c ↔ b ≤ a ⊔ c ∧ c ≤ a ⊔ 
 lemma sup_eq_sup_iff_right : a ⊔ c = b ⊔ c ↔ a ≤ b ⊔ c ∧ b ≤ a ⊔ c :=
 ⟨λ h, ⟨h ▸ le_sup_left, h.symm ▸ le_sup_left⟩, λ h, sup_congr_right h.1 h.2⟩
 
+lemma ne.lt_sup_or_lt_sup (hab : a ≠ b) : a < a ⊔ b ∨ b < a ⊔ b :=
+by { rw [left_lt_sup, right_lt_sup], exact hab.symm.not_le_or_not_le }
+
 /-- If `f` is monotone, `g` is antitone, and `f ≤ g`, then for all `a`, `b` we have `f a ≤ g b`. -/
 theorem monotone.forall_le_of_antitone {β : Type*} [preorder β] {f g : α → β}
   (hf : monotone f) (hg : antitone g) (h : f ≤ g) (m n : α) :
@@ -384,6 +387,9 @@ lemma inf_eq_inf_iff_left : a ⊓ b = a ⊓ c ↔ a ⊓ c ≤ b ∧ a ⊓ b ≤ 
 
 lemma inf_eq_inf_iff_right : a ⊓ c = b ⊓ c ↔ b ⊓ c ≤ a ∧ a ⊓ c ≤ b :=
 @sup_eq_sup_iff_right αᵒᵈ _ _ _ _
+
+lemma ne.inf_lt_or_inf_lt (hab : a ≠ b) : a ⊓ b < a ∨ a ⊓ b < b :=
+by { rw [inf_lt_left, inf_lt_right], exact hab.not_le_or_not_le }
 
 theorem semilattice_inf.ext_inf {α} {A B : semilattice_inf α}
   (H : ∀ x y : α, (by haveI := A; exact x ≤ y) ↔ x ≤ y)


### PR DESCRIPTION
`a ⩿ c → b ⩿ c → a ≠ b → a ⊔ b = c` and dually.

This is precisely one of the two Jordan-Hölder lattice laws when we set `is_maximal := (⋖)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
