### PR TITLE
[Merged by Bors] - fix(tactic/norm_num): bug in prove_div_mod

### DIFF
--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -1601,7 +1601,8 @@ meta def prove_div_mod (ic : instance_cache) :
     (ic, q) ← ic.of_int nq,
     (ic, r) ← ic.of_int nr,
     (ic, m, pm) ← prove_mul_rat ic q b (rat.of_int nq) (rat.of_int nb),
-    (ic, p) ← prove_add_rat ic r m a (rat.of_int nr) (rat.of_int nm) (rat.of_int na),
+    (ic, a') ← ic.of_rat na, -- ensure `a` is in normal form
+    (ic, p) ← prove_add_rat ic r m a' (rat.of_int nr) (rat.of_int nm) (rat.of_int na),
     (ic, p') ← prove_lt_nat ic r b,
     if ic.α = `(nat) then
       if mod then return (ic, r, `(nat_mod).mk_app [a, b, q, r, m, pm, p, p'])

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -59,6 +59,8 @@ example : 10 = (-1 : ℤ) % 11 := by norm_num
 example : (12321 - 2 : ℤ) = 12319 := by norm_num
 example : (63:ℚ) ≥ 5 := by norm_num
 
+example : nat.zero.succ.succ.succ.succ.succ.succ % 4 = 2 := by norm_num1
+
 example (x : ℤ) (h : 1000 + 2000 < x) : 100 * 30 < x :=
 by norm_num at *; try_for 100 {exact h}
 


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/norm_num.20produces.20bad.20proof.20term).