### PR TITLE
[Merged by Bors] - feat(data/finset/basic): add lemmas about filter and (co)disjoint

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -287,7 +287,7 @@ lemma prod_filter_mul_prod_filter_not (s : finset α) (p : α → Prop) [decidab
   (∏ x in s.filter p, f x) * (∏ x in s.filter (λ x, ¬p x), f x) = ∏ x in s, f x :=
 begin
   haveI := classical.dec_eq α,
-  rw [← prod_union (filter_inter_filter_neg_eq p s).le, filter_union_filter_neg_eq]
+  rw [← prod_union (disjoint_filter_filter_neg _ _ p), filter_union_filter_neg_eq]
 end
 
 section to_list

--- a/src/combinatorics/set_family/compression/down.lean
+++ b/src/combinatorics/set_family/compression/down.lean
@@ -181,7 +181,7 @@ end
 begin
   rw [compression, card_disj_union, image_filter, card_image_of_inj_on ((erase_inj_on' _).mono $
     λ s hs, _), ←card_disjoint_union, filter_union_filter_neg_eq],
-  { exact disjoint_filter_filter_neg _ _ },
+  { exact disjoint_filter_filter_neg _ _ _ },
   rw [mem_coe, mem_filter] at hs,
   exact not_imp_comm.1 erase_eq_of_not_mem (ne_of_mem_of_not_mem hs.1 hs.2).symm,
 end

--- a/src/combinatorics/set_family/compression/uv.lean
+++ b/src/combinatorics/set_family/compression/uv.lean
@@ -171,7 +171,7 @@ begin
   rw [compression, card_disjoint_union (compress_disjoint _ _), image_filter, card_image_of_inj_on,
     ←card_disjoint_union, filter_union_filter_neg_eq],
   { rw disjoint_iff_inter_eq_empty,
-    exact filter_inter_filter_neg_eq _ _ },
+    exact filter_inter_filter_neg_eq _ _ _ },
   intros a ha b hb hab,
   dsimp at hab,
   rw [mem_coe, mem_filter, function.comp_app] at ha hb,

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1777,13 +1777,27 @@ by { simp [subset.antisymm_iff],
        ... ⊇ s₁ \ ∅         : by mono using [(⊇)]
        ... ⊇ s₁             : by simp [(⊇)] } }
 
-theorem filter_union_filter_neg_eq [decidable_pred (λ a, ¬ p a)]
-  (s : finset α) : s.filter p ∪ s.filter (λa, ¬ p a) = s :=
-by simp only [filter_not, union_sdiff_of_subset (filter_subset p s)]
+theorem filter_union_filter_of_codisjoint (s : finset α) (h : codisjoint p q) :
+  s.filter p ∪ s.filter q = s :=
+(filter_or _ _ _).symm.trans $ filter_true_of_mem $ λ x hx, h x trivial
 
-theorem filter_inter_filter_neg_eq [decidable_pred (λ a, ¬ p a)]
-  (s : finset α) : s.filter p ∩ s.filter (λa, ¬ p a) = ∅ :=
-by simp only [filter_not, inter_sdiff_self]
+theorem filter_inter_filter_of_disjoint (s t : finset α) (h : disjoint p q) :
+  s.filter p ∩ t.filter q = ∅ :=
+begin
+  ext,
+  simp only [mem_inter, mem_filter, not_mem_empty, iff_false],
+  rintros ⟨⟨ha, hp⟩, ⟨hb, hq⟩⟩,
+  exact h _ ⟨hp, hq⟩,
+end
+
+theorem filter_union_filter_neg_eq [decidable_pred (λ a, ¬ p a)] (s : finset α) :
+  s.filter p ∪ s.filter (λ a, ¬ p a) = s :=
+filter_union_filter_of_codisjoint _ _ _
+  (@disjoint_compl_right _ _ (order_dual.to_dual p)).dual
+
+theorem filter_inter_filter_neg_eq [decidable_pred (λ a, ¬ p a)] (s t : finset α) :
+  s.filter p ∩ t.filter (λ a, ¬ p a) = ∅ :=
+filter_inter_filter_of_disjoint _ _ _ _ disjoint_compl_right
 
 lemma subset_union_elim {s : finset α} {t₁ t₂ : set α} (h : ↑s ⊆ t₁ ∪ t₂) :
   ∃ s₁ s₂ : finset α, s₁ ∪ s₂ = s ∧ ↑s₁ ⊆ t₁ ∧ ↑s₂ ⊆ t₂ \ t₁ :=

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1777,28 +1777,6 @@ by { simp [subset.antisymm_iff],
        ... ⊇ s₁ \ ∅         : by mono using [(⊇)]
        ... ⊇ s₁             : by simp [(⊇)] } }
 
-theorem filter_union_filter_of_codisjoint (s : finset α) (h : codisjoint p q) :
-  s.filter p ∪ s.filter q = s :=
-(filter_or _ _ _).symm.trans $ filter_true_of_mem $ λ x hx, h x trivial
-
-theorem filter_inter_filter_of_disjoint (s t : finset α) (h : disjoint p q) :
-  s.filter p ∩ t.filter q = ∅ :=
-begin
-  ext,
-  simp only [mem_inter, mem_filter, not_mem_empty, iff_false],
-  rintros ⟨⟨ha, hp⟩, ⟨hb, hq⟩⟩,
-  exact h _ ⟨hp, hq⟩,
-end
-
-theorem filter_union_filter_neg_eq [decidable_pred (λ a, ¬ p a)] (s : finset α) :
-  s.filter p ∪ s.filter (λ a, ¬ p a) = s :=
-filter_union_filter_of_codisjoint _ _ _
-  (@disjoint_compl_right _ _ (order_dual.to_dual p)).dual
-
-theorem filter_inter_filter_neg_eq [decidable_pred (λ a, ¬ p a)] (s t : finset α) :
-  s.filter p ∩ t.filter (λ a, ¬ p a) = ∅ :=
-filter_inter_filter_of_disjoint _ _ _ _ disjoint_compl_right
-
 lemma subset_union_elim {s : finset α} {t₁ t₂ : set α} (h : ↑s ⊆ t₁ ∪ t₂) :
   ∃ s₁ s₂ : finset α, s₁ ∪ s₂ = s ∧ ↑s₁ ⊆ t₁ ∧ ↑s₂ ⊆ t₂ \ t₁ :=
 begin
@@ -1873,9 +1851,32 @@ lemma disjoint_filter_filter {s t : finset α} {p q : α → Prop}
   disjoint s t → disjoint (s.filter p) (t.filter q) :=
 disjoint.mono (filter_subset _ _) (filter_subset _ _)
 
-lemma disjoint_filter_filter_neg (s : finset α) (p : α → Prop) [decidable_pred p] :
-  disjoint (s.filter p) (s.filter $ λ a, ¬ p a) :=
-(disjoint_filter.2 $ λ a _, id).symm
+lemma disjoint_filter_filter' (s t : finset α) {p q : α → Prop}
+  [decidable_pred p] [decidable_pred q] (h : disjoint p q) :
+  disjoint (s.filter p) (t.filter q) :=
+begin
+  simp_rw [disjoint_left, mem_filter],
+  rintros a ⟨hs, hp⟩ ⟨ht, hq⟩,
+  exact h _ ⟨hp, hq⟩,
+end
+
+lemma disjoint_filter_filter_neg (s t : finset α) (p : α → Prop)
+  [decidable_pred p] [decidable_pred (λ a, ¬ p a)] :
+  disjoint (s.filter p) (t.filter $ λ a, ¬ p a) :=
+disjoint_filter_filter' s t disjoint_compl_right
+
+theorem filter_inter_filter_neg_eq [decidable_pred (λ a, ¬ p a)] (s t : finset α) :
+  s.filter p ∩ t.filter (λ a, ¬ p a) = ∅ :=
+(disjoint_filter_filter_neg s t p).eq_bot
+
+theorem filter_union_filter_of_codisjoint (s : finset α) (h : codisjoint p q) :
+  s.filter p ∪ s.filter q = s :=
+(filter_or _ _ _).symm.trans $ filter_true_of_mem $ λ x hx, h x trivial
+
+theorem filter_union_filter_neg_eq [decidable_pred (λ a, ¬ p a)] (s : finset α) :
+  s.filter p ∪ s.filter (λ a, ¬ p a) = s :=
+filter_union_filter_of_codisjoint _ _ _
+  (@disjoint_compl_right _ _ (order_dual.to_dual p)).dual
 
 end filter
 

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1875,8 +1875,7 @@ theorem filter_union_filter_of_codisjoint (s : finset α) (h : codisjoint p q) :
 
 theorem filter_union_filter_neg_eq [decidable_pred (λ a, ¬ p a)] (s : finset α) :
   s.filter p ∪ s.filter (λ a, ¬ p a) = s :=
-filter_union_filter_of_codisjoint _ _ _
-  (@disjoint_compl_right _ _ (order_dual.to_dual p)).dual
+filter_union_filter_of_codisjoint _ _ _ codisjoint_hnot_right
 
 end filter
 

--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -213,7 +213,8 @@ end
 @[simp] lemma diag_union_off_diag : s.diag ∪ s.off_diag = s ×ˢ s :=
 filter_union_filter_neg_eq _ _
 
-@[simp] lemma disjoint_diag_off_diag : disjoint s.diag s.off_diag := disjoint_filter_filter_neg _ _
+@[simp] lemma disjoint_diag_off_diag : disjoint s.diag s.off_diag :=
+disjoint_filter_filter_neg _ _ _
 
 lemma product_sdiff_diag : s ×ˢ s \ s.diag = s.off_diag :=
 by rw [←diag_union_off_diag, union_comm, union_sdiff_self,


### PR DESCRIPTION
This generalizes `finset.filter_inter_filter_neg_eq` to when the sets are different, and then further to when the propositions are not complementary but only disjoint.

A similar story is true of the `union` lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
