### PR TITLE
[Merged by Bors] - feat(measure_theory/integral): lintegral_tsum'

### DIFF
--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2020,7 +2020,8 @@ begin
         apply_rules [hz₁, hz₂], },
       { simp only [ae_seq, hx, if_false],
         exact le_rfl, }, }, },
-  convert (lintegral_supr_directed_of_measurable (ae_seq.measurable hf p) h_ae_seq_directed) using 1,
+  convert (lintegral_supr_directed_of_measurable (ae_seq.measurable hf p) 
+    h_ae_seq_directed) using 1,
   { simp_rw ←supr_apply,
     rw lintegral_congr_ae (ae_seq.supr hf hp).symm, },
   { congr' 1,

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2419,7 +2419,7 @@ begin
   ext1 s hs,
   simp_rw [sum_apply _ hs, with_density_apply _ hs],
   change ∫⁻ x in s, (∑' n, f n) x ∂μ = ∑' (i : ℕ), ∫⁻ x, f i x ∂(μ.restrict s),
-  rw ← lintegral_tsum h,
+  rw ← lintegral_tsum (λ i, (h i).ae_measurable),
   refine lintegral_congr (λ x, tsum_apply (pi.summable.2 (λ _, ennreal.summable))),
 end
 

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -1975,7 +1975,7 @@ section
 open encodable
 
 /-- Monotone convergence for a supremum over a directed family and indexed by a countable type -/
-theorem lintegral_supr_directed [countable β] {f : β → α → ℝ≥0∞}
+theorem lintegral_supr_directed_of_measurable [countable β] {f : β → α → ℝ≥0∞}
   (hf : ∀ b, measurable (f b)) (h_directed : directed (≤) f) :
   ∫⁻ a, ⨆ b, f b a ∂μ = ⨆ b, ∫⁻ a, f b a ∂μ :=
 begin
@@ -2000,7 +2000,7 @@ begin
 end
 
 /-- Monotone convergence for a supremum over a directed family and indexed by a countable type. -/
-theorem lintegral_supr_directed' [countable β] {f : β → α → ℝ≥0∞}
+theorem lintegral_supr_directed [countable β] {f : β → α → ℝ≥0∞}
   (hf : ∀ b, ae_measurable (f b) μ) (h_directed : directed (≤) f) :
   ∫⁻ a, ⨆ b, f b a ∂μ = ⨆ b, ∫⁻ a, f b a ∂μ :=
 begin
@@ -2020,7 +2020,7 @@ begin
         apply_rules [hz₁, hz₂], },
       { simp only [ae_seq, hx, if_false],
         exact le_rfl, }, }, },
-  convert (lintegral_supr_directed (ae_seq.measurable hf p) h_ae_seq_directed) using 1,
+  convert (lintegral_supr_directed_of_measurable (ae_seq.measurable hf p) h_ae_seq_directed) using 1,
   { simp_rw ←supr_apply,
     rw lintegral_congr_ae (ae_seq.supr hf hp).symm, },
   { congr' 1,
@@ -2032,25 +2032,11 @@ end
 
 end
 
-lemma lintegral_tsum [countable β] {f : β → α → ℝ≥0∞} (hf : ∀i, measurable (f i)) :
+lemma lintegral_tsum [countable β] {f : β → α → ℝ≥0∞} (hf : ∀i, ae_measurable (f i) μ) :
   ∫⁻ a, ∑' i, f i a ∂μ = ∑' i, ∫⁻ a, f i a ∂μ :=
 begin
   simp only [ennreal.tsum_eq_supr_sum],
   rw [lintegral_supr_directed],
-  { simp [lintegral_finset_sum _ (λ i _, hf i)] },
-  { assume b, exact finset.measurable_sum _ (λ i _, hf i) },
-  { assume s t,
-    use [s ∪ t],
-    split,
-    { exact assume a, finset.sum_le_sum_of_subset (finset.subset_union_left _ _), },
-    { exact assume a, finset.sum_le_sum_of_subset (finset.subset_union_right _ _) } }
-end
-
-lemma lintegral_tsum' [countable β] {f : β → α → ℝ≥0∞} (hf : ∀i, ae_measurable (f i) μ) :
-  ∫⁻ a, ∑' i, f i a ∂μ = ∑' i, ∫⁻ a, f i a ∂μ :=
-begin
-  simp only [ennreal.tsum_eq_supr_sum],
-  rw [lintegral_supr_directed'],
   { simp [lintegral_finset_sum' _ (λ i _, hf i)] },
   { assume b, exact finset.ae_measurable_sum _ (λ i _, hf i) },
   { assume s t,

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2042,8 +2042,22 @@ begin
   { assume s t,
     use [s ∪ t],
     split,
-    exact assume a, finset.sum_le_sum_of_subset (finset.subset_union_left _ _),
-    exact assume a, finset.sum_le_sum_of_subset (finset.subset_union_right _ _) }
+    { exact assume a, finset.sum_le_sum_of_subset (finset.subset_union_left _ _), },
+    { exact assume a, finset.sum_le_sum_of_subset (finset.subset_union_right _ _) } }
+end
+
+lemma lintegral_tsum' [countable β] {f : β → α → ℝ≥0∞} (hf : ∀i, ae_measurable (f i) μ) :
+  ∫⁻ a, ∑' i, f i a ∂μ = ∑' i, ∫⁻ a, f i a ∂μ :=
+begin
+  simp only [ennreal.tsum_eq_supr_sum],
+  rw [lintegral_supr_directed'],
+  { simp [lintegral_finset_sum' _ (λ i _, hf i)] },
+  { assume b, exact finset.ae_measurable_sum _ (λ i _, hf i) },
+  { assume s t,
+    use [s ∪ t],
+    split,
+    { exact assume a, finset.sum_le_sum_of_subset (finset.subset_union_left _ _), },
+    { exact assume a, finset.sum_le_sum_of_subset (finset.subset_union_right _ _) } }
 end
 
 open measure

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -1976,8 +1976,8 @@ open encodable
 
 /-- Monotone convergence for a supremum over a directed family and indexed by a countable type -/
 theorem lintegral_supr_directed [countable β] {f : β → α → ℝ≥0∞}
-  (hf : ∀b, measurable (f b)) (h_directed : directed (≤) f) :
-  ∫⁻ a, ⨆b, f b a ∂μ = ⨆b, ∫⁻ a, f b a ∂μ :=
+  (hf : ∀ b, measurable (f b)) (h_directed : directed (≤) f) :
+  ∫⁻ a, ⨆ b, f b a ∂μ = ⨆ b, ∫⁻ a, f b a ∂μ :=
 begin
   casesI nonempty_encodable β,
   casesI is_empty_or_nonempty β, { simp [supr_of_empty] },
@@ -1997,6 +1997,37 @@ begin
       { exact le_supr_of_le (encode b + 1)
           (lintegral_mono $ h_directed.le_sequence b) }
     end
+end
+
+/-- Monotone convergence for a supremum over a directed family and indexed by a countable type. -/
+theorem lintegral_supr_directed' [countable β] {f : β → α → ℝ≥0∞}
+  (hf : ∀ b, ae_measurable (f b) μ) (h_directed : directed (≤) f) :
+  ∫⁻ a, ⨆ b, f b a ∂μ = ⨆ b, ∫⁻ a, f b a ∂μ :=
+begin
+  simp_rw ←supr_apply,
+  let p : α → (β → ennreal) → Prop := λ x f', directed has_le.le f',
+  have hp : ∀ᵐ x ∂μ, p x (λ i, f i x),
+  { filter_upwards with x i j,
+    obtain ⟨z, hz₁, hz₂⟩ := h_directed i j,
+    exact ⟨z, hz₁ x, hz₂ x⟩, },
+  have h_ae_seq_directed : directed has_le.le (ae_seq hf p),
+  { intros b₁ b₂,
+    obtain ⟨z, hz₁, hz₂⟩ := h_directed b₁ b₂,
+    refine ⟨z, _, _⟩;
+    { intros x,
+      by_cases hx : x ∈ ae_seq_set hf p,
+      { repeat { rw ae_seq.ae_seq_eq_fun_of_mem_ae_seq_set hf hx },
+        apply_rules [hz₁, hz₂], },
+      { simp only [ae_seq, hx, if_false],
+        exact le_rfl, }, }, },
+  convert (lintegral_supr_directed (ae_seq.measurable hf p) h_ae_seq_directed) using 1,
+  { simp_rw ←supr_apply,
+    rw lintegral_congr_ae (ae_seq.supr hf hp).symm, },
+  { congr' 1,
+    ext1 b,
+    rw lintegral_congr_ae,
+    symmetry,
+    refine ae_seq.ae_seq_n_eq_fun_n_ae hf hp _, },
 end
 
 end

--- a/src/measure_theory/integral/vitali_caratheodory.lean
+++ b/src/measure_theory/integral/vitali_caratheodory.lean
@@ -168,7 +168,7 @@ begin
       (λ x y hxy, ennreal.coe_le_coe.2 hxy) },
   { calc ∫⁻ x, ∑' (n : ℕ), g n x ∂μ
     = ∑' n, ∫⁻ x, g n x ∂μ :
-      by rw lintegral_tsum (λ n, (gcont n).measurable.coe_nnreal_ennreal)
+      by rw lintegral_tsum (λ n, (gcont n).measurable.coe_nnreal_ennreal.ae_measurable)
     ... ≤ ∑' n, (∫⁻ x, eapprox_diff f n x ∂μ + δ n) : ennreal.tsum_le_tsum hg
     ... = ∑' n, (∫⁻ x, eapprox_diff f n x ∂μ) + ∑' n, δ n : ennreal.tsum_add
     ... ≤ ∫⁻ (x : α), f x ∂μ + ε :
@@ -176,7 +176,7 @@ begin
         refine add_le_add _ hδ.le,
         rw [← lintegral_tsum],
         { simp_rw [tsum_eapprox_diff f hf, le_refl] },
-        { assume n, exact (simple_func.measurable _).coe_nnreal_ennreal }
+        { assume n, exact (simple_func.measurable _).coe_nnreal_ennreal.ae_measurable }
       end }
 end
 

--- a/src/measure_theory/measure/giry_monad.lean
+++ b/src/measure_theory/measure/giry_monad.lean
@@ -91,7 +91,7 @@ measure.of_measurable
     assume f hf h,
     simp_rw [measure_Union h hf],
     apply lintegral_tsum,
-    assume i, exact measurable_coe (hf i)
+    assume i, exact (measurable_coe (hf i)).ae_measurable
   end
 
 @[simp] lemma join_apply {m : measure (measure α)} {s : set α} (hs : measurable_set s) :


### PR DESCRIPTION
A version of `lintegral_supr_directed` and `lintegral_tsum` assuming only `ae_measurable` and not `measurable`.

Co-authored-by: Heather Macbeth <25316162+hrmacbeth@users.noreply.github.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
