### PR TITLE
[Merged by Bors] - chore(data/nat/basic): drop some `nat`-specific lemmas

### DIFF
--- a/archive/100-theorems-list/45_partition.lean
+++ b/archive/100-theorems-list/45_partition.lean
@@ -335,7 +335,7 @@ begin
       rw multiset.count_eq_zero_of_not_mem,
       intro a, exact nat.lt_irrefl 0 (hs 0 (hp₂.2 0 a)),
       intro a, exact nat.lt_irrefl 0 (hs 0 (hp₁.2 0 a)) },
-    { rwa [nat.nsmul_eq_mul, nat.nsmul_eq_mul, nat.mul_left_inj i.succ_pos] at h } },
+    { rwa [nat.nsmul_eq_mul, nat.nsmul_eq_mul, mul_left_inj' i.succ_ne_zero] at h } },
   { simp only [mem_filter, mem_cut, mem_univ, exists_prop, true_and, and_assoc],
     rintros f ⟨hf₁, hf₂, hf₃⟩,
     refine ⟨⟨∑ i in s, multiset.repeat i (f i / i), _, _⟩, _, _, _⟩,

--- a/src/analysis/special_functions/log/deriv.lean
+++ b/src/analysis/special_functions/log/deriv.lean
@@ -279,7 +279,7 @@ begin
     rw [odd.neg_pow (⟨n, rfl⟩ : odd (2 * n + 1)) x],
     push_cast,
     ring_nf, },
-  rw [← h_term_eq_goal, (nat.mul_right_injective two_pos).has_sum_iff],
+  rw [← h_term_eq_goal, (mul_right_injective₀ (@two_ne_zero ℕ _ _)).has_sum_iff],
   { have h₁ := (has_sum_pow_div_log_of_abs_lt_1 (eq.trans_lt (abs_neg x) h)).mul_left (-1),
     convert h₁.add (has_sum_pow_div_log_of_abs_lt_1 h),
     ring_nf },

--- a/src/data/int/gcd.lean
+++ b/src/data/int/gcd.lean
@@ -437,7 +437,7 @@ lemma nat_gcd_helper_1 (d x y a b u v tx ty : ℕ) (hu : d * u = x) (hv : d * v 
 
 lemma nat_lcm_helper (x y d m n : ℕ) (hd : nat.gcd x y = d) (d0 : 0 < d)
   (xy : x * y = n) (dm : d * m = n) : nat.lcm x y = m :=
-(nat.mul_right_inj d0).1 $ by rw [dm, ← xy, ← hd, nat.gcd_mul_lcm]
+mul_right_injective₀ d0.ne' $ by rw [dm, ← xy, ← hd, nat.gcd_mul_lcm]
 
 lemma nat_coprime_helper_zero_left (x : ℕ) (h : 1 < x) : ¬ nat.coprime 0 x :=
 mt (nat.coprime_zero_left _).1 $ ne_of_gt h

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -276,29 +276,15 @@ by rw [add_comm, add_one, pred_succ]
 theorem two_mul_ne_two_mul_add_one {n m} : 2 * n ≠ 2 * m + 1 :=
 mt (congr_arg (%2)) (by { rw [add_comm, add_mul_mod_self_left, mul_mod_right, mod_eq_of_lt]; simp })
 
-
-
-protected theorem mul_left_inj {a b c : ℕ} (ha : 0 < a) : b * a = c * a ↔ b = c :=
-⟨nat.eq_of_mul_eq_mul_right ha, λ e, e ▸ rfl⟩
-
-protected theorem mul_right_inj {a b c : ℕ} (ha : 0 < a) : a * b = a * c ↔ b = c :=
-⟨nat.eq_of_mul_eq_mul_left ha, λ e, e ▸ rfl⟩
-
-lemma mul_left_injective {a : ℕ} (ha : 0 < a) : function.injective (λ x, x * a) :=
-λ _ _, eq_of_mul_eq_mul_right ha
-
-lemma mul_right_injective {a : ℕ} (ha : 0 < a) : function.injective (λ x, a * x) :=
-λ _ _, nat.eq_of_mul_eq_mul_left ha
-
 lemma mul_ne_mul_left {a b c : ℕ} (ha : 0 < a) : b * a ≠ c * a ↔ b ≠ c :=
-(mul_left_injective ha).ne_iff
+(mul_left_injective₀ ha.ne').ne_iff
 
 lemma mul_ne_mul_right {a b c : ℕ} (ha : 0 < a) : a * b ≠ a * c ↔ b ≠ c :=
-(mul_right_injective ha).ne_iff
+(mul_right_injective₀ ha.ne').ne_iff
 
 lemma mul_right_eq_self_iff {a b : ℕ} (ha : 0 < a) : a * b = a ↔ b = 1 :=
 suffices a * b = a * 1 ↔ b = 1, by rwa mul_one at this,
-nat.mul_right_inj ha
+mul_right_inj' ha.ne'
 
 lemma mul_left_eq_self_iff {a b : ℕ} (hb : 0 < b) : a * b = b ↔ a = 1 :=
 by rw [mul_comm, nat.mul_right_eq_self_iff hb]
@@ -632,10 +618,10 @@ protected theorem dvd_add_right {k m n : ℕ} (h : k ∣ m) : k ∣ m + n ↔ k 
 (nat.dvd_add_iff_right h).symm
 
 protected theorem mul_dvd_mul_iff_left {a b c : ℕ} (ha : 0 < a) : a * b ∣ a * c ↔ b ∣ c :=
-exists_congr $ λ d, by rw [mul_assoc, nat.mul_right_inj ha]
+exists_congr $ λ d, by rw [mul_assoc, mul_right_inj' ha.ne']
 
 protected theorem mul_dvd_mul_iff_right {a b c : ℕ} (hc : 0 < c) : a * c ∣ b * c ↔ a ∣ b :=
-exists_congr $ λ d, by rw [mul_right_comm, nat.mul_left_inj hc]
+exists_congr $ λ d, by rw [mul_right_comm, mul_left_inj' hc.ne']
 
 @[simp] theorem mod_mod_of_dvd (n : nat) {m k : nat} (h : m ∣ k) : n % k % m = n % m :=
 begin

--- a/src/data/nat/choose/sum.lean
+++ b/src/data/nat/choose/sum.lean
@@ -93,7 +93,7 @@ lemma sum_range_choose_halfway (m : nat) :
 have ∑ i in range (m + 1), choose (2 * m + 1) (2 * m + 1 - i) =
   ∑ i in range (m + 1), choose (2 * m + 1) i,
 from sum_congr rfl $ λ i hi, choose_symm $ by linarith [mem_range.1 hi],
-(nat.mul_right_inj zero_lt_two).1 $
+mul_right_injective₀ two_ne_zero $
 calc 2 * (∑ i in range (m + 1), choose (2 * m + 1) i) =
   (∑ i in range (m + 1), choose (2 * m + 1) i) +
     ∑ i in range (m + 1), choose (2 * m + 1) (2 * m + 1 - i) :

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -211,7 +211,8 @@ begin
     dsimp [of_digits] at w,
     rcases m with ⟨rfl⟩,
     { apply nat.eq_zero_of_add_eq_zero_right w },
-    { exact ih ((nat.mul_right_inj h).mp (nat.eq_zero_of_add_eq_zero_left w)) _ m, }, }
+    { exact ih (mul_right_injective₀ (pos_iff_ne_zero.1 h)
+        (nat.eq_zero_of_add_eq_zero_left w)) _ m, }, }
 end
 
 lemma digits_of_digits

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -326,7 +326,7 @@ end
 lemma div_mod_eq_mod_mul_div (a b c : ℕ) : a / b % c = a % (b * c) / b :=
 if hb0 : b = 0 then by simp [hb0]
 else by rw [← @add_right_cancel_iff _ _ (c * (a / b / c)), mod_add_div, nat.div_div_eq_div_mul,
-  ← nat.mul_right_inj (nat.pos_of_ne_zero hb0),← @add_left_cancel_iff _ _ (a % b), mod_add_div,
+  ← mul_right_inj' hb0, ← @add_left_cancel_iff _ _ (a % b), mod_add_div,
   mul_add, ← @add_left_cancel_iff _ _ (a % (b * c) % b), add_left_comm,
   ← add_assoc (a % (b * c) % b), mod_add_div, ← mul_assoc, mod_add_div, mod_mul_right_mod]
 
@@ -360,7 +360,7 @@ by rw [← add_mod_add_ite, if_pos hc]
 lemma add_div {a b c : ℕ} (hc0 : 0 < c) : (a + b) / c = a / c + b / c +
   if c ≤ a % c + b % c then 1 else 0 :=
 begin
-  rw [← nat.mul_right_inj hc0, ← @add_left_cancel_iff _ _ ((a + b) % c + a % c + b % c)],
+  rw [← mul_right_inj' hc0.ne', ← @add_left_cancel_iff _ _ ((a + b) % c + a % c + b % c)],
   suffices : (a + b) % c + c * ((a + b) / c) + a % c + b % c =
     a % c + c * (a / c) + (b % c + c * (b / c)) + c * (if c ≤ a % c + b % c then 1 else 0) +
       (a + b) % c,
@@ -407,7 +407,7 @@ lemma odd_mul_odd_div_two {m n : ℕ} (hm1 : m % 2 = 1) (hn1 : n % 2 = 1) :
   (m * n) / 2 = m * (n / 2) + m / 2 :=
 have hm0 : 0 < m := nat.pos_of_ne_zero (λ h, by simp * at *),
 have hn0 : 0 < n := nat.pos_of_ne_zero (λ h, by simp * at *),
-(nat.mul_right_inj zero_lt_two).1 $
+mul_right_injective₀ two_ne_zero $
 by rw [mul_add, two_mul_odd_div_two hm1, mul_left_comm, two_mul_odd_div_two hn1,
   two_mul_odd_div_two (nat.odd_mul_odd hm1 hn1), mul_tsub, mul_one,
   ← add_tsub_assoc_of_le (succ_le_of_lt hm0),

--- a/src/data/nat/order.lean
+++ b/src/data/nat/order.lean
@@ -416,7 +416,7 @@ lt_of_mul_lt_mul_left
 
 protected lemma div_eq_zero_iff {a b : ℕ} (hb : 0 < b) : a / b = 0 ↔ a < b :=
 ⟨λ h, by rw [← mod_add_div a b, h, mul_zero, add_zero]; exact mod_lt _ hb,
-  λ h, by rw [← nat.mul_right_inj hb, ← @add_left_cancel_iff _ _ (a % b), mod_add_div,
+  λ h, by rw [← mul_right_inj' hb.ne', ← @add_left_cancel_iff _ _ (a % b), mod_add_div,
     mod_eq_of_lt h, mul_zero, add_zero]⟩
 
 protected lemma div_eq_zero {a b : ℕ} (hb : a < b) : a / b = 0 :=

--- a/src/data/nat/order.lean
+++ b/src/data/nat/order.lean
@@ -476,12 +476,12 @@ by conv {to_rhs, rw [← nat.mod_add_div n 2, hn, add_tsub_cancel_left]}
 lemma div_dvd_of_dvd {a b : ℕ} (h : b ∣ a) : (a / b) ∣ a :=
 ⟨b, (nat.div_mul_cancel h).symm⟩
 
-protected lemma div_div_self : ∀ {a b : ℕ}, b ∣ a → 0 < a → a / (a / b) = b
-| a     0     h₁ h₂ := by rw [eq_zero_of_zero_dvd h₁, nat.div_zero, nat.div_zero]
-| 0     b     h₁ h₂ := absurd h₂ dec_trivial
-| (a+1) (b+1) h₁ h₂ :=
-(nat.mul_left_inj (nat.div_pos (le_of_dvd (succ_pos a) h₁) (succ_pos b))).1 $
-  by rw [nat.div_mul_cancel (div_dvd_of_dvd h₁), nat.mul_div_cancel' h₁]
+protected lemma div_div_self {a b : ℕ} (h : b ∣ a) (ha : a ≠ 0) : a / (a / b) = b :=
+begin
+  rcases h with ⟨a, rfl⟩,
+  rw mul_ne_zero_iff at ha,
+  rw [nat.mul_div_right _ (nat.pos_of_ne_zero ha.1), nat.mul_div_left _ (nat.pos_of_ne_zero ha.2)]
+end
 
 lemma mod_mul_right_div_self (a b c : ℕ) : a % (b * c) / b = (a / b) % c :=
 begin

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -82,7 +82,7 @@ begin
   simp only [nat.is_unit_iff],
   apply or.imp_right _ (h.2 a _),
   { rintro rfl,
-    rw [←nat.mul_right_inj (pos_of_gt h1), ←hab, mul_one] },
+    rw [← mul_right_inj' (pos_of_gt h1).ne', ←hab, mul_one] },
   { rw hab,
     exact dvd_mul_right _ _ }
 end
@@ -620,12 +620,12 @@ begin
   wlog := hp.dvd_mul.1 pdvdxy using x y,
   cases case with a ha,
   have hap : a ∣ p, from ⟨y, by rwa [ha, sq,
-        mul_assoc, nat.mul_right_inj hp.pos, eq_comm] at h⟩,
+        mul_assoc, mul_right_inj' hp.ne_zero, eq_comm] at h⟩,
   exact ((nat.dvd_prime hp).1 hap).elim
-    (λ _, by clear_aux_decl; simp [*, sq, nat.mul_right_inj hp.pos] at *
+    (λ _, by clear_aux_decl; simp [*, sq, mul_right_inj' hp.ne_zero] at *
       {contextual := tt})
     (λ _, by clear_aux_decl; simp [*, sq, mul_comm, mul_assoc,
-      nat.mul_right_inj hp.pos, nat.mul_right_eq_self_iff hp.pos] at *
+      mul_right_inj' hp.ne_zero, nat.mul_right_eq_self_iff hp.pos] at *
       {contextual := tt})
 end,
 λ ⟨h₁, h₂⟩, h₁.symm ▸ h₂.symm ▸ (sq _).symm⟩

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -185,8 +185,8 @@ calc φ (p ^ (n + 1))
       exact h b (lt_of_mul_lt_mul_left ha (zero_le _)) (mul_comm _ _) }
   end
 ... = _ :
-have h1 : set.inj_on (* p) (range (p ^ n)),
-  from λ x _ y _, (nat.mul_left_inj hp.pos).1,
+have h1 : function.injective (* p),
+  from mul_left_injective₀ hp.ne_zero,
 have h2 : (range (p ^ n)).image (* p) ⊆ range (p ^ (n + 1)),
   from λ a, begin
     simp only [mem_image, mem_range, exists_imp_distrib],
@@ -195,7 +195,7 @@ have h2 : (range (p ^ n)).image (* p) ⊆ range (p ^ (n + 1)),
     exact (mul_lt_mul_right hp.pos).2 h
   end,
 begin
-  rw [card_sdiff h2, card_image_of_inj_on h1, card_range,
+  rw [card_sdiff h2, card_image_of_inj_on (h1.inj_on _), card_range,
     card_range, ← one_mul (p ^ n), pow_succ, ← tsub_mul,
     one_mul, mul_comm]
 end

--- a/src/field_theory/tower.lean
+++ b/src/field_theory/tower.lean
@@ -128,7 +128,7 @@ lemma finrank_linear_map' (F : Type u) (K : Type v) (V : Type w)
   [field F] [field K] [algebra F K] [finite_dimensional F K]
   [add_comm_group V] [module F V] [finite_dimensional F V] :
   finrank K (V →ₗ[F] K) = finrank F V :=
-(nat.mul_right_inj $ show 0 < finrank F K, from finrank_pos).1 $
+mul_right_injective₀ finrank_pos.ne' $
 calc  finrank F K * finrank K (V →ₗ[F] K)
     = finrank F (V →ₗ[F] K) : finrank_mul_finrank _ _ _
 ... = finrank F V * finrank F K : finrank_linear_map F V K

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -357,10 +357,10 @@ begin
   rw [card_eq_card_quotient_mul_card_subgroup (center G), mul_comm, hk] at hG,
   have hk2 := (nat.pow_dvd_pow_iff_le_right (fact.out p.prime).one_lt).1 ⟨_, hG.symm⟩,
   interval_cases k,
-  { rw [sq, pow_one, nat.mul_right_inj (fact.out p.prime).pos] at hG,
+  { rw [sq, pow_one, mul_right_inj' (fact.out p.prime).ne_zero] at hG,
     exact is_cyclic_of_prime_card hG },
-  { exact @is_cyclic_of_subsingleton _ _ ⟨fintype.card_le_one_iff.1 ((nat.mul_right_inj
-      (pow_pos (fact.out p.prime).pos 2)).1 (hG.trans (mul_one (p ^ 2)).symm)).le⟩ },
+  { exact @is_cyclic_of_subsingleton _ _ ⟨fintype.card_le_one_iff.1 (mul_right_injective₀
+      (pow_ne_zero 2 (ne_zero.ne p)) (hG.trans (mul_one (p ^ 2)).symm)).le⟩ },
 end
 
 /-- A group of order `p ^ 2` is commutative. See also `is_p_group.commutative_of_card_eq_prime_sq`

--- a/src/group_theory/schur_zassenhaus.lean
+++ b/src/group_theory/schur_zassenhaus.lean
@@ -158,8 +158,9 @@ begin
     exact h1.coprime_dvd_left (card_comap_dvd_of_injective N K.subtype subtype.coe_injective) },
   obtain ⟨H, hH⟩ := h2 K h5 h6,
   replace hH : fintype.card (H.map K.subtype) = N.index :=
-  ((set.card_image_of_injective _ subtype.coe_injective).trans (nat.mul_left_injective
-    fintype.card_pos (hH.symm.card_mul.trans (N.comap K.subtype).index_mul_card.symm))).trans h4,
+    ((set.card_image_of_injective _ subtype.coe_injective).trans (mul_left_injective₀
+      fintype.card_ne_zero (hH.symm.card_mul.trans (N.comap K.subtype).index_mul_card.symm))).trans
+      h4,
   have h7 : fintype.card N * fintype.card (H.map K.subtype) = fintype.card G,
   { rw [hH, ←N.index_mul_card, mul_comm] },
   have h8 : (fintype.card N).coprime (fintype.card (H.map K.subtype)),

--- a/src/group_theory/specific_groups/cyclic.lean
+++ b/src/group_theory/specific_groups/cyclic.lean
@@ -309,7 +309,7 @@ begin
     simp only [mem_filter, mem_range, mem_proper_divisors] at hm,
     refine IH m hm.2 (hm.1.trans hd) (finset.card_pos.2 ⟨a ^ (d / m), _⟩),
     simp only [mem_filter, mem_univ, order_of_pow a, ha, true_and,
-      nat.gcd_eq_right (div_dvd_of_dvd hm.1), nat.div_div_self hm.1 hd_pos] },
+      nat.gcd_eq_right (div_dvd_of_dvd hm.1), nat.div_div_self hm.1 hd_pos.ne'] },
   have h2 : ∑ m in d.divisors, (univ.filter (λ a : α, order_of a = m)).card =
     ∑ m in d.divisors, φ m,
     { rw [←filter_dvd_eq_divisors hd_pos.ne', sum_card_order_of_eq_card_pow_eq_one hd_pos,

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -470,8 +470,7 @@ lemma prime_dvd_card_quotient_normalizer [fintype G] {p : ℕ} {n : ℕ} [hp : f
   p ∣ card (normalizer H ⧸ (subgroup.comap ((normalizer H).subtype : normalizer H →* G) H)) :=
 let ⟨s, hs⟩ := exists_eq_mul_left_of_dvd hdvd in
 have hcard : card (G ⧸ H) = s * p :=
-  (nat.mul_left_inj (show card H > 0, from fintype.card_pos_iff.2
-      ⟨⟨1, H.one_mem⟩⟩)).1
+  (mul_left_inj' (show card H ≠ 0, from fintype.card_ne_zero)).1
     (by rwa [← card_eq_card_quotient_mul_card_subgroup H, hH, hs,
       pow_succ', mul_assoc, mul_comm p]),
 have hm : s * p % p =
@@ -496,8 +495,7 @@ theorem exists_subgroup_card_pow_succ [fintype G] {p : ℕ} {n : ℕ} [hp : fact
   ∃ K : subgroup G, fintype.card K = p ^ (n + 1) ∧ H ≤ K :=
 let ⟨s, hs⟩ := exists_eq_mul_left_of_dvd hdvd in
 have hcard : card (G ⧸ H) = s * p :=
-  (nat.mul_left_inj (show card H > 0, from fintype.card_pos_iff.2
-      ⟨⟨1, H.one_mem⟩⟩)).1
+  (mul_left_inj' (show card H ≠ 0, from fintype.card_ne_zero)).1
     (by rwa [← card_eq_card_quotient_mul_card_subgroup H, hH, hs,
       pow_succ', mul_assoc, mul_comm p]),
 have hm : s * p % p =

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -435,8 +435,7 @@ begin
     exact div_dvd_of_dvd hx1.1 },
   { rw [mem_divisors, mem_image],
     rintros ⟨h1, -⟩,
-    exact ⟨n/a, mem_divisors.mpr ⟨div_dvd_of_dvd h1, hn⟩,
-           nat.div_div_self h1 (pos_iff_ne_zero.mpr hn)⟩ },
+    exact ⟨n/a, mem_divisors.mpr ⟨div_dvd_of_dvd h1, hn⟩, nat.div_div_self h1 hn⟩ },
 end
 
 @[simp, to_additive sum_div_divisors]

--- a/src/ring_theory/polynomial/eisenstein.lean
+++ b/src/ring_theory/polynomial/eisenstein.lean
@@ -275,7 +275,7 @@ begin
     obtain ⟨k, hk⟩ := int.coe_nat_dvd.1 h,
     rw [← mul_assoc, mul_one, mul_assoc] at hk,
     nth_rewrite 0 [← nat.mul_one p] at hk,
-    rw [nat.mul_right_inj hp.out.pos] at hk,
+    rw [mul_right_inj' hp.out.ne_zero] at hk,
     exact nat.prime.not_dvd_one hp.out (dvd.intro k (hk.symm)) }
 end
 
@@ -319,7 +319,7 @@ begin
     obtain ⟨k, hk⟩ := int.coe_nat_dvd.1 h,
     rw [← mul_assoc, mul_one, mul_assoc] at hk,
     nth_rewrite 0 [← nat.mul_one p] at hk,
-    rw [nat.mul_right_inj hp.out.pos] at hk,
+    rw [mul_right_inj' hp.out.ne_zero] at hk,
     exact nat.prime.not_dvd_one hp.out (dvd.intro k (hk.symm)) }
 end
 

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -383,7 +383,7 @@ begin
   obtain ⟨a, ha⟩ := i.gcd_dvd_left k,
   obtain ⟨b, hb⟩ := i.gcd_dvd_right k,
   suffices : b = k,
-  { rwa [this, ← one_mul k, nat.mul_left_inj h0, eq_comm] at hb { occs := occurrences.pos [1] } },
+  { rwa [this, ← one_mul k, mul_left_inj' h0.ne', eq_comm] at hb { occs := occurrences.pos [1] } },
   rw [ha] at hi,
   rw [mul_comm] at hb,
   apply nat.dvd_antisymm ⟨i.gcd k, hb⟩ (hi.dvd_of_pow_eq_one b _),


### PR DESCRIPTION
* Drop `nat.mul_left_inj`, `nat.mul_right_inj`, `nat.mul_left_injective`, and `nat.mul_right_injective`. Use general `cancel_monoid_with_zero` lemmas instead.
* Fix proofs broken by this API change.
* Assume `≠ 0` instead of `0 <` in `nat.div_div_self`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
