### PR TITLE
[Merged by Bors] - doc(analysis/locally_convex/with_seminorms): fix hyperlink and add first countable

### DIFF
--- a/src/analysis/locally_convex/with_seminorms.lean
+++ b/src/analysis/locally_convex/with_seminorms.lean
@@ -19,8 +19,10 @@ bounded by a finite number of seminorms in `E`.
 
 ## Main statements
 
-* `seminorm_family.to_locally_convex_space`: A space equipped with a family of seminorms is locally
+* `with_seminorms.to_locally_convex_space`: A space equipped with a family of seminorms is locally
 convex.
+* `with_seminorms.first_countable`: A space is first countable if it's topology is induced by a
+countable family of seminorms.
 
 ## Continuity of semilinear maps
 


### PR DESCRIPTION
This fixes the hyperlink for `with_seminorms.to_locally_convex_space` and adds `with_seminorms.first_countable` to the module docstring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
