### PR TITLE
chore(data/finsupp/defs): make `finsupp.single` more similar to `pi.single`

### DIFF
--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -317,11 +317,17 @@ variables [semiring k]
 local attribute [reducible] monoid_algebra
 
 lemma mul_apply [decidable_eq G] [has_mul G] (f g : monoid_algebra k G) (x : G) :
-  (f * g) x = (f.sum $ λa₁ b₁, g.sum $ λa₂ b₂, if a₁ * a₂ = x then b₁ * b₂ else 0) :=
+  (f * g) x = (f.sum $ λa₁ b₁, g.sum $ λa₂ b₂, if x = a₁ * a₂ then b₁ * b₂ else 0) :=
 begin
   rw [mul_def],
   simp only [finsupp.sum_apply, single_apply],
+  -- decidable issues
+  congr' with a₁ b₁,
+  congr' with a₂ b₂,
+  convert rfl,
 end
+
+#exit
 
 lemma mul_apply_antidiagonal [has_mul G] (f g : monoid_algebra k G) (x : G) (s : finset (G × G))
   (hs : ∀ {p : G × G}, p ∈ s ↔ p.1 * p.2 = x) :

--- a/src/algebra/monoid_algebra/no_zero_divisors.lean
+++ b/src/algebra/monoid_algebra/no_zero_divisors.lean
@@ -53,11 +53,11 @@ begin
   classical,
   rw mul_apply,
   refine (finset.sum_eq_single a0 _ _).trans _,
-  { exact λ b H hb, finset.sum_eq_zero (λ x H1, if_neg (h H H1 (or.inl hb))) },
+  { exact λ b H hb, finset.sum_eq_zero (λ x H1, if_neg (h H H1 (or.inl hb)).symm) },
   { exact λ af0, by simp [not_mem_support_iff.mp af0] },
   { refine (finset.sum_eq_single b0 (λ b bg b0, _) _).trans (if_pos rfl),
     { by_cases af : a0 ∈ f.support,
-      { exact if_neg (h af bg (or.inr b0)) },
+      { exact if_neg (h af bg (or.inr b0)).symm },
       { simp only [not_mem_support_iff.mp af, zero_mul, if_t_t] } },
     { exact λ bf0, by simp [not_mem_support_iff.mp bf0] } },
 end

--- a/src/algebra/monoid_algebra/support.lean
+++ b/src/algebra/monoid_algebra/support.lean
@@ -49,7 +49,7 @@ begin
   obtain ⟨y, yf, rfl⟩ : ∃ (a : G), a ∈ f.support ∧ x * a = y,
   { simpa only [finset.mem_image, exists_prop] using hy },
   simp only [mul_apply, mem_support_iff.mp yf, hr, mem_support_iff, sum_single_index,
-    finsupp.sum_ite_eq', ne.def, not_false_iff, if_true, zero_mul, if_t_t, sum_zero, lx.eq_iff]
+    finsupp.sum_ite_eq, ne.def, not_false_iff, if_true, zero_mul, if_t_t, sum_zero, lx.eq_iff]
 end
 
 lemma support_mul_single_eq_image [decidable_eq G] [has_mul G]
@@ -60,7 +60,7 @@ begin
   obtain ⟨y, yf, rfl⟩ : ∃ (a : G), a ∈ f.support ∧ a * x = y,
   { simpa only [finset.mem_image, exists_prop] using hy },
   simp only [mul_apply, mem_support_iff.mp yf, hr, mem_support_iff, sum_single_index,
-    finsupp.sum_ite_eq', ne.def, not_false_iff, if_true, mul_zero, if_t_t, sum_zero, rx.eq_iff]
+    finsupp.sum_ite_eq, ne.def, not_false_iff, if_true, mul_zero, if_t_t, sum_zero, rx.eq_iff]
 end
 
 lemma support_mul [has_mul G] [decidable_eq G] (a b : monoid_algebra k G) :

--- a/src/data/dfinsupp/basic.lean
+++ b/src/data/dfinsupp/basic.lean
@@ -486,13 +486,13 @@ def single (i : ι) (b : β i) : Π₀ i, β i :=
 ⟨pi.single i b,
   trunc.mk ⟨{i}, λ j, (decidable.eq_or_ne j i).imp (by simp) (λ h, pi.single_eq_of_ne h _)⟩⟩
 
-lemma single_eq_pi_single {i b} : ⇑(single i b : Π₀ i, β i) = pi.single i b :=
+lemma coe_single {i b} : ⇑(single i b : Π₀ i, β i) = pi.single i b :=
 rfl
 
 @[simp] lemma single_apply {i i' b} :
   (single i b : Π₀ i, β i) i' = (if h : i = i' then eq.rec_on h b else 0) :=
 begin
-  rw [single_eq_pi_single, pi.single, function.update],
+  rw [coe_single, pi.single, function.update],
   simp [@eq_comm _ i i'],
 end
 
@@ -563,11 +563,11 @@ by { cases h, refl }
 
 @[simp] lemma equiv_fun_on_fintype_single [fintype ι] (i : ι) (m : β i) :
   (@dfinsupp.equiv_fun_on_fintype ι β _ _) (dfinsupp.single i m) = pi.single i m :=
-by { ext, simp [dfinsupp.single_eq_pi_single], }
+by { ext, simp [dfinsupp.coe_single], }
 
 @[simp] lemma equiv_fun_on_fintype_symm_single [fintype ι] (i : ι) (m : β i) :
   (@dfinsupp.equiv_fun_on_fintype ι β _ _).symm (pi.single i m) = dfinsupp.single i m :=
-by { ext i', simp only [← single_eq_pi_single, equiv_fun_on_fintype_symm_coe] }
+by { ext i', simp only [← coe_single, equiv_fun_on_fintype_symm_coe] }
 
 /-- Redefine `f i` to be `0`. -/
 def erase (i : ι) (x : Π₀ i, β i) : Π₀ i, β i :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -536,24 +536,18 @@ lemma map_domain_apply' (S : set α) {f : α → β} (x : α →₀ M)
 begin
   rw [map_domain, sum_apply, sum],
   simp_rw single_apply,
-  have : ∀ (b : α) (ha1 : b ∈ x.support),
-    (if f b = f a then x b else 0) = if f b = f a then x a else 0,
-  { intros b hb,
-    refine if_ctx_congr iff.rfl (λ hh, _) (λ _, rfl),
-    rw hf (hS hb) ha hh, },
-  conv in (ite _ _ _)
-  { rw [this _ H], },
-  by_cases ha : a ∈ x.support,
-  { rw [← finset.add_sum_erase _ _ ha, if_pos rfl],
+  by_cases hax : a ∈ x.support,
+  { rw [← finset.add_sum_erase _ _ hax, if_pos rfl],
     convert add_zero _,
-    have : ∀ i ∈ x.support.erase a, f i ≠ f a,
-    { intros i hi,
-      exact (finset.ne_of_mem_erase hi) ∘ (hf (hS $ finset.mem_of_mem_erase hi) (hS ha)), },
-    conv in (ite _ _ _)
-    { rw if_neg (this x H), },
-    exact finset.sum_const_zero, },
-  { rw [mem_support_iff, not_not] at ha,
-    simp [ha], }
+    apply finset.sum_eq_zero,
+    intros i hi,
+    refine if_neg _,
+    exact (hf.mono hS).ne hax (finset.mem_of_mem_erase hi) (finset.ne_of_mem_erase hi).symm, },
+  { rw not_mem_support_iff.1 hax,
+    apply finset.sum_eq_zero,
+    intros i hi,
+    refine if_neg _,
+    exact hf.ne ha (hS hi) (ne_of_mem_of_not_mem hi hax).symm }
 end
 
 lemma map_domain_support_of_inj_on [decidable_eq β] {f : α → β} (s : α →₀ M)

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1076,12 +1076,12 @@ f.sum $ λp c, single p.1 (single p.2 c)
 @[simp] lemma curry_apply (f : (α × β) →₀ M) (x : α) (y : β) :
   f.curry x y = f (x, y) :=
 begin
-  have : ∀ (b : α × β), single b.fst (single b.snd (f b)) x y = if b = (x, y) then f b else 0,
+  have : ∀ (b : α × β), single b.fst (single b.snd (f b)) x y = if (x, y) = b then f b else 0,
   { rintros ⟨b₁, b₂⟩,
     simp [single_apply, ite_apply, prod.ext_iff, ite_and],
     split_ifs; simp [single_apply, *] },
   rw [finsupp.curry, sum_apply, sum_apply, finsupp.sum, finset.sum_eq_single, this, if_pos rfl],
-  { intros b hb b_ne, rw [this b, if_neg b_ne] },
+  { intros b hb b_ne, rw [this b, if_neg b_ne.symm] },
   { intros hxy, rw [this (x, y), if_pos rfl, not_mem_support_iff.mp hxy] }
 end
 

--- a/src/data/finsupp/defs.lean
+++ b/src/data/finsupp/defs.lean
@@ -202,32 +202,32 @@ variables [has_zero M] {a a' : α} {b : M}
 
 /-- `single a b` is the finitely supported function with value `b` at `a` and zero otherwise. -/
 def single (a : α) (b : M) : α →₀ M :=
-⟨if b = 0 then ∅ else {a}, λ a', if a = a' then b else 0, λ a', begin
-  by_cases hb : b = 0; by_cases a = a';
-    simp only [hb, h, if_pos, if_false, mem_singleton],
-  { exact ⟨false.elim, λ H, H rfl⟩ },
-  { exact ⟨false.elim, λ H, H rfl⟩ },
-  { exact ⟨λ _, hb, λ _, rfl⟩ },
-  { exact ⟨λ H _, h H.symm, λ H, (H rfl).elim⟩ }
+⟨if b = 0 then ∅ else {a}, pi.single a b, λ a', begin
+  obtain rfl | hb := eq_or_ne b 0,
+  { simp },
+  rw [if_neg hb, mem_singleton],
+  obtain rfl | ha := eq_or_ne a' a,
+  { simp [hb] },
+  simp [pi.single_eq_of_ne', ha],
 end⟩
 
-lemma single_apply [decidable (a = a')] : single a b a' = if a = a' then b else 0 :=
+lemma single_eq_pi_single [decidable_eq α] (a : α) (b : M) : ⇑(single a b) = pi.single a b :=
 by convert rfl
+
+lemma single_apply [decidable (a = a')] : single a b a' = if a' = a then b else 0 :=
+pi.single_apply _ _ _
 
 lemma single_eq_indicator : ⇑(single a b) = set.indicator {a} (λ _, b) :=
 by { ext, simp [single_apply, set.indicator, @eq_comm _ a] }
 
 @[simp] lemma single_eq_same : (single a b : α →₀ M) a = b :=
-if_pos rfl
+pi.single_eq_same a b
 
 @[simp] lemma single_eq_of_ne (h : a ≠ a') : (single a b : α →₀ M) a' = 0 :=
-if_neg h
+pi.single_eq_of_ne' h _
 
 lemma single_eq_update [decidable_eq α] (a : α) (b : M) : ⇑(single a b) = function.update 0 a b :=
-by rw [single_eq_indicator, ← set.piecewise_eq_indicator, set.piecewise_singleton]
-
-lemma single_eq_pi_single [decidable_eq α] (a : α) (b : M) : ⇑(single a b) = pi.single a b :=
-single_eq_update a b
+single_eq_pi_single _ _
 
 @[simp] lemma single_zero (a : α) : (single a 0 : α →₀ M) = 0 :=
 coe_fn_injective $ by simpa only [single_eq_update, coe_zero]
@@ -572,7 +572,7 @@ support_on_finset_subset
 
 @[simp] lemma map_range_single {f : M → N} {hf : f 0 = 0} {a : α} {b : M} :
   map_range f hf (single a b) = single a (f b) :=
-ext $ λ a', show f (ite _ _ _) = ite _ _ _, by split_ifs; [refl, exact hf]
+ext $ λ a', pi.apply_single _ (λ _, hf) a b a'
 
 lemma support_map_range_of_injective
   {e : M → N} (he0 : e 0 = 0) (f : ι →₀ M) (he : function.injective e) :
@@ -671,9 +671,7 @@ begin
     rw [← emb_domain_apply f l, h],
     by_cases h_cases : c = d,
     { simp only [eq.symm h_cases, hc₂, single_eq_same] },
-    { rw [single_apply, single_apply, if_neg, if_neg h_cases],
-      by_contra hfd,
-      exact h_cases (f.injective (hc₂.trans hfd)) } },
+    { rw [single_eq_of_ne h_cases, ←hc₂, single_eq_of_ne (f.injective.ne h_cases)] } },
   { exact hc₂ }
 end
 

--- a/src/data/finsupp/defs.lean
+++ b/src/data/finsupp/defs.lean
@@ -211,7 +211,7 @@ def single (a : α) (b : M) : α →₀ M :=
   simp [pi.single_eq_of_ne', ha],
 end⟩
 
-lemma single_eq_pi_single [decidable_eq α] (a : α) (b : M) : ⇑(single a b) = pi.single a b :=
+lemma coe_single [decidable_eq α] (a : α) (b : M) : ⇑(single a b) = pi.single a b :=
 by convert rfl
 
 lemma single_apply [decidable (a = a')] : single a b a' = if a' = a then b else 0 :=
@@ -227,7 +227,7 @@ pi.single_eq_same a b
 pi.single_eq_of_ne' h _
 
 lemma single_eq_update [decidable_eq α] (a : α) (b : M) : ⇑(single a b) = function.update 0 a b :=
-single_eq_pi_single _ _
+coe_single _ _
 
 @[simp] lemma single_zero (a : α) : (single a 0 : α →₀ M) = 0 :=
 coe_fn_injective $ by simpa only [single_eq_update, coe_zero]
@@ -377,11 +377,11 @@ by simp only [card_le_one_iff_subset_singleton, support_subset_singleton']
 
 @[simp] lemma equiv_fun_on_fintype_single [decidable_eq α] [fintype α] (x : α) (m : M) :
   (@finsupp.equiv_fun_on_fintype α M _ _) (finsupp.single x m) = pi.single x m :=
-by { ext, simp [finsupp.single_eq_pi_single, finsupp.equiv_fun_on_fintype], }
+finsupp.coe_single _ _
 
 @[simp] lemma equiv_fun_on_fintype_symm_single [decidable_eq α] [fintype α] (x : α) (m : M) :
   (@finsupp.equiv_fun_on_fintype α M _ _).symm (pi.single x m) = finsupp.single x m :=
-by { ext, simp [finsupp.single_eq_pi_single, finsupp.equiv_fun_on_fintype], }
+by { ext, simp [finsupp.coe_single, finsupp.equiv_fun_on_fintype], }
 
 end single
 
@@ -951,7 +951,7 @@ lemma single_add_single_eq_single_add_single [add_comm_monoid M]
   single k u + single l v = single m u + single n v ↔
   (k = m ∧ l = n) ∨ (u = v ∧ k = n ∧ l = m) ∨ (u + v = 0 ∧ k = l ∧ m = n) :=
 begin
-  simp_rw [fun_like.ext_iff, coe_add, single_eq_pi_single, ←funext_iff],
+  simp_rw [fun_like.ext_iff, coe_add, coe_single, ←funext_iff],
   exact pi.single_add_single_eq_single_add_single hu hv,
 end
 

--- a/src/data/finsupp/to_dfinsupp.lean
+++ b/src/data/finsupp/to_dfinsupp.lean
@@ -76,7 +76,7 @@ variables [decidable_eq ι] [has_zero M]
 
 @[simp] lemma finsupp.to_dfinsupp_single (i : ι) (m : M) :
   (finsupp.single i m).to_dfinsupp = dfinsupp.single i m :=
-by { ext, simp [finsupp.single_apply, dfinsupp.single_apply] }
+dfinsupp.coe_fn_injective $ finsupp.coe_single _ _
 
 variables [Π m : M, decidable (m ≠ 0)]
 
@@ -97,7 +97,7 @@ by { ext, simp, }
 
 @[simp] lemma dfinsupp.to_finsupp_single (i : ι) (m : M) :
   (dfinsupp.single i m : Π₀ i : ι, M).to_finsupp = finsupp.single i m :=
-by { ext, simp [finsupp.single_apply, dfinsupp.single_apply] }
+finsupp.coe_fn_injective $ (finsupp.coe_single i m).symm
 
 @[simp] lemma finsupp.to_dfinsupp_to_finsupp (f : ι →₀ M) : f.to_dfinsupp.to_finsupp = f :=
 finsupp.coe_fn_injective rfl
@@ -251,8 +251,8 @@ begin
     simp [split_apply, finsupp.single_apply] },
   suffices : finsupp.single (⟨i, a⟩ : Σ i, η i) n ⟨j, b⟩ = 0,
   { simp [split_apply, dif_neg h, this] },
-  have H : (⟨i, a⟩ : Σ i, η i) ≠ ⟨j, b⟩ := by simp [h],
-  rw [finsupp.single_apply, if_neg H]
+  rw finsupp.single_eq_of_ne,
+  simp [h],
 end
 
 -- Without this Lean fails to find the `add_zero_class` instance on `Π₀ i, (η i →₀ N)`.

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -440,8 +440,11 @@ by { rintro ⟨p⟩ ⟨q⟩, simp only [coeff, fun_like.coe_fn_eq, imp_self] }
 
 @[simp] lemma coeff_inj : p.coeff = q.coeff ↔ p = q := coeff_injective.eq_iff
 
-lemma coeff_monomial : coeff (monomial n a) m = if n = m then a else 0 :=
-by { simp only [←of_finsupp_single, coeff, linear_map.coe_mk], rw finsupp.single_apply }
+lemma coeff_monomial_eq : coeff (monomial n a) = pi.single n a :=
+by simp_rw [←of_finsupp_single, coeff, finsupp.coe_single]
+
+lemma coeff_monomial : coeff (monomial n a) m = if m = n then a else 0 :=
+by rw [coeff_monomial_eq, pi.single_apply]
 
 @[simp] lemma coeff_zero (n : ℕ) : coeff (0 : R[X]) n = 0 := rfl
 
@@ -453,12 +456,12 @@ by { rw [← monomial_zero_one, coeff_monomial], simp }
 @[simp] lemma coeff_X_zero : coeff (X : R[X]) 0 = 0 := coeff_monomial
 
 @[simp] lemma coeff_monomial_succ : coeff (monomial (n+1) a) 0 = 0 :=
-by simp [coeff_monomial]
+by simp [coeff_monomial, @eq_comm _ (0 : ℕ) ]
 
-lemma coeff_X : coeff (X : R[X]) n = if 1 = n then 1 else 0 := coeff_monomial
+lemma coeff_X : coeff (X : R[X]) n = if n = 1 then 1 else 0 := coeff_monomial
 
 lemma coeff_X_of_ne_one {n : ℕ} (hn : n ≠ 1) : coeff (X : R[X]) n = 0 :=
-by rw [coeff_X, if_neg hn.symm]
+by rw [coeff_X, if_neg hn]
 
 @[simp] lemma mem_support_iff : n ∈ p.support ↔ p.coeff n ≠ 0 :=
 by { rcases p, simp }
@@ -466,8 +469,7 @@ by { rcases p, simp }
 lemma not_mem_support_iff : n ∉ p.support ↔ p.coeff n = 0 :=
 by simp
 
-lemma coeff_C : coeff (C a) n = ite (n = 0) a 0 :=
-by { convert coeff_monomial using 2, simp [eq_comm], }
+lemma coeff_C : coeff (C a) n = ite (n = 0) a 0 := coeff_monomial
 
 @[simp] lemma coeff_C_zero : coeff (C a) 0 = a := coeff_monomial
 

--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -29,7 +29,7 @@ variables [semiring R] {p q r : R[X]}
 
 section coeff
 
-lemma coeff_one (n : ℕ) : coeff (1 : R[X]) n = if 0 = n then 1 else 0 :=
+lemma coeff_one (n : ℕ) : coeff (1 : R[X]) n = if n = 0 then 1 else 0 :=
 coeff_monomial
 
 @[simp]
@@ -104,7 +104,7 @@ by simp
 
 lemma coeff_C_mul_X_pow (x : R) (k n : ℕ) :
   coeff (C x * X^k : R[X]) n = if n = k then x else 0 :=
-by { rw [← monomial_eq_C_mul_X, coeff_monomial], congr' 1, simp [eq_comm] }
+by { rw [← monomial_eq_C_mul_X, coeff_monomial] }
 
 lemma coeff_C_mul_X (x : R) (n : ℕ) : coeff (C x * X : R[X]) n = if n = 1 then x else 0 :=
 by rw [← pow_one X, coeff_C_mul_X_pow]
@@ -276,7 +276,7 @@ begin
     use ψ,
     ext i,
     simp only [ψ, c', coeff_C_mul, mem_support_iff, coeff_monomial,
-               finset_sum_coeff, finset.sum_ite_eq'],
+               finset_sum_coeff, finset.sum_ite_eq],
     split_ifs with hi hi,
     { rw hc },
     { rw [not_not] at hi, rwa mul_zero } },

--- a/src/data/polynomial/inductions.lean
+++ b/src/data/polynomial/inductions.lean
@@ -32,7 +32,7 @@ def div_X (p : R[X]) : R[X] :=
 @[simp] lemma coeff_div_X : (div_X p).coeff n = p.coeff (n+1) :=
 begin
   simp only [div_X, coeff_monomial, true_and, finset_sum_coeff, not_lt,
-    mem_Ico, zero_le, finset.sum_ite_eq', ite_eq_left_iff],
+    mem_Ico, zero_le, finset.sum_ite_eq, ite_eq_left_iff],
   intro h,
   rw coeff_eq_zero_of_nat_degree_lt (nat.lt_succ_of_le h)
 end

--- a/src/data/polynomial/monomial.lean
+++ b/src/data/polynomial/monomial.lean
@@ -45,7 +45,7 @@ begin
     { have : f.coeff i = 0,
       { rw ← not_mem_support_iff,
         exact λ hi', hi (finset.mem_singleton.1 (hn hi')) },
-      simp [this, ne.symm hi, coeff_monomial] } },
+      simp [this, hi, coeff_monomial] } },
   { rintros ⟨n, a, rfl⟩,
     rw ← finset.card_singleton n,
     apply finset.card_le_of_subset,

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -780,7 +780,7 @@ basis.of_repr $ e.trans $ linear_equiv.symm $ finsupp.linear_equiv_fun_on_fintyp
 @[simp] lemma basis.coe_of_equiv_fun (e : M ≃ₗ[R] (ι → R)) :
   (basis.of_equiv_fun e : ι → M) = λ i, e.symm (function.update 0 i 1) :=
 funext $ λ i, e.injective $ funext $ λ j,
-  by simp [basis.of_equiv_fun, ←finsupp.single_eq_pi_single, finsupp.single_eq_update]
+  by simp [basis.of_equiv_fun, ←finsupp.coe_single, finsupp.single_eq_update]
 
 @[simp] lemma basis.of_equiv_fun_equiv_fun
   (v : basis ι R M) : basis.of_equiv_fun v.equiv_fun = v :=

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -121,7 +121,7 @@ linear_equiv.apply_symm_apply _ _
 
 lemma repr_self_apply (j) [decidable (i = j)] :
   b.repr (b i) j = if i = j then 1 else 0 :=
-by rw [repr_self, finsupp.single_apply]
+by simp_rw [repr_self, finsupp.single_apply, eq_comm]
 
 @[simp] lemma repr_symm_apply (v) : b.repr.symm v = finsupp.total ι M R b v :=
 calc b.repr.symm v = b.repr.symm (v.sum finsupp.single) : by simp

--- a/src/linear_algebra/contraction.lean
+++ b/src/linear_algebra/contraction.lean
@@ -102,7 +102,7 @@ theorem to_matrix_dual_tensor_hom
 begin
   ext i' j',
   by_cases hij : (i = i' ∧ j = j');
-  simp [linear_map.to_matrix_apply, finsupp.single_eq_pi_single, hij],
+  simp [linear_map.to_matrix_apply, finsupp.coe_single, hij],
   rw [and_iff_not_or_not, not_not] at hij, cases hij; simp [hij],
 end
 

--- a/src/linear_algebra/direct_sum/finsupp.lean
+++ b/src/linear_algebra/direct_sum/finsupp.lean
@@ -57,9 +57,9 @@ begin
     { intros g₁ g₂ hg₁ hg₂, simp [tmul_add, hg₁, hg₂], },
     { intros k' n,
       simp only [finsupp_tensor_finsupp_single],
-      simp only [finsupp.single, finsupp.coe_mk],
+      simp only [finsupp.single_apply, finsupp.coe_mk],
       -- split_ifs; finish can close the goal from here
-      by_cases h1 : (i', k') = (i, k),
+      by_cases h1 : (i, k) = (i', k'),
       { simp only [prod.mk.inj_iff] at h1, simp [h1] },
       { simp only [h1, if_false],
         simp only [prod.mk.inj_iff, not_and_distrib] at h1,
@@ -89,6 +89,6 @@ by simp [finsupp_tensor_finsupp']
 @[simp] lemma finsupp_tensor_finsupp'_single_tmul_single (a : α) (b : β) (r₁ r₂ : S) :
   finsupp_tensor_finsupp' S α β (finsupp.single a r₁ ⊗ₜ[S] finsupp.single b r₂) =
     finsupp.single (a, b) (r₁ * r₂) :=
-by { ext ⟨a', b'⟩, simp [finsupp.single, ite_and] }
+by { ext ⟨a', b'⟩, simp [finsupp.single_apply, ite_and] }
 
 end tensor_product

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -730,17 +730,7 @@ end
 
 @[simp] lemma lcongr_symm {ι κ : Sort*} (e₁ : ι ≃ κ) (e₂ : M ≃ₗ[R] N) :
   (lcongr e₁ e₂).symm = lcongr e₁.symm e₂.symm :=
-begin
-  ext f i,
-  simp only [equiv.symm_symm, finsupp.lcongr_apply_apply],
-  apply finsupp.induction_linear f,
-  { simp, },
-  { intros f g hf hg, simp [map_add, hf, hg], },
-  { intros k m,
-    simp only [finsupp.lcongr_symm_single],
-    simp only [finsupp.single, equiv.symm_apply_eq, finsupp.coe_mk],
-    split_ifs; simp, },
-end
+by { ext, refl }
 
 section sum
 

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -1010,7 +1010,7 @@ begin
   ext x y,
   dsimp [splitting_of_fun_on_fintype_surjective],
   rw [linear_equiv_fun_on_fintype_symm_single, finsupp.sum_single_index, one_smul,
-    (s (finsupp.single x 1)).some_spec, finsupp.single_eq_pi_single],
+    (s (finsupp.single x 1)).some_spec, finsupp.coe_single],
   rw [zero_smul],
 end
 

--- a/src/linear_algebra/std_basis.lean
+++ b/src/linear_algebra/std_basis.lean
@@ -147,7 +147,7 @@ end
 
 lemma std_basis_eq_single {a : R} :
   (λ (i : ι), (std_basis R (λ _ : ι, R) i) a) = λ (i : ι), (finsupp.single i a) :=
-funext $ λ i, (finsupp.single_eq_pi_single i a).symm
+funext $ λ i, (finsupp.coe_single i a).symm
 
 end linear_map
 

--- a/src/linear_algebra/trace.lean
+++ b/src/linear_algebra/trace.lean
@@ -128,7 +128,7 @@ begin
   by_cases hij : i = j,
   { rw [hij], simp },
   rw matrix.std_basis_matrix.trace_zero j i (1:R) hij,
-  simp [finsupp.single_eq_pi_single, hij],
+  simp [finsupp.coe_single, hij],
 end
 
 /-- The trace of a linear map correspond to the contraction pairing under the isomorphism


### PR DESCRIPTION
They're still not defeq because the former has no `decidable_eq` argument; but this at least makes some lemmas easier.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [ ] depends on: #17356