### PR TITLE
[Merged by Bors] - fix(tactic/linarith): fix bug in linarith

### DIFF
--- a/src/analysis/normed/group/add_circle.lean
+++ b/src/analysis/normed/group/add_circle.lean
@@ -197,12 +197,18 @@ begin
     rintros y ⟨⟨hy₁, hy₂⟩, hy₀⟩,
     obtain ⟨hy₃, hy₄⟩ := hs hy₀,
     rcases lt_trichotomy 0 p with hp | rfl | hp,
-    { cases int.cast_le_neg_one_or_one_le_cast_of_ne_zero ℝ hz with hz' hz';
-      nlinarith [hz', abs_eq_self.mpr hp.le], },
+    { cases int.cast_le_neg_one_or_one_le_cast_of_ne_zero ℝ hz with hz' hz',
+      { have : ↑z * p ≤ - p, nlinarith,
+        linarith [abs_eq_self.mpr hp.le] },
+      { have : p ≤ ↑z * p, nlinarith,
+        linarith [abs_eq_self.mpr hp.le] } },
     { simp only [mul_zero, add_zero, abs_zero, zero_div] at hy₁ hy₂ hε,
-      linarith, },
-    { cases int.cast_le_neg_one_or_one_le_cast_of_ne_zero ℝ hz with hz' hz';
-      nlinarith [hz', abs_eq_neg_self.mpr hp.le], }, },
+      linarith },
+    { cases int.cast_le_neg_one_or_one_le_cast_of_ne_zero ℝ hz with hz' hz',
+      { have : - p ≤ ↑z * p, nlinarith,
+        linarith [abs_eq_neg_self.mpr hp.le] },
+      { have : ↑z * p ≤ p, nlinarith,
+        linarith [abs_eq_neg_self.mpr hp.le] } } },
 end
 
 end add_circle

--- a/src/tactic/linarith/elimination.lean
+++ b/src/tactic/linarith/elimination.lean
@@ -100,9 +100,9 @@ meta structure pcomp : Type :=
 (c : comp)
 (src : comp_source)
 (history : rb_set ℕ)
-(vars : rb_set ℕ)
 (effective : rb_set ℕ)
 (implicit : rb_set ℕ)
+(vars : rb_set ℕ)
 
 /--
 Any comparison whose history is not minimal is redundant,
@@ -165,7 +165,7 @@ let c := c1.c.add c2.c,
     vars := c1.vars.union c2.vars,
     effective := (c1.effective.union c2.effective).insert elim_var,
     implicit := (vars.sdiff (rb_set.of_list c.vars)).sdiff effective in
-⟨c, src, history, vars, effective, implicit⟩
+⟨c, src, history, effective, implicit, vars⟩
 
 /--
 `pcomp.assump c n` creates a `pcomp` whose comparison is `c` and whose source is
@@ -177,9 +177,9 @@ meta def pcomp.assump (c : comp) (n : ℕ) : pcomp :=
 { c := c,
   src := comp_source.assump n,
   history := mk_rb_set.insert n,
-  vars := rb_set.of_list c.vars,
   effective := mk_rb_set,
-  implicit := mk_rb_set, }
+  implicit := mk_rb_set,
+  vars := rb_set.of_list c.vars }
 
 meta instance pcomp.to_format : has_to_format pcomp :=
 ⟨λ p, to_fmt p.c.coeffs ++ to_string p.c.str ++ "0"⟩

--- a/src/tactic/linarith/elimination.lean
+++ b/src/tactic/linarith/elimination.lean
@@ -81,16 +81,15 @@ The *historical set* `pcomp.history` stores the labels of expressions
 that were used in deriving the current `pcomp`.
 Variables are also indexed by natural numbers. The sets `pcomp.effective`, `pcomp.implicit`,
 and `pcomp.vars` contain variable indices.
-* `pcomp.vars` contains the variables that appear in `pcomp.c`. We store them in `pcomp` to
-  avoid recomputing the set, which requires folding over a list. (TODO: is this really needed?)
+* `pcomp.vars` contains the union of all variables that appear in the historical set.
 * `pcomp.effective` contains the variables that have been effectively eliminated from `pcomp`.
   A variable `n` is said to be *effectively eliminated* in `pcomp` if the elimination of `n`
   produced at least one of the ancestors of `pcomp`.
 * `pcomp.implicit` contains the variables that have been implicitly eliminated from `pcomp`.
   A variable `n` is said to be *implicitly eliminated* in `pcomp` if it satisfies the following
   properties:
-  - There is some `ancestor` of `pcomp` such that `n` appears in `ancestor.vars`.
-  - `n` does not appear in `pcomp.vars`.
+  - `n` appears in the historical set (i.e. in `pcomp.vars`).
+  - `n` does not appear in `p.c.vars` (i.e. it has been eliminated).
   - `n` was not effectively eliminated.
 
 We track these sets in order to compute whether the history of a `pcomp` is *minimal*.

--- a/src/tactic/linarith/elimination.lean
+++ b/src/tactic/linarith/elimination.lean
@@ -151,6 +151,11 @@ additional fields of `pcomp`.
   with `elim_var` inserted.
 * The implicitly eliminated variables of `c1 + c2` are those that appear in
   `vars` but not `c.vars` or `effective`.
+(Note that the description of the implicitly eliminated variables of `c1 + c2` in the algorithm
+described in Section 6 of https://doi.org/10.1016/B978-0-444-88771-9.50019-2 seems to be wrong:
+that says it should be `(c1.implicit.union c2.implicit).sdiff explicit`.
+Since the implicitly eliminated sets start off empty for the assumption,
+this formula would leave them always empty.)
 -/
 meta def pcomp.add (c1 c2 : pcomp) (elim_var : ℕ) : pcomp :=
 let c := c1.c.add c2.c,

--- a/src/tactic/linarith/elimination.lean
+++ b/src/tactic/linarith/elimination.lean
@@ -79,15 +79,16 @@ along with information about how this comparison was derived.
 The original expressions fed into `linarith` are each assigned a unique natural number label.
 The *historical set* `pcomp.history` stores the labels of expressions
 that were used in deriving the current `pcomp`.
-Variables are also indexed by natural numbers. The sets `pcomp.effective`, and `pcomp.implicit`,
+Variables are also indexed by natural numbers. The sets `PComp.effective`, `PComp.implicit`,
+and `PComp.vars` contain variable indices.
 * `pcomp.vars` contains the variables that appear in any inequality in the historical set.
 * `pcomp.effective` contains the variables that have been effectively eliminated from `pcomp`.
   A variable `n` is said to be *effectively eliminated* in `p : pcomp` if the elimination of `n`
-  produced at least one of the ancestors of `p : pcomp` (or `p` itself).
+  produced at least one of the ancestors of `p` (or `p` itself).
 * `pcomp.implicit` contains the variables that have been implicitly eliminated from `pcomp`.
-  A variable `n` is said to be *implicitly eliminated* in `pcomp` if it satisfies the following
+  A variable `n` is said to be *implicitly eliminated* in `p` if it satisfies the following
   properties:
-  - `n` appears in the historical set (i.e. in `pcomp.vars`).
+  - `n` appears in some inequality in the historical set (i.e. in `p.vars`).
   - `n` does not appear in `p.c.vars` (i.e. it has been eliminated).
   - `n` was not effectively eliminated.
 
@@ -145,8 +146,8 @@ The computation assumes, but does not enforce, that `elim_var` appears in both `
 and does not appear in the sum.
 Computing the sum of the two comparisons is easy; the complicated details lie in tracking the
 additional fields of `pcomp`.
-* `vars` is the union of `c1.vars` and `c2.vars`.
 * The historical set `pcomp.history` of `c1 + c2` is the union of the two historical sets.
+* `vars` is the union of `c1.vars` and `c2.vars`.
 * The effectively eliminated variables of `c1 + c2` are the union of the two effective sets,
   with `elim_var` inserted.
 * The implicitly eliminated variables of `c1 + c2` are those that appear in

--- a/src/tactic/linarith/elimination.lean
+++ b/src/tactic/linarith/elimination.lean
@@ -172,7 +172,7 @@ let c := c1.c.add c2.c,
 The history is the singleton set `{n}`.
 No variables have been eliminated (effectively or implicitly).
 -/
-meta def pcomp.assump (c : comp) (n max_var : ℕ) : pcomp :=
+meta def pcomp.assump (c : comp) (n : ℕ) : pcomp :=
 { c := c,
   src := comp_source.assump n,
   history := mk_rb_set.insert n,
@@ -310,7 +310,7 @@ do mv ← get_max_var,
 those hypotheses. It produces an initial state for the elimination monad.
 -/
 meta def mk_linarith_structure (hyps : list comp) (max_var : ℕ) : linarith_structure :=
-let pcomp_list : list pcomp := hyps.enum.map $ λ ⟨n, cmp⟩, pcomp.assump cmp n max_var,
+let pcomp_list : list pcomp := hyps.enum.map $ λ ⟨n, cmp⟩, pcomp.assump cmp n,
     pcomp_set := rb_set.of_list_core mk_pcomp_set pcomp_list in
 ⟨max_var, pcomp_set⟩
 

--- a/src/tactic/linarith/elimination.lean
+++ b/src/tactic/linarith/elimination.lean
@@ -162,7 +162,7 @@ let c := c1.c.add c2.c,
     history := c1.history.union c2.history,
     vars := (c1.vars.union c2.vars),
     effective := (c1.effective.union c2.effective).insert elim_var,
-    implicit := (vars.sdiff (native.rb_set.of_list c.vars)).erase elim_var in
+    implicit := (vars.sdiff (native.rb_set.of_list c.vars)).sdiff effective in
 ⟨c, src, history, effective, implicit, vars⟩
 
 /--

--- a/src/tactic/linarith/elimination.lean
+++ b/src/tactic/linarith/elimination.lean
@@ -160,9 +160,9 @@ meta def pcomp.add (c1 c2 : pcomp) (elim_var : ℕ) : pcomp :=
 let c := c1.c.add c2.c,
     src := c1.src.add c2.src,
     history := c1.history.union c2.history,
-    vars := native.rb_set.of_list c.vars,
+    vars := (c1.vars.union c2.vars),
     effective := (c1.effective.union c2.effective).insert elim_var,
-    implicit := ((c1.vars.union c2.vars).sdiff vars).erase elim_var in
+    implicit := (vars.sdiff (native.rb_set.of_list c.vars)).erase elim_var in
 ⟨c, src, history, effective, implicit, vars⟩
 
 /--

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -211,20 +211,19 @@ example (a b c z : ℚ) (_ : a ≤ z) (E0 : b ≤ c) (E1 : c ≤ a) (E2 : 0 ≤ 
 example (u v x y A B : ℚ)
 (a_7 : 0 < A - u)
 (a_8 : 0 < A - v) :
-(0 <= A * (1 - A))
--> (0 <= A * (B - 1))
--> (0 < A * (A - u))
--> (0 <= (B - 1) * (A - u))
--> (0 <= (B - 1) * (A - v))
--> (0 <= (B - x) * v)
--> (0 <= (B - y) * u)
--> (0 <= u * (A - v))
-->
- u * y + v * x + u * v < 3 * A * B :=
- begin
+(0 ≤ A * (1 - A))
+→ (0 ≤ A * (B - 1))
+→ (0 < A * (A - u))
+→ (0 ≤ (B - 1) * (A - u))
+→ (0 ≤ (B - 1) * (A - v))
+→ (0 ≤ (B - x) * v)
+→ (0 ≤ (B - y) * u)
+→ (0 ≤ u * (A - v))
+→ u * y + v * x + u * v < 3 * A * B :=
+begin
   intros,
   linarith
- end
+end
 
 example (u v x y A B : ℚ)
 (a : 0 < A)
@@ -318,11 +317,11 @@ example (u v x y A B : ℚ)
 -> (0 < (A - v) * (A - u))
 -> (0 < (A - v) * (A - v))
 ->
- u * y + v * x + u * v < 3 * A * B :=
- begin
+  u * y + v * x + u * v < 3 * A * B :=
+begin
   intros,
   linarith
- end
+end
 
 example (A B : ℚ) : (0 < A) → (1 ≤ B) → (0 < A / 8 * B) :=
 begin

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -206,6 +206,26 @@ begin
   nlinarith
 end
 
+example (a b c z : ℚ) (_ : a ≤ z) (E0 : b ≤ c) (E1 : c ≤ a) (E2 : 0 ≤ c) : b ≤ a + c := by linarith
+
+example (u v x y A B : ℚ)
+(a_7 : 0 < A - u)
+(a_8 : 0 < A - v) :
+(0 <= A * (1 - A))
+-> (0 <= A * (B - 1))
+-> (0 < A * (A - u))
+-> (0 <= (B - 1) * (A - u))
+-> (0 <= (B - 1) * (A - v))
+-> (0 <= (B - x) * v)
+-> (0 <= (B - y) * u)
+-> (0 <= u * (A - v))
+->
+ u * y + v * x + u * v < 3 * A * B :=
+ begin
+  intros,
+  linarith
+ end
+
 example (u v x y A B : ℚ)
 (a : 0 < A)
 (a_1 : 0 <= 1 - A)


### PR DESCRIPTION
I discovered this bug while porting linarith to mathlib4, and @digama0 minimised and identified the problem. There is a [zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/bug.20in.20linarith) explaining the details.

When applying [Imbert's first acceleration theorem](https://en.wikipedia.org/wiki/Fourier%E2%80%93Motzkin_elimination#Imbert's_acceleration_theorems) the code was incorrectly interpreting what an "implicitly eliminated variable" was.

I've added two tests, a one-liner that Mario reduced the problem too, as well as a longer one which had been failing in the mathlib4 port (due to different variable ordering).

The change causes one proof to timeout, which has been sped up.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
