### PR TITLE
[Merged by Bors] - refactor(analysis/complex): use Liouville to prove algebraic closedness

### DIFF
--- a/src/analysis/complex/polynomial.lean
+++ b/src/analysis/complex/polynomial.lean
@@ -25,14 +25,11 @@ lemma exists_root {f : ℂ[X]} (hf : 0 < degree f) : ∃ z : ℂ, is_root f z :=
 begin
   contrapose! hf,
   obtain ⟨c, hc⟩ := (f.differentiable.inv hf).exists_const_forall_eq_of_bounded _,
-  { convert degree_C_le,
-    refine polynomial.funext (λ z, _),
-    exacts [c⁻¹, by rw [eval_C, ← hc z, inv_inv]] },
+  { obtain rfl : f = C c⁻¹ := polynomial.funext (λ z, by rw [eval_C, ← hc z, inv_inv]),
+    exact degree_C_le },
   { obtain ⟨z₀, h₀⟩ := f.exists_forall_norm_le,
-    simp_rw [metric.bounded_iff_subset_ball (0 : ℂ), set.range_subset_iff,
-             metric.mem_closed_ball, dist_eq, sub_zero, ← norm_eq_abs, norm_inv],
-    have := _, refine ⟨_, λ y, (inv_le_inv _ this).2 $ h₀ y⟩,
-    exacts [this.trans_le (h₀ y), norm_pos_iff.2 (hf z₀)] },
+    simp only [bounded_iff_forall_norm_le, set.forall_range_iff, norm_inv],
+    exact ⟨∥eval z₀ f∥⁻¹, λ z, inv_le_inv_of_le (norm_pos_iff.2 $ hf z₀) (h₀ z)⟩ },
 end
 
 instance is_alg_closed : is_alg_closed ℂ :=

--- a/src/analysis/complex/polynomial.lean
+++ b/src/analysis/complex/polynomial.lean
@@ -1,11 +1,10 @@
 /-
 Copyright (c) 2019 Chris Hughes All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chris Hughes
+Authors: Chris Hughes, Junyan Xu
 -/
-import analysis.special_functions.pow
+import analysis.complex.liouville
 import field_theory.is_alg_closed.basic
-import topology.algebra.polynomial
 
 /-!
 # The fundamental theorem of algebra
@@ -15,85 +14,29 @@ This file proves that every nonconstant complex polynomial has a root.
 As a consequence, the complex numbers are algebraically closed.
 -/
 
-open complex polynomial metric filter set
+/-open complex polynomial metric filter set
 open_locale classical
+-/
+open polynomial
 open_locale polynomial
 
 namespace complex
 
-/- The following proof uses the method given at
-<https://ncatlab.org/nlab/show/fundamental+theorem+of+algebra#classical_fta_via_advanced_calculus>
--/
 /-- **Fundamental theorem of algebra**: every non constant complex polynomial
   has a root -/
 lemma exists_root {f : ℂ[X]} (hf : 0 < degree f) : ∃ z : ℂ, is_root f z :=
-let ⟨z₀, hz₀⟩ := f.exists_forall_norm_le in
-exists.intro z₀ $ classical.by_contradiction $ λ hf0,
-have hfX : f - C (f.eval z₀) ≠ 0,
-  from mt sub_eq_zero.1 (λ h, not_le_of_gt hf (h.symm ▸ degree_C_le)),
-let n := root_multiplicity z₀ (f - C (f.eval z₀)) in
-let g := (f - C (f.eval z₀)) /ₘ ((X - C z₀) ^ n) in
-have hg0 : g.eval z₀ ≠ 0, from eval_div_by_monic_pow_root_multiplicity_ne_zero _ hfX,
-have hg : g * (X - C z₀) ^ n = f - C (f.eval z₀),
-  from div_by_monic_mul_pow_root_multiplicity_eq _ _,
-have hn0 : n ≠ 0, from λ hn0, by simpa [g, hn0] using hg0,
-let ⟨δ', hδ'₁, hδ'₂⟩ := continuous_iff.1 (polynomial.continuous g) z₀
-  ((g.eval z₀).abs) (abs.pos hg0) in
-let δ := min (min (δ' / 2) 1) (((f.eval z₀).abs / (g.eval z₀).abs) / 2) in
-have hf0' : 0 < (f.eval z₀).abs, from abs.pos hf0,
-have hg0' : 0 < (eval z₀ g).abs, from abs.pos hg0,
-have hfg0 : 0 < (f.eval z₀).abs / abs (eval z₀ g), from div_pos hf0' hg0',
-have hδ0 : 0 < δ, from lt_min (lt_min (half_pos hδ'₁) (by norm_num)) (half_pos hfg0),
-have hδ : ∀ z : ℂ, abs (z - z₀) = δ → abs (g.eval z - g.eval z₀) < (g.eval z₀).abs,
-  from λ z hz, hδ'₂ z (by rw [complex.dist_eq, hz];
-    exact ((min_le_left _ _).trans (min_le_left _ _)).trans_lt (half_lt_self hδ'₁)),
-have hδ1 : δ ≤ 1, from le_trans (min_le_left _ _) (min_le_right _ _),
-let F : ℂ[X] := C (f.eval z₀) + C (g.eval z₀) * (X - C z₀) ^ n in
-let z' := (-f.eval z₀ * (g.eval z₀).abs * δ ^ n /
-  ((f.eval z₀).abs * g.eval z₀)) ^ (n⁻¹ : ℂ) + z₀ in
-have hF₁ : F.eval z' = f.eval z₀ - f.eval z₀ * (g.eval z₀).abs * δ ^ n / (f.eval z₀).abs,
-  by simp only [F, cpow_nat_inv_pow _ hn0, div_eq_mul_inv, eval_pow, mul_assoc,
-      mul_comm (g.eval z₀), mul_left_comm (g.eval z₀), mul_left_comm (g.eval z₀)⁻¹, mul_inv,
-      inv_mul_cancel hg0, eval_C, eval_add, eval_neg, sub_eq_add_neg, eval_mul, eval_X,
-      add_neg_cancel_right, neg_mul, mul_one, div_eq_mul_inv];
-    simp only [mul_comm, mul_left_comm, mul_assoc],
-have hδs : (g.eval z₀).abs * δ ^ n / (f.eval z₀).abs < 1,
-  from (div_lt_one hf0').2 $ (lt_div_iff' hg0').1 $
-  calc δ ^ n ≤ δ : pow_le_of_le_one (le_of_lt hδ0) hδ1 hn0
-         ... ≤ ((f.eval z₀).abs / (g.eval z₀).abs) / 2 : min_le_right _ _
-         ... < _ : half_lt_self (div_pos hf0' hg0'),
-have hF₂ : (F.eval z').abs = (f.eval z₀).abs - (g.eval z₀).abs * δ ^ n,
-  from calc (F.eval z').abs = (f.eval z₀ - f.eval z₀ * (g.eval z₀).abs
-    * δ ^ n / (f.eval z₀).abs).abs : congr_arg abs hF₁
-  ... = abs (f.eval z₀) * complex.abs (1 - (g.eval z₀).abs * δ ^ n /
-      (f.eval z₀).abs : ℝ) : by rw [←map_mul];
-        exact congr_arg complex.abs
-          (by simp only [mul_add, mul_assoc, div_eq_mul_inv, sub_eq_add_neg, of_real_add, mul_one,
-                         of_real_one, of_real_neg, of_real_mul, of_real_pow, of_real_inv, mul_neg])
-  ... = _ : by rw [complex.abs_of_nonneg (sub_nonneg.2 (le_of_lt hδs)),
-      mul_sub, mul_div_cancel' _ (ne.symm (ne_of_lt hf0')), mul_one],
-have hef0 : abs (eval z₀ g) * (eval z₀ f).abs ≠ 0,
-  from mul_ne_zero (abs.ne_zero hg0) (abs.ne_zero hf0),
-have hz'z₀ : abs (z' - z₀) = δ,
-  by simp only [z', mul_assoc, mul_left_comm _ (_ ^ n), mul_comm _ (_ ^ n), mul_comm (eval _ f).abs,
-                _root_.mul_div_cancel _ hef0, of_real_mul, neg_mul, neg_div, map_pow, abs_of_real,
-                add_sub_cancel, abs_cpow_inv_nat, absolute_value.map_neg, map_div₀, map_mul,
-                abs_abs, complex.abs_of_nonneg hδ0.le, real.pow_nat_rpow_nat_inv hδ0.le hn0],
-have hF₃ : (f.eval z' - F.eval z').abs < (g.eval z₀).abs * δ ^ n,
-  from calc (f.eval z' - F.eval z').abs
-      = (g.eval z' - g.eval z₀).abs * (z' - z₀).abs ^ n :
-        by rw [← eq_sub_iff_add_eq.1 hg, ←map_pow abs, ←map_mul, sub_mul];
-           simp only [eval_pow, eval_add, eval_mul, eval_C, eval_X, eval_neg, sub_eq_add_neg,
-                      add_assoc, neg_add_rev, add_neg_cancel_comm_assoc]
-  ... = (g.eval z' - g.eval z₀).abs * δ ^ n : by rw hz'z₀
-  ... < _ : (mul_lt_mul_right (pow_pos hδ0 _)).2 (hδ _ hz'z₀),
-lt_irrefl (f.eval z₀).abs $
-  calc (f.eval z₀).abs ≤ (f.eval z').abs : hz₀ _
-    ... = (F.eval z' + (f.eval z' - F.eval z')).abs : by simp
-    ... ≤ (F.eval z').abs + (f.eval z' - F.eval z').abs : abs.add_le _ _
-    ... < (f.eval z₀).abs - (g.eval z₀).abs * δ ^ n + (g.eval z₀).abs * δ ^ n :
-      add_lt_add_of_le_of_lt (by rw hF₂) hF₃
-    ... = (f.eval z₀).abs : sub_add_cancel _ _
+begin
+  contrapose! hf,
+  obtain ⟨c, hc⟩ := (f.differentiable.inv hf).exists_const_forall_eq_of_bounded _,
+  { convert degree_C_le,
+    refine polynomial.funext (λ z, _),
+    exacts [c⁻¹, by rw [eval_C, ← hc z, inv_inv]] },
+  { obtain ⟨z₀, h₀⟩ := f.exists_forall_norm_le,
+    simp_rw [metric.bounded_iff_subset_ball (0 : ℂ), set.range_subset_iff,
+             metric.mem_closed_ball, dist_eq, sub_zero, ← norm_eq_abs, norm_inv],
+    have := _, refine ⟨_, λ y, (inv_le_inv _ this).2 $ h₀ y⟩,
+    exacts [this.trans_le (h₀ y), norm_pos_iff.2 (hf z₀)] },
+end
 
 instance is_alg_closed : is_alg_closed ℂ :=
 is_alg_closed.of_exists_root _ $ λ p _ hp, complex.exists_root $ degree_pos_of_irreducible hp

--- a/src/analysis/complex/polynomial.lean
+++ b/src/analysis/complex/polynomial.lean
@@ -9,14 +9,11 @@ import field_theory.is_alg_closed.basic
 /-!
 # The fundamental theorem of algebra
 
-This file proves that every nonconstant complex polynomial has a root.
+This file proves that every nonconstant complex polynomial has a root using Liouville's theorem.
 
 As a consequence, the complex numbers are algebraically closed.
 -/
 
-/-open complex polynomial metric filter set
-open_locale classical
--/
 open polynomial
 open_locale polynomial
 

--- a/src/analysis/special_functions/trigonometric/complex.lean
+++ b/src/analysis/special_functions/trigonometric/complex.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne, Benjamin Davidson
 -/
 import algebra.quadratic_discriminant
-import analysis.complex.polynomial
-import field_theory.is_alg_closed.basic
 import analysis.special_functions.trigonometric.basic
 import analysis.convex.specific_functions
 
@@ -162,8 +160,8 @@ lemma cos_surjective : function.surjective cos :=
 begin
   intro x,
   obtain ⟨w, w₀, hw⟩ : ∃ w ≠ 0, 1 * w * w + (-2 * x) * w + 1 = 0,
-  { rcases exists_quadratic_eq_zero (@one_ne_zero ℂ _ _) (is_alg_closed.exists_eq_mul_self _)
-      with ⟨w, hw⟩,
+  { rcases exists_quadratic_eq_zero (@one_ne_zero ℂ _ _)
+      ⟨_, ((cpow_nat_inv_pow _ two_ne_zero).symm.trans $ pow_two _)⟩ with ⟨w, hw⟩,
     refine ⟨w, _, hw⟩,
     rintro rfl,
     simpa only [zero_add, one_ne_zero, mul_zero] using hw },


### PR DESCRIPTION
To avoid cyclic import, one proof in *analysis/special_functions/trigonometric/complex* is changed.

Inspired by #17329.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
