### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/trigonometric/angle): adding and subtracting `π / 2`

### DIFF
--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -325,6 +325,42 @@ begin
   exact real.cos_sq_add_sin_sq θ,
 end
 
+lemma sin_add_pi_div_two (θ : angle) : sin (θ + ↑(π / 2)) = cos θ :=
+begin
+  induction θ using real.angle.induction_on,
+  exact sin_add_pi_div_two _
+end
+
+lemma sin_sub_pi_div_two (θ : angle) : sin (θ - ↑(π / 2)) = -cos θ :=
+begin
+  induction θ using real.angle.induction_on,
+  exact sin_sub_pi_div_two _
+end
+
+lemma sin_pi_div_two_sub (θ : angle) : sin (↑(π / 2) - θ) = cos θ :=
+begin
+  induction θ using real.angle.induction_on,
+  exact sin_pi_div_two_sub _
+end
+
+lemma cos_add_pi_div_two (θ : angle) : cos (θ + ↑(π / 2)) = -sin θ :=
+begin
+  induction θ using real.angle.induction_on,
+  exact cos_add_pi_div_two _
+end
+
+lemma cos_sub_pi_div_two (θ : angle) : cos (θ - ↑(π / 2)) = sin θ :=
+begin
+  induction θ using real.angle.induction_on,
+  exact cos_sub_pi_div_two _
+end
+
+lemma cos_pi_div_two_sub (θ : angle) : cos (↑(π / 2) - θ) = sin θ :=
+begin
+  induction θ using real.angle.induction_on,
+  exact cos_pi_div_two_sub _
+end
+
 @[simp] lemma coe_to_Ico_mod (θ ψ : ℝ) : ↑(to_Ico_mod ψ two_pi_pos θ) = (θ : angle) :=
 begin
   rw angle_eq_iff_two_pi_dvd_sub,


### PR DESCRIPTION
Add a series of lemmas about `real.angle.sin` and `real.angle.cos` for angles given by an addition or subtraction involving `π / 2`, all trivially deduced from the corresponding `real.sin` and `real.cos` lemmas.

---

Since the `real` lemmas aren't `simp` lemmas, neither are these ones.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
