### PR TITLE
[Merged by Bors] - ci(bors): set update_base_for_deletes

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -6,4 +6,5 @@ use_squash_merge = true
 timeout_sec = 28800
 block_labels = ["not-ready-to-merge", "WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI"]
 delete_merged_branches = true
+update_base_for_deletes = true
 cut_body_after = "---"


### PR DESCRIPTION
From the source, this doesn't do anything to the git history, but does prevent chained PRs being closed after bors closes the first one.

This still doesn't work very well for us, but it's better than randomly closing PRs that haven't been merged.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
