### PR TITLE
[Merged by Bors] - fix(analysis/normed_space/pi_Lp): remove bad simp lemmas for `pi_Lp.equiv`

### DIFF
--- a/src/analysis/matrix.lean
+++ b/src/analysis/matrix.lean
@@ -399,7 +399,7 @@ instance frobenius_normed_star_group [star_add_monoid α] [normed_star_group α]
 @[simp] lemma frobenius_norm_row (v : m → α) : ∥row v∥ = ∥(pi_Lp.equiv 2 _).symm v∥ :=
 begin
   rw [frobenius_norm_def, fintype.sum_unique, pi_Lp.norm_eq_of_L2, real.sqrt_eq_rpow],
-  simp only [row_apply, real.rpow_two, pi_Lp.equiv_symm_apply'],
+  simp only [row_apply, real.rpow_two, pi_Lp.equiv_symm_apply],
 end
 @[simp] lemma frobenius_nnnorm_row (v : m → α) : ∥row v∥₊ = ∥(pi_Lp.equiv 2 _).symm v∥₊ :=
 subtype.ext $ frobenius_norm_row v
@@ -407,7 +407,7 @@ subtype.ext $ frobenius_norm_row v
 @[simp] lemma frobenius_norm_col (v : n → α) : ∥col v∥ = ∥(pi_Lp.equiv 2 _).symm v∥ :=
 begin
   simp_rw [frobenius_norm_def, fintype.sum_unique, pi_Lp.norm_eq_of_L2, real.sqrt_eq_rpow],
-  simp only [col_apply, real.rpow_two, pi_Lp.equiv_symm_apply']
+  simp only [col_apply, real.rpow_two, pi_Lp.equiv_symm_apply]
 end
 @[simp] lemma frobenius_nnnorm_col (v : n → α) : ∥col v∥₊ = ∥(pi_Lp.equiv 2 _).symm v∥₊ :=
 subtype.ext $ frobenius_norm_col v

--- a/src/analysis/normed_space/pi_Lp.lean
+++ b/src/analysis/normed_space/pi_Lp.lean
@@ -713,6 +713,19 @@ rfl
   (basis_fun p 𝕜 ι).map (pi_Lp.linear_equiv p 𝕜 (λ _ : ι, 𝕜)) = pi.basis_fun 𝕜 ι :=
 rfl
 
+open_locale matrix
+
+lemma basis_to_matrix_basis_fun_mul (b : basis ι 𝕜 (pi_Lp p (λ i : ι, 𝕜))) (A : matrix ι ι 𝕜) :
+  b.to_matrix (pi_Lp.basis_fun _ _ _) ⬝ A =
+    matrix.of (λ i j, b.repr ((pi_Lp.equiv _ _).symm (Aᵀ j)) i) :=
+begin
+  have := basis_to_matrix_basis_fun_mul (b.map (pi_Lp.linear_equiv _ 𝕜 _)) A,
+  simp_rw [←pi_Lp.basis_fun_map p, basis.map_repr, linear_equiv.trans_apply,
+    pi_Lp.linear_equiv_symm_apply, basis.to_matrix_map, function.comp, basis.map_apply,
+    linear_equiv.symm_apply_apply] at this,
+  exact this,
+end
+
 end basis
 
 end pi_Lp

--- a/src/analysis/normed_space/pi_Lp.lean
+++ b/src/analysis/normed_space/pi_Lp.lean
@@ -63,21 +63,19 @@ open_locale big_operators uniformity topological_space nnreal ennreal
 
 noncomputable theory
 
-variables {ι : Type*}
-
 /-- A copy of a Pi type, on which we will put the `L^p` distance. Since the Pi type itself is
 already endowed with the `L^∞` distance, we need the type synonym to avoid confusing typeclass
 resolution. Also, we let it depend on `p`, to get a whole family of type on which we can put
 different distances. -/
 @[nolint unused_arguments]
-def pi_Lp {ι : Type*} (p : ℝ≥0∞) (α : ι → Type*) : Type* := Π (i : ι), α i
+def pi_Lp (p : ℝ≥0∞) {ι : Type*} (α : ι → Type*) : Type* := Π (i : ι), α i
 
-instance {ι : Type*} (p : ℝ≥0∞) (α : ι → Type*) [Π i, inhabited (α i)] : inhabited (pi_Lp p α) :=
+instance (p : ℝ≥0∞) {ι : Type*} (α : ι → Type*) [Π i, inhabited (α i)] : inhabited (pi_Lp p α) :=
 ⟨λ i, default⟩
 
 namespace pi_Lp
 
-variables (p : ℝ≥0∞) (𝕜 : Type*) (α : ι → Type*) (β : ι → Type*)
+variables (p : ℝ≥0∞) (𝕜 : Type*) {ι : Type*} (α : ι → Type*) (β : ι → Type*)
 
 /-- Canonical bijection between `pi_Lp p α` and the original Pi type. We introduce it to be able
 to compare the `L^p` and `L^∞` distances through it. -/
@@ -689,5 +687,32 @@ protected def linear_equiv : pi_Lp p β ≃ₗ[𝕜] Π i, β i :=
 { to_fun := pi_Lp.equiv _ _,
   inv_fun := (pi_Lp.equiv _ _).symm,
   ..linear_equiv.refl _ _}
+
+section basis
+
+variables (ι)
+
+/-- A version of `pi.basis_fun` for `pi_Lp`. -/
+def basis_fun : basis ι 𝕜 (pi_Lp p (λ _, 𝕜)) :=
+basis.of_equiv_fun (pi_Lp.linear_equiv p 𝕜 (λ _ : ι, 𝕜))
+
+@[simp] lemma basis_fun_apply [decidable_eq ι] (i) :
+  basis_fun p 𝕜 ι i = (pi_Lp.equiv p _).symm (pi.single i 1) :=
+by { simp_rw [basis_fun, basis.coe_of_equiv_fun, pi_Lp.linear_equiv_symm_apply, pi.single],
+     congr /- Get rid of a `decidable_eq` mismatch. -/ }
+
+@[simp] lemma basis_fun_repr (x : pi_Lp p (λ i : ι, 𝕜)) (i : ι) :
+  (basis_fun p 𝕜 ι).repr x i = x i :=
+rfl
+
+lemma basis_fun_eq_pi_basis_fun :
+  basis_fun p 𝕜 ι = (pi.basis_fun 𝕜 ι).map (pi_Lp.linear_equiv p 𝕜 (λ _ : ι, 𝕜)).symm :=
+rfl
+
+@[simp] lemma basis_fun_map :
+  (basis_fun p 𝕜 ι).map (pi_Lp.linear_equiv p 𝕜 (λ _ : ι, 𝕜)) = pi.basis_fun 𝕜 ι :=
+rfl
+
+end basis
 
 end pi_Lp

--- a/src/analysis/normed_space/pi_Lp.lean
+++ b/src/analysis/normed_space/pi_Lp.lean
@@ -84,11 +84,11 @@ to compare the `L^p` and `L^∞` distances through it. -/
 protected def equiv : pi_Lp p α ≃ Π (i : ι), α i :=
 equiv.refl _
 
-lemma equiv_apply (x : pi_Lp p α) (i : ι) : pi_Lp.equiv p α x i = x i := rfl
-lemma equiv_symm_apply (x : Π i, α i) (i : ι) : (pi_Lp.equiv p α).symm x i = x i := rfl
+/-! Note that the unapplied versions of these lemmas are deliberately omitted, as they break
+the use of the type synonym. -/
 
-@[simp] lemma equiv_apply' (x : pi_Lp p α) : pi_Lp.equiv p α x = x := rfl
-@[simp] lemma equiv_symm_apply' (x : Π i, α i) : (pi_Lp.equiv p α).symm x = x := rfl
+@[simp] lemma equiv_apply (x : pi_Lp p α) (i : ι) : pi_Lp.equiv p α x i = x i := rfl
+@[simp] lemma equiv_symm_apply (x : Π i, α i) (i : ι) : (pi_Lp.equiv p α).symm x i = x i := rfl
 
 section dist_norm
 variables [fintype ι]
@@ -320,7 +320,7 @@ lemma lipschitz_with_equiv_aux : lipschitz_with 1 (pi_Lp.equiv p β) :=
 begin
   intros x y,
   unfreezingI { rcases p.dichotomy with (rfl | h) },
-  { simpa only [equiv_apply', ennreal.coe_one, one_mul, edist_eq_supr, edist, finset.sup_le_iff,
+  { simpa only [ennreal.coe_one, one_mul, edist_eq_supr, edist, finset.sup_le_iff,
       finset.mem_univ, forall_true_left] using le_supr (λ i, edist (x i) (y i)), },
   { have cancel : p.to_real * (1/p.to_real) = 1 := mul_div_cancel' 1 (zero_lt_one.trans_le h).ne',
     rw edist_eq_sum (zero_lt_one.trans_le h),
@@ -343,13 +343,13 @@ begin
   intros x y,
   unfreezingI { rcases p.dichotomy with (rfl | h) },
   { simp only [edist_eq_supr, ennreal.div_top, ennreal.zero_to_real, nnreal.rpow_zero,
-      ennreal.coe_one, equiv_apply', one_mul, supr_le_iff],
+      ennreal.coe_one, one_mul, supr_le_iff],
     exact λ i, finset.le_sup (finset.mem_univ i), },
   { have pos : 0 < p.to_real := zero_lt_one.trans_le h,
     have nonneg : 0 ≤ 1 / p.to_real := one_div_nonneg.2 (le_of_lt pos),
     have cancel : p.to_real * (1/p.to_real) = 1 := mul_div_cancel' 1 (ne_of_gt pos),
     rw [edist_eq_sum pos, ennreal.to_real_div 1 p],
-    simp only [edist, equiv_apply', ←one_div, ennreal.one_to_real],
+    simp only [edist, ←one_div, ennreal.one_to_real],
     calc (∑ i, edist (x i) (y i) ^ p.to_real) ^ (1 / p.to_real) ≤
     (∑ i, edist (pi_Lp.equiv p β x) (pi_Lp.equiv p β y) ^ p.to_real) ^ (1 / p.to_real) :
     begin
@@ -650,7 +650,7 @@ lemma nnnorm_equiv_symm_const' {β} [seminormed_add_comm_group β] [nonempty ι]
   fintype.card ι ^ (1 / p).to_real * ∥b∥₊ :=
 begin
   unfreezingI { rcases (em $ p = ∞) with (rfl | hp) },
-  { simp only [equiv_symm_apply', ennreal.div_top, ennreal.zero_to_real, nnreal.rpow_zero, one_mul,
+  { simp only [equiv_symm_apply, ennreal.div_top, ennreal.zero_to_real, nnreal.rpow_zero, one_mul,
       nnnorm_eq_csupr, function.const_apply, csupr_const], },
   { exact nnnorm_equiv_symm_const hp b, },
 end

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1868,6 +1868,9 @@ def conj (e : M ≃ₗ[R] M₂) : (module.End R M) ≃ₗ[R] (module.End R M₂)
 lemma conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M) :
   e.conj f = ((↑e : M →ₗ[R] M₂).comp f).comp (e.symm : M₂ →ₗ[R] M) := rfl
 
+lemma conj_apply_apply (e : M ≃ₗ[R] M₂) (f : module.End R M) (x : M₂) :
+  e.conj f x = e (f (e.symm x)) := rfl
+
 lemma symm_conj_apply (e : M ≃ₗ[R] M₂) (f : module.End R M₂) :
   e.symm.conj f = ((↑e.symm : M₂ →ₗ[R] M).comp f).comp (e : M →ₗ[R] M₂) := rfl
 

--- a/src/linear_algebra/matrix/spectrum.lean
+++ b/src/linear_algebra/matrix/spectrum.lean
@@ -19,26 +19,11 @@ spectral theorem, diagonalization theorem
 
 namespace matrix
 
-open_locale matrix
-
-
 variables {𝕜 : Type*} [is_R_or_C 𝕜] [decidable_eq 𝕜] {n : Type*} [fintype n] [decidable_eq n]
 variables {A : matrix n n 𝕜}
 
 open_locale matrix
 open_locale big_operators
-
-lemma _root_.pi_Lp.basis_to_matrix_basis_fun_mul (p : ennreal) [fact (1 ≤ p)]
-  (b : basis n 𝕜 (pi_Lp p (λ i : n, 𝕜))) (A : matrix n n 𝕜) :
-  b.to_matrix (pi_Lp.basis_fun _ _ _) ⬝ A =
-    of (λ i j, b.repr ((pi_Lp.equiv _ _).symm (Aᵀ j)) i) :=
-begin
-  have := basis_to_matrix_basis_fun_mul (b.map (pi_Lp.linear_equiv _ 𝕜 _)) A,
-  simp_rw [←pi_Lp.basis_fun_map p, basis.map_repr, linear_equiv.trans_apply,
-    pi_Lp.linear_equiv_symm_apply, basis.to_matrix_map, function.comp, basis.map_apply,
-    linear_equiv.symm_apply_apply] at this,
-  exact this,
-end
 
 namespace is_hermitian
 

--- a/src/linear_algebra/matrix/spectrum.lean
+++ b/src/linear_algebra/matrix/spectrum.lean
@@ -28,16 +28,16 @@ variables {A : matrix n n 𝕜}
 open_locale matrix
 open_locale big_operators
 
-lemma _root_.euclidean_space.basis_to_matrix_single_mul
-  (b : basis n 𝕜 (euclidean_space 𝕜 n)) (A : matrix n n 𝕜) :
-  b.to_matrix (λ i, euclidean_space.single i 1) ⬝ A =
+lemma _root_.pi_Lp.basis_to_matrix_basis_fun_mul (p : ennreal) [fact (1 ≤ p)]
+  (b : basis n 𝕜 (pi_Lp p (λ i : n, 𝕜))) (A : matrix n n 𝕜) :
+  b.to_matrix (pi_Lp.basis_fun _ _ _) ⬝ A =
     of (λ i j, b.repr ((pi_Lp.equiv _ _).symm (Aᵀ j)) i) :=
 begin
   have := basis_to_matrix_basis_fun_mul (b.map (pi_Lp.linear_equiv _ 𝕜 _)) A,
-  simp_rw [basis.to_matrix_map, basis.map_repr, function.comp, pi.basis_fun_apply,
-    linear_map.std_basis, linear_map.coe_single, linear_equiv.trans_apply,
-    pi_Lp.linear_equiv_symm_apply, pi_Lp.equiv_symm_single] at this,
-  rw this,
+  simp_rw [←pi_Lp.basis_fun_map p, basis.map_repr, linear_equiv.trans_apply,
+    pi_Lp.linear_equiv_symm_apply, basis.to_matrix_map, function.comp, basis.map_apply,
+    linear_equiv.symm_apply_apply] at this,
+  exact this,
 end
 
 namespace is_hermitian
@@ -60,18 +60,15 @@ noncomputable def eigenvector_basis : orthonormal_basis n 𝕜 (euclidean_space 
 
 /-- A matrix whose columns are an orthonormal basis of eigenvectors of a hermitian matrix. -/
 noncomputable def eigenvector_matrix : matrix n n 𝕜 :=
-((pi.basis_fun 𝕜 n).map
-  (pi_Lp.linear_equiv _ 𝕜 (λ _ : n, 𝕜)).symm).to_matrix (eigenvector_basis hA).to_basis
+(pi_Lp.basis_fun _ 𝕜 n).to_matrix (eigenvector_basis hA).to_basis
 
 /-- The inverse of `eigenvector_matrix` -/
 noncomputable def eigenvector_matrix_inv : matrix n n 𝕜 :=
-(eigenvector_basis hA).to_basis.to_matrix (λ i, euclidean_space.single i 1)
+(eigenvector_basis hA).to_basis.to_matrix (pi_Lp.basis_fun _ 𝕜 n)
 
 lemma eigenvector_matrix_mul_inv :
   hA.eigenvector_matrix ⬝ hA.eigenvector_matrix_inv = 1 :=
 by apply basis.to_matrix_mul_to_matrix_flip
-
-#check basis.to_matrix_mul_to_matrix_flip
 
 noncomputable instance : invertible hA.eigenvector_matrix_inv :=
 invertible_of_left_inverse _ _ hA.eigenvector_matrix_mul_inv
@@ -81,15 +78,14 @@ invertible_of_right_inverse _ _ hA.eigenvector_matrix_mul_inv
 
 lemma eigenvector_matrix_apply (i j : n) : hA.eigenvector_matrix i j = hA.eigenvector_basis j i :=
 by simp_rw [eigenvector_matrix, basis.to_matrix_apply, orthonormal_basis.coe_to_basis,
-    basis.map_repr, linear_equiv.symm_symm, linear_equiv.trans_apply, pi_Lp.linear_equiv_apply,
-    pi.basis_fun_repr, pi_Lp.equiv_apply]
+    pi_Lp.basis_fun_repr]
 
 lemma eigenvector_matrix_inv_apply (i j : n) :
   hA.eigenvector_matrix_inv i j = star (hA.eigenvector_basis i j) :=
 begin
   rw [eigenvector_matrix_inv, basis.to_matrix_apply, orthonormal_basis.coe_to_basis_repr_apply,
-    orthonormal_basis.repr_apply_apply, euclidean_space.inner_single_right],
-  simp only [one_mul, conj_transpose_apply, is_R_or_C.star_def],
+    orthonormal_basis.repr_apply_apply, pi_Lp.basis_fun_apply, pi_Lp.equiv_symm_single,
+    euclidean_space.inner_single_right, one_mul, is_R_or_C.star_def],
 end
 
 lemma conj_transpose_eigenvector_matrix_inv : hA.eigenvector_matrix_invᴴ = hA.eigenvector_matrix :=
@@ -99,7 +95,6 @@ by { ext i j,
 lemma conj_transpose_eigenvector_matrix : hA.eigenvector_matrixᴴ = hA.eigenvector_matrix_inv :=
 by rw [← conj_transpose_eigenvector_matrix_inv, conj_transpose_conj_transpose]
 
-
 /-- *Diagonalization theorem*, *spectral theorem* for matrices; A hermitian matrix can be
 diagonalized by a change of basis.
 
@@ -108,10 +103,7 @@ theorem spectral_theorem :
   hA.eigenvector_matrix_inv ⬝ A =
     diagonal (coe ∘ hA.eigenvalues) ⬝ hA.eigenvector_matrix_inv :=
 begin
-  simp_rw [eigenvector_matrix_inv, pi.basis_fun_apply],
-  dsimp [linear_map.std_basis, linear_map.coe_single, pi_Lp.equiv_symm_single],
-  rw euclidean_space.basis_to_matrix_single_mul,
-   -- equiv.apply_symm_apply, basis_to_matrix_basis_fun_mul],
+  rw [eigenvector_matrix_inv, pi_Lp.basis_to_matrix_basis_fun_mul],
   ext i j,
   have : linear_map.is_symmetric _ := is_hermitian_iff_is_symmetric.1 hA,
   convert this.diagonalization_basis_apply_self_apply finrank_euclidean_space
@@ -129,7 +121,7 @@ begin
   { simp only [diagonal_mul, (∘), eigenvalues, eigenvector_basis],
     rw [basis.to_matrix_apply,
       orthonormal_basis.coe_to_basis_repr_apply, orthonormal_basis.reindex_repr,
-      eigenvalues₀] }
+      eigenvalues₀, pi_Lp.basis_fun_apply, pi_Lp.equiv_symm_single] }
 end
 
 lemma eigenvalues_eq (i : n) :

--- a/src/linear_algebra/matrix/spectrum.lean
+++ b/src/linear_algebra/matrix/spectrum.lean
@@ -71,6 +71,8 @@ lemma eigenvector_matrix_mul_inv :
   hA.eigenvector_matrix ⬝ hA.eigenvector_matrix_inv = 1 :=
 by apply basis.to_matrix_mul_to_matrix_flip
 
+#check basis.to_matrix_mul_to_matrix_flip
+
 noncomputable instance : invertible hA.eigenvector_matrix_inv :=
 invertible_of_left_inverse _ _ hA.eigenvector_matrix_mul_inv
 
@@ -78,16 +80,15 @@ noncomputable instance : invertible hA.eigenvector_matrix :=
 invertible_of_right_inverse _ _ hA.eigenvector_matrix_mul_inv
 
 lemma eigenvector_matrix_apply (i j : n) : hA.eigenvector_matrix i j = hA.eigenvector_basis j i :=
-by simp only [eigenvector_matrix, basis.to_matrix_apply, orthonormal_basis.coe_to_basis,
-  pi.basis_fun_repr, pi_Lp.equiv_apply]
+by simp_rw [eigenvector_matrix, basis.to_matrix_apply, orthonormal_basis.coe_to_basis,
+    basis.map_repr, linear_equiv.symm_symm, linear_equiv.trans_apply, pi_Lp.linear_equiv_apply,
+    pi.basis_fun_repr, pi_Lp.equiv_apply]
 
 lemma eigenvector_matrix_inv_apply (i j : n) :
   hA.eigenvector_matrix_inv i j = star (hA.eigenvector_basis i j) :=
 begin
   rw [eigenvector_matrix_inv, basis.to_matrix_apply, orthonormal_basis.coe_to_basis_repr_apply,
-    pi.basis_fun_apply, linear_map.coe_std_basis, orthonormal_basis.repr_apply_apply],
-  change inner (hA.eigenvector_basis i) (euclidean_space.single j 1) = _,
-  rw [euclidean_space.inner_single_right],
+    orthonormal_basis.repr_apply_apply, euclidean_space.inner_single_right],
   simp only [one_mul, conj_transpose_apply, is_R_or_C.star_def],
 end
 

--- a/src/linear_algebra/matrix/spectrum.lean
+++ b/src/linear_algebra/matrix/spectrum.lean
@@ -92,14 +92,16 @@ theorem spectral_theorem :
 begin
   rw [eigenvector_matrix_inv, basis_to_matrix_basis_fun_mul],
   ext i j,
-  convert @linear_map.is_symmetric.diagonalization_basis_apply_self_apply 𝕜 _ _
-    (pi_Lp 2 (λ (_ : n), 𝕜)) _ A.to_lin' (is_hermitian_iff_is_symmetric.1 hA) _ (fintype.card n)
-    finrank_euclidean_space (euclidean_space.single j 1)
+  have : linear_map.is_symmetric _ := is_hermitian_iff_is_symmetric.1 hA,
+  convert this.diagonalization_basis_apply_self_apply finrank_euclidean_space
+    (euclidean_space.single j 1)
     ((fintype.equiv_of_card_eq (fintype.card_fin _)).symm i),
-  { rw [eigenvector_basis, to_lin'_apply],
+  { dsimp only [linear_equiv.conj_apply_apply, pi_Lp.linear_equiv_apply,
+      pi_Lp.linear_equiv_symm_apply, pi_Lp.equiv_single],
+    rw [eigenvector_basis, to_lin'_apply],
     simp only [basis.to_matrix, basis.coe_to_orthonormal_basis_repr, basis.equiv_fun_apply],
     simp_rw [orthonormal_basis.coe_to_basis_repr_apply, orthonormal_basis.reindex_repr,
-      euclidean_space.single, pi_Lp.equiv_symm_apply', mul_vec_single, mul_one],
+      mul_vec_single, mul_one],
     refl },
   { simp only [diagonal_mul, (∘), eigenvalues, eigenvector_basis],
     rw [basis.to_matrix_apply,


### PR DESCRIPTION
This regression was introduced in #14231. These lemmas are a bad idea for the same reason that a lemma stating `multiplicative.of_add x = x` would be; it discards the type information that is the sole reason for the existance of the `def`!

This also adds a new `pi_Lp.basis_fun` which is the `pi_Lp` version of `pi.basis_fun`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
