### PR TITLE
[Merged by Bors] - feat(group_theory/*): Add `finite` instances

### DIFF
--- a/src/algebra/group/conj.lean
+++ b/src/algebra/group/conj.lean
@@ -7,7 +7,7 @@ import algebra.group.semiconj
 import algebra.group_with_zero.basic
 import algebra.hom.aut
 import algebra.hom.group
-import data.fintype.basic
+import data.finite.basic
 
 /-!
 # Conjugacy of group elements
@@ -177,6 +177,9 @@ instance [fintype α] [decidable_rel (is_conj : α → α → Prop)] :
   fintype (conj_classes α) :=
 quotient.fintype (is_conj.setoid α)
 
+instance [finite α] : finite (conj_classes α) :=
+quotient.finite _
+
 /--
 Certain instances trigger further searches when they are considered as candidate instances;
 these instances should be assigned a priority lower than the default of 1000 (for example, 900).
@@ -191,7 +194,7 @@ If those conditions hold, the instance `instT` should be assigned lower priority
 For example, suppose the search for an instance of `decidable_eq (multiset α)` tries the
 candidate instance `con.quotient.decidable_eq (c : con M) : decidable_eq c.quotient`.
 Since `multiset` and `con.quotient` are both quotient types, unification will check
-that the relations `list.perm` and `c.to_setoid.r` unify. However, `c.to_setoid` depends on 
+that the relations `list.perm` and `c.to_setoid.r` unify. However, `c.to_setoid` depends on
 a `has_mul M` instance, so this unification triggers a search for `has_mul (list α)`;
 this will traverse all subclasses of `has_mul` before failing.
 On the other hand, the search for an instance of `decidable_eq (con.quotient c)` for `c : con M`

--- a/src/group_theory/abelianization.lean
+++ b/src/group_theory/abelianization.lean
@@ -91,6 +91,9 @@ instance [fintype G] [decidable_pred (∈ commutator G)] :
   fintype (abelianization G) :=
 quotient_group.fintype (commutator G)
 
+instance [finite G] : finite (abelianization G) :=
+quotient.finite _
+
 variable {G}
 
 /-- `of` is the canonical projection from G to its abelianization. -/

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -339,6 +339,10 @@ instance (K : subgroup G) [d : decidable_pred (∈ K)] [fintype G] : fintype K :
 show fintype {g : G // g ∈ K}, from infer_instance
 
 @[to_additive]
+instance (K : subgroup G) [finite G] : finite K :=
+subtype.finite
+
+@[to_additive]
 theorem to_submonoid_injective :
   function.injective (to_submonoid : subgroup G → submonoid G) :=
 λ p q h, set_like.ext'_iff.2 (show _, from set_like.ext'_iff.1 h)


### PR DESCRIPTION
To facilitate the transition from `fintype` to `finite` in the group theory library, here are some `finite` instances that mirror existing `fintype` instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
