### PR TITLE
style(geometry/manifold/smooth_manifold_with_corners) Notation for ext_chart_at

### DIFF
--- a/src/geometry/manifold/cont_mdiff.lean
+++ b/src/geometry/manifold/cont_mdiff.lean
@@ -186,7 +186,7 @@ cont_mdiff_within_at I I' n f univ x
 
 lemma cont_mdiff_at_iff {n : ℕ∞} {f : M → M'} {x : M} :
   cont_mdiff_at I I' n f x ↔ continuous_at f x ∧ cont_diff_within_at 𝕜 n
-    (ext_chart_at I' (f x) ∘ f ∘ (ext_chart_at I x).symm) (range I) (ext_chart_at I x x) :=
+    (𝓔(I', f x) ∘ f ∘ 𝓔(I, x).symm) (range I) (𝓔(I, x) x) :=
 lift_prop_at_iff.trans $ by { rw [cont_diff_within_at_prop, preimage_univ, univ_inter], refl }
 
 /-- Abbreviation for `cont_mdiff_at I I' ⊤ f x`. See also documentation for `smooth`. -/
@@ -263,9 +263,9 @@ lemma smooth_on_univ : smooth_on I I' f univ ↔ smooth I I' f := cont_mdiff_on_
 point, and smoothness in the corresponding extended chart. -/
 lemma cont_mdiff_within_at_iff :
   cont_mdiff_within_at I I' n f s x ↔ continuous_within_at f s x ∧
-    cont_diff_within_at 𝕜 n ((ext_chart_at I' (f x)) ∘ f ∘ (ext_chart_at I x).symm)
-    ((ext_chart_at I x).symm ⁻¹' s ∩ range I)
-    (ext_chart_at I x x) :=
+    cont_diff_within_at 𝕜 n (𝓔(I', f x) ∘ f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x).symm ⁻¹' s ∩ range I)
+    (𝓔(I, x) x) :=
 iff.rfl
 
 /-- One can reformulate smoothness within a set at a point as continuity within this set at this
@@ -273,18 +273,18 @@ point, and smoothness in the corresponding extended chart. This form states smoo
 written in such a way that the set is restricted to lie within the domain/codomain of the
 corresponding charts.
 Even though this expression is more complicated than the one in `cont_mdiff_within_at_iff`, it is
-a smaller set, but their germs at `ext_chart_at I x x` are equal. It is sometimes useful to rewrite
+a smaller set, but their germs at `𝓔(I, x) x` are equal. It is sometimes useful to rewrite
 using this in the goal.
 -/
 lemma cont_mdiff_within_at_iff' :
   cont_mdiff_within_at I I' n f s x ↔ continuous_within_at f s x ∧
-    cont_diff_within_at 𝕜 n ((ext_chart_at I' (f x)) ∘ f ∘ (ext_chart_at I x).symm)
-    ((ext_chart_at I x).target ∩
-      (ext_chart_at I x).symm ⁻¹' (s ∩ f ⁻¹' (ext_chart_at I' (f x)).source))
-    (ext_chart_at I x x) :=
+    cont_diff_within_at 𝕜 n (𝓔(I', f x) ∘ f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x).target ∩
+      𝓔(I, x).symm ⁻¹' (s ∩ f ⁻¹' 𝓔(I', f x).source))
+    (𝓔(I, x) x) :=
 begin
   rw [cont_mdiff_within_at_iff, and.congr_right_iff],
-  set e := ext_chart_at I x, set e' := ext_chart_at I' (f x),
+  set e := 𝓔(I, x), set e' := 𝓔(I', f x),
   refine λ hc, cont_diff_within_at_congr_nhds _,
   rw [← e.image_source_inter_eq', ← ext_chart_at_map_nhds_within_eq_image,
       ← ext_chart_at_map_nhds_within, inter_comm, nhds_within_inter_of_mem],
@@ -295,11 +295,11 @@ end
 point, and smoothness in the corresponding extended chart in the target. -/
 lemma cont_mdiff_within_at_iff_target :
   cont_mdiff_within_at I I' n f s x ↔ continuous_within_at f s x ∧
-    cont_mdiff_within_at I 𝓘(𝕜, E') n (ext_chart_at I' (f x) ∘ f) s x :=
+    cont_mdiff_within_at I 𝓘(𝕜, E') n (𝓔(I', f x) ∘ f) s x :=
 begin
   simp_rw [cont_mdiff_within_at, lift_prop_within_at, ← and_assoc],
   have cont : (continuous_within_at f s x ∧
-      continuous_within_at (ext_chart_at I' (f x) ∘ f) s x) ↔
+      continuous_within_at (𝓔(I', f x) ∘ f) s x) ↔
       continuous_within_at f s x,
   { refine ⟨λ h, h.1, λ h, ⟨h, _⟩⟩,
     have h₂ := (chart_at H' (f x)).continuous_to_fun.continuous_within_at (mem_chart_source _ _),
@@ -313,23 +313,23 @@ end
 
 lemma smooth_within_at_iff :
   smooth_within_at I I' f s x ↔ continuous_within_at f s x ∧
-    cont_diff_within_at 𝕜 ∞ (ext_chart_at I' (f x) ∘ f ∘ (ext_chart_at I x).symm)
-    ((ext_chart_at I x).symm ⁻¹' s ∩ range I)
-    (ext_chart_at I x x) :=
+    cont_diff_within_at 𝕜 ∞ (𝓔(I', f x) ∘ f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x).symm ⁻¹' s ∩ range I)
+    (𝓔(I, x) x) :=
 cont_mdiff_within_at_iff
 
 lemma smooth_within_at_iff_target :
   smooth_within_at I I' f s x ↔ continuous_within_at f s x ∧
-    smooth_within_at I 𝓘(𝕜, E') (ext_chart_at I' (f x) ∘ f) s x :=
+    smooth_within_at I 𝓘(𝕜, E') (𝓔(I', f x) ∘ f) s x :=
 cont_mdiff_within_at_iff_target
 
 lemma cont_mdiff_at_iff_target {x : M} :
   cont_mdiff_at I I' n f x ↔
-    continuous_at f x ∧ cont_mdiff_at I 𝓘(𝕜, E') n (ext_chart_at I' (f x) ∘ f) x :=
+    continuous_at f x ∧ cont_mdiff_at I 𝓘(𝕜, E') n (𝓔(I', f x) ∘ f) x :=
 by rw [cont_mdiff_at, cont_mdiff_at, cont_mdiff_within_at_iff_target, continuous_within_at_univ]
 
 lemma smooth_at_iff_target {x : M} :
-  smooth_at I I' f x ↔ continuous_at f x ∧ smooth_at I 𝓘(𝕜, E') (ext_chart_at I' (f x) ∘ f) x :=
+  smooth_at I I' f x ↔ continuous_at f x ∧ smooth_at I 𝓘(𝕜, E') (𝓔(I', f x) ∘ f) x :=
 cont_mdiff_at_iff_target
 
 include Is I's
@@ -339,9 +339,9 @@ point, and smoothness in any chart containing that point. -/
 lemma cont_mdiff_within_at_iff_of_mem_source {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).source)
   (hy : f x' ∈ (chart_at H' y).source) :
   cont_mdiff_within_at I I' n f s x' ↔ continuous_within_at f s x' ∧
-    cont_diff_within_at 𝕜 n (ext_chart_at I' y ∘ f ∘ (ext_chart_at I x).symm)
-    ((ext_chart_at I x).symm ⁻¹' s ∩ range I)
-    (ext_chart_at I x x') :=
+    cont_diff_within_at 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x).symm ⁻¹' s ∩ range I)
+    (𝓔(I, x) x') :=
 (cont_diff_within_at_local_invariant_prop I I' n).lift_prop_within_at_indep_chart
   (structure_groupoid.chart_mem_maximal_atlas _ x) hx
   (structure_groupoid.chart_mem_maximal_atlas _ y) hy
@@ -349,15 +349,15 @@ lemma cont_mdiff_within_at_iff_of_mem_source {x' : M} {y : M'} (hx : x' ∈ (cha
 lemma cont_mdiff_within_at_iff_of_mem_source' {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).source)
   (hy : f x' ∈ (chart_at H' y).source) :
   cont_mdiff_within_at I I' n f s x' ↔ continuous_within_at f s x' ∧
-    cont_diff_within_at 𝕜 n ((ext_chart_at I' y) ∘ f ∘ (ext_chart_at I x).symm)
-    ((ext_chart_at I x).target ∩ (ext_chart_at I x).symm ⁻¹' (s ∩ f ⁻¹' (ext_chart_at I' y).source))
-    (ext_chart_at I x x') :=
+    cont_diff_within_at 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x).target ∩ 𝓔(I, x).symm ⁻¹' (s ∩ f ⁻¹' 𝓔(I', y).source))
+    (𝓔(I, x) x') :=
 begin
   refine (cont_mdiff_within_at_iff_of_mem_source hx hy).trans _,
   rw [← ext_chart_at_source I] at hx,
   rw [← ext_chart_at_source I'] at hy,
   rw [and.congr_right_iff],
-  set e := ext_chart_at I x, set e' := ext_chart_at I' (f x),
+  set e := 𝓔(I, x), set e' := 𝓔(I', f x),
   refine λ hc, cont_diff_within_at_congr_nhds _,
   rw [← e.image_source_inter_eq', ← ext_chart_at_map_nhds_within_eq_image' I x hx,
       ← ext_chart_at_map_nhds_within' I x hx, inter_comm, nhds_within_inter_of_mem],
@@ -367,9 +367,9 @@ end
 lemma cont_mdiff_at_iff_of_mem_source {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).source)
   (hy : f x' ∈ (chart_at H' y).source) :
   cont_mdiff_at I I' n f x' ↔ continuous_at f x' ∧
-    cont_diff_within_at 𝕜 n (ext_chart_at I' y ∘ f ∘ (ext_chart_at I x).symm)
+    cont_diff_within_at 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
     (range I)
-    (ext_chart_at I x x') :=
+    (𝓔(I, x) x') :=
 (cont_mdiff_within_at_iff_of_mem_source hx hy).trans $
   by rw [continuous_within_at_univ, preimage_univ, univ_inter]
 
@@ -378,7 +378,7 @@ omit Is
 lemma cont_mdiff_within_at_iff_target_of_mem_source
   {x : M} {y : M'} (hy : f x ∈ (chart_at H' y).source) :
   cont_mdiff_within_at I I' n f s x ↔ continuous_within_at f s x ∧
-    cont_mdiff_within_at I 𝓘(𝕜, E') n (ext_chart_at I' y ∘ f) s x :=
+    cont_mdiff_within_at I 𝓘(𝕜, E') n (𝓔(I', y) ∘ f) s x :=
 begin
   simp_rw [cont_mdiff_within_at],
   rw [(cont_diff_within_at_local_invariant_prop I I' n).lift_prop_within_at_indep_chart_target
@@ -394,7 +394,7 @@ end
 lemma cont_mdiff_at_iff_target_of_mem_source
   {x : M} {y : M'} (hy : f x ∈ (chart_at H' y).source) :
   cont_mdiff_at I I' n f x ↔ continuous_at f x ∧
-    cont_mdiff_at I 𝓘(𝕜, E') n (ext_chart_at I' y ∘ f) x :=
+    cont_mdiff_at I 𝓘(𝕜, E') n (𝓔(I', y) ∘ f) x :=
 begin
   rw [cont_mdiff_at, cont_mdiff_within_at_iff_target_of_mem_source hy,
     continuous_within_at_univ, cont_mdiff_at],
@@ -418,8 +418,8 @@ variable {I}
 
 lemma ext_chart_at_symm_continuous_within_at_comp_right_iff {X} [topological_space X] {f : M → X}
   {s : set M} {x x' : M} :
-  continuous_within_at (f ∘ (ext_chart_at I x).symm) ((ext_chart_at I x).symm ⁻¹' s ∩ range I)
-    (ext_chart_at I x x') ↔
+  continuous_within_at (f ∘ 𝓔(I, x).symm) (𝓔(I, x).symm ⁻¹' s ∩ range I)
+    (𝓔(I, x) x') ↔
   continuous_within_at (f ∘ (chart_at H x).symm) ((chart_at H x).symm ⁻¹' s) (chart_at H x x') :=
 by convert I.symm_continuous_within_at_comp_right_iff; refl
 
@@ -428,8 +428,8 @@ include Is
 lemma cont_mdiff_within_at_iff_source_of_mem_source
   {x' : M} (hx' : x' ∈ (chart_at H x).source) :
   cont_mdiff_within_at I I' n f s x' ↔
-    cont_mdiff_within_at 𝓘(𝕜, E) I' n (f ∘ (ext_chart_at I x).symm)
-    ((ext_chart_at I x).symm ⁻¹' s ∩ range I) (ext_chart_at I x x') :=
+    cont_mdiff_within_at 𝓘(𝕜, E) I' n (f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x).symm ⁻¹' s ∩ range I) (𝓔(I, x) x') :=
 begin
   have h2x' := hx', rw [← ext_chart_at_source I] at h2x',
   simp_rw [cont_mdiff_within_at,
@@ -437,30 +437,30 @@ begin
     (chart_mem_maximal_atlas I x) hx', structure_groupoid.lift_prop_within_at_self_source,
     ext_chart_at_symm_continuous_within_at_comp_right_iff, cont_diff_within_at_prop_self_source,
     cont_diff_within_at_prop, function.comp, (chart_at H x).left_inv hx',
-    (ext_chart_at I x).left_inv h2x'],
+    𝓔(I, x).left_inv h2x'],
   refl,
 end
 
 lemma cont_mdiff_at_iff_source_of_mem_source
   {x' : M} (hx' : x' ∈ (chart_at H x).source) :
-  cont_mdiff_at I I' n f x' ↔ cont_mdiff_within_at 𝓘(𝕜, E) I' n (f ∘ (ext_chart_at I x).symm)
-    (range I) (ext_chart_at I x x') :=
+  cont_mdiff_at I I' n f x' ↔ cont_mdiff_within_at 𝓘(𝕜, E) I' n (f ∘ 𝓔(I, x).symm)
+    (range I) (𝓔(I, x) x') :=
 by simp_rw [cont_mdiff_at, cont_mdiff_within_at_iff_source_of_mem_source hx', preimage_univ,
   univ_inter]
 
 lemma cont_mdiff_at_ext_chart_at' {x' : M} (h : x' ∈ (chart_at H x).source) :
-  cont_mdiff_at I 𝓘(𝕜, E) n (ext_chart_at I x) x' :=
+  cont_mdiff_at I 𝓘(𝕜, E) n 𝓔(I, x) x' :=
 begin
   refine (cont_mdiff_at_iff_of_mem_source h (mem_chart_source _ _)).mpr _,
   rw [← ext_chart_at_source I] at h,
   refine ⟨ext_chart_at_continuous_at' _ _ h, _⟩,
   refine cont_diff_within_at_id.congr_of_eventually_eq _ _,
   { refine eventually_eq_of_mem (ext_chart_at_target_mem_nhds_within' I x h) (λ x₂ hx₂, _),
-    simp_rw [function.comp_apply, (ext_chart_at I x).right_inv hx₂], refl },
-  simp_rw [function.comp_apply, (ext_chart_at I x).right_inv ((ext_chart_at I x).maps_to h)], refl
+    simp_rw [function.comp_apply, 𝓔(I, x).right_inv hx₂], refl },
+  simp_rw [function.comp_apply, 𝓔(I, x).right_inv (𝓔(I, x).maps_to h)], refl
 end
 
-lemma cont_mdiff_at_ext_chart_at : cont_mdiff_at I 𝓘(𝕜, E) n (ext_chart_at I x) x :=
+lemma cont_mdiff_at_ext_chart_at : cont_mdiff_at I 𝓘(𝕜, E) n 𝓔(I, x) x :=
 cont_mdiff_at_ext_chart_at' $ mem_chart_source H x
 
 include I's
@@ -468,14 +468,14 @@ include I's
 /-- If the set where you want `f` to be smooth lies entirely in a single chart, and `f` maps it
   into a single chart, the smoothness of `f` on that set can be expressed by purely looking in
   these charts.
-  Note: this lemma uses `ext_chart_at I x '' s` instead of `(ext_chart_at I x).symm ⁻¹' s` to ensure
-  that this set lies in `(ext_chart_at I x).target`. -/
+  Note: this lemma uses `𝓔(I, x) '' s` instead of `𝓔(I, x).symm ⁻¹' s` to ensure
+  that this set lies in `𝓔(I, x).target`. -/
 lemma cont_mdiff_on_iff_of_subset_source {x : M} {y : M'}
   (hs : s ⊆ (chart_at H x).source)
   (h2s : maps_to f s (chart_at H' y).source) :
   cont_mdiff_on I I' n f s ↔ continuous_on f s ∧
-    cont_diff_on 𝕜 n (ext_chart_at I' y ∘ f ∘ (ext_chart_at I x).symm)
-    (ext_chart_at I x '' s) :=
+    cont_diff_on 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x) '' s) :=
 begin
   split,
   { refine λ H, ⟨λ x hx, (H x hx).1, _⟩,
@@ -489,7 +489,7 @@ begin
       ⟨h1.continuous_within_at hx', _⟩,
     refine (h2 _ $ mem_image_of_mem _ hx').mono_of_mem _,
     rw [← ext_chart_at_source I] at hs,
-    rw [(ext_chart_at I x).image_eq_target_inter_inv_preimage hs],
+    rw [𝓔(I, x).image_eq_target_inter_inv_preimage hs],
     refine inter_mem _ (ext_chart_preimage_mem_nhds_within' I x (hs hx') self_mem_nhds_within),
     have := ext_chart_at_target_mem_nhds_within' I x (hs hx'),
     refine nhds_within_mono _ (inter_subset_right _ _) this }
@@ -499,15 +499,15 @@ end
 extended chart. -/
 lemma cont_mdiff_on_iff :
   cont_mdiff_on I I' n f s ↔ continuous_on f s ∧
-    ∀ (x : M) (y : M'), cont_diff_on 𝕜 n (ext_chart_at I' y ∘ f ∘ (ext_chart_at I x).symm)
-    ((ext_chart_at I x).target ∩
-      (ext_chart_at I x).symm ⁻¹' (s ∩ f ⁻¹' (ext_chart_at I' y).source)) :=
+    ∀ (x : M) (y : M'), cont_diff_on 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x).target ∩
+      𝓔(I, x).symm ⁻¹' (s ∩ f ⁻¹' 𝓔(I', y).source)) :=
 begin
   split,
   { assume h,
     refine ⟨λ x hx, (h x hx).1, λ x y z hz, _⟩,
     simp only with mfld_simps at hz,
-    let w := (ext_chart_at I x).symm z,
+    let w := 𝓔(I, x).symm z,
     have : w ∈ s, by simp only [w, hz] with mfld_simps,
     specialize h w this,
     have w1 : w ∈ (chart_at H x).source, by simp only [w, hz] with mfld_simps,
@@ -519,7 +519,7 @@ begin
     refine ((cont_diff_within_at_local_invariant_prop I I' n).lift_prop_within_at_iff $
       hcont x hx).mpr _,
     dsimp [cont_diff_within_at_prop],
-    convert hdiff x (f x) (ext_chart_at I x x) (by simp only [hx] with mfld_simps) using 1,
+    convert hdiff x (f x) (𝓔(I, x) x) (by simp only [hx] with mfld_simps) using 1,
     mfld_set_tac }
 end
 
@@ -527,8 +527,8 @@ end
 extended chart in the target. -/
 lemma cont_mdiff_on_iff_target :
   cont_mdiff_on I I' n f s ↔ continuous_on f s ∧ ∀ (y : M'),
-    cont_mdiff_on I 𝓘(𝕜, E') n (ext_chart_at I' y ∘ f)
-    (s ∩ f ⁻¹' (ext_chart_at I' y).source) :=
+    cont_mdiff_on I 𝓘(𝕜, E') n (𝓔(I', y) ∘ f)
+    (s ∩ f ⁻¹' 𝓔(I', y).source) :=
 begin
   inhabit E',
   simp only [cont_mdiff_on_iff, model_with_corners.source_eq, chart_at_self_eq,
@@ -545,30 +545,30 @@ end
 
 lemma smooth_on_iff :
   smooth_on I I' f s ↔ continuous_on f s ∧
-    ∀ (x : M) (y : M'), cont_diff_on 𝕜 ⊤ (ext_chart_at I' y ∘ f ∘ (ext_chart_at I x).symm)
-    ((ext_chart_at I x).target ∩
-      (ext_chart_at I x).symm ⁻¹' (s ∩ f ⁻¹' (ext_chart_at I' y).source)) :=
+    ∀ (x : M) (y : M'), cont_diff_on 𝕜 ⊤ (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x).target ∩
+      𝓔(I, x).symm ⁻¹' (s ∩ f ⁻¹' 𝓔(I', y).source)) :=
 cont_mdiff_on_iff
 
 lemma smooth_on_iff_target :
   smooth_on I I' f s ↔ continuous_on f s ∧ ∀ (y : M'),
-    smooth_on I 𝓘(𝕜, E') (ext_chart_at I' y ∘ f)
-    (s ∩ f ⁻¹' (ext_chart_at I' y).source) :=
+    smooth_on I 𝓘(𝕜, E') (𝓔(I', y) ∘ f)
+    (s ∩ f ⁻¹' 𝓔(I', y).source) :=
 cont_mdiff_on_iff_target
 
 /-- One can reformulate smoothness as continuity and smoothness in any extended chart. -/
 lemma cont_mdiff_iff :
   cont_mdiff I I' n f ↔ continuous f ∧
-    ∀ (x : M) (y : M'), cont_diff_on 𝕜 n (ext_chart_at I' y ∘ f ∘ (ext_chart_at I x).symm)
-    ((ext_chart_at I x).target ∩ (ext_chart_at I x).symm ⁻¹' (f ⁻¹' (ext_chart_at I' y).source)) :=
+    ∀ (x : M) (y : M'), cont_diff_on 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x).target ∩ 𝓔(I, x).symm ⁻¹' (f ⁻¹' 𝓔(I', y).source)) :=
 by simp [← cont_mdiff_on_univ, cont_mdiff_on_iff, continuous_iff_continuous_on_univ]
 
 /-- One can reformulate smoothness as continuity and smoothness in any extended chart in the
 target. -/
 lemma cont_mdiff_iff_target :
   cont_mdiff I I' n f ↔ continuous f ∧
-    ∀ (y : M'), cont_mdiff_on I 𝓘(𝕜, E') n (ext_chart_at I' y ∘ f)
-    (f ⁻¹' (ext_chart_at I' y).source) :=
+    ∀ (y : M'), cont_mdiff_on I 𝓘(𝕜, E') n (𝓔(I', y) ∘ f)
+    (f ⁻¹' 𝓔(I', y).source) :=
 begin
   rw [← cont_mdiff_on_univ, cont_mdiff_on_iff_target],
   simp [continuous_iff_continuous_on_univ]
@@ -576,13 +576,13 @@ end
 
 lemma smooth_iff :
   smooth I I' f ↔ continuous f ∧
-    ∀ (x : M) (y : M'), cont_diff_on 𝕜 ⊤ (ext_chart_at I' y ∘ f ∘ (ext_chart_at I x).symm)
-    ((ext_chart_at I x).target ∩ (ext_chart_at I x).symm ⁻¹' (f ⁻¹' (ext_chart_at I' y).source)) :=
+    ∀ (x : M) (y : M'), cont_diff_on 𝕜 ⊤ (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
+    (𝓔(I, x).target ∩ 𝓔(I, x).symm ⁻¹' (f ⁻¹' 𝓔(I', y).source)) :=
 cont_mdiff_iff
 
 lemma smooth_iff_target :
-  smooth I I' f ↔ continuous f ∧ ∀ (y : M'), smooth_on I 𝓘(𝕜, E') (ext_chart_at I' y ∘ f)
-    (f ⁻¹' (ext_chart_at I' y).source) :=
+  smooth I I' f ↔ continuous f ∧ ∀ (y : M'), smooth_on I 𝓘(𝕜, E') (𝓔(I', y) ∘ f)
+    (f ⁻¹' 𝓔(I', y).source) :=
 cont_mdiff_iff_target
 
 omit Is I's
@@ -726,7 +726,7 @@ h.cont_mdiff_at hx
 include Is
 
 lemma cont_mdiff_on_ext_chart_at :
-  cont_mdiff_on I 𝓘(𝕜, E) n (ext_chart_at I x) (chart_at H x).source :=
+  cont_mdiff_on I 𝓘(𝕜, E) n 𝓔(I, x) (chart_at H x).source :=
 λ x' hx', (cont_mdiff_at_ext_chart_at' hx').cont_mdiff_within_at
 
 include I's
@@ -756,7 +756,7 @@ begin
     rcases h.2.cont_diff_on le_rfl with ⟨u, u_nhds, u_subset, hu⟩,
     -- pull it back to the manifold, and intersect with a suitable neighborhood of `x`, to get the
     -- desired good neighborhood `v`.
-    let v := ((insert x s) ∩ o) ∩ (ext_chart_at I x) ⁻¹' u,
+    let v := ((insert x s) ∩ o) ∩ 𝓔(I, x) ⁻¹' u,
     have v_incl : v ⊆ (chart_at H x).source := λ y hy, ho hy.1.2,
     have v_incl' : ∀ y ∈ v, f y ∈ (chart_at H' (f x)).source,
     { assume y hy,
@@ -767,7 +767,7 @@ begin
     show v ∈ 𝓝[insert x s] x,
     { rw nhds_within_restrict _ xo o_open,
       refine filter.inter_mem self_mem_nhds_within _,
-      suffices : u ∈ 𝓝[(ext_chart_at I x) '' (insert x s ∩ o)] (ext_chart_at I x x),
+      suffices : u ∈ 𝓝[𝓔(I, x) '' (insert x s ∩ o)] (𝓔(I, x) x),
         from (ext_chart_at_continuous_at I x).continuous_within_at.preimage_mem_nhds_within' this,
       apply nhds_within_mono _ _ u_nhds,
       rw image_subset_iff,
@@ -890,9 +890,9 @@ lemma cont_mdiff_within_at.comp {t : set M'} {g : M' → M''} (x : M)
 begin
   rw cont_mdiff_within_at_iff at hg hf ⊢,
   refine ⟨hg.1.comp hf.1 st, _⟩,
-  set e := ext_chart_at I x,
-  set e' := ext_chart_at I' (f x),
-  set e'' := ext_chart_at I'' (g (f x)),
+  set e := 𝓔(I, x),
+  set e' := 𝓔(I', f x),
+  set e'' := 𝓔(I'', g (f x)),
   have : e' (f x) = (written_in_ext_chart_at I I' x f) (e x),
     by simp only [e, e'] with mfld_simps,
   rw this at hg,
@@ -1211,7 +1211,7 @@ lemma cont_diff_within_at.comp_cont_mdiff_within_at
 begin
   rw cont_mdiff_within_at_iff at *,
   refine ⟨hg.continuous_within_at.comp hf.1 h, _⟩,
-  rw [← (ext_chart_at I x).left_inv (mem_ext_chart_source I x)] at hg,
+  rw [← 𝓔(I, x).left_inv (mem_ext_chart_source I x)] at hg,
   apply cont_diff_within_at.comp _ (by exact hg) hf.2 _,
   exact (inter_subset_left _ _).trans (preimage_mono h)
 end

--- a/src/geometry/manifold/cont_mdiff.lean
+++ b/src/geometry/manifold/cont_mdiff.lean
@@ -264,8 +264,7 @@ point, and smoothness in the corresponding extended chart. -/
 lemma cont_mdiff_within_at_iff :
   cont_mdiff_within_at I I' n f s x ↔ continuous_within_at f s x ∧
     cont_diff_within_at 𝕜 n (𝓔(I', f x) ∘ f ∘ 𝓔(I, x).symm)
-    (𝓔(I, x).symm ⁻¹' s ∩ range I)
-    (𝓔(I, x) x) :=
+    (𝓔(I, x).symm ⁻¹' s ∩ range I) (𝓔(I, x) x) :=
 iff.rfl
 
 /-- One can reformulate smoothness within a set at a point as continuity within this set at this
@@ -279,9 +278,7 @@ using this in the goal.
 lemma cont_mdiff_within_at_iff' :
   cont_mdiff_within_at I I' n f s x ↔ continuous_within_at f s x ∧
     cont_diff_within_at 𝕜 n (𝓔(I', f x) ∘ f ∘ 𝓔(I, x).symm)
-    (𝓔(I, x).target ∩
-      𝓔(I, x).symm ⁻¹' (s ∩ f ⁻¹' 𝓔(I', f x).source))
-    (𝓔(I, x) x) :=
+    (𝓔(I, x).target ∩ 𝓔(I, x).symm ⁻¹' (s ∩ f ⁻¹' 𝓔(I', f x).source)) (𝓔(I, x) x) :=
 begin
   rw [cont_mdiff_within_at_iff, and.congr_right_iff],
   set e := 𝓔(I, x), set e' := 𝓔(I', f x),
@@ -314,8 +311,7 @@ end
 lemma smooth_within_at_iff :
   smooth_within_at I I' f s x ↔ continuous_within_at f s x ∧
     cont_diff_within_at 𝕜 ∞ (𝓔(I', f x) ∘ f ∘ 𝓔(I, x).symm)
-    (𝓔(I, x).symm ⁻¹' s ∩ range I)
-    (𝓔(I, x) x) :=
+    (𝓔(I, x).symm ⁻¹' s ∩ range I) (𝓔(I, x) x) :=
 cont_mdiff_within_at_iff
 
 lemma smooth_within_at_iff_target :
@@ -340,8 +336,7 @@ lemma cont_mdiff_within_at_iff_of_mem_source {x' : M} {y : M'} (hx : x' ∈ (cha
   (hy : f x' ∈ (chart_at H' y).source) :
   cont_mdiff_within_at I I' n f s x' ↔ continuous_within_at f s x' ∧
     cont_diff_within_at 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
-    (𝓔(I, x).symm ⁻¹' s ∩ range I)
-    (𝓔(I, x) x') :=
+    (𝓔(I, x).symm ⁻¹' s ∩ range I) (𝓔(I, x) x') :=
 (cont_diff_within_at_local_invariant_prop I I' n).lift_prop_within_at_indep_chart
   (structure_groupoid.chart_mem_maximal_atlas _ x) hx
   (structure_groupoid.chart_mem_maximal_atlas _ y) hy
@@ -367,9 +362,7 @@ end
 lemma cont_mdiff_at_iff_of_mem_source {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).source)
   (hy : f x' ∈ (chart_at H' y).source) :
   cont_mdiff_at I I' n f x' ↔ continuous_at f x' ∧
-    cont_diff_within_at 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
-    (range I)
-    (𝓔(I, x) x') :=
+    cont_diff_within_at 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm) (range I) (𝓔(I, x) x') :=
 (cont_mdiff_within_at_iff_of_mem_source hx hy).trans $
   by rw [continuous_within_at_univ, preimage_univ, univ_inter]
 
@@ -418,8 +411,7 @@ variable {I}
 
 lemma ext_chart_at_symm_continuous_within_at_comp_right_iff {X} [topological_space X] {f : M → X}
   {s : set M} {x x' : M} :
-  continuous_within_at (f ∘ 𝓔(I, x).symm) (𝓔(I, x).symm ⁻¹' s ∩ range I)
-    (𝓔(I, x) x') ↔
+  continuous_within_at (f ∘ 𝓔(I, x).symm) (𝓔(I, x).symm ⁻¹' s ∩ range I) (𝓔(I, x) x') ↔
   continuous_within_at (f ∘ (chart_at H x).symm) ((chart_at H x).symm ⁻¹' s) (chart_at H x x') :=
 by convert I.symm_continuous_within_at_comp_right_iff; refl
 
@@ -474,8 +466,7 @@ lemma cont_mdiff_on_iff_of_subset_source {x : M} {y : M'}
   (hs : s ⊆ (chart_at H x).source)
   (h2s : maps_to f s (chart_at H' y).source) :
   cont_mdiff_on I I' n f s ↔ continuous_on f s ∧
-    cont_diff_on 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
-    (𝓔(I, x) '' s) :=
+    cont_diff_on 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm) (𝓔(I, x) '' s) :=
 begin
   split,
   { refine λ H, ⟨λ x hx, (H x hx).1, _⟩,
@@ -500,8 +491,7 @@ extended chart. -/
 lemma cont_mdiff_on_iff :
   cont_mdiff_on I I' n f s ↔ continuous_on f s ∧
     ∀ (x : M) (y : M'), cont_diff_on 𝕜 n (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
-    (𝓔(I, x).target ∩
-      𝓔(I, x).symm ⁻¹' (s ∩ f ⁻¹' 𝓔(I', y).source)) :=
+    (𝓔(I, x).target ∩ 𝓔(I, x).symm ⁻¹' (s ∩ f ⁻¹' 𝓔(I', y).source)) :=
 begin
   split,
   { assume h,
@@ -527,8 +517,7 @@ end
 extended chart in the target. -/
 lemma cont_mdiff_on_iff_target :
   cont_mdiff_on I I' n f s ↔ continuous_on f s ∧ ∀ (y : M'),
-    cont_mdiff_on I 𝓘(𝕜, E') n (𝓔(I', y) ∘ f)
-    (s ∩ f ⁻¹' 𝓔(I', y).source) :=
+    cont_mdiff_on I 𝓘(𝕜, E') n (𝓔(I', y) ∘ f) (s ∩ f ⁻¹' 𝓔(I', y).source) :=
 begin
   inhabit E',
   simp only [cont_mdiff_on_iff, model_with_corners.source_eq, chart_at_self_eq,
@@ -546,14 +535,12 @@ end
 lemma smooth_on_iff :
   smooth_on I I' f s ↔ continuous_on f s ∧
     ∀ (x : M) (y : M'), cont_diff_on 𝕜 ⊤ (𝓔(I', y) ∘ f ∘ 𝓔(I, x).symm)
-    (𝓔(I, x).target ∩
-      𝓔(I, x).symm ⁻¹' (s ∩ f ⁻¹' 𝓔(I', y).source)) :=
+    (𝓔(I, x).target ∩ 𝓔(I, x).symm ⁻¹' (s ∩ f ⁻¹' 𝓔(I', y).source)) :=
 cont_mdiff_on_iff
 
 lemma smooth_on_iff_target :
   smooth_on I I' f s ↔ continuous_on f s ∧ ∀ (y : M'),
-    smooth_on I 𝓘(𝕜, E') (𝓔(I', y) ∘ f)
-    (s ∩ f ⁻¹' 𝓔(I', y).source) :=
+    smooth_on I 𝓘(𝕜, E') (𝓔(I', y) ∘ f) (s ∩ f ⁻¹' 𝓔(I', y).source) :=
 cont_mdiff_on_iff_target
 
 /-- One can reformulate smoothness as continuity and smoothness in any extended chart. -/
@@ -567,8 +554,7 @@ by simp [← cont_mdiff_on_univ, cont_mdiff_on_iff, continuous_iff_continuous_on
 target. -/
 lemma cont_mdiff_iff_target :
   cont_mdiff I I' n f ↔ continuous f ∧
-    ∀ (y : M'), cont_mdiff_on I 𝓘(𝕜, E') n (𝓔(I', y) ∘ f)
-    (f ⁻¹' 𝓔(I', y).source) :=
+    ∀ (y : M'), cont_mdiff_on I 𝓘(𝕜, E') n (𝓔(I', y) ∘ f) (f ⁻¹' 𝓔(I', y).source) :=
 begin
   rw [← cont_mdiff_on_univ, cont_mdiff_on_iff_target],
   simp [continuous_iff_continuous_on_univ]

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -39,6 +39,7 @@ specific type class for `C^∞` manifolds as these are the most commonly used.
   but often we may want to use their `E`-valued version, obtained by composing the charts with `I`.
   Since the target is in general not open, we can not register them as local homeomorphisms, but
   we register them as local equivs. `ext_chart_at I x` is the canonical such local equiv around `x`.
+  We provide the notation `𝓔(I, x)` for `ext_chart_at I x`.
 
 As specific examples of models with corners, we define (in the file `real_instances.lean`)
 * `model_with_corners_self ℝ (euclidean_space (fin n))` for the model space used to define
@@ -708,238 +709,240 @@ of `x` to the model vector space. -/
 @[simp, mfld_simps] def ext_chart_at (x : M) : local_equiv M E :=
 (chart_at H x).to_local_equiv.trans I.to_local_equiv
 
-lemma ext_chart_at_coe : ⇑(ext_chart_at I x) = I ∘ chart_at H x := rfl
+localized "notation (name := ext_chart_at) `𝓔(` I `, ` x `)` := ext_chart_at I x" in manifold
+
+lemma ext_chart_at_coe : ⇑𝓔(I, x) = I ∘ chart_at H x := rfl
 
 lemma ext_chart_at_coe_symm :
-  ⇑(ext_chart_at I x).symm = (chart_at H x).symm ∘ I.symm := rfl
+  ⇑𝓔(I, x).symm = (chart_at H x).symm ∘ I.symm := rfl
 
-lemma ext_chart_at_source : (ext_chart_at I x).source = (chart_at H x).source :=
+lemma ext_chart_at_source : 𝓔(I, x).source = (chart_at H x).source :=
 by rw [ext_chart_at, local_equiv.trans_source, I.source_eq, preimage_univ, inter_univ]
 
-lemma ext_chart_at_open_source : is_open (ext_chart_at I x).source :=
+lemma ext_chart_at_open_source : is_open 𝓔(I, x).source :=
 by { rw ext_chart_at_source, exact (chart_at H x).open_source }
 
-lemma mem_ext_chart_source : x ∈ (ext_chart_at I x).source :=
+lemma mem_ext_chart_source : x ∈ 𝓔(I, x).source :=
 by simp only [ext_chart_at_source, mem_chart_source]
 
-lemma ext_chart_at_target (x : M) : (ext_chart_at I x).target =
+lemma ext_chart_at_target (x : M) : 𝓔(I, x).target =
   I.symm ⁻¹' (chart_at H x).target ∩ range I :=
 by simp_rw [ext_chart_at, local_equiv.trans_target, I.target_eq, I.to_local_equiv_coe_symm,
   inter_comm]
 
 lemma ext_chart_at_to_inv :
-  (ext_chart_at I x).symm ((ext_chart_at I x) x) = x :=
-(ext_chart_at I x).left_inv (mem_ext_chart_source I x)
+  𝓔(I, x).symm (𝓔(I, x) x) = x :=
+𝓔(I, x).left_inv (mem_ext_chart_source I x)
 
 lemma maps_to_ext_chart_at (hs : s ⊆ (chart_at H x).source) :
-  maps_to (ext_chart_at I x) s ((ext_chart_at I x).symm ⁻¹' s ∩ range I) :=
+  maps_to 𝓔(I, x) s (𝓔(I, x).symm ⁻¹' s ∩ range I) :=
 begin
   rw [maps_to', ext_chart_at_coe, ext_chart_at_coe_symm, preimage_comp, ← I.image_eq, image_comp,
     (chart_at H x).image_eq_target_inter_inv_preimage hs],
   exact image_subset _ (inter_subset_right _ _)
 end
 
-lemma ext_chart_at_source_mem_nhds' {x' : M} (h : x' ∈ (ext_chart_at I x).source) :
-  (ext_chart_at I x).source ∈ 𝓝 x' :=
+lemma ext_chart_at_source_mem_nhds' {x' : M} (h : x' ∈ 𝓔(I, x).source) :
+  𝓔(I, x).source ∈ 𝓝 x' :=
 is_open.mem_nhds (ext_chart_at_open_source I x) h
 
-lemma ext_chart_at_source_mem_nhds : (ext_chart_at I x).source ∈ 𝓝 x :=
+lemma ext_chart_at_source_mem_nhds : 𝓔(I, x).source ∈ 𝓝 x :=
 ext_chart_at_source_mem_nhds' I x (mem_ext_chart_source I x)
 
-lemma ext_chart_at_source_mem_nhds_within' {x' : M} (h : x' ∈ (ext_chart_at I x).source) :
-  (ext_chart_at I x).source ∈ 𝓝[s] x' :=
+lemma ext_chart_at_source_mem_nhds_within' {x' : M} (h : x' ∈ 𝓔(I, x).source) :
+  𝓔(I, x).source ∈ 𝓝[s] x' :=
 mem_nhds_within_of_mem_nhds (ext_chart_at_source_mem_nhds' I x h)
 
 lemma ext_chart_at_source_mem_nhds_within :
-  (ext_chart_at I x).source ∈ 𝓝[s] x :=
+  𝓔(I, x).source ∈ 𝓝[s] x :=
 mem_nhds_within_of_mem_nhds (ext_chart_at_source_mem_nhds I x)
 
 lemma ext_chart_at_continuous_on :
-  continuous_on (ext_chart_at I x) (ext_chart_at I x).source :=
+  continuous_on 𝓔(I, x) 𝓔(I, x).source :=
 begin
   refine I.continuous.comp_continuous_on _,
   rw ext_chart_at_source,
   exact (chart_at H x).continuous_on
 end
 
-lemma ext_chart_at_continuous_at' {x' : M} (h : x' ∈ (ext_chart_at I x).source) :
-  continuous_at (ext_chart_at I x) x' :=
+lemma ext_chart_at_continuous_at' {x' : M} (h : x' ∈ 𝓔(I, x).source) :
+  continuous_at 𝓔(I, x) x' :=
 (ext_chart_at_continuous_on I x).continuous_at $ ext_chart_at_source_mem_nhds' I x h
 
-lemma ext_chart_at_continuous_at : continuous_at (ext_chart_at I x) x :=
+lemma ext_chart_at_continuous_at : continuous_at 𝓔(I, x) x :=
 ext_chart_at_continuous_at' _ _ (mem_ext_chart_source I x)
 
 lemma ext_chart_at_continuous_on_symm :
-  continuous_on (ext_chart_at I x).symm (ext_chart_at I x).target :=
+  continuous_on 𝓔(I, x).symm 𝓔(I, x).target :=
 (chart_at H x).continuous_on_symm.comp I.continuous_on_symm $
   (maps_to_preimage _ _).mono_left (inter_subset_right _ _)
 
-lemma ext_chart_at_map_nhds' {x y : M} (hy : y ∈ (ext_chart_at I x).source) :
-  map (ext_chart_at I x) (𝓝 y) = 𝓝[range I] (ext_chart_at I x y) :=
+lemma ext_chart_at_map_nhds' {x y : M} (hy : y ∈ 𝓔(I, x).source) :
+  map 𝓔(I, x) (𝓝 y) = 𝓝[range I] (𝓔(I, x) y) :=
 begin
   rw [ext_chart_at_coe, (∘), ← I.map_nhds_eq, ← (chart_at H x).map_nhds_eq, map_map],
   rwa ext_chart_at_source at hy
 end
 
 lemma ext_chart_at_map_nhds :
-  map (ext_chart_at I x) (𝓝 x) = 𝓝[range I] (ext_chart_at I x x) :=
+  map 𝓔(I, x) (𝓝 x) = 𝓝[range I] (𝓔(I, x) x) :=
 ext_chart_at_map_nhds' I $ mem_ext_chart_source I x
 
-lemma ext_chart_at_target_mem_nhds_within' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
-  (ext_chart_at I x).target ∈ 𝓝[range I] (ext_chart_at I x y) :=
+lemma ext_chart_at_target_mem_nhds_within' {y : M} (hy : y ∈ 𝓔(I, x).source) :
+  𝓔(I, x).target ∈ 𝓝[range I] (𝓔(I, x) y) :=
 begin
   rw [← local_equiv.image_source_eq_target, ← ext_chart_at_map_nhds' I hy],
   exact image_mem_map (ext_chart_at_source_mem_nhds' _ _ hy)
 end
 
 lemma ext_chart_at_target_mem_nhds_within :
-  (ext_chart_at I x).target ∈ 𝓝[range I] (ext_chart_at I x x) :=
+  𝓔(I, x).target ∈ 𝓝[range I] (𝓔(I, x) x) :=
 ext_chart_at_target_mem_nhds_within' I x (mem_ext_chart_source I x)
 
-lemma ext_chart_at_target_subset_range : (ext_chart_at I x).target ⊆ range I :=
+lemma ext_chart_at_target_subset_range : 𝓔(I, x).target ⊆ range I :=
 by simp only with mfld_simps
 
-lemma nhds_within_ext_chart_target_eq' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
-  𝓝[(ext_chart_at I x).target] (ext_chart_at I x y) =
-  𝓝[range I] (ext_chart_at I x y) :=
+lemma nhds_within_ext_chart_target_eq' {y : M} (hy : y ∈ 𝓔(I, x).source) :
+  𝓝[𝓔(I, x).target] (𝓔(I, x) y) =
+  𝓝[range I] (𝓔(I, x) y) :=
 (nhds_within_mono _ (ext_chart_at_target_subset_range _ _)).antisymm $
   nhds_within_le_of_mem (ext_chart_at_target_mem_nhds_within' _ _ hy)
 
 lemma nhds_within_ext_chart_target_eq :
-  𝓝[(ext_chart_at I x).target] ((ext_chart_at I x) x) =
-  𝓝[range I] ((ext_chart_at I x) x) :=
+  𝓝[𝓔(I, x).target] (𝓔(I, x) x) =
+  𝓝[range I] (𝓔(I, x) x) :=
 nhds_within_ext_chart_target_eq' I x (mem_ext_chart_source I x)
 
-lemma ext_chart_continuous_at_symm'' {y : E} (h : y ∈ (ext_chart_at I x).target) :
-  continuous_at (ext_chart_at I x).symm y :=
+lemma ext_chart_continuous_at_symm'' {y : E} (h : y ∈ 𝓔(I, x).target) :
+  continuous_at 𝓔(I, x).symm y :=
 continuous_at.comp ((chart_at H x).continuous_at_symm h.2) (I.continuous_symm.continuous_at)
 
-lemma ext_chart_continuous_at_symm' {x' : M} (h : x' ∈ (ext_chart_at I x).source) :
-  continuous_at (ext_chart_at I x).symm (ext_chart_at I x x') :=
-ext_chart_continuous_at_symm'' I _ $ (ext_chart_at I x).map_source h
+lemma ext_chart_continuous_at_symm' {x' : M} (h : x' ∈ 𝓔(I, x).source) :
+  continuous_at 𝓔(I, x).symm (𝓔(I, x) x') :=
+ext_chart_continuous_at_symm'' I _ $ 𝓔(I, x).map_source h
 
 lemma ext_chart_continuous_at_symm :
-  continuous_at (ext_chart_at I x).symm ((ext_chart_at I x) x) :=
+  continuous_at 𝓔(I, x).symm (𝓔(I, x) x) :=
 ext_chart_continuous_at_symm' I x (mem_ext_chart_source I x)
 
 lemma ext_chart_continuous_on_symm :
-  continuous_on (ext_chart_at I x).symm (ext_chart_at I x).target :=
+  continuous_on 𝓔(I, x).symm 𝓔(I, x).target :=
 λ y hy, (ext_chart_continuous_at_symm'' _ _ hy).continuous_within_at
 
 lemma ext_chart_preimage_open_of_open' {s : set E} (hs : is_open s) :
-  is_open ((ext_chart_at I x).source ∩ ext_chart_at I x ⁻¹' s) :=
+  is_open (𝓔(I, x).source ∩ 𝓔(I, x) ⁻¹' s) :=
 (ext_chart_at_continuous_on I x).preimage_open_of_open (ext_chart_at_open_source _ _) hs
 
 lemma ext_chart_preimage_open_of_open {s : set E} (hs : is_open s) :
-  is_open ((chart_at H x).source ∩ ext_chart_at I x ⁻¹' s) :=
+  is_open ((chart_at H x).source ∩ 𝓔(I, x) ⁻¹' s) :=
 by { rw ← ext_chart_at_source I, exact ext_chart_preimage_open_of_open' I x hs }
 
-lemma ext_chart_at_map_nhds_within_eq_image' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
-  map (ext_chart_at I x) (𝓝[s] y) =
-    𝓝[ext_chart_at I x '' ((ext_chart_at I x).source ∩ s)] (ext_chart_at I x y) :=
-by set e := ext_chart_at I x;
+lemma ext_chart_at_map_nhds_within_eq_image' {y : M} (hy : y ∈ 𝓔(I, x).source) :
+  map 𝓔(I, x) (𝓝[s] y) =
+    𝓝[𝓔(I, x) '' (𝓔(I, x).source ∩ s)] (𝓔(I, x) y) :=
+by set e := 𝓔(I, x);
 calc map e (𝓝[s] y) = map e (𝓝[e.source ∩ s] y) :
   congr_arg (map e) (nhds_within_inter_of_mem (ext_chart_at_source_mem_nhds_within' I x hy)).symm
 ... = 𝓝[e '' (e.source ∩ s)] (e y) :
-  ((ext_chart_at I x).left_inv_on.mono $ inter_subset_left _ _).map_nhds_within_eq
-    ((ext_chart_at I x).left_inv hy)
+  (𝓔(I, x).left_inv_on.mono $ inter_subset_left _ _).map_nhds_within_eq
+    (𝓔(I, x).left_inv hy)
     (ext_chart_continuous_at_symm' I x hy).continuous_within_at
     (ext_chart_at_continuous_at' I x hy).continuous_within_at
 
 lemma ext_chart_at_map_nhds_within_eq_image :
-  map (ext_chart_at I x) (𝓝[s] x) =
-    𝓝[ext_chart_at I x '' ((ext_chart_at I x).source ∩ s)] (ext_chart_at I x x) :=
+  map 𝓔(I, x) (𝓝[s] x) =
+    𝓝[𝓔(I, x) '' (𝓔(I, x).source ∩ s)] (𝓔(I, x) x) :=
 ext_chart_at_map_nhds_within_eq_image' I x (mem_ext_chart_source I x)
 
-lemma ext_chart_at_map_nhds_within' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
-  map (ext_chart_at I x) (𝓝[s] y) =
-    𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] (ext_chart_at I x y) :=
+lemma ext_chart_at_map_nhds_within' {y : M} (hy : y ∈ 𝓔(I, x).source) :
+  map 𝓔(I, x) (𝓝[s] y) =
+    𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) y) :=
 by rw [ext_chart_at_map_nhds_within_eq_image' I x hy, nhds_within_inter,
   ← nhds_within_ext_chart_target_eq' _ _ hy, ← nhds_within_inter,
-  (ext_chart_at I x).image_source_inter_eq', inter_comm]
+  𝓔(I, x).image_source_inter_eq', inter_comm]
 
 lemma ext_chart_at_map_nhds_within :
-  map (ext_chart_at I x) (𝓝[s] x) =
-    𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] (ext_chart_at I x x) :=
+  map 𝓔(I, x) (𝓝[s] x) =
+    𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x) :=
 ext_chart_at_map_nhds_within' I x (mem_ext_chart_source I x)
 
-lemma ext_chart_at_symm_map_nhds_within' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
-  map (ext_chart_at I x).symm
-    (𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] (ext_chart_at I x y)) = 𝓝[s] y :=
+lemma ext_chart_at_symm_map_nhds_within' {y : M} (hy : y ∈ 𝓔(I, x).source) :
+  map 𝓔(I, x).symm
+    (𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) y)) = 𝓝[s] y :=
 begin
   rw [← ext_chart_at_map_nhds_within' I x hy, map_map, map_congr, map_id],
-  exact (ext_chart_at I x).left_inv_on.eq_on.eventually_eq_of_mem
+  exact 𝓔(I, x).left_inv_on.eq_on.eventually_eq_of_mem
     (ext_chart_at_source_mem_nhds_within' _ _ hy)
 end
 
-lemma ext_chart_at_symm_map_nhds_within_range' {y : M} (hy : y ∈ (ext_chart_at I x).source) :
-  map (ext_chart_at I x).symm (𝓝[range I] (ext_chart_at I x y)) = 𝓝 y :=
+lemma ext_chart_at_symm_map_nhds_within_range' {y : M} (hy : y ∈ 𝓔(I, x).source) :
+  map 𝓔(I, x).symm (𝓝[range I] (𝓔(I, x) y)) = 𝓝 y :=
 by rw [← nhds_within_univ, ← ext_chart_at_symm_map_nhds_within' I x hy, preimage_univ, univ_inter]
 
 lemma ext_chart_at_symm_map_nhds_within :
-  map (ext_chart_at I x).symm
-    (𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] (ext_chart_at I x x)) = 𝓝[s] x :=
+  map 𝓔(I, x).symm
+    (𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x)) = 𝓝[s] x :=
 ext_chart_at_symm_map_nhds_within' I x (mem_ext_chart_source I x)
 
 lemma ext_chart_at_symm_map_nhds_within_range :
-  map (ext_chart_at I x).symm (𝓝[range I] (ext_chart_at I x x)) = 𝓝 x :=
+  map 𝓔(I, x).symm (𝓝[range I] (𝓔(I, x) x)) = 𝓝 x :=
 ext_chart_at_symm_map_nhds_within_range' I x (mem_ext_chart_source I x)
 
 /-- Technical lemma ensuring that the preimage under an extended chart of a neighborhood of a point
 in the source is a neighborhood of the preimage, within a set. -/
-lemma ext_chart_preimage_mem_nhds_within' {x' : M} (h : x' ∈ (ext_chart_at I x).source)
+lemma ext_chart_preimage_mem_nhds_within' {x' : M} (h : x' ∈ 𝓔(I, x).source)
   (ht : t ∈ 𝓝[s] x') :
-  (ext_chart_at I x).symm ⁻¹' t ∈
-    𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] ((ext_chart_at I x) x') :=
+  𝓔(I, x).symm ⁻¹' t ∈
+    𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x') :=
 by rwa [← ext_chart_at_symm_map_nhds_within' I x h, mem_map] at ht
 
 /-- Technical lemma ensuring that the preimage under an extended chart of a neighborhood of the
 base point is a neighborhood of the preimage, within a set. -/
 lemma ext_chart_preimage_mem_nhds_within (ht : t ∈ 𝓝[s] x) :
-  (ext_chart_at I x).symm ⁻¹' t ∈
-    𝓝[(ext_chart_at I x).symm ⁻¹' s ∩ range I] ((ext_chart_at I x) x) :=
+  𝓔(I, x).symm ⁻¹' t ∈
+    𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x) :=
 ext_chart_preimage_mem_nhds_within' I x (mem_ext_chart_source I x) ht
 
-lemma ext_chart_preimage_mem_nhds' {x' : M} (h : x' ∈ (ext_chart_at I x).source) (ht : t ∈ 𝓝 x') :
-  (ext_chart_at I x).symm ⁻¹' t ∈ 𝓝 (ext_chart_at I x x') :=
+lemma ext_chart_preimage_mem_nhds' {x' : M} (h : x' ∈ 𝓔(I, x).source) (ht : t ∈ 𝓝 x') :
+  𝓔(I, x).symm ⁻¹' t ∈ 𝓝 (𝓔(I, x) x') :=
 begin
   apply (ext_chart_continuous_at_symm' I x h).preimage_mem_nhds,
-  rwa (ext_chart_at I x).left_inv h
+  rwa 𝓔(I, x).left_inv h
 end
 
 /-- Technical lemma ensuring that the preimage under an extended chart of a neighborhood of a point
 is a neighborhood of the preimage. -/
 lemma ext_chart_preimage_mem_nhds (ht : t ∈ 𝓝 x) :
-  (ext_chart_at I x).symm ⁻¹' t ∈ 𝓝 ((ext_chart_at I x) x) :=
+  𝓔(I, x).symm ⁻¹' t ∈ 𝓝 (𝓔(I, x) x) :=
 begin
   apply (ext_chart_continuous_at_symm I x).preimage_mem_nhds,
-  rwa (ext_chart_at I x).left_inv (mem_ext_chart_source _ _)
+  rwa 𝓔(I, x).left_inv (mem_ext_chart_source _ _)
 end
 
 /-- Technical lemma to rewrite suitably the preimage of an intersection under an extended chart, to
 bring it into a convenient form to apply derivative lemmas. -/
 lemma ext_chart_preimage_inter_eq :
-  ((ext_chart_at I x).symm ⁻¹' (s ∩ t) ∩ range I)
-  = ((ext_chart_at I x).symm ⁻¹' s ∩ range I) ∩ ((ext_chart_at I x).symm ⁻¹' t) :=
+  (𝓔(I, x).symm ⁻¹' (s ∩ t) ∩ range I)
+  = (𝓔(I, x).symm ⁻¹' s ∩ range I) ∩ (𝓔(I, x).symm ⁻¹' t) :=
 by mfld_set_tac
 
-/-! We use the name `ext_coord_change` for `(ext_chart_at I x').symm ≫ ext_chart_at I x`. -/
+/-! We use the name `ext_coord_change` for `(𝓔(I, x)').symm ≫ 𝓔(I, x)`. -/
 
 lemma ext_coord_change_source (x x' : M) :
-  ((ext_chart_at I x').symm ≫ ext_chart_at I x).source =
+  ((𝓔(I, x')).symm ≫ 𝓔(I, x)).source =
   I '' ((chart_at H x').symm ≫ₕ (chart_at H x)).source :=
 by { simp_rw [local_equiv.trans_source, I.image_eq, ext_chart_at_source, local_equiv.symm_source,
       ext_chart_at_target, inter_right_comm _ (range I)], refl }
 
 lemma cont_diff_on_ext_coord_change [smooth_manifold_with_corners I M] (x x' : M) :
-  cont_diff_on 𝕜 ⊤ (ext_chart_at I x ∘ (ext_chart_at I x').symm)
-  ((ext_chart_at I x').symm ≫ ext_chart_at I x).source :=
+  cont_diff_on 𝕜 ⊤ (𝓔(I, x) ∘ (𝓔(I, x')).symm)
+  ((𝓔(I, x')).symm ≫ 𝓔(I, x)).source :=
 by { rw [ext_coord_change_source, I.image_eq], exact (has_groupoid.compatible
   (cont_diff_groupoid ⊤ I) (chart_mem_atlas H x') (chart_mem_atlas H x)).1 }
 
 lemma cont_diff_within_at_ext_coord_change [smooth_manifold_with_corners I M] (x x' : M) {y : E}
-  (hy : y ∈ ((ext_chart_at I x').symm ≫ ext_chart_at I x).source) :
-  cont_diff_within_at 𝕜 ⊤ (ext_chart_at I x ∘ (ext_chart_at I x').symm) (range I) y :=
+  (hy : y ∈ ((𝓔(I, x')).symm ≫ 𝓔(I, x)).source) :
+  cont_diff_within_at 𝕜 ⊤ (𝓔(I, x) ∘ (𝓔(I, x')).symm) (range I) y :=
 begin
   apply (cont_diff_on_ext_coord_change I x x' y hy).mono_of_mem,
   rw [ext_coord_change_source] at hy ⊢,
@@ -950,24 +953,24 @@ end
 /-- Conjugating a function to write it in the preferred charts around `x`.
 The manifold derivative of `f` will just be the derivative of this conjugated function. -/
 @[simp, mfld_simps] def written_in_ext_chart_at (x : M) (f : M → M') : E → E' :=
-ext_chart_at I' (f x) ∘ f ∘ (ext_chart_at I x).symm
+𝓔(I', f x) ∘ f ∘ 𝓔(I, x).symm
 
 variable (𝕜)
 
-lemma ext_chart_self_eq {x : H} : ⇑(ext_chart_at I x) = I := rfl
-lemma ext_chart_self_apply {x y : H} : ext_chart_at I x y = I y := rfl
+lemma ext_chart_self_eq {x : H} : ⇑𝓔(I, x) = I := rfl
+lemma ext_chart_self_apply {x y : H} : 𝓔(I, x) y = I y := rfl
 
 /-- In the case of the manifold structure on a vector space, the extended charts are just the
 identity.-/
-lemma ext_chart_model_space_eq_id (x : E) : ext_chart_at 𝓘(𝕜, E) x = local_equiv.refl E :=
+lemma ext_chart_model_space_eq_id (x : E) : 𝓔(𝓘(𝕜, E), x) = local_equiv.refl E :=
 by simp only with mfld_simps
 
-lemma ext_chart_model_space_apply {x y : E} : ext_chart_at 𝓘(𝕜, E) x y = y := rfl
+lemma ext_chart_model_space_apply {x y : E} : 𝓔(𝓘(𝕜, E), x) y = y := rfl
 
 variable {𝕜}
 
 lemma ext_chart_at_prod (x : M × M') :
-  ext_chart_at (I.prod I') x = (ext_chart_at I x.1).prod (ext_chart_at I' x.2) :=
+  𝓔((I.prod I'), x) = 𝓔(I, x.1).prod 𝓔(I', x.2) :=
 by simp only with mfld_simps
 
 end extended_charts

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -955,7 +955,7 @@ lemma ext_chart_model_space_apply {x y : E} : 𝓔(𝓘(𝕜, E), x) y = y := rf
 variable {𝕜}
 
 lemma ext_chart_at_prod (x : M × M') :
-  𝓔((I.prod I'), x) = 𝓔(I, x.1).prod 𝓔(I', x.2) :=
+  𝓔(I.prod I', x) = 𝓔(I, x.1).prod 𝓔(I', x.2) :=
 by simp only with mfld_simps
 
 end extended_charts

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -713,8 +713,7 @@ localized "notation (name := ext_chart_at) `𝓔(` I `, ` x `)` := ext_chart_at 
 
 lemma ext_chart_at_coe : ⇑𝓔(I, x) = I ∘ chart_at H x := rfl
 
-lemma ext_chart_at_coe_symm :
-  ⇑𝓔(I, x).symm = (chart_at H x).symm ∘ I.symm := rfl
+lemma ext_chart_at_coe_symm : ⇑𝓔(I, x).symm = (chart_at H x).symm ∘ I.symm := rfl
 
 lemma ext_chart_at_source : 𝓔(I, x).source = (chart_at H x).source :=
 by rw [ext_chart_at, local_equiv.trans_source, I.source_eq, preimage_univ, inter_univ]
@@ -730,8 +729,7 @@ lemma ext_chart_at_target (x : M) : 𝓔(I, x).target =
 by simp_rw [ext_chart_at, local_equiv.trans_target, I.target_eq, I.to_local_equiv_coe_symm,
   inter_comm]
 
-lemma ext_chart_at_to_inv :
-  𝓔(I, x).symm (𝓔(I, x) x) = x :=
+lemma ext_chart_at_to_inv : 𝓔(I, x).symm (𝓔(I, x) x) = x :=
 𝓔(I, x).left_inv (mem_ext_chart_source I x)
 
 lemma maps_to_ext_chart_at (hs : s ⊆ (chart_at H x).source) :
@@ -753,12 +751,10 @@ lemma ext_chart_at_source_mem_nhds_within' {x' : M} (h : x' ∈ 𝓔(I, x).sourc
   𝓔(I, x).source ∈ 𝓝[s] x' :=
 mem_nhds_within_of_mem_nhds (ext_chart_at_source_mem_nhds' I x h)
 
-lemma ext_chart_at_source_mem_nhds_within :
-  𝓔(I, x).source ∈ 𝓝[s] x :=
+lemma ext_chart_at_source_mem_nhds_within : 𝓔(I, x).source ∈ 𝓝[s] x :=
 mem_nhds_within_of_mem_nhds (ext_chart_at_source_mem_nhds I x)
 
-lemma ext_chart_at_continuous_on :
-  continuous_on 𝓔(I, x) 𝓔(I, x).source :=
+lemma ext_chart_at_continuous_on : continuous_on 𝓔(I, x) 𝓔(I, x).source :=
 begin
   refine I.continuous.comp_continuous_on _,
   rw ext_chart_at_source,
@@ -803,14 +799,12 @@ lemma ext_chart_at_target_subset_range : 𝓔(I, x).target ⊆ range I :=
 by simp only with mfld_simps
 
 lemma nhds_within_ext_chart_target_eq' {y : M} (hy : y ∈ 𝓔(I, x).source) :
-  𝓝[𝓔(I, x).target] (𝓔(I, x) y) =
-  𝓝[range I] (𝓔(I, x) y) :=
+  𝓝[𝓔(I, x).target] (𝓔(I, x) y) = 𝓝[range I] (𝓔(I, x) y) :=
 (nhds_within_mono _ (ext_chart_at_target_subset_range _ _)).antisymm $
   nhds_within_le_of_mem (ext_chart_at_target_mem_nhds_within' _ _ hy)
 
 lemma nhds_within_ext_chart_target_eq :
-  𝓝[𝓔(I, x).target] (𝓔(I, x) x) =
-  𝓝[range I] (𝓔(I, x) x) :=
+  𝓝[𝓔(I, x).target] (𝓔(I, x) x) = 𝓝[range I] (𝓔(I, x) x) :=
 nhds_within_ext_chart_target_eq' I x (mem_ext_chart_source I x)
 
 lemma ext_chart_continuous_at_symm'' {y : E} (h : y ∈ 𝓔(I, x).target) :
@@ -838,8 +832,7 @@ lemma ext_chart_preimage_open_of_open {s : set E} (hs : is_open s) :
 by { rw ← ext_chart_at_source I, exact ext_chart_preimage_open_of_open' I x hs }
 
 lemma ext_chart_at_map_nhds_within_eq_image' {y : M} (hy : y ∈ 𝓔(I, x).source) :
-  map 𝓔(I, x) (𝓝[s] y) =
-    𝓝[𝓔(I, x) '' (𝓔(I, x).source ∩ s)] (𝓔(I, x) y) :=
+  map 𝓔(I, x) (𝓝[s] y) = 𝓝[𝓔(I, x) '' (𝓔(I, x).source ∩ s)] (𝓔(I, x) y) :=
 by set e := 𝓔(I, x);
 calc map e (𝓝[s] y) = map e (𝓝[e.source ∩ s] y) :
   congr_arg (map e) (nhds_within_inter_of_mem (ext_chart_at_source_mem_nhds_within' I x hy)).symm
@@ -850,25 +843,21 @@ calc map e (𝓝[s] y) = map e (𝓝[e.source ∩ s] y) :
     (ext_chart_at_continuous_at' I x hy).continuous_within_at
 
 lemma ext_chart_at_map_nhds_within_eq_image :
-  map 𝓔(I, x) (𝓝[s] x) =
-    𝓝[𝓔(I, x) '' (𝓔(I, x).source ∩ s)] (𝓔(I, x) x) :=
+  map 𝓔(I, x) (𝓝[s] x) = 𝓝[𝓔(I, x) '' (𝓔(I, x).source ∩ s)] (𝓔(I, x) x) :=
 ext_chart_at_map_nhds_within_eq_image' I x (mem_ext_chart_source I x)
 
 lemma ext_chart_at_map_nhds_within' {y : M} (hy : y ∈ 𝓔(I, x).source) :
-  map 𝓔(I, x) (𝓝[s] y) =
-    𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) y) :=
+  map 𝓔(I, x) (𝓝[s] y) = 𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) y) :=
 by rw [ext_chart_at_map_nhds_within_eq_image' I x hy, nhds_within_inter,
   ← nhds_within_ext_chart_target_eq' _ _ hy, ← nhds_within_inter,
   𝓔(I, x).image_source_inter_eq', inter_comm]
 
 lemma ext_chart_at_map_nhds_within :
-  map 𝓔(I, x) (𝓝[s] x) =
-    𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x) :=
+  map 𝓔(I, x) (𝓝[s] x) = 𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x) :=
 ext_chart_at_map_nhds_within' I x (mem_ext_chart_source I x)
 
 lemma ext_chart_at_symm_map_nhds_within' {y : M} (hy : y ∈ 𝓔(I, x).source) :
-  map 𝓔(I, x).symm
-    (𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) y)) = 𝓝[s] y :=
+  map 𝓔(I, x).symm (𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) y)) = 𝓝[s] y :=
 begin
   rw [← ext_chart_at_map_nhds_within' I x hy, map_map, map_congr, map_id],
   exact 𝓔(I, x).left_inv_on.eq_on.eventually_eq_of_mem
@@ -880,8 +869,7 @@ lemma ext_chart_at_symm_map_nhds_within_range' {y : M} (hy : y ∈ 𝓔(I, x).so
 by rw [← nhds_within_univ, ← ext_chart_at_symm_map_nhds_within' I x hy, preimage_univ, univ_inter]
 
 lemma ext_chart_at_symm_map_nhds_within :
-  map 𝓔(I, x).symm
-    (𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x)) = 𝓝[s] x :=
+  map 𝓔(I, x).symm (𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x)) = 𝓝[s] x :=
 ext_chart_at_symm_map_nhds_within' I x (mem_ext_chart_source I x)
 
 lemma ext_chart_at_symm_map_nhds_within_range :
@@ -892,15 +880,13 @@ ext_chart_at_symm_map_nhds_within_range' I x (mem_ext_chart_source I x)
 in the source is a neighborhood of the preimage, within a set. -/
 lemma ext_chart_preimage_mem_nhds_within' {x' : M} (h : x' ∈ 𝓔(I, x).source)
   (ht : t ∈ 𝓝[s] x') :
-  𝓔(I, x).symm ⁻¹' t ∈
-    𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x') :=
+  𝓔(I, x).symm ⁻¹' t ∈ 𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x') :=
 by rwa [← ext_chart_at_symm_map_nhds_within' I x h, mem_map] at ht
 
 /-- Technical lemma ensuring that the preimage under an extended chart of a neighborhood of the
 base point is a neighborhood of the preimage, within a set. -/
 lemma ext_chart_preimage_mem_nhds_within (ht : t ∈ 𝓝[s] x) :
-  𝓔(I, x).symm ⁻¹' t ∈
-    𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x) :=
+  𝓔(I, x).symm ⁻¹' t ∈ 𝓝[𝓔(I, x).symm ⁻¹' s ∩ range I] (𝓔(I, x) x) :=
 ext_chart_preimage_mem_nhds_within' I x (mem_ext_chart_source I x) ht
 
 lemma ext_chart_preimage_mem_nhds' {x' : M} (h : x' ∈ 𝓔(I, x).source) (ht : t ∈ 𝓝 x') :
@@ -929,20 +915,19 @@ by mfld_set_tac
 /-! We use the name `ext_coord_change` for `(𝓔(I, x)').symm ≫ 𝓔(I, x)`. -/
 
 lemma ext_coord_change_source (x x' : M) :
-  ((𝓔(I, x')).symm ≫ 𝓔(I, x)).source =
+  (𝓔(I, x').symm ≫ 𝓔(I, x)).source =
   I '' ((chart_at H x').symm ≫ₕ (chart_at H x)).source :=
 by { simp_rw [local_equiv.trans_source, I.image_eq, ext_chart_at_source, local_equiv.symm_source,
       ext_chart_at_target, inter_right_comm _ (range I)], refl }
 
 lemma cont_diff_on_ext_coord_change [smooth_manifold_with_corners I M] (x x' : M) :
-  cont_diff_on 𝕜 ⊤ (𝓔(I, x) ∘ (𝓔(I, x')).symm)
-  ((𝓔(I, x')).symm ≫ 𝓔(I, x)).source :=
+  cont_diff_on 𝕜 ⊤ (𝓔(I, x) ∘ 𝓔(I, x').symm) (𝓔(I, x').symm ≫ 𝓔(I, x)).source :=
 by { rw [ext_coord_change_source, I.image_eq], exact (has_groupoid.compatible
   (cont_diff_groupoid ⊤ I) (chart_mem_atlas H x') (chart_mem_atlas H x)).1 }
 
 lemma cont_diff_within_at_ext_coord_change [smooth_manifold_with_corners I M] (x x' : M) {y : E}
-  (hy : y ∈ ((𝓔(I, x')).symm ≫ 𝓔(I, x)).source) :
-  cont_diff_within_at 𝕜 ⊤ (𝓔(I, x) ∘ (𝓔(I, x')).symm) (range I) y :=
+  (hy : y ∈ (𝓔(I, x').symm ≫ 𝓔(I, x)).source) :
+  cont_diff_within_at 𝕜 ⊤ (𝓔(I, x) ∘ 𝓔(I, x').symm) (range I) y :=
 begin
   apply (cont_diff_on_ext_coord_change I x x' y hy).mono_of_mem,
   rw [ext_coord_change_source] at hy ⊢,


### PR DESCRIPTION
New notation `𝓔(I, x)` for `ext_chart_at I x`, the preferred extended local chart around `x : M`, where `M` is a manifold with model `I`. It is then shorter and easier to write `𝓔(I, x).source`, `𝓔(I, x) ∘ 𝓔(I, x').symm`, etc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
