### PR TITLE
refactor(algebra/field/basic): split out algebra.field.defs

### DIFF
--- a/src/algebra/big_operators/ring.lean
+++ b/src/algebra/big_operators/ring.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl
 -/
 
 import algebra.big_operators.basic
-import algebra.field.basic
+import algebra.field.defs
 import data.finset.pi
 import data.finset.powerset
 

--- a/src/algebra/continued_fractions/basic.lean
+++ b/src/algebra/continued_fractions/basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Kappelmann
 -/
 import data.seq.seq
-import algebra.field.basic
+import algebra.field.defs
 /-!
 # Basic Definitions/Theorems for Continued Fractions
 

--- a/src/algebra/field/basic.lean
+++ b/src/algebra/field/basic.lean
@@ -4,42 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 -/
 import data.rat.defs
+import algebra.field.defs
+import algebra.ring.basic
 
 /-!
-# Division (semi)rings and (semi)fields
+# Lemmas about division (semi)rings and (semi)fields
 
-This file introduces fields and division rings (also known as skewfields) and proves some basic
-statements about them. For a more extensive theory of fields, see the `field_theory` folder.
-
-## Main definitions
-
-* `division_semiring`: Nontrivial semiring with multiplicative inverses for nonzero elements.
-* `division_ring`: : Nontrivial ring with multiplicative inverses for nonzero elements.
-* `semifield`: Commutative division semiring.
-* `field`: Commutative division ring.
-* `is_field`: Predicate on a (semi)ring that it is a (semi)field, i.e. that the multiplication is
-  commutative, that it has more than one element and that all non-zero elements have a
-  multiplicative inverse. In contrast to `field`, which contains the data of a function associating
-  to an element of the field its multiplicative inverse, this predicate only assumes the existence
-  and can therefore more easily be used to e.g. transfer along ring isomorphisms.
-
-## Implementation details
-
-By convention `0⁻¹ = 0` in a field or division ring. This is due to the fact that working with total
-functions has the advantage of not constantly having to check that `x ≠ 0` when writing `x⁻¹`. With
-this convention in place, some statements like `(a + b) * c⁻¹ = a * c⁻¹ + b * c⁻¹` still remain
-true, while others like the defining property `a * a⁻¹ = 1` need the assumption `a ≠ 0`. If you are
-a beginner in using Lean and are confused by that, you can read more about why this convention is
-taken in Kevin Buzzard's
-[blogpost](https://xenaproject.wordpress.com/2020/07/05/division-by-zero-in-type-theory-a-faq/)
-
-A division ring or field is an example of a `group_with_zero`. If you cannot find
-a division ring / field lemma that does not involve `+`, you can try looking for
-a `group_with_zero` lemma instead.
-
-## Tags
-
-field, division ring, skew field, skew-field, skewfield
 -/
 
 open function order_dual set
@@ -48,71 +18,6 @@ set_option old_structure_cmd true
 
 universe u
 variables {α β K : Type*}
-
-/-- The default definition of the coercion `(↑(a : ℚ) : K)` for a division ring `K`
-is defined as `(a / b : K) = (a : K) * (b : K)⁻¹`.
-Use `coe` instead of `rat.cast_rec` for better definitional behaviour.
--/
-def rat.cast_rec [has_lift_t ℕ K] [has_lift_t ℤ K] [has_mul K] [has_inv K] : ℚ → K
-| ⟨a, b, _, _⟩ := ↑a * (↑b)⁻¹
-
-/--
-Type class for the canonical homomorphism `ℚ → K`.
--/
-@[protect_proj]
-class has_rat_cast (K : Type u) :=
-(rat_cast : ℚ → K)
-
-/-- The default definition of the scalar multiplication `(a : ℚ) • (x : K)` for a division ring `K`
-is given by `a • x = (↑ a) * x`.
-Use `(a : ℚ) • (x : K)` instead of `qsmul_rec` for better definitional behaviour.
--/
-def qsmul_rec (coe : ℚ → K) [has_mul K] (a : ℚ) (x : K) : K :=
-coe a * x
-
-/-- A `division_semiring` is a `semiring` with multiplicative inverses for nonzero elements. -/
-@[protect_proj, ancestor semiring group_with_zero]
-class division_semiring (α : Type*) extends semiring α, group_with_zero α
-
-/-- A `division_ring` is a `ring` with multiplicative inverses for nonzero elements.
-
-An instance of `division_ring K` includes maps `of_rat : ℚ → K` and `qsmul : ℚ → K → K`.
-If the division ring has positive characteristic p, we define `of_rat (1 / p) = 1 / 0 = 0`
-for consistency with our division by zero convention.
-The fields `of_rat` and `qsmul` are needed to implement the
-`algebra_rat [division_ring K] : algebra ℚ K` instance, since we need to control the specific
-definitions for some special cases of `K` (in particular `K = ℚ` itself).
-See also Note [forgetful inheritance].
--/
-@[protect_proj, ancestor ring div_inv_monoid nontrivial]
-class division_ring (K : Type u) extends ring K, div_inv_monoid K, nontrivial K, has_rat_cast K :=
-(mul_inv_cancel : ∀ {a : K}, a ≠ 0 → a * a⁻¹ = 1)
-(inv_zero : (0 : K)⁻¹ = 0)
-(rat_cast := rat.cast_rec)
-(rat_cast_mk : ∀ (a : ℤ) (b : ℕ) h1 h2, rat_cast ⟨a, b, h1, h2⟩ = a * b⁻¹ . try_refl_tac)
-(qsmul : ℚ → K → K := qsmul_rec rat_cast)
-(qsmul_eq_mul' : ∀ (a : ℚ) (x : K), qsmul a x = rat_cast a * x . try_refl_tac)
-
-@[priority 100] -- see Note [lower instance priority]
-instance division_ring.to_division_semiring [division_ring α] : division_semiring α :=
-{ ..‹division_ring α›, ..(infer_instance : semiring α) }
-
-/-- A `semifield` is a `comm_semiring` with multiplicative inverses for nonzero elements. -/
-@[protect_proj, ancestor comm_semiring division_semiring comm_group_with_zero]
-class semifield (α : Type*) extends comm_semiring α, division_semiring α, comm_group_with_zero α
-
-/-- A `field` is a `comm_ring` with multiplicative inverses for nonzero elements.
-
-An instance of `field K` includes maps `of_rat : ℚ → K` and `qsmul : ℚ → K → K`.
-If the field has positive characteristic p, we define `of_rat (1 / p) = 1 / 0 = 0`
-for consistency with our division by zero convention.
-The fields `of_rat` and `qsmul are needed to implement the
-`algebra_rat [division_ring K] : algebra ℚ K` instance, since we need to control the specific
-definitions for some special cases of `K` (in particular `K = ℚ` itself).
-See also Note [forgetful inheritance].
--/
-@[protect_proj, ancestor comm_ring div_inv_monoid nontrivial]
-class field (K : Type u) extends comm_ring K, division_ring K
 
 section division_semiring
 variables [division_semiring α] {a b c : α}
@@ -187,30 +92,6 @@ end division_monoid
 section division_ring
 variables [division_ring K] {a b : K}
 
-namespace rat
-
-/-- Construct the canonical injection from `ℚ` into an arbitrary
-  division ring. If the field has positive characteristic `p`,
-  we define `1 / p = 1 / 0 = 0` for consistency with our
-  division by zero convention. -/
--- see Note [coercion into rings]
-@[priority 900] instance cast_coe {K : Type*} [has_rat_cast K] : has_coe_t ℚ K :=
-⟨has_rat_cast.rat_cast⟩
-
-theorem cast_mk' (a b h1 h2) : ((⟨a, b, h1, h2⟩ : ℚ) : K) = a * b⁻¹ :=
-division_ring.rat_cast_mk _ _ _ _
-
-theorem cast_def : ∀ (r : ℚ), (r : K) = r.num / r.denom
-| ⟨a, b, h1, h2⟩ := (cast_mk' _ _ _ _).trans (div_eq_mul_inv _ _).symm
-
-@[priority 100]
-instance smul_division_ring : has_smul ℚ K :=
-⟨division_ring.qsmul⟩
-
-lemma smul_def (a : ℚ) (x : K) : a • x = ↑a * x := division_ring.qsmul_eq_mul' a x
-
-end rat
-
 @[simp] lemma div_neg_self {a : K} (h : a ≠ 0) : a / -a = -1 :=
 by rw [div_neg_eq_neg_div, div_self h]
 
@@ -264,10 +145,6 @@ section field
 
 variable [field K]
 
-@[priority 100] -- see Note [lower instance priority]
-instance field.to_semifield : semifield K :=
-{ .. ‹field K›, .. (infer_instance : semiring K) }
-
 local attribute [simp] mul_assoc mul_comm mul_left_comm
 
 @[field_simps] lemma div_sub_div (a : K) {b : K} (c : K) {d : K} (hb : b ≠ 0) (hd : d ≠ 0) :
@@ -292,69 +169,6 @@ instance field.is_domain : is_domain K :=
 { ..division_ring.is_domain }
 
 end field
-
-section is_field
-
-/-- A predicate to express that a (semi)ring is a (semi)field.
-
-This is mainly useful because such a predicate does not contain data,
-and can therefore be easily transported along ring isomorphisms.
-Additionaly, this is useful when trying to prove that
-a particular ring structure extends to a (semi)field. -/
-structure is_field (R : Type u) [semiring R] : Prop :=
-(exists_pair_ne : ∃ (x y : R), x ≠ y)
-(mul_comm : ∀ (x y : R), x * y = y * x)
-(mul_inv_cancel : ∀ {a : R}, a ≠ 0 → ∃ b, a * b = 1)
-
-/-- Transferring from `semifield` to `is_field`. -/
-lemma semifield.to_is_field (R : Type u) [semifield R] : is_field R :=
-{ mul_inv_cancel := λ a ha, ⟨a⁻¹, mul_inv_cancel ha⟩,
-  ..‹semifield R› }
-
-/-- Transferring from `field` to `is_field`. -/
-lemma field.to_is_field (R : Type u) [field R] : is_field R := semifield.to_is_field _
-
-@[simp] lemma is_field.nontrivial {R : Type u} [semiring R] (h : is_field R) : nontrivial R :=
-⟨h.exists_pair_ne⟩
-
-@[simp] lemma not_is_field_of_subsingleton (R : Type u) [semiring R] [subsingleton R] :
-  ¬is_field R :=
-λ h, let ⟨x, y, h⟩ := h.exists_pair_ne in h (subsingleton.elim _ _)
-
-open_locale classical
-
-/-- Transferring from `is_field` to `semifield`. -/
-noncomputable def is_field.to_semifield {R : Type u} [semiring R] (h : is_field R) : semifield R :=
-{ inv := λ a, if ha : a = 0 then 0 else classical.some (is_field.mul_inv_cancel h ha),
-  inv_zero := dif_pos rfl,
-  mul_inv_cancel := λ a ha,
-    begin
-      convert classical.some_spec (is_field.mul_inv_cancel h ha),
-      exact dif_neg ha
-    end,
-  .. ‹semiring R›, ..h }
-
-/-- Transferring from `is_field` to `field`. -/
-noncomputable def is_field.to_field {R : Type u} [ring R] (h : is_field R) : field R :=
-{ .. ‹ring R›, ..is_field.to_semifield h }
-
-/-- For each field, and for each nonzero element of said field, there is a unique inverse.
-Since `is_field` doesn't remember the data of an `inv` function and as such,
-a lemma that there is a unique inverse could be useful.
--/
-lemma uniq_inv_of_is_field (R : Type u) [ring R] (hf : is_field R) :
-  ∀ (x : R), x ≠ 0 → ∃! (y : R), x * y = 1 :=
-begin
-  intros x hx,
-  apply exists_unique_of_exists_of_unique,
-  { exact hf.mul_inv_cancel hx },
-  { intros y z hxy hxz,
-    calc y = y * (x * z) : by rw [hxz, mul_one]
-       ... = (x * y) * z : by rw [← mul_assoc, hf.mul_comm y x]
-       ... = z           : by rw [hxy, one_mul] }
-end
-
-end is_field
 
 namespace ring_hom
 

--- a/src/algebra/field/defs.lean
+++ b/src/algebra/field/defs.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2014 Robert Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
+-/
+import data.rat.init
+import algebra.ring.defs
+
+/-!
+# Division (semi)rings and (semi)fields
+
+This file introduces fields and division rings (also known as skewfields) and proves some basic
+statements about them. For a more extensive theory of fields, see the `field_theory` folder.
+
+## Main definitions
+
+* `division_semiring`: Nontrivial semiring with multiplicative inverses for nonzero elements.
+* `division_ring`: : Nontrivial ring with multiplicative inverses for nonzero elements.
+* `semifield`: Commutative division semiring.
+* `field`: Commutative division ring.
+* `is_field`: Predicate on a (semi)ring that it is a (semi)field, i.e. that the multiplication is
+  commutative, that it has more than one element and that all non-zero elements have a
+  multiplicative inverse. In contrast to `field`, which contains the data of a function associating
+  to an element of the field its multiplicative inverse, this predicate only assumes the existence
+  and can therefore more easily be used to e.g. transfer along ring isomorphisms.
+
+## Implementation details
+
+By convention `0⁻¹ = 0` in a field or division ring. This is due to the fact that working with total
+functions has the advantage of not constantly having to check that `x ≠ 0` when writing `x⁻¹`. With
+this convention in place, some statements like `(a + b) * c⁻¹ = a * c⁻¹ + b * c⁻¹` still remain
+true, while others like the defining property `a * a⁻¹ = 1` need the assumption `a ≠ 0`. If you are
+a beginner in using Lean and are confused by that, you can read more about why this convention is
+taken in Kevin Buzzard's
+[blogpost](https://xenaproject.wordpress.com/2020/07/05/division-by-zero-in-type-theory-a-faq/)
+
+A division ring or field is an example of a `group_with_zero`. If you cannot find
+a division ring / field lemma that does not involve `+`, you can try looking for
+a `group_with_zero` lemma instead.
+
+## Tags
+
+field, division ring, skew field, skew-field, skewfield
+-/
+
+open function set
+
+set_option old_structure_cmd true
+
+universe u
+variables {α β K : Type*}
+
+/-- The default definition of the coercion `(↑(a : ℚ) : K)` for a division ring `K`
+is defined as `(a / b : K) = (a : K) * (b : K)⁻¹`.
+Use `coe` instead of `rat.cast_rec` for better definitional behaviour.
+-/
+def rat.cast_rec [has_lift_t ℕ K] [has_lift_t ℤ K] [has_mul K] [has_inv K] : ℚ → K
+| ⟨a, b, _, _⟩ := ↑a * (↑b)⁻¹
+
+/--
+Type class for the canonical homomorphism `ℚ → K`.
+-/
+@[protect_proj]
+class has_rat_cast (K : Type u) :=
+(rat_cast : ℚ → K)
+
+/-- The default definition of the scalar multiplication `(a : ℚ) • (x : K)` for a division ring `K`
+is given by `a • x = (↑ a) * x`.
+Use `(a : ℚ) • (x : K)` instead of `qsmul_rec` for better definitional behaviour.
+-/
+def qsmul_rec (coe : ℚ → K) [has_mul K] (a : ℚ) (x : K) : K :=
+coe a * x
+
+/-- A `division_semiring` is a `semiring` with multiplicative inverses for nonzero elements. -/
+@[protect_proj, ancestor semiring group_with_zero]
+class division_semiring (α : Type*) extends semiring α, group_with_zero α
+
+/-- A `division_ring` is a `ring` with multiplicative inverses for nonzero elements.
+
+An instance of `division_ring K` includes maps `rat_cast : ℚ → K` and `qsmul : ℚ → K → K`.
+If the division ring has positive characteristic p, we define `rat_cast (1 / p) = 1 / 0 = 0`
+for consistency with our division by zero convention.
+The fields `rat_cast` and `qsmul` are needed to implement the
+`algebra_rat [division_ring K] : algebra ℚ K` instance, since we need to control the specific
+definitions for some special cases of `K` (in particular `K = ℚ` itself).
+See also Note [forgetful inheritance].
+-/
+@[protect_proj, ancestor ring div_inv_monoid nontrivial]
+class division_ring (K : Type u) extends ring K, div_inv_monoid K, nontrivial K, has_rat_cast K :=
+(mul_inv_cancel : ∀ {a : K}, a ≠ 0 → a * a⁻¹ = 1)
+(inv_zero : (0 : K)⁻¹ = 0)
+(rat_cast := rat.cast_rec)
+(rat_cast_mk : ∀ (a : ℤ) (b : ℕ) h1 h2, rat_cast ⟨a, b, h1, h2⟩ = a * b⁻¹ . try_refl_tac)
+(qsmul : ℚ → K → K := qsmul_rec rat_cast)
+(qsmul_eq_mul' : ∀ (a : ℚ) (x : K), qsmul a x = rat_cast a * x . try_refl_tac)
+
+@[priority 100] -- see Note [lower instance priority]
+instance division_ring.to_division_semiring [division_ring α] : division_semiring α :=
+{ ..‹division_ring α›, ..(infer_instance : semiring α) }
+
+/-- A `semifield` is a `comm_semiring` with multiplicative inverses for nonzero elements. -/
+@[protect_proj, ancestor comm_semiring division_semiring comm_group_with_zero]
+class semifield (α : Type*) extends comm_semiring α, division_semiring α, comm_group_with_zero α
+
+/-- A `field` is a `comm_ring` with multiplicative inverses for nonzero elements.
+
+An instance of `field K` includes maps `of_rat : ℚ → K` and `qsmul : ℚ → K → K`.
+If the field has positive characteristic p, we define `of_rat (1 / p) = 1 / 0 = 0`
+for consistency with our division by zero convention.
+The fields `of_rat` and `qsmul are needed to implement the
+`algebra_rat [division_ring K] : algebra ℚ K` instance, since we need to control the specific
+definitions for some special cases of `K` (in particular `K = ℚ` itself).
+See also Note [forgetful inheritance].
+-/
+@[protect_proj, ancestor comm_ring div_inv_monoid nontrivial]
+class field (K : Type u) extends comm_ring K, division_ring K
+
+section division_ring
+variables [division_ring K] {a b : K}
+
+namespace rat
+
+/-- Construct the canonical injection from `ℚ` into an arbitrary
+  division ring. If the field has positive characteristic `p`,
+  we define `1 / p = 1 / 0 = 0` for consistency with our
+  division by zero convention. -/
+-- see Note [coercion into rings]
+@[priority 900] instance cast_coe {K : Type*} [has_rat_cast K] : has_coe_t ℚ K :=
+⟨has_rat_cast.rat_cast⟩
+
+theorem cast_mk' (a b h1 h2) : ((⟨a, b, h1, h2⟩ : ℚ) : K) = a * b⁻¹ :=
+division_ring.rat_cast_mk _ _ _ _
+
+theorem cast_def : ∀ (r : ℚ), (r : K) = r.num / r.denom
+| ⟨a, b, h1, h2⟩ := (cast_mk' _ _ _ _).trans (div_eq_mul_inv _ _).symm
+
+@[priority 100]
+instance smul_division_ring : has_smul ℚ K :=
+⟨division_ring.qsmul⟩
+
+lemma smul_def (a : ℚ) (x : K) : a • x = ↑a * x := division_ring.qsmul_eq_mul' a x
+
+end rat
+
+end division_ring
+
+section field
+
+variable [field K]
+
+@[priority 100] -- see Note [lower instance priority]
+instance field.to_semifield : semifield K :=
+{ .. ‹field K›, .. (infer_instance : semiring K) }
+
+end field
+
+section is_field
+
+/-- A predicate to express that a (semi)ring is a (semi)field.
+
+This is mainly useful because such a predicate does not contain data,
+and can therefore be easily transported along ring isomorphisms.
+Additionaly, this is useful when trying to prove that
+a particular ring structure extends to a (semi)field. -/
+structure is_field (R : Type u) [semiring R] : Prop :=
+(exists_pair_ne : ∃ (x y : R), x ≠ y)
+(mul_comm : ∀ (x y : R), x * y = y * x)
+(mul_inv_cancel : ∀ {a : R}, a ≠ 0 → ∃ b, a * b = 1)
+
+/-- Transferring from `semifield` to `is_field`. -/
+lemma semifield.to_is_field (R : Type u) [semifield R] : is_field R :=
+{ mul_inv_cancel := λ a ha, ⟨a⁻¹, mul_inv_cancel ha⟩,
+  ..‹semifield R› }
+
+/-- Transferring from `field` to `is_field`. -/
+lemma field.to_is_field (R : Type u) [field R] : is_field R := semifield.to_is_field _
+
+@[simp] lemma is_field.nontrivial {R : Type u} [semiring R] (h : is_field R) : nontrivial R :=
+⟨h.exists_pair_ne⟩
+
+@[simp] lemma not_is_field_of_subsingleton (R : Type u) [semiring R] [subsingleton R] :
+  ¬is_field R :=
+λ h, let ⟨x, y, h⟩ := h.exists_pair_ne in h (subsingleton.elim _ _)
+
+open_locale classical
+
+/-- Transferring from `is_field` to `semifield`. -/
+noncomputable def is_field.to_semifield {R : Type u} [semiring R] (h : is_field R) : semifield R :=
+{ inv := λ a, if ha : a = 0 then 0 else classical.some (is_field.mul_inv_cancel h ha),
+  inv_zero := dif_pos rfl,
+  mul_inv_cancel := λ a ha,
+    begin
+      convert classical.some_spec (is_field.mul_inv_cancel h ha),
+      exact dif_neg ha
+    end,
+  .. ‹semiring R›, ..h }
+
+/-- Transferring from `is_field` to `field`. -/
+noncomputable def is_field.to_field {R : Type u} [ring R] (h : is_field R) : field R :=
+{ .. ‹ring R›, ..is_field.to_semifield h }
+
+/-- For each field, and for each nonzero element of said field, there is a unique inverse.
+Since `is_field` doesn't remember the data of an `inv` function and as such,
+a lemma that there is a unique inverse could be useful.
+-/
+lemma uniq_inv_of_is_field (R : Type u) [ring R] (hf : is_field R) :
+  ∀ (x : R), x ≠ 0 → ∃! (y : R), x * y = 1 :=
+begin
+  intros x hx,
+  apply exists_unique_of_exists_of_unique,
+  { exact hf.mul_inv_cancel hx },
+  { intros y z hxy hxz,
+    calc y = y * (x * z) : by rw [hxz, mul_one]
+       ... = (x * y) * z : by rw [← mul_assoc, hf.mul_comm y x]
+       ... = z           : by rw [hxy, one_mul] }
+end
+
+end is_field

--- a/src/algebra/field/opposite.lean
+++ b/src/algebra/field/opposite.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import algebra.field.basic
+import algebra.field.defs
 import algebra.ring.opposite
 
 /-!

--- a/src/algebra/field/power.lean
+++ b/src/algebra/field/power.lean
@@ -3,7 +3,7 @@ Copyright (c) 2014 Robert Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 -/
-import algebra.field.basic
+import algebra.field.defs
 import algebra.group_with_zero.power
 
 /-!

--- a/src/algebra/order/field/basic.lean
+++ b/src/algebra/order/field/basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
 -/
 import order.bounds.order_iso
+import algebra.field.basic
 import algebra.order.field.defs
 
 /-!

--- a/src/algebra/order/field/defs.lean
+++ b/src/algebra/order/field/defs.lean
@@ -3,8 +3,9 @@ Copyright (c) 2014 Robert Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
 -/
-import algebra.field.basic
-import algebra.order.ring.basic
+import algebra.field.defs
+import algebra.order.ring.canonical
+import algebra.order.with_zero
 
 /-!
 # Linear ordered (semi)fields

--- a/src/algebra/ring/equiv.lean
+++ b/src/algebra/ring/equiv.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 -/
 import algebra.big_operators.basic
-import algebra.field.basic
 import algebra.hom.equiv
 import algebra.ring.opposite
 

--- a/src/algebra/ring/ulift.lean
+++ b/src/algebra/ring/ulift.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import algebra.group.ulift
+import algebra.field.defs
 import algebra.ring.equiv
 
 /-!

--- a/src/data/rat/defs.lean
+++ b/src/data/rat/defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import data.rat.init
 import data.int.cast
 import data.int.div
 import data.nat.gcd.basic
@@ -14,53 +15,21 @@ import tactic.nth_rewrite
 
 ## Summary
 
-We define a rational number `q` as a structure `{ num, denom, pos, cop }`, where
-- `num` is the numerator of `q`,
-- `denom` is the denominator of `q`,
-- `pos` is a proof that `denom > 0`, and
-- `cop` is a proof `num` and `denom` are coprime.
-
-We then define the integral domain structure on `ℚ` and prove basic lemmas about it.
+We define the integral domain structure on `ℚ` and prove basic lemmas about it.
 The definition of the field structure on `ℚ` will be done in `data.rat.basic` once the
 `field` class has been defined.
 
 ## Main Definitions
 
-- `rat` is the structure encoding `ℚ`.
 - `rat.mk n d` constructs a rational number `q = n / d` from `n d : ℤ`.
 
 ## Notations
 
 - `/.` is infix notation for `rat.mk`.
 
-## Tags
-
-rat, rationals, field, ℚ, numerator, denominator, num, denom
 -/
 
-/-- `rat`, or `ℚ`, is the type of rational numbers. It is defined
-  as the set of pairs ⟨n, d⟩ of integers such that `d` is positive and `n` and
-  `d` are coprime. This representation is preferred to the quotient
-  because without periodic reduction, the numerator and denominator can grow
-  exponentially (for example, adding 1/2 to itself repeatedly). -/
-structure rat := mk' ::
-(num : ℤ)
-(denom : ℕ)
-(pos : 0 < denom)
-(cop : num.nat_abs.coprime denom)
-notation `ℚ` := rat
-
 namespace rat
-
-/-- String representation of a rational numbers, used in `has_repr`, `has_to_string`, and
-`has_to_format` instances. -/
-protected def repr : ℚ → string
-| ⟨n, d, _, _⟩ := if d = 1 then _root_.repr n else
-  _root_.repr n ++ "/" ++ _root_.repr d
-
-instance : has_repr ℚ := ⟨rat.repr⟩
-instance : has_to_string ℚ := ⟨rat.repr⟩
-meta instance : has_to_format ℚ := ⟨coe ∘ rat.repr⟩
 
 /-- Embed an integer as a rational number -/
 def of_int (n : ℤ) : ℚ :=
@@ -69,12 +38,6 @@ def of_int (n : ℤ) : ℚ :=
 instance : has_zero ℚ := ⟨of_int 0⟩
 instance : has_one ℚ := ⟨of_int 1⟩
 instance : inhabited ℚ := ⟨0⟩
-
-lemma ext_iff {p q : ℚ} : p = q ↔ p.num = q.num ∧ p.denom = q.denom :=
-by { cases p, cases q, simp }
-
-@[ext] lemma ext {p q : ℚ} (hn : p.num = q.num) (hd : p.denom = q.denom) : p = q :=
-rat.ext_iff.mpr ⟨hn, hd⟩
 
 /-- Form the quotient `n / d` where `n:ℤ` and `d:ℕ+` (not necessarily coprime) -/
 def mk_pnat (n : ℤ) : ℕ+ → ℚ | ⟨d, dpos⟩ :=

--- a/src/data/rat/init.lean
+++ b/src/data/rat/init.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2019 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro
+-/
+import tactic.ext
+
+/-!
+# The definition of the Rational Numbers
+
+## Summary
+
+We define a rational number `q` as a structure `{ num, denom, pos, cop }`, where
+- `num` is the numerator of `q`,
+- `denom` is the denominator of `q`,
+- `pos` is a proof that `denom > 0`, and
+- `cop` is a proof `num` and `denom` are coprime.
+
+Basic constructions and results are set up in `data.rat.defs`.
+As we transition to Lean 4, these two files can probably be merged again,
+as so much of the needed material will be in Std4 anyway.
+
+For now, this split allows us to give the definitions of division rings and fields
+without significant theory imports.
+
+The definition of the field structure on `ℚ` will be done in `data.rat.basic` once the
+`field` class has been defined.
+
+## Main Definitions
+
+- `rat` is the structure encoding `ℚ`.
+
+## Notations
+
+## Tags
+
+rat, rationals, field, ℚ, numerator, denominator, num, denom
+-/
+
+/-- `rat`, or `ℚ`, is the type of rational numbers. It is defined
+  as the set of pairs ⟨n, d⟩ of integers such that `d` is positive and `n` and
+  `d` are coprime. This representation is preferred to the quotient
+  because without periodic reduction, the numerator and denominator can grow
+  exponentially (for example, adding 1/2 to itself repeatedly). -/
+structure rat := mk' ::
+(num : ℤ)
+(denom : ℕ)
+(pos : 0 < denom)
+(cop : num.nat_abs.coprime denom)
+notation `ℚ` := rat
+
+namespace rat
+
+/-- String representation of a rational numbers, used in `has_repr`, `has_to_string`, and
+`has_to_format` instances. -/
+protected def repr : ℚ → string
+| ⟨n, d, _, _⟩ := if d = 1 then _root_.repr n else
+  _root_.repr n ++ "/" ++ _root_.repr d
+
+instance : has_repr ℚ := ⟨rat.repr⟩
+instance : has_to_string ℚ := ⟨rat.repr⟩
+meta instance : has_to_format ℚ := ⟨coe ∘ rat.repr⟩
+
+lemma ext_iff {p q : ℚ} : p = q ↔ p.num = q.num ∧ p.denom = q.denom :=
+by { cases p, cases q, simp }
+
+@[ext] lemma ext {p q : ℚ} (hn : p.num = q.num) (hd : p.denom = q.denom) : p = q :=
+rat.ext_iff.mpr ⟨hn, hd⟩
+
+end rat


### PR DESCRIPTION
This refactor allows us to give the definition of division rings and fields with essentially no theory imports.

This will be merged as part of #17405, so please delegate rather than merge.

- [x] depends on: #17407 (relative diff at 038b667aca8e0251878ca90aa04af594ef298f5b)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
