### PR TITLE
feat(linear_algebra.finsupp): Add `span_range_eq_map_total` as special case of `span_image_eq_map_total`

### DIFF
--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -517,8 +517,8 @@ b.constr_eq S $ λ x, rfl
 lemma constr_range [nonempty ι] {f : ι  → M'} :
   (b.constr S f).range = span R (range f) :=
 by rw [b.constr_def S f, linear_map.range_comp, linear_map.range_comp, linear_equiv.range,
-       ← finsupp.supported_univ, finsupp.lmap_domain_supported, ←set.image_univ,
-       ← finsupp.span_image_eq_map_total, set.image_id]
+       ←finsupp.supported_univ, finsupp.lmap_domain_supported,
+       ←finsupp.span_image_eq_map_total, set.image_id, set.image_univ]
 
 @[simp]
 lemma constr_comp (f : M' →ₗ[R] M') (v : ι → M') :

--- a/src/linear_algebra/finsupp.lean
+++ b/src/linear_algebra/finsupp.lean
@@ -518,7 +518,7 @@ theorem mem_span_iff_total (s : set M) (x : M) :
   x ∈ span R s ↔ ∃ l : s →₀ R, finsupp.total s M R coe l = x :=
 (set_like.ext_iff.1 $ span_eq_range_total _ _) x
 
-theorem span_image_eq_map_total (s : set α):
+theorem span_image_eq_map_total (s : set α) :
   span R (v '' s) = submodule.map (finsupp.total α M R v) (supported R R s) :=
 begin
   apply span_eq_of_le,
@@ -536,6 +536,11 @@ begin
       { simp [(finsupp.mem_supported' R _).1 hz _ h] } },
     refine sum_mem _, simp [this] }
 end
+
+/-- Special case of `span_image_eq_map_total`. -/
+lemma span_range_eq_map_total :
+  span R (set.range v) = submodule.map (finsupp.total α M R v) (supported R R set.univ) :=
+by rw [←set.image_univ, span_image_eq_map_total]
 
 theorem mem_span_image_iff_total {s : set α} {x : M} :
   x ∈ span R (v '' s) ↔ ∃ l ∈ supported R R s, finsupp.total α M R v l = x :=

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -186,7 +186,7 @@ family of vectors. See also `linear_independent.map'` for a special case assumin
 lemma linear_independent.map (hv : linear_independent R v) {f : M →ₗ[R] M'}
   (hf_inj : disjoint (span R (range v)) f.ker) : linear_independent R (f ∘ v) :=
 begin
-  rw [disjoint, ← set.image_univ, finsupp.span_image_eq_map_total, map_inf_eq_map_inf_comap,
+  rw [disjoint, finsupp.span_range_eq_map_total, map_inf_eq_map_inf_comap,
     map_le_iff_le_comap, comap_bot, finsupp.supported_univ, top_inf_eq] at hf_inj,
   unfold linear_independent at hv ⊢,
   rw [hv, le_bot_iff] at hf_inj,


### PR DESCRIPTION
Add special case of `span_image_eq_map_total` for the case where the set is `set.univ` as `simp` reduces `f '' univ` to `set.range f` and one needs to manually call `rw ←set.image_univ` to undo this simplification.

---

Also helps searchability as looking for "span_range" is more intuitive than "span_image" when confronted with a term of the form `span R (range f)`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
