### PR TITLE
[Merged by Bors] - feat(data/finsupp/basic): add a `has_repr` instance

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1633,4 +1633,16 @@ sigma_finsupp_add_equiv_pi_finsupp f j i = f ⟨j, i⟩ := rfl
 
 end sigma
 
+/-! ### Meta declarations -/
+
+/-- Stringify a `finsupp` as a sequence of `finsupp.single` terms.
+
+Note this is `meta` as it has to choose some order for the terms. -/
+meta instance (ι α : Type*) [has_zero α] [has_repr ι] [has_repr α] :
+  has_repr (ι →₀ α) :=
+{ repr := λ f,
+  if f.support.card = 0 then "0"
+  else " + ".intercalate $
+    f.support.val.unquot.map (λ i, "finsupp.single " ++ repr i ++ " " ++ repr (f i)) }
+
 end finsupp

--- a/test/slim_check.lean
+++ b/test/slim_check.lean
@@ -403,6 +403,7 @@ begin
 Found problems!
 
 f := [0 ↦ 1, _ ↦ 0]
+issue: finsupp.single 0 1 = 0 does not hold
 (2 shrinks)
 -------------------
 ",


### PR DESCRIPTION
This is difficult to test because `finsupp.single` is `noncomputable`; but a good example of where this provides value is with `nat.factorization`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
