### PR TITLE
[Merged by Bors] - feat(group_theory/commutator): Define the set of commutators

### DIFF
--- a/src/group_theory/abelianization.lean
+++ b/src/group_theory/abelianization.lean
@@ -36,24 +36,24 @@ def commutator : subgroup G :=
 
 lemma commutator_def : commutator G = ⁅(⊤ : subgroup G), ⊤⁆ := rfl
 
-lemma commutator_eq_closure : commutator G = subgroup.closure (commutators G) :=
-by simp_rw [commutator, subgroup.commutator_def, subgroup.mem_top, exists_true_left, commutators]
+lemma commutator_eq_closure : commutator G = subgroup.closure (commutator_set G) :=
+by simp [commutator, subgroup.commutator_def, commutator_set]
 
 lemma commutator_eq_normal_closure :
-  commutator G = subgroup.normal_closure (commutators G) :=
-by simp_rw [commutator, subgroup.commutator_def', subgroup.mem_top, exists_true_left, commutators]
+  commutator G = subgroup.normal_closure (commutator_set G) :=
+by simp [commutator, subgroup.commutator_def', commutator_set]
 
 instance commutator_characteristic : (commutator G).characteristic :=
 subgroup.commutator_characteristic ⊤ ⊤
 
-instance [finite (commutators G)] : group.fg (commutator G) :=
+instance [finite (commutator_set G)] : group.fg (commutator G) :=
 begin
   rw commutator_eq_closure,
   apply group.closure_finite_fg,
 end
 
-lemma rank_commutator_le_card [finite (commutators G)] :
-  group.rank (commutator G) ≤ nat.card (commutators G) :=
+lemma rank_commutator_le_card [finite (commutator_set G)] :
+  group.rank (commutator G) ≤ nat.card (commutator_set G) :=
 begin
   rw subgroup.rank_congr (commutator_eq_closure G),
   apply subgroup.rank_closure_finite_le_nat_card,

--- a/src/group_theory/abelianization.lean
+++ b/src/group_theory/abelianization.lean
@@ -36,24 +36,24 @@ def commutator : subgroup G :=
 
 lemma commutator_def : commutator G = ⁅(⊤ : subgroup G), ⊤⁆ := rfl
 
-lemma commutator_eq_closure : commutator G = subgroup.closure {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} :=
-by simp_rw [commutator, subgroup.commutator_def, subgroup.mem_top, exists_true_left]
+lemma commutator_eq_closure : commutator G = subgroup.closure (commutators G) :=
+by simp_rw [commutator, subgroup.commutator_def, subgroup.mem_top, exists_true_left, commutators]
 
 lemma commutator_eq_normal_closure :
-  commutator G = subgroup.normal_closure {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} :=
-by simp_rw [commutator, subgroup.commutator_def', subgroup.mem_top, exists_true_left]
+  commutator G = subgroup.normal_closure (commutators G) :=
+by simp_rw [commutator, subgroup.commutator_def', subgroup.mem_top, exists_true_left, commutators]
 
 instance commutator_characteristic : (commutator G).characteristic :=
 subgroup.commutator_characteristic ⊤ ⊤
 
-instance [finite {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}] : group.fg (commutator G) :=
+instance [finite (commutators G)] : group.fg (commutator G) :=
 begin
   rw commutator_eq_closure,
   apply group.closure_finite_fg,
 end
 
-lemma rank_commutator_le_card [finite {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}] :
-  group.rank (commutator G) ≤ nat.card {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} :=
+lemma rank_commutator_le_card [finite (commutators G)] :
+  group.rank (commutator G) ≤ nat.card (commutators G) :=
 begin
   rw subgroup.rank_congr (commutator_eq_closure G),
   apply subgroup.rank_closure_finite_le_nat_card,

--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -204,3 +204,13 @@ begin
 end
 
 end subgroup
+
+variables (G)
+
+def commutators : set G :=
+{g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}
+
+lemma commutators_def : commutators G = {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} := rfl
+
+instance : nonempty (commutators G) :=
+⟨⟨1, 1, 1, commutator_element_self 1⟩⟩

--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -208,21 +208,21 @@ end subgroup
 variables (G)
 
 /-- The set of commutator elements `⁅g₁, g₂⁆` in `G`. -/
-def commutators : set G :=
+def commutator_set : set G :=
 {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}
 
-lemma commutators_def : commutators G = {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} := rfl
+lemma commutator_set_def : commutator_set G = {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} := rfl
 
-lemma one_mem_commutators : (1 : G) ∈ commutators G :=
+lemma one_mem_commutator_set : (1 : G) ∈ commutator_set G :=
 ⟨1, 1, commutator_element_self 1⟩
 
-instance : nonempty (commutators G) :=
-⟨⟨1, one_mem_commutators G⟩⟩
+instance : nonempty (commutator_set G) :=
+⟨⟨1, one_mem_commutator_set G⟩⟩
 
 variables {G g}
 
-lemma mem_commutators_iff : g ∈ commutators G ↔ ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g :=
+lemma mem_commutator_set_iff : g ∈ commutator_set G ↔ ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g :=
 iff.rfl
 
-lemma commutator_mem_commutators : ⁅g₁, g₂⁆ ∈ commutators G :=
+lemma commutator_mem_commutator_set : ⁅g₁, g₂⁆ ∈ commutator_set G :=
 ⟨g₁, g₂, rfl⟩

--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -207,6 +207,7 @@ end subgroup
 
 variables (G)
 
+/-- The set of commutator elements `⁅g₁, g₂⁆` in `G`. -/
 def commutators : set G :=
 {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}
 

--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -212,5 +212,16 @@ def commutators : set G :=
 
 lemma commutators_def : commutators G = {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} := rfl
 
+lemma one_mem_commutators : (1 : G) ∈ commutators G :=
+⟨1, 1, commutator_element_self 1⟩
+
 instance : nonempty (commutators G) :=
-⟨⟨1, 1, 1, commutator_element_self 1⟩⟩
+⟨⟨1, one_mem_commutators G⟩⟩
+
+variables {G g}
+
+lemma mem_commutators_iff : g ∈ commutators G ↔ ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g :=
+iff.rfl
+
+lemma commutator_mem_commutators : ⁅g₁, g₂⁆ ∈ commutators G :=
+⟨g₁, g₂, rfl⟩

--- a/src/group_theory/schreier.lean
+++ b/src/group_theory/schreier.lean
@@ -146,8 +146,9 @@ variables (G)
 
 /-- If `G` has `n` commutators `[g₁, g₂]`, then `|G'| ∣ [G : Z(G)] ^ ([G : Z(G)] * n + 1)`,
 where `G'` denotes the commutator of `G`. -/
-lemma card_commutator_dvd_index_center_pow [finite (commutators G)] :
-  nat.card (commutator G) ∣ (center G).index ^ ((center G).index * nat.card (commutators G) + 1) :=
+lemma card_commutator_dvd_index_center_pow [finite (commutator_set G)] :
+  nat.card (commutator G) ∣
+    (center G).index ^ ((center G).index * nat.card (commutator_set G) + 1) :=
 begin
   -- First handle the case when `Z(G)` has infinite index and `[G : Z(G)]` is defined to be `0`
   by_cases hG : (center G).index = 0,

--- a/src/group_theory/schreier.lean
+++ b/src/group_theory/schreier.lean
@@ -146,9 +146,8 @@ variables (G)
 
 /-- If `G` has `n` commutators `[g₁, g₂]`, then `|G'| ∣ [G : Z(G)] ^ ([G : Z(G)] * n + 1)`,
 where `G'` denotes the commutator of `G`. -/
-lemma card_commutator_dvd_index_center_pow [finite {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g}] :
-  nat.card (commutator G) ∣
-    (center G).index ^ ((center G).index * nat.card {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} + 1) :=
+lemma card_commutator_dvd_index_center_pow [finite (commutators G)] :
+  nat.card (commutator G) ∣ (center G).index ^ ((center G).index * nat.card (commutators G) + 1) :=
 begin
   -- First handle the case when `Z(G)` has infinite index and `[G : Z(G)]` is defined to be `0`
   by_cases hG : (center G).index = 0,


### PR DESCRIPTION
With some of my upcoming group theory PRs, it is going to start being helpful to have a name for the set of commutators.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
