### PR TITLE
[Merged by Bors] - feat(category_theory/triangulated): changing namespaces, introducing triangulated categories

### DIFF
--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -22,7 +22,7 @@ open category_theory.limits
 
 universes v v₀ v₁ v₂ u u₀ u₁ u₂
 
-namespace category_theory.triangulated
+namespace category_theory.pretriangulated
 open category_theory.category
 
 /-
@@ -42,6 +42,8 @@ structure triangle := mk' ::
 (mor₁ : obj₁ ⟶ obj₂)
 (mor₂ : obj₂ ⟶ obj₃)
 (mor₃ : obj₃ ⟶ obj₁⟦(1:ℤ)⟧)
+
+variable {C}
 
 /--
 A triangle `(X,Y,Z,f,g,h)` in `C` is defined by the morphisms `f : X ⟶ Y`, `g : Y ⟶ Z`
@@ -67,11 +69,9 @@ instance : inhabited (triangle C) :=
 For each object in `C`, there is a triangle of the form `(X,X,0,𝟙 X,0,0)`
 -/
 @[simps]
-def contractible_triangle (X : C) : triangle C := triangle.mk C (𝟙 X) (0 : X ⟶ 0) 0
+def contractible_triangle (X : C) : triangle C := triangle.mk (𝟙 X) (0 : X ⟶ 0) 0
 
 end
-
-variable {C}
 
 /--
 A morphism of triangles `(X,Y,Z,f,g,h) ⟶ (X',Y',Z',f',g',h')` in `C` is a triple of morphisms
@@ -135,4 +135,4 @@ instance triangle_category : category (triangle C) :=
   id    := λ A, triangle_morphism_id A,
   comp  := λ A B C f g, f.comp g }
 
-end category_theory.triangulated
+end category_theory.pretriangulated

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -78,7 +78,9 @@ class pretriangulated :=
   (∃ (c : T₁.obj₃ ⟶ T₂.obj₃), (T₁.mor₂ ≫ c = b ≫ T₂.mor₂) ∧ (T₁.mor₃ ≫ a⟦1⟧' = c ≫ T₂.mor₃) ))
 
 namespace pretriangulated
-variables [pretriangulated C] [pretriangulated D]
+variables [hC : pretriangulated C]
+
+include hC
 
 notation `dist_triang `:20 C := distinguished_triangles C
 /--
@@ -141,6 +143,8 @@ TODO: If `C` is pretriangulated with respect to a shift,
 then `Cᵒᵖ` is pretriangulated with respect to the inverse shift.
 -/
 
+omit hC
+
 /--
 The underlying structure of a triangulated functor between pretriangulated categories `C` and `D`
 is a functor `F : C ⥤ D` together with given functorial isomorphisms `ξ X : F(X⟦1⟧) ⟶ F(X)⟦1⟧`.
@@ -181,7 +185,9 @@ def map_triangle (F : triangulated_functor_struct C D) : triangle C ⥤ triangle
 
 end triangulated_functor_struct
 
-variables (C D)
+include hC
+variables (C D) [pretriangulated D]
+
 /--
 A triangulated functor between pretriangulated categories `C` and `D` is a functor `F : C ⥤ D`
 together with given functorial isomorphisms `ξ X : F(X⟦1⟧) ⟶ F(X)⟦1⟧` such that for every

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -78,7 +78,7 @@ class pretriangulated :=
   (∃ (c : T₁.obj₃ ⟶ T₂.obj₃), (T₁.mor₂ ≫ c = b ≫ T₂.mor₂) ∧ (T₁.mor₃ ≫ a⟦1⟧' = c ≫ T₂.mor₃) ))
 
 namespace pretriangulated
-variables [pretriangulated C]
+variables [pretriangulated C] [pretriangulated D]
 
 notation `dist_triang `:20 C := distinguished_triangles C
 /--
@@ -189,12 +189,11 @@ distinguished triangle `(X,Y,Z,f,g,h)` of `C`, the triangle
 `(F(X), F(Y), F(Z), F(f), F(g), F(h) ≫ (ξ X))` is a distinguished triangle of `D`.
 See <https://stacks.math.columbia.edu/tag/014V>
 -/
-structure triangulated_functor [pretriangulated C] [pretriangulated D] extends
-  triangulated_functor_struct C D :=
+structure triangulated_functor extends triangulated_functor_struct C D :=
 (map_distinguished' : Π (T : triangle C), (T ∈ dist_triang C) →
   (to_triangulated_functor_struct.map_triangle.obj T ∈ dist_triang D) )
 
-instance [pretriangulated C] : inhabited (triangulated_functor C C) :=
+instance : inhabited (triangulated_functor C C) :=
 ⟨{obj := λ X, X,
   map := λ _ _ f, f,
   comm_shift := by refl ,
@@ -204,7 +203,7 @@ instance [pretriangulated C] : inhabited (triangulated_functor C C) :=
     rwa category.comp_id,
   end }⟩
 
-variables {C D} [pretriangulated C] [pretriangulated D]
+variables {C D}
 /--
 Given a `triangulated_functor` we can define a functor from triangles of `C` to triangles of `D`.
 -/

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -29,14 +29,16 @@ open category_theory.limits
 
 universes v v₀ v₁ v₂ u u₀ u₁ u₂
 
-namespace category_theory.triangulated
-open category_theory.category
+namespace category_theory
+open category pretriangulated
 
 /-
 We work in a preadditive category `C` equipped with an additive shift.
 -/
 variables (C : Type u) [category.{v} C] [has_zero_object C] [has_shift C ℤ] [preadditive C]
   [∀ n : ℤ, functor.additive (shift_functor C n)]
+variables (D : Type u₂) [category.{v₂} D] [has_zero_object D] [has_shift D ℤ] [preadditive D]
+  [∀ n : ℤ, functor.additive (shift_functor D n)]
 
 /--
 A preadditive category `C` with an additive shift, and a class of "distinguished triangles"
@@ -64,10 +66,10 @@ class pretriangulated :=
 (distinguished_triangles [] : set (triangle C))
 (isomorphic_distinguished : Π (T₁ ∈ distinguished_triangles) (T₂ ≅ T₁),
   T₂ ∈ distinguished_triangles)
-(contractible_distinguished : Π (X : C), (contractible_triangle C X) ∈ distinguished_triangles)
+(contractible_distinguished : Π (X : C), (contractible_triangle X) ∈ distinguished_triangles)
 (distinguished_cocone_triangle : Π (X Y : C) (f : X ⟶ Y), (∃ (Z : C) (g : Y ⟶ Z)
   (h : Z ⟶ X⟦(1:ℤ)⟧),
-  triangle.mk _ f g h ∈ distinguished_triangles))
+  triangle.mk f g h ∈ distinguished_triangles))
 (rotate_distinguished_triangle : Π (T : triangle C),
   T ∈ distinguished_triangles ↔ T.rotate ∈ distinguished_triangles)
 (complete_distinguished_triangle_morphism : Π (T₁ T₂ : triangle C)
@@ -103,16 +105,10 @@ See <https://stacks.math.columbia.edu/tag/0146>
 -/
 lemma comp_dist_triangle_mor_zero₁₂ (T ∈ dist_triang C) : T.mor₁ ≫ T.mor₂ = 0 :=
 begin
-  have h := contractible_distinguished T.obj₁,
-  have f := complete_distinguished_triangle_morphism,
-  specialize f (contractible_triangle C T.obj₁) T h H (𝟙 T.obj₁) T.mor₁,
-  have t : (contractible_triangle C T.obj₁).mor₁ ≫ T.mor₁ = 𝟙 T.obj₁ ≫ T.mor₁,
-    by refl,
-  specialize f t,
-  cases f with c f,
-  rw ← f.left,
-  simp only [limits.zero_comp, contractible_triangle_mor₂],
-end -- TODO : tidy this proof up
+  obtain ⟨c, hc⟩ := complete_distinguished_triangle_morphism _ _
+    (contractible_distinguished T.obj₁) H (𝟙 T.obj₁) T.mor₁ rfl,
+  simpa only [contractible_triangle_mor₂, zero_comp] using hc.left.symm,
+end
 
 /--
 Given any distinguished triangle
@@ -144,16 +140,6 @@ by simpa using comp_dist_triangle_mor_zero₁₂ C (T.rotate.rotate) H₂
 TODO: If `C` is pretriangulated with respect to a shift,
 then `Cᵒᵖ` is pretriangulated with respect to the inverse shift.
 -/
-end pretriangulated
-end category_theory.triangulated
-
-namespace category_theory.triangulated
-namespace pretriangulated
-
-variables (C : Type u₁) [category.{v₁} C] [has_zero_object C] [has_shift C ℤ] [preadditive C]
-  [∀ n : ℤ, functor.additive (shift_functor C n)]
-variables (D : Type u₂) [category.{v₂} D] [has_zero_object D] [has_shift D ℤ] [preadditive D]
-  [∀ n : ℤ, functor.additive (shift_functor D n)]
 
 /--
 The underlying structure of a triangulated functor between pretriangulated categories `C` and `D`
@@ -179,7 +165,7 @@ triangles of `D`.
 -/
 @[simps]
 def map_triangle (F : triangulated_functor_struct C D) : triangle C ⥤ triangle D :=
-{ obj := λ T, triangle.mk _ (F.map T.mor₁) (F.map T.mor₂)
+{ obj := λ T, triangle.mk (F.map T.mor₁) (F.map T.mor₂)
     (F.map T.mor₃ ≫ F.comm_shift.hom.app T.obj₁),
   map := λ S T f,
   { hom₁ := F.map f.hom₁,
@@ -234,6 +220,5 @@ maps onto in `D` is also distinguished.
 lemma triangulated_functor.map_distinguished (F : triangulated_functor C D) (T : triangle C)
   (h : T ∈ dist_triang C) : (F.map_triangle.obj T) ∈ dist_triang D := F.map_distinguished' T h
 
-
 end pretriangulated
-end category_theory.triangulated
+end category_theory

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -22,7 +22,7 @@ open category_theory.limits
 
 universes v v₀ v₁ v₂ u u₀ u₁ u₂
 
-namespace category_theory.triangulated
+namespace category_theory.pretriangulated
 open category_theory.category
 
 /--
@@ -47,7 +47,7 @@ applying `rotate` gives a triangle of the form:
 ```
 -/
 @[simps]
-def triangle.rotate (T : triangle C) : triangle C := triangle.mk _ T.mor₂ T.mor₃ (-T.mor₁⟦1⟧')
+def triangle.rotate (T : triangle C) : triangle C := triangle.mk T.mor₂ T.mor₃ (-T.mor₁⟦1⟧')
 
 section
 local attribute [semireducible] shift_shift_neg shift_neg_shift
@@ -68,7 +68,7 @@ not necessarily equal to `Z`, but it is isomorphic, by the `counit_iso` of `shif
 -/
 @[simps]
 def triangle.inv_rotate (T : triangle C) : triangle C :=
-triangle.mk _ (-T.mor₃⟦(-1:ℤ)⟧' ≫ (shift_shift_neg _ _).hom) T.mor₁
+triangle.mk (-T.mor₃⟦(-1:ℤ)⟧' ≫ (shift_shift_neg _ _).hom) T.mor₁
   (T.mor₂ ≫ (shift_neg_shift _ _).inv)
 
 end
@@ -351,4 +351,4 @@ by { change is_equivalence (triangle_rotation C).functor, apply_instance, }
 instance : is_equivalence (inv_rotate C) :=
 by { change is_equivalence (triangle_rotation C).inverse, apply_instance, }
 
-end category_theory.triangulated
+end category_theory.pretriangulated

--- a/src/category_theory/triangulated/triangulated.lean
+++ b/src/category_theory/triangulated/triangulated.lean
@@ -24,77 +24,71 @@ open_locale zero_object
 variables {C : Type*} [category C] [preadditive C] [has_zero_object C] [has_shift C ℤ]
   [∀ (n : ℤ), functor.additive (shift_functor C n)] [pretriangulated C]
 
-namespace triangulated
-
 variables {X₁ X₂ X₃ Z₁₂ Z₂₃ Z₁₃ : C} {u₁₂ : X₁ ⟶ X₂} {u₂₃ : X₂ ⟶ X₃} {u₁₃ : X₁ ⟶ X₃}
   (comm : u₁₂ ≫ u₂₃ = u₁₃)
   {v₁₂ : X₂ ⟶ Z₁₂} {w₁₂ : Z₁₂ ⟶ X₁⟦(1 : ℤ)⟧} (h₁₂ : triangle.mk u₁₂ v₁₂ w₁₂ ∈ dist_triang C)
   {v₂₃ : X₃ ⟶ Z₂₃} {w₂₃ : Z₂₃ ⟶ X₂⟦(1 : ℤ)⟧} (h₂₃ : triangle.mk u₂₃ v₂₃ w₂₃ ∈ dist_triang C)
   {v₁₃ : X₃ ⟶ Z₁₃} {w₁₃ : Z₁₃ ⟶ X₁⟦(1 : ℤ)⟧} (h₁₃ : triangle.mk u₁₃ v₁₃ w₁₃ ∈ dist_triang C)
 
+namespace triangulated
+
 include comm h₁₂ h₂₃ h₁₃
 
-/-- The octahedron axiom (TR 4), see https://stacks.math.columbia.edu/tag/05QK -/
-@[nolint unused_arguments]
-def octahedron_exists : Prop :=
-∃ (m₁ : Z₁₂ ⟶ Z₁₃) (m₃ : Z₁₃ ⟶ Z₂₃) (comm₁ : v₁₂ ≫ m₁ = u₂₃ ≫ v₁₃)
-    (comm₂ : w₁₂ = m₁ ≫ w₁₃) (comm₃ : v₁₃ ≫ m₃ = v₂₃) (comm₄ : w₁₃ ≫ u₁₂⟦1⟧' = m₃ ≫ w₂₃),
-    triangle.mk m₁ m₃ (w₂₃ ≫ v₁₂⟦1⟧') ∈ dist_triang C
+/-- An octahedron is a type of datum whose existence is asserted by
+the octahedron axiom (TR 4), see https://stacks.math.columbia.edu/tag/05QK -/
+structure octahedron :=
+(m₁ : Z₁₂ ⟶ Z₁₃)
+(m₃ : Z₁₃ ⟶ Z₂₃)
+(comm₁ : v₁₂ ≫ m₁ = u₂₃ ≫ v₁₃)
+(comm₂ : w₁₂ = m₁ ≫ w₁₃)
+(comm₃ : v₁₃ ≫ m₃ = v₂₃)
+(comm₄ : w₁₃ ≫ u₁₂⟦1⟧' = m₃ ≫ w₂₃)
+(mem : triangle.mk m₁ m₃ (w₂₃ ≫ v₁₂⟦1⟧') ∈ dist_triang C)
 
 omit comm h₁₂ h₂₃ h₁₃
 
-namespace octahedron_exists
+instance (X : C) : nonempty (octahedron (comp_id (𝟙 X)) (contractible_distinguished X)
+  (contractible_distinguished X) (contractible_distinguished X)) :=
+begin
+  refine ⟨⟨0, 0, _, _, _, _, by convert contractible_distinguished (0 : C)⟩⟩,
+  all_goals { apply subsingleton.elim, },
+end
 
-variables {comm h₁₂ h₂₃ h₁₃} (h : octahedron_exists comm h₁₂ h₂₃ h₁₃)
+namespace octahedron
 
-/-- A choice of morphism `m₁ : Z₁₂ ⟶ Z₁₃` for the octahedron axiom. -/
-def m₁ : Z₁₂ ⟶ Z₁₃ := h.some
+attribute [reassoc] comm₁ comm₃ comm₄
 
-/-- A choice of morphism `m₃ : Z₁₃ ⟶ Z₂₃` for the octahedron axiom. -/
-def m₃ : Z₁₃ ⟶ Z₂₃ := h.some_spec.some
+variables {comm h₁₂ h₂₃ h₁₃} (h : octahedron comm h₁₂ h₂₃ h₁₃)
 
-/-- The triangle `Z₁₂ ⟶ Z₁₃ ⟶ Z₂₃ ⟶ Z₁₂⟦1⟧` given by the octahedron axiom. -/
+/-- The triangle `Z₁₂ ⟶ Z₁₃ ⟶ Z₂₃ ⟶ Z₁₂⟦1⟧` given by an octahedron. -/
 @[simps]
 def triangle : triangle C := triangle.mk h.m₁ h.m₃ (w₂₃ ≫ v₁₂⟦1⟧')
 
-/-- The triangle `Z₁₂ ⟶ Z₁₃ ⟶ Z₂₃ ⟶ Z₁₂⟦1⟧` given by the octahedron axiom
-is distringuished. -/
-lemma mem_dist_triang : h.triangle ∈ dist_triang C :=
-h.some_spec.some_spec.some_spec.some_spec.some_spec.some_spec
-
-/-- The first morphism of triangles asserted by the octahedron axiom. -/
+/-- The first morphism of triangles given by an octahedron. -/
 @[simps]
 def triangle_morphism₁ : triangle.mk u₁₂ v₁₂ w₁₂ ⟶ triangle.mk u₁₃ v₁₃ w₁₃ :=
 { hom₁ := 𝟙 X₁,
   hom₂ := u₂₃,
   hom₃ := h.m₁,
   comm₁' := by { dsimp, rw [id_comp, comm], },
-  comm₂' := h.some_spec.some_spec.some,
-  comm₃' := begin
-    dsimp,
-    simpa only [functor.map_id, comp_id]
-      using h.some_spec.some_spec.some_spec.some,
-  end }
+  comm₂' := h.comm₁,
+  comm₃' := by { dsimp, simpa only [functor.map_id, comp_id] using h.comm₂, }, }
 
-/-- The second morphism of triangles asserted by the octahedron axiom. -/
+/-- The second morphism of triangles given an octahedron. -/
 @[simps]
 def triangle_morphism₂ : triangle.mk u₁₃ v₁₃ w₁₃ ⟶ triangle.mk u₂₃ v₂₃ w₂₃ :=
 { hom₁ := u₁₂,
   hom₂ := 𝟙 X₃,
   hom₃ := h.m₃,
   comm₁' := by { dsimp, rw [comp_id, comm], },
-  comm₂' := begin
-    dsimp,
-    simpa only [id_comp] using
-      h.some_spec.some_spec.some_spec.some_spec.some,
-  end,
-  comm₃' := h.some_spec.some_spec.some_spec.some_spec.some_spec.some, }
+  comm₂' := by { dsimp, rw [id_comp, h.comm₃], },
+  comm₃' := h.comm₄, }
 
-/- TODO (@joelriou): show that in order to verify the octahedron axiom, one may
+/- TODO (@joelriou): show that in order to verify the existence of an octahedron, one may
 replace the composable maps `u₁₂` and `u₂₃` by any isomorphic composable maps
 and the given "cones" of `u₁₂`, `u₂₃`, `u₁₃` by any choice of cones. -/
 
-end octahedron_exists
+end octahedron
 
 end triangulated
 
@@ -102,13 +96,24 @@ open triangulated
 
 variable (C)
 
-/-- A triangulated category is a pretriangulated which satisfies the octahedron axiom. -/
-class triangulated :=
-(octahedron' : ∀ ⦃X₁ X₂ X₃ Z₁₂ Z₂₃ Z₁₃ : C⦄ ⦃u₁₂ : X₁ ⟶ X₂⦄ ⦃u₂₃ : X₂ ⟶ X₃⦄ ⦃u₁₃ : X₁ ⟶ X₃⦄
+/-- A triangulated category is a pretriangulated category which satisfies
+the octahedron axiom (TR 4), see https://stacks.math.columbia.edu/tag/05QK -/
+class is_triangulated :=
+(octahedron_axiom : ∀ ⦃X₁ X₂ X₃ Z₁₂ Z₂₃ Z₁₃ : C⦄ ⦃u₁₂ : X₁ ⟶ X₂⦄ ⦃u₂₃ : X₂ ⟶ X₃⦄ ⦃u₁₃ : X₁ ⟶ X₃⦄
   (comm : u₁₂ ≫ u₂₃ = u₁₃)
   ⦃v₁₂ : X₂ ⟶ Z₁₂⦄ ⦃w₁₂ : Z₁₂ ⟶ X₁⟦1⟧⦄ (h₁₂ : triangle.mk u₁₂ v₁₂ w₁₂ ∈ dist_triang C)
   ⦃v₂₃ : X₃ ⟶ Z₂₃⦄ ⦃w₂₃ : Z₂₃ ⟶ X₂⟦1⟧⦄ (h₂₃ : triangle.mk u₂₃ v₂₃ w₂₃ ∈ dist_triang C)
   ⦃v₁₃ : X₃ ⟶ Z₁₃⦄ ⦃w₁₃ : Z₁₃ ⟶ X₁⟦1⟧⦄ (h₁₃ : triangle.mk u₁₃ v₁₃ w₁₃ ∈ dist_triang C),
-  triangulated.octahedron_exists comm h₁₂ h₂₃ h₁₃)
+  nonempty (octahedron comm h₁₂ h₂₃ h₁₃))
+
+namespace triangulated
+
+variable {C}
+
+/-- A choice of octahedron given by the octahedron axiom. -/
+def some_octahedron [is_triangulated C] : octahedron comm h₁₂ h₂₃ h₁₃ :=
+(is_triangulated.octahedron_axiom comm h₁₂ h₂₃ h₁₃).some
+
+end triangulated
 
 end category_theory

--- a/src/category_theory/triangulated/triangulated.lean
+++ b/src/category_theory/triangulated/triangulated.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2022 Luke Kershaw. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import category_theory.triangulated.pretriangulated
+
+/-!
+# Triangulated Categories
+
+This file contains the definition of triangulated categories, which are
+pretriangulated categories which satisfy the octahedron axiom.
+
+-/
+
+noncomputable theory
+
+namespace category_theory
+
+open limits category preadditive pretriangulated
+open_locale zero_object
+
+variables {C : Type*} [category C] [preadditive C] [has_zero_object C] [has_shift C ℤ]
+  [∀ (n : ℤ), functor.additive (shift_functor C n)] [pretriangulated C]
+
+namespace triangulated
+
+variables {X₁ X₂ X₃ Z₁₂ Z₂₃ Z₁₃ : C} {u₁₂ : X₁ ⟶ X₂} {u₂₃ : X₂ ⟶ X₃} {u₁₃ : X₁ ⟶ X₃}
+  (comm : u₁₂ ≫ u₂₃ = u₁₃)
+  {v₁₂ : X₂ ⟶ Z₁₂} {w₁₂ : Z₁₂ ⟶ X₁⟦(1 : ℤ)⟧} (h₁₂ : triangle.mk u₁₂ v₁₂ w₁₂ ∈ dist_triang C)
+  {v₂₃ : X₃ ⟶ Z₂₃} {w₂₃ : Z₂₃ ⟶ X₂⟦(1 : ℤ)⟧} (h₂₃ : triangle.mk u₂₃ v₂₃ w₂₃ ∈ dist_triang C)
+  {v₁₃ : X₃ ⟶ Z₁₃} {w₁₃ : Z₁₃ ⟶ X₁⟦(1 : ℤ)⟧} (h₁₃ : triangle.mk u₁₃ v₁₃ w₁₃ ∈ dist_triang C)
+
+include comm h₁₂ h₂₃ h₁₃
+
+/-- The octahedron axiom (TR 4), see https://stacks.math.columbia.edu/tag/05QK -/
+@[nolint unused_arguments]
+def octahedron_exists : Prop :=
+∃ (m₁ : Z₁₂ ⟶ Z₁₃) (m₃ : Z₁₃ ⟶ Z₂₃) (comm₁ : v₁₂ ≫ m₁ = u₂₃ ≫ v₁₃)
+    (comm₂ : w₁₂ = m₁ ≫ w₁₃) (comm₃ : v₁₃ ≫ m₃ = v₂₃) (comm₄ : w₁₃ ≫ u₁₂⟦1⟧' = m₃ ≫ w₂₃),
+    triangle.mk m₁ m₃ (w₂₃ ≫ v₁₂⟦1⟧') ∈ dist_triang C
+
+omit comm h₁₂ h₂₃ h₁₃
+
+namespace octahedron_exists
+
+variables {comm h₁₂ h₂₃ h₁₃} (h : octahedron_exists comm h₁₂ h₂₃ h₁₃)
+
+/-- A choice of morphism `m₁ : Z₁₂ ⟶ Z₁₃` for the octahedron axiom. -/
+def m₁ : Z₁₂ ⟶ Z₁₃ := h.some
+
+/-- A choice of morphism `m₃ : Z₁₃ ⟶ Z₂₃` for the octahedron axiom. -/
+def m₃ : Z₁₃ ⟶ Z₂₃ := h.some_spec.some
+
+/-- The triangle `Z₁₂ ⟶ Z₁₃ ⟶ Z₂₃ ⟶ Z₁₂⟦1⟧` given by the octahedron axiom. -/
+@[simps]
+def triangle : triangle C := triangle.mk h.m₁ h.m₃ (w₂₃ ≫ v₁₂⟦1⟧')
+
+/-- The triangle `Z₁₂ ⟶ Z₁₃ ⟶ Z₂₃ ⟶ Z₁₂⟦1⟧` given by the octahedron axiom
+is distringuished. -/
+lemma mem_dist_triang : h.triangle ∈ dist_triang C :=
+h.some_spec.some_spec.some_spec.some_spec.some_spec.some_spec
+
+/-- The first morphism of triangles asserted by the octahedron axiom. -/
+@[simps]
+def triangle_morphism₁ : triangle.mk u₁₂ v₁₂ w₁₂ ⟶ triangle.mk u₁₃ v₁₃ w₁₃ :=
+{ hom₁ := 𝟙 X₁,
+  hom₂ := u₂₃,
+  hom₃ := h.m₁,
+  comm₁' := by { dsimp, rw [id_comp, comm], },
+  comm₂' := h.some_spec.some_spec.some,
+  comm₃' := begin
+    dsimp,
+    simpa only [functor.map_id, comp_id]
+      using h.some_spec.some_spec.some_spec.some,
+  end }
+
+/-- The second morphism of triangles asserted by the octahedron axiom. -/
+@[simps]
+def triangle_morphism₂ : triangle.mk u₁₃ v₁₃ w₁₃ ⟶ triangle.mk u₂₃ v₂₃ w₂₃ :=
+{ hom₁ := u₁₂,
+  hom₂ := 𝟙 X₃,
+  hom₃ := h.m₃,
+  comm₁' := by { dsimp, rw [comp_id, comm], },
+  comm₂' := begin
+    dsimp,
+    simpa only [id_comp] using
+      h.some_spec.some_spec.some_spec.some_spec.some,
+  end,
+  comm₃' := h.some_spec.some_spec.some_spec.some_spec.some_spec.some, }
+
+/- TODO (@joelriou): show that in order to verify the octahedron axiom, one may
+replace the composable maps `u₁₂` and `u₂₃` by any isomorphic composable maps
+and the given "cones" of `u₁₂`, `u₂₃`, `u₁₃` by any choice of cones. -/
+
+end octahedron_exists
+
+end triangulated
+
+open triangulated
+
+variable (C)
+
+/-- A triangulated category is a pretriangulated which satisfies the octahedron axiom. -/
+class triangulated :=
+(octahedron' : ∀ ⦃X₁ X₂ X₃ Z₁₂ Z₂₃ Z₁₃ : C⦄ ⦃u₁₂ : X₁ ⟶ X₂⦄ ⦃u₂₃ : X₂ ⟶ X₃⦄ ⦃u₁₃ : X₁ ⟶ X₃⦄
+  (comm : u₁₂ ≫ u₂₃ = u₁₃)
+  ⦃v₁₂ : X₂ ⟶ Z₁₂⦄ ⦃w₁₂ : Z₁₂ ⟶ X₁⟦1⟧⦄ (h₁₂ : triangle.mk u₁₂ v₁₂ w₁₂ ∈ dist_triang C)
+  ⦃v₂₃ : X₃ ⟶ Z₂₃⦄ ⦃w₂₃ : Z₂₃ ⟶ X₂⟦1⟧⦄ (h₂₃ : triangle.mk u₂₃ v₂₃ w₂₃ ∈ dist_triang C)
+  ⦃v₁₃ : X₃ ⟶ Z₁₃⦄ ⦃w₁₃ : Z₁₃ ⟶ X₁⟦1⟧⦄ (h₁₃ : triangle.mk u₁₃ v₁₃ w₁₃ ∈ dist_triang C),
+  triangulated.octahedron_exists comm h₁₂ h₂₃ h₁₃)
+
+end category_theory

--- a/src/category_theory/triangulated/triangulated.lean
+++ b/src/category_theory/triangulated/triangulated.lean
@@ -40,7 +40,7 @@ structure octahedron :=
 (m₁ : Z₁₂ ⟶ Z₁₃)
 (m₃ : Z₁₃ ⟶ Z₂₃)
 (comm₁ : v₁₂ ≫ m₁ = u₂₃ ≫ v₁₃)
-(comm₂ : w₁₂ = m₁ ≫ w₁₃)
+(comm₂ : m₁ ≫ w₁₃ = w₁₂)
 (comm₃ : v₁₃ ≫ m₃ = v₂₃)
 (comm₄ : w₁₃ ≫ u₁₂⟦1⟧' = m₃ ≫ w₂₃)
 (mem : triangle.mk m₁ m₃ (w₂₃ ≫ v₁₂⟦1⟧') ∈ dist_triang C)
@@ -56,7 +56,7 @@ end
 
 namespace octahedron
 
-attribute [reassoc] comm₁ comm₃ comm₄
+attribute [reassoc] comm₁ comm₂ comm₃ comm₄
 
 variables {comm h₁₂ h₂₃ h₁₃} (h : octahedron comm h₁₂ h₂₃ h₁₃)
 
@@ -72,7 +72,7 @@ def triangle_morphism₁ : triangle.mk u₁₂ v₁₂ w₁₂ ⟶ triangle.mk u
   hom₃ := h.m₁,
   comm₁' := by { dsimp, rw [id_comp, comm], },
   comm₂' := h.comm₁,
-  comm₃' := by { dsimp, simpa only [functor.map_id, comp_id] using h.comm₂, }, }
+  comm₃' := by { dsimp, simpa only [functor.map_id, comp_id] using h.comm₂.symm, }, }
 
 /-- The second morphism of triangles given an octahedron. -/
 @[simps]

--- a/src/category_theory/triangulated/triangulated.lean
+++ b/src/category_theory/triangulated/triangulated.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Luke Kershaw. All rights reserved.
+Copyright (c) 2022 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/


### PR DESCRIPTION
This PR moves the namespace `category_theory.triangulated.pretriangulated` to `category_theory.pretriangulated`, and introduces triangulated categories.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
