### PR TITLE
refactor(algebra/ring/basic): better split

### DIFF
--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Louis Carlin, Mario Carneiro
 -/
 import algebra.field.basic
-import algebra.ring.basic
 
 /-!
 # Euclidean domains

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johan Commelin
 -/
 import algebra.hom.equiv
-import algebra.ring.basic
+import algebra.ring.defs
 import logic.equiv.defs
 import logic.equiv.option
 

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
 -/
 import algebra.ring.defs
+import algebra.ring.inj_surj
 import algebra.regular.basic
 import algebra.hom.group
 import algebra.opposites
@@ -16,158 +17,13 @@ This is analogous to `algebra.group.basic`,
 the difference being that the former is about `+` and `*` separately, while
 the present file is about their interaction.
 
-For the definitions of semirings and rings see `algebra.ring.degs`.
+For the definitions of semirings and rings see `algebra.ring.defs`.
 
 -/
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {R : Type x}
 
 open function
-
-/-!
-### `distrib` class
--/
-
-/-- Pullback a `distrib` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.distrib {S} [has_mul R] [has_add R] [distrib S]
-  (f : R → S) (hf : injective f) (add : ∀ x y, f (x + y) = f x + f y)
-  (mul : ∀ x y, f (x * y) = f x * f y) :
-  distrib R :=
-{ mul := (*),
-  add := (+),
-  left_distrib := λ x y z, hf $ by simp only [*, left_distrib],
-  right_distrib := λ x y z, hf $ by simp only [*, right_distrib] }
-
-/-- Pushforward a `distrib` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.distrib {S} [distrib R] [has_add S] [has_mul S]
-  (f : R → S) (hf : surjective f) (add : ∀ x y, f (x + y) = f x + f y)
-  (mul : ∀ x y, f (x * y) = f x * f y) :
-  distrib S :=
-{ mul := (*),
-  add := (+),
-  left_distrib := hf.forall₃.2 $ λ x y z, by simp only [← add, ← mul, left_distrib],
-  right_distrib := hf.forall₃.2 $ λ x y z, by simp only [← add, ← mul, right_distrib] }
-
-/-!
-### Semirings
--/
-
-section injective_surjective_maps
-
-variables [has_zero β] [has_add β] [has_mul β] [has_smul ℕ β]
-
-/-- Pullback a `non_unital_non_assoc_semiring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.non_unital_non_assoc_semiring
-  {α : Type u} [non_unital_non_assoc_semiring α]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
-  non_unital_non_assoc_semiring β :=
-{ .. hf.mul_zero_class f zero mul, .. hf.add_comm_monoid f zero add nsmul, .. hf.distrib f add mul }
-
-/-- Pullback a `non_unital_semiring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.non_unital_semiring
-  {α : Type u} [non_unital_semiring α]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
-  non_unital_semiring β :=
-{ .. hf.non_unital_non_assoc_semiring f zero add mul nsmul, .. hf.semigroup_with_zero f zero mul }
-
-/-- Pullback a `non_assoc_semiring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.non_assoc_semiring
-  {α : Type u} [non_assoc_semiring α]
-  {β : Type v} [has_zero β] [has_one β] [has_mul β] [has_add β]
-  [has_smul ℕ β] [has_nat_cast β]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x)
-  (nat_cast : ∀ n : ℕ, f n = n) :
-  non_assoc_semiring β :=
-{ .. hf.add_monoid_with_one f zero one add nsmul nat_cast,
-  .. hf.non_unital_non_assoc_semiring f zero add mul nsmul,
-  .. hf.mul_one_class f one mul }
-
-/-- Pullback a `semiring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.semiring
-  {α : Type u} [semiring α]
-  {β : Type v} [has_zero β] [has_one β] [has_add β] [has_mul β] [has_pow β ℕ]
-  [has_smul ℕ β] [has_nat_cast β]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
-  (nat_cast : ∀ n : ℕ, f n = n) :
-  semiring β :=
-{ .. hf.non_assoc_semiring f zero one add mul nsmul nat_cast,
-  .. hf.monoid_with_zero f zero one mul npow,
-  .. hf.distrib f add mul }
-
-/-- Pushforward a `non_unital_non_assoc_semiring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.non_unital_non_assoc_semiring
-  {α : Type u} [non_unital_non_assoc_semiring α]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
-  non_unital_non_assoc_semiring β :=
-{ .. hf.mul_zero_class f zero mul, .. hf.add_comm_monoid f zero add nsmul, .. hf.distrib f add mul }
-
-/-- Pushforward a `non_unital_semiring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.non_unital_semiring
-  {α : Type u} [non_unital_semiring α]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
-  non_unital_semiring β :=
-{ .. hf.non_unital_non_assoc_semiring f zero add mul nsmul, .. hf.semigroup_with_zero f zero mul }
-
-/-- Pushforward a `non_assoc_semiring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.non_assoc_semiring
-  {α : Type u} [non_assoc_semiring α]
-  {β : Type v} [has_zero β] [has_one β] [has_add β] [has_mul β]
-  [has_smul ℕ β] [has_nat_cast β]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x)
-  (nat_cast : ∀ n : ℕ, f n = n) :
-  non_assoc_semiring β :=
-{ .. hf.add_monoid_with_one f zero one add nsmul nat_cast,
-  .. hf.non_unital_non_assoc_semiring f zero add mul nsmul, .. hf.mul_one_class f one mul }
-
-/-- Pushforward a `semiring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.semiring
-  {α : Type u} [semiring α]
-  {β : Type v} [has_zero β] [has_one β] [has_add β] [has_mul β] [has_pow β ℕ]
-  [has_smul ℕ β] [has_nat_cast β]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
-  (nat_cast : ∀ n : ℕ, f n = n) :
-  semiring β :=
-{ .. hf.non_assoc_semiring f zero one add mul nsmul nat_cast,
-  .. hf.monoid_with_zero f zero one mul npow, .. hf.add_comm_monoid f zero add nsmul,
-  .. hf.distrib f add mul }
-
-end injective_surjective_maps
 
 namespace add_hom
 
@@ -216,84 +72,10 @@ lemma mul_right_apply {R : Type*} [non_unital_non_assoc_semiring R] (a r : R) :
 
 end add_monoid_hom
 
-section non_unital_comm_semiring
-variables [non_unital_comm_semiring α] [non_unital_comm_semiring β] {a b c : α}
-
-/-- Pullback a `non_unital_semiring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.non_unital_comm_semiring [has_zero γ] [has_add γ] [has_mul γ]
-  [has_smul ℕ γ] (f : γ → α) (hf : injective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
-  non_unital_comm_semiring γ :=
-{ .. hf.non_unital_semiring f zero add mul nsmul, .. hf.comm_semigroup f mul }
-
-/-- Pushforward a `non_unital_semiring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.non_unital_comm_semiring [has_zero γ] [has_add γ] [has_mul γ]
-  [has_smul ℕ γ] (f : α → γ) (hf : surjective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
-  non_unital_comm_semiring γ :=
-{ .. hf.non_unital_semiring f zero add mul nsmul, .. hf.comm_semigroup f mul }
-
-end non_unital_comm_semiring
-
-section comm_semiring
-variables [comm_semiring α] [comm_semiring β] {a b c : α}
-
-/-- Pullback a `semiring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.comm_semiring
-  [has_zero γ] [has_one γ] [has_add γ] [has_mul γ] [has_smul ℕ γ] [has_nat_cast γ]
-  [has_pow γ ℕ] (f : γ → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
-  (nat_cast : ∀ n : ℕ, f n = n) :
-  comm_semiring γ :=
-{ .. hf.semiring f zero one add mul nsmul npow nat_cast, .. hf.comm_semigroup f mul }
-
-/-- Pushforward a `semiring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.comm_semiring
-  [has_zero γ] [has_one γ] [has_add γ] [has_mul γ] [has_smul ℕ γ] [has_nat_cast γ]
-  [has_pow γ ℕ] (f : α → γ) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
-  (nat_cast : ∀ n : ℕ, f n = n) :
-  comm_semiring γ :=
-{ .. hf.semiring f zero one add mul nsmul npow nat_cast, .. hf.comm_semigroup f mul }
-
-end comm_semiring
-
 section has_distrib_neg
 
 section has_mul
 variables [has_mul α] [has_distrib_neg α]
-
-/-- A type endowed with `-` and `*` has distributive negation, if it admits an injective map that
-preserves `-` and `*` to a type which has distributive negation. -/
-@[reducible] -- See note [reducible non-instances]
-protected def function.injective.has_distrib_neg [has_neg β] [has_mul β] (f : β → α)
-  (hf : injective f) (neg : ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
-  has_distrib_neg β :=
-{ neg_mul := λ x y, hf $ by erw [neg, mul, neg, neg_mul, mul],
-  mul_neg := λ x y, hf $ by erw [neg, mul, neg, mul_neg, mul],
-  ..hf.has_involutive_neg _ neg, ..‹has_mul β› }
-
-/-- A type endowed with `-` and `*` has distributive negation, if it admits a surjective map that
-preserves `-` and `*` from a type which has distributive negation. -/
-@[reducible] -- See note [reducible non-instances]
-protected def function.surjective.has_distrib_neg [has_neg β] [has_mul β] (f : α → β)
-  (hf : surjective f) (neg : ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
-  has_distrib_neg β :=
-{ neg_mul := hf.forall₂.2 $ λ x y, by { erw [←neg, ← mul, neg_mul, neg, mul], refl },
-  mul_neg := hf.forall₂.2 $ λ x y, by { erw [←neg, ← mul, mul_neg, neg, mul], refl },
-  ..hf.has_involutive_neg _ neg, ..‹has_mul β› }
 
 namespace add_opposite
 
@@ -319,149 +101,6 @@ by rw [eq_comm, eq_inv_iff_mul_eq_one, neg_mul, mul_neg,neg_neg, mul_left_inv]
 end group
 
 end has_distrib_neg
-
-/-!
-### Rings
--/
-
-section non_unital_non_assoc_ring
-variables [non_unital_non_assoc_ring α]
-
-/-- Pullback a `non_unital_non_assoc_ring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.non_unital_non_assoc_ring
-  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β] [has_smul ℕ β] [has_smul ℤ β]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
-  non_unital_non_assoc_ring β :=
-{ .. hf.add_comm_group f zero add neg sub nsmul zsmul, ..hf.mul_zero_class f zero mul,
-  .. hf.distrib f add mul }
-
-/-- Pushforward a `non_unital_non_assoc_ring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.non_unital_non_assoc_ring
-  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β] [has_smul ℕ β] [has_smul ℤ β]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
-  non_unital_non_assoc_ring β :=
-{ .. hf.add_comm_group f zero add neg sub nsmul zsmul, .. hf.mul_zero_class f zero mul,
-  .. hf.distrib f add mul }
-
-end non_unital_non_assoc_ring
-
-section non_unital_ring
-variables [non_unital_ring α]
-
-/-- Pullback a `non_unital_ring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.non_unital_ring
-  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β] [has_smul ℕ β] [has_smul ℤ β]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (gsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
-  non_unital_ring β :=
-{ .. hf.add_comm_group f zero add neg sub nsmul gsmul, ..hf.mul_zero_class f zero mul,
-  .. hf.distrib f add mul, .. hf.semigroup f mul }
-
-/-- Pushforward a `non_unital_ring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.non_unital_ring
-  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β] [has_smul ℕ β] [has_smul ℤ β]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (gsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
-  non_unital_ring β :=
-{ .. hf.add_comm_group f zero add neg sub nsmul gsmul, .. hf.mul_zero_class f zero mul,
-  .. hf.distrib f add mul, .. hf.semigroup f mul }
-
-end non_unital_ring
-
-section non_assoc_ring
-variables [non_assoc_ring α]
-
-/-- Pullback a `non_assoc_ring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.non_assoc_ring
-  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
-  [has_smul ℕ β] [has_smul ℤ β] [has_nat_cast β] [has_int_cast β]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (gsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
-  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
-  non_assoc_ring β :=
-{ .. hf.add_comm_group f zero add neg sub nsmul gsmul,
-  .. hf.add_group_with_one f zero one add neg sub nsmul gsmul nat_cast int_cast,
-  .. hf.mul_zero_class f zero mul, .. hf.distrib f add mul,
-  .. hf.mul_one_class f one mul }
-
-/-- Pushforward a `non_unital_ring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.non_assoc_ring
-  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
-  [has_smul ℕ β] [has_smul ℤ β] [has_nat_cast β] [has_int_cast β]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (gsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
-  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
-  non_assoc_ring β :=
-{ .. hf.add_comm_group f zero add neg sub nsmul gsmul, .. hf.mul_zero_class f zero mul,
-  .. hf.add_group_with_one f zero one add neg sub nsmul gsmul nat_cast int_cast,
-  .. hf.distrib f add mul, .. hf.mul_one_class f one mul }
-
-end non_assoc_ring
-
-section ring
-variables [ring α] {a b c d e : α}
-
-/-- Pullback a `ring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.ring
-  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
-  [has_smul ℕ β] [has_smul ℤ β] [has_pow β ℕ] [has_nat_cast β] [has_int_cast β]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
-  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
-  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
-  ring β :=
-{ .. hf.add_group_with_one f zero one add neg sub nsmul zsmul nat_cast int_cast,
-  .. hf.add_comm_group f zero add neg sub nsmul zsmul,
-  .. hf.monoid f one mul npow, .. hf.distrib f add mul }
-
-/-- Pushforward a `ring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.ring
-  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
-  [has_smul ℕ β] [has_smul ℤ β] [has_pow β ℕ] [has_nat_cast β] [has_int_cast β]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
-  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
-  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
-  ring β :=
-{ .. hf.add_group_with_one f zero one add neg sub nsmul zsmul nat_cast int_cast,
-  .. hf.add_comm_group f zero add neg sub nsmul zsmul,
-  .. hf.monoid f one mul npow, .. hf.distrib f add mul }
-
-end ring
 
 namespace units
 
@@ -529,32 +168,6 @@ lemma is_unit.sub_iff [ring α] {x y : α} :
 section non_unital_comm_ring
 variables [non_unital_comm_ring α] {a b c : α}
 
-/-- Pullback a `comm_ring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.non_unital_comm_ring
-  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
-  [has_smul ℕ β] [has_smul ℤ β]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
-  non_unital_comm_ring β :=
-{ .. hf.non_unital_ring f zero add mul neg sub nsmul zsmul, .. hf.comm_semigroup f mul }
-
-/-- Pushforward a `non_unital_comm_ring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.non_unital_comm_ring
-  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
-  [has_smul ℕ β] [has_smul ℤ β]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
-  non_unital_comm_ring β :=
-{ .. hf.non_unital_ring f zero add mul neg sub nsmul zsmul, .. hf.comm_semigroup f mul }
-
 local attribute [simp] add_assoc add_comm add_left_comm mul_comm
 
 /-- Vieta's formula for a quadratic equation, relating the coefficients of the polynomial with
@@ -570,43 +183,6 @@ begin
 end
 
 end non_unital_comm_ring
-
-section comm_ring
-variables [comm_ring α] {a b c : α}
-
-/-- Pullback a `comm_ring` instance along an injective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.injective.comm_ring
-  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
-  [has_smul ℕ β] [has_smul ℤ β] [has_pow β ℕ] [has_nat_cast β] [has_int_cast β]
-  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
-  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
-  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
-  comm_ring β :=
-{ .. hf.ring f zero one add mul neg sub nsmul zsmul npow nat_cast int_cast,
-  .. hf.comm_semigroup f mul }
-
-/-- Pushforward a `comm_ring` instance along a surjective function.
-See note [reducible non-instances]. -/
-@[reducible]
-protected def function.surjective.comm_ring
-  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
-  [has_smul ℕ β] [has_smul ℤ β] [has_pow β ℕ] [has_nat_cast β] [has_int_cast β]
-  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
-  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
-  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
-  comm_ring β :=
-{ .. hf.ring f zero one add mul neg sub nsmul zsmul npow nat_cast int_cast,
-  .. hf.comm_semigroup f mul }
-
-end comm_ring
 
 lemma succ_ne_self [non_assoc_ring α] [nontrivial α] (a : α) : a + 1 ≠ a :=
 λ h, one_ne_zero ((add_right_inj a).mp (by simp [h]))

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
 -/
+import algebra.ring.defs
 import algebra.regular.basic
 import algebra.hom.group
 import algebra.opposites
@@ -10,73 +11,22 @@ import algebra.opposites
 /-!
 # Semirings and rings
 
-This file defines semirings, rings and domains. This is analogous to `algebra.group.defs` and
-`algebra.group.basic`, the difference being that the former is about `+` and `*` separately, while
+This file gives lemmas about semirings, rings and domains.
+This is analogous to `algebra.group.basic`,
+the difference being that the former is about `+` and `*` separately, while
 the present file is about their interaction.
 
-## Main definitions
+For the definitions of semirings and rings see `algebra.ring.degs`.
 
-* `distrib`: Typeclass for distributivity of multiplication over addition.
-* `has_distrib_neg`: Typeclass for commutativity of negation and multiplication. This is useful when
-  dealing with multiplicative submonoids which are closed under negation without being closed under
-  addition, for example `units`.
-* `(non_unital_)(non_assoc_)(semi)ring`: Typeclasses for possibly non-unital or non-associative
-  rings and semirings. Some combinations are not defined yet because they haven't found use.
-
-## Tags
-
-`semiring`, `comm_semiring`, `ring`, `comm_ring`, `domain`, `is_domain`, `nonzero`, `units`
 -/
 universes u v w x
 variables {α : Type u} {β : Type v} {γ : Type w} {R : Type x}
 
-set_option old_structure_cmd true
 open function
 
 /-!
 ### `distrib` class
 -/
-
-/-- A typeclass stating that multiplication is left and right distributive
-over addition. -/
-@[protect_proj, ancestor has_mul has_add]
-class distrib (R : Type*) extends has_mul R, has_add R :=
-(left_distrib : ∀ a b c : R, a * (b + c) = a * b + a * c)
-(right_distrib : ∀ a b c : R, (a + b) * c = a * c + b * c)
-
-/-- A typeclass stating that multiplication is left distributive over addition. -/
-@[protect_proj]
-class left_distrib_class (R : Type*) [has_mul R] [has_add R] :=
-(left_distrib : ∀ a b c : R, a * (b + c) = a * b + a * c)
-
-/-- A typeclass stating that multiplication is right distributive over addition. -/
-@[protect_proj]
-class right_distrib_class (R : Type*) [has_mul R] [has_add R] :=
-(right_distrib : ∀ a b c : R, (a + b) * c = a * c + b * c)
-
-@[priority 100] -- see Note [lower instance priority]
-instance distrib.left_distrib_class (R : Type*) [distrib R] : left_distrib_class R :=
-⟨distrib.left_distrib⟩
-
-@[priority 100] -- see Note [lower instance priority]
-instance distrib.right_distrib_class (R : Type*) [distrib R] : right_distrib_class R :=
-⟨distrib.right_distrib⟩
-
-lemma left_distrib [has_mul R] [has_add R] [left_distrib_class R] (a b c : R) :
-  a * (b + c) = a * b + a * c :=
-left_distrib_class.left_distrib a b c
-
-alias left_distrib ← mul_add
-
-lemma right_distrib [has_mul R] [has_add R] [right_distrib_class R] (a b c : R) :
-  (a + b) * c = a * c + b * c :=
-right_distrib_class.right_distrib a b c
-
-alias right_distrib ← add_mul
-
-lemma distrib_three_right [has_mul R] [has_add R] [right_distrib_class R] (a b c d : R) :
-  (a + b + c) * d = a * d + b * d + c * d :=
-by simp [right_distrib]
 
 /-- Pullback a `distrib` instance along an injective function.
 See note [reducible non-instances]. -/
@@ -105,28 +55,6 @@ protected def function.surjective.distrib {S} [distrib R] [has_add S] [has_mul S
 /-!
 ### Semirings
 -/
-
-/-- A not-necessarily-unital, not-necessarily-associative semiring. -/
-@[protect_proj, ancestor add_comm_monoid distrib mul_zero_class]
-class non_unital_non_assoc_semiring (α : Type u) extends
-  add_comm_monoid α, distrib α, mul_zero_class α
-
-/-- An associative but not-necessarily unital semiring. -/
-@[protect_proj, ancestor non_unital_non_assoc_semiring semigroup_with_zero]
-class non_unital_semiring (α : Type u) extends
-  non_unital_non_assoc_semiring α, semigroup_with_zero α
-
-/-- A unital but not-necessarily-associative semiring. -/
-@[protect_proj, ancestor non_unital_non_assoc_semiring mul_zero_one_class]
-class non_assoc_semiring (α : Type u) extends
-  non_unital_non_assoc_semiring α, mul_zero_one_class α, add_comm_monoid_with_one α
-
-/-- A semiring is a type with the following structures: additive commutative monoid
-(`add_comm_monoid`), multiplicative monoid (`monoid`), distributive laws (`distrib`), and
-multiplication by zero law (`mul_zero_class`). The actual definition extends `monoid_with_zero`
-instead of `monoid` and `mul_zero_class`. -/
-@[protect_proj, ancestor non_unital_semiring non_assoc_semiring monoid_with_zero]
-class semiring (α : Type u) extends non_unital_semiring α, non_assoc_semiring α, monoid_with_zero α
 
 section injective_surjective_maps
 
@@ -241,81 +169,6 @@ protected def function.surjective.semiring
 
 end injective_surjective_maps
 
-section has_one_has_add
-
-variables [has_one α] [has_add α]
-
-lemma one_add_one_eq_two : 1 + 1 = (2 : α) := rfl
-
-end has_one_has_add
-
-section distrib_mul_one_class
-variables [has_add α] [mul_one_class α]
-
-lemma add_one_mul [right_distrib_class α] (a b : α) : (a + 1) * b = a * b + b :=
-by rw [add_mul, one_mul]
-lemma mul_add_one [left_distrib_class α] (a b : α) : a * (b + 1) = a * b + a :=
-by rw [mul_add, mul_one]
-lemma one_add_mul [right_distrib_class α] (a b : α) : (1 + a) * b = b + a * b :=
-by rw [add_mul, one_mul]
-lemma mul_one_add [left_distrib_class α] (a b : α) : a * (1 + b) = a + a * b :=
-by rw [mul_add, mul_one]
-
-theorem two_mul [right_distrib_class α] (n : α) : 2 * n = n + n :=
-eq.trans (right_distrib 1 1 n) (by simp)
-
-theorem bit0_eq_two_mul [right_distrib_class α] (n : α) : bit0 n = 2 * n :=
-(two_mul _).symm
-
-theorem mul_two [left_distrib_class α] (n : α) : n * 2 = n + n :=
-(left_distrib n 1 1).trans (by simp)
-
-end distrib_mul_one_class
-
-section semiring
-variables [semiring α]
-
-@[to_additive] lemma mul_ite {α} [has_mul α] (P : Prop) [decidable P] (a b c : α) :
-  a * (if P then b else c) = if P then a * b else a * c :=
-by split_ifs; refl
-
-@[to_additive] lemma ite_mul {α} [has_mul α] (P : Prop) [decidable P] (a b c : α) :
-  (if P then a else b) * c = if P then a * c else b * c :=
-by split_ifs; refl
-
--- We make `mul_ite` and `ite_mul` simp lemmas,
--- but not `add_ite` or `ite_add`.
--- The problem we're trying to avoid is dealing with
--- summations of the form `∑ x in s, (f x + ite P 1 0)`,
--- in which `add_ite` followed by `sum_ite` would needlessly slice up
--- the `f x` terms according to whether `P` holds at `x`.
--- There doesn't appear to be a corresponding difficulty so far with
--- `mul_ite` and `ite_mul`.
-attribute [simp] mul_ite ite_mul
-
-@[simp] lemma mul_boole {α} [mul_zero_one_class α] (P : Prop) [decidable P] (a : α) :
-  a * (if P then 1 else 0) = if P then a else 0 :=
-by simp
-
-@[simp] lemma boole_mul {α} [mul_zero_one_class α] (P : Prop) [decidable P] (a : α) :
-  (if P then 1 else 0) * a = if P then a else 0 :=
-by simp
-
-lemma ite_mul_zero_left {α : Type*} [mul_zero_class α] (P : Prop) [decidable P] (a b : α) :
-  ite P (a * b) 0 = ite P a 0 * b :=
-by { by_cases h : P; simp [h], }
-
-lemma ite_mul_zero_right {α : Type*} [mul_zero_class α] (P : Prop) [decidable P] (a b : α) :
-  ite P (a * b) 0 = a * ite P b 0 :=
-by { by_cases h : P; simp [h], }
-
-lemma ite_and_mul_zero {α : Type*} [mul_zero_class α]
-  (P Q : Prop) [decidable P] [decidable Q] (a b : α) :
-  ite (P ∧ Q) (a * b) 0 = ite P a 0 * ite Q b 0 :=
-by simp only [←ite_and, ite_mul, mul_ite, mul_zero, zero_mul, and_comm]
-
-end semiring
-
 namespace add_hom
 
 /-- Left multiplication by an element of a type with distributive multiplication is an `add_hom`. -/
@@ -363,13 +216,6 @@ lemma mul_right_apply {R : Type*} [non_unital_non_assoc_semiring R] (a r : R) :
 
 end add_monoid_hom
 
-/-- A non-unital commutative semiring is a `non_unital_semiring` with commutative multiplication.
-In other words, it is a type with the following structures: additive commutative monoid
-(`add_comm_monoid`), commutative semigroup (`comm_semigroup`), distributive laws (`distrib`), and
-multiplication by zero law (`mul_zero_class`). -/
-@[protect_proj, ancestor non_unital_semiring comm_semigroup]
-class non_unital_comm_semiring (α : Type u) extends non_unital_semiring α, comm_semigroup α
-
 section non_unital_comm_semiring
 variables [non_unital_comm_semiring α] [non_unital_comm_semiring β] {a b c : α}
 
@@ -394,21 +240,6 @@ protected def function.surjective.non_unital_comm_semiring [has_zero γ] [has_ad
 { .. hf.non_unital_semiring f zero add mul nsmul, .. hf.comm_semigroup f mul }
 
 end non_unital_comm_semiring
-
-/-- A commutative semiring is a `semiring` with commutative multiplication. In other words, it is a
-type with the following structures: additive commutative monoid (`add_comm_monoid`), multiplicative
-commutative monoid (`comm_monoid`), distributive laws (`distrib`), and multiplication by zero law
-(`mul_zero_class`). -/
-@[protect_proj, ancestor semiring comm_monoid]
-class comm_semiring (α : Type u) extends semiring α, comm_monoid α
-
-@[priority 100] -- see Note [lower instance priority]
-instance comm_semiring.to_non_unital_comm_semiring [comm_semiring α] : non_unital_comm_semiring α :=
-{ .. comm_semiring.to_comm_monoid α, .. comm_semiring.to_semiring α }
-
-@[priority 100] -- see Note [lower instance priority]
-instance comm_semiring.to_comm_monoid_with_zero [comm_semiring α] : comm_monoid_with_zero α :=
-{ .. comm_semiring.to_comm_monoid α, .. comm_semiring.to_semiring α }
 
 section comm_semiring
 variables [comm_semiring α] [comm_semiring β] {a b c : α}
@@ -437,41 +268,12 @@ protected def function.surjective.comm_semiring
   comm_semiring γ :=
 { .. hf.semiring f zero one add mul nsmul npow nat_cast, .. hf.comm_semigroup f mul }
 
-lemma add_mul_self_eq (a b : α) : (a + b) * (a + b) = a*a + 2*a*b + b*b :=
-by simp only [two_mul, add_mul, mul_add, add_assoc, mul_comm b]
-
 end comm_semiring
 
 section has_distrib_neg
 
-/-- Typeclass for a negation operator that distributes across multiplication.
-
-This is useful for dealing with submonoids of a ring that contain `-1` without having to duplicate
-lemmas. -/
-class has_distrib_neg (α : Type*) [has_mul α] extends has_involutive_neg α :=
-(neg_mul : ∀ x y : α, -x * y = -(x * y))
-(mul_neg : ∀ x y : α, x * -y = -(x * y))
-
 section has_mul
 variables [has_mul α] [has_distrib_neg α]
-
-@[simp] lemma neg_mul (a b : α) : - a * b = - (a * b) :=
-has_distrib_neg.neg_mul _ _
-
-@[simp] lemma mul_neg (a b : α) : a * - b = - (a * b) :=
-has_distrib_neg.mul_neg _ _
-
-lemma neg_mul_neg (a b : α) : -a * -b = a * b :=
-by simp
-
-lemma neg_mul_eq_neg_mul (a b : α) : -(a * b) = -a * b :=
-(neg_mul _ _).symm
-
-lemma neg_mul_eq_mul_neg (a b : α) : -(a * b) = a * -b :=
-(mul_neg _ _).symm
-
-lemma neg_mul_comm (a b : α) : -a * b = a * -b :=
-by simp
 
 /-- A type endowed with `-` and `*` has distributive negation, if it admits an injective map that
 preserves `-` and `*` to a type which has distributive negation. -/
@@ -508,33 +310,6 @@ instance : has_distrib_neg αᵐᵒᵖ :=
 
 end has_mul
 
-section mul_one_class
-variables [mul_one_class α] [has_distrib_neg α]
-
-theorem neg_eq_neg_one_mul (a : α) : -a = -1 * a :=
-by simp
-
-/-- An element of a ring multiplied by the additive inverse of one is the element's additive
-  inverse. -/
-lemma mul_neg_one (a : α) : a * -1 = -a := by simp
-
-/-- The additive inverse of one multiplied by an element of a ring is the element's additive
-  inverse. -/
-lemma neg_one_mul (a : α) : -1 * a = -a := by simp
-
-end mul_one_class
-
-section mul_zero_class
-variables [mul_zero_class α] [has_distrib_neg α]
-
-@[priority 100]
-instance mul_zero_class.neg_zero_class : neg_zero_class α :=
-{ neg_zero := by rw [←zero_mul (0 : α), ←neg_mul, mul_zero, mul_zero],
-  ..mul_zero_class.to_has_zero α,
-  ..has_distrib_neg.to_has_involutive_neg α }
-
-end mul_zero_class
-
 section group
 variables [group α] [has_distrib_neg α]
 
@@ -549,14 +324,8 @@ end has_distrib_neg
 ### Rings
 -/
 
-/-- A not-necessarily-unital, not-necessarily-associative ring. -/
-@[protect_proj, ancestor add_comm_group non_unital_non_assoc_semiring]
-class non_unital_non_assoc_ring (α : Type u) extends
-  add_comm_group α, non_unital_non_assoc_semiring α
-
 section non_unital_non_assoc_ring
 variables [non_unital_non_assoc_ring α]
-
 
 /-- Pullback a `non_unital_non_assoc_ring` instance along an injective function.
 See note [reducible non-instances]. -/
@@ -622,11 +391,6 @@ calc
 
 end non_unital_non_assoc_ring
 
-/-- An associative but not-necessarily unital ring. -/
-@[protect_proj, ancestor non_unital_non_assoc_ring non_unital_semiring]
-class non_unital_ring (α : Type*) extends
-  non_unital_non_assoc_ring α, non_unital_semiring α
-
 section non_unital_ring
 variables [non_unital_ring α]
 
@@ -657,11 +421,6 @@ protected def function.surjective.non_unital_ring
   .. hf.distrib f add mul, .. hf.semigroup f mul }
 
 end non_unital_ring
-
-/-- A unital but not-necessarily-associative ring. -/
-@[protect_proj, ancestor non_unital_non_assoc_ring non_assoc_semiring]
-class non_assoc_ring (α : Type*) extends
-  non_unital_non_assoc_ring α, non_assoc_semiring α, add_group_with_one α
 
 section non_assoc_ring
 variables [non_assoc_ring α]
@@ -710,42 +469,8 @@ by rw [mul_sub, mul_one]
 
 end non_assoc_ring
 
-/-- A ring is a type with the following structures: additive commutative group (`add_comm_group`),
-multiplicative monoid (`monoid`), and distributive laws (`distrib`).  Equivalently, a ring is a
-`semiring` with a negation operation making it an additive group.  -/
-@[protect_proj, ancestor add_comm_group monoid distrib]
-class ring (α : Type u) extends add_comm_group_with_one α, monoid α, distrib α
-
 section ring
 variables [ring α] {a b c d e : α}
-
-/- A (unital, associative) ring is a not-necessarily-unital ring -/
-@[priority 100] -- see Note [lower instance priority]
-instance ring.to_non_unital_ring :
-  non_unital_ring α :=
-{ zero_mul := λ a, add_left_cancel $ show 0 * a + 0 * a = 0 * a + 0,
-    by rw [← add_mul, zero_add, add_zero],
-  mul_zero := λ a, add_left_cancel $ show a * 0 + a * 0 = a * 0 + 0,
-    by rw [← mul_add, add_zero, add_zero],
-  ..‹ring α› }
-
-/- A (unital, associative) ring is a not-necessarily-associative ring -/
-@[priority 100] -- see Note [lower instance priority]
-instance ring.to_non_assoc_ring :
-  non_assoc_ring α :=
-{ zero_mul := λ a, add_left_cancel $ show 0 * a + 0 * a = 0 * a + 0,
-    by rw [← add_mul, zero_add, add_zero],
-  mul_zero := λ a, add_left_cancel $ show a * 0 + a * 0 = a * 0 + 0,
-    by rw [← mul_add, add_zero, add_zero],
-  ..‹ring α› }
-
-/- The instance from `ring` to `semiring` happens often in linear algebra, for which all the basic
-definitions are given in terms of semirings, but many applications use rings or fields. We increase
-a little bit its priority above 100 to try it quickly, but remaining below the default 1000 so that
-more specific instances are tried first. -/
-@[priority 200]
-instance ring.to_semiring : semiring α :=
-{ ..‹ring α›, .. ring.to_non_unital_ring }
 
 /-- Pullback a `ring` instance along an injective function.
 See note [reducible non-instances]. -/
@@ -846,31 +571,6 @@ lemma is_unit.sub_iff [ring α] {x y : α} :
   is_unit (x - y) ↔ is_unit (y - x) :=
 (is_unit.neg_iff _).symm.trans $ neg_sub x y ▸ iff.rfl
 
-namespace ring_hom
-
-end ring_hom
-
-/-- A non-unital commutative ring is a `non_unital_ring` with commutative multiplication. -/
-@[protect_proj, ancestor non_unital_ring comm_semigroup]
-class non_unital_comm_ring (α : Type u) extends non_unital_ring α, comm_semigroup α
-
-@[priority 100] -- see Note [lower instance priority]
-instance non_unital_comm_ring.to_non_unital_comm_semiring [s : non_unital_comm_ring α] :
-  non_unital_comm_semiring α :=
-{ ..s }
-
-/-- A commutative ring is a `ring` with commutative multiplication. -/
-@[protect_proj, ancestor ring comm_semigroup]
-class comm_ring (α : Type u) extends ring α, comm_monoid α
-
-@[priority 100] -- see Note [lower instance priority]
-instance comm_ring.to_comm_semiring [s : comm_ring α] : comm_semiring α :=
-{ mul_zero := mul_zero, zero_mul := zero_mul, ..s }
-
-@[priority 100] -- see Note [lower instance priority]
-instance comm_ring.to_non_unital_comm_ring [s : comm_ring α] : non_unital_comm_ring α :=
-{ mul_zero := mul_zero, zero_mul := zero_mul, ..s }
-
 section non_unital_comm_ring
 variables [non_unital_comm_ring α] {a b c : α}
 
@@ -958,14 +658,6 @@ lemma succ_ne_self [non_assoc_ring α] [nontrivial α] (a : α) : a + 1 ≠ a :=
 
 lemma pred_ne_self [non_assoc_ring α] [nontrivial α] (a : α) : a - 1 ≠ a :=
 λ h, one_ne_zero (neg_injective ((add_right_inj a).mp (by simpa [sub_eq_add_neg] using h)))
-
-/-- A domain is a nontrivial ring with no zero divisors, i.e. satisfying
-  the condition `a * b = 0 ↔ a = 0 ∨ b = 0`.
-
-  This is implemented as a mixin for `ring α`.
-  To obtain an integral domain use `[comm_ring α] [is_domain α]`. -/
-@[protect_proj] class is_domain (α : Type u) [ring α]
-  extends no_zero_divisors α, nontrivial α : Prop
 
 namespace semiconj_by
 

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -353,42 +353,6 @@ protected def function.surjective.non_unital_non_assoc_ring
 { .. hf.add_comm_group f zero add neg sub nsmul zsmul, .. hf.mul_zero_class f zero mul,
   .. hf.distrib f add mul }
 
-@[priority 100]
-instance non_unital_non_assoc_ring.to_has_distrib_neg : has_distrib_neg α :=
-{ neg := has_neg.neg,
-  neg_neg := neg_neg,
-  neg_mul := λ a b, eq_neg_of_add_eq_zero_left $ by rw [←right_distrib, add_left_neg, zero_mul],
-  mul_neg := λ a b, eq_neg_of_add_eq_zero_left $ by rw [←left_distrib, add_left_neg, mul_zero] }
-
-lemma mul_sub_left_distrib (a b c : α) : a * (b - c) = a * b - a * c :=
-by simpa only [sub_eq_add_neg, neg_mul_eq_mul_neg] using mul_add a b (-c)
-
-alias mul_sub_left_distrib ← mul_sub
-
-lemma mul_sub_right_distrib (a b c : α) : (a - b) * c = a * c - b * c :=
-by simpa only [sub_eq_add_neg, neg_mul_eq_neg_mul] using add_mul a (-b) c
-
-alias mul_sub_right_distrib ← sub_mul
-
-variables {a b c d e : α}
-
-/-- An iff statement following from right distributivity in rings and the definition
-  of subtraction. -/
-theorem mul_add_eq_mul_add_iff_sub_mul_add_eq : a * e + c = b * e + d ↔ (a - b) * e + c = d :=
-calc
-  a * e + c = b * e + d ↔ a * e + c = d + b * e : by simp [add_comm]
-    ... ↔ a * e + c - b * e = d : iff.intro (λ h, begin rw h, simp end) (λ h,
-                                                  begin rw ← h, simp end)
-    ... ↔ (a - b) * e + c = d   : begin simp [sub_mul, sub_add_eq_add_sub] end
-
-/-- A simplification of one side of an equation exploiting right distributivity in rings
-  and the definition of subtraction. -/
-theorem sub_mul_add_eq_of_mul_add_eq_mul_add : a * e + c = b * e + d → (a - b) * e + c = d :=
-assume h,
-calc
-  (a - b) * e + c = (a * e + c) - b * e : begin simp [sub_mul, sub_add_eq_add_sub] end
-              ... = d                   : begin rw h, simp [@add_sub_cancel α] end
-
 end non_unital_non_assoc_ring
 
 section non_unital_ring
@@ -457,15 +421,6 @@ protected def function.surjective.non_assoc_ring
 { .. hf.add_comm_group f zero add neg sub nsmul gsmul, .. hf.mul_zero_class f zero mul,
   .. hf.add_group_with_one f zero one add neg sub nsmul gsmul nat_cast int_cast,
   .. hf.distrib f add mul, .. hf.mul_one_class f one mul }
-
-lemma sub_one_mul (a b : α) : (a - 1) * b = a * b - b :=
-by rw [sub_mul, one_mul]
-lemma mul_sub_one (a b : α) : a * (b - 1) = a * b - a :=
-by rw [mul_sub, mul_one]
-lemma one_sub_mul (a b : α) : (1 - a) * b = b - a * b :=
-by rw [sub_mul, one_mul]
-lemma mul_one_sub (a b : α) : a * (1 - b) = a - a * b :=
-by rw [mul_sub, mul_one]
 
 end non_assoc_ring
 

--- a/src/algebra/ring/comp_typeclasses.lean
+++ b/src/algebra/ring/comp_typeclasses.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis, Heather Macbeth
 -/
 
-import algebra.ring.basic
 import algebra.ring.equiv
 
 /-!

--- a/src/algebra/ring/defs.lean
+++ b/src/algebra/ring/defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
 -/
+import algebra.group.basic
 import algebra.group_with_zero.defs
 import data.int.cast.defs
 
@@ -297,6 +298,62 @@ multiplicative monoid (`monoid`), and distributive laws (`distrib`).  Equivalent
 `semiring` with a negation operation making it an additive group.  -/
 @[protect_proj, ancestor add_comm_group monoid distrib]
 class ring (α : Type u) extends add_comm_group_with_one α, monoid α, distrib α
+
+section non_unital_non_assoc_ring
+variables [non_unital_non_assoc_ring α]
+
+@[priority 100]
+instance non_unital_non_assoc_ring.to_has_distrib_neg : has_distrib_neg α :=
+{ neg := has_neg.neg,
+  neg_neg := neg_neg,
+  neg_mul := λ a b, eq_neg_of_add_eq_zero_left $ by rw [←right_distrib, add_left_neg, zero_mul],
+  mul_neg := λ a b, eq_neg_of_add_eq_zero_left $ by rw [←left_distrib, add_left_neg, mul_zero] }
+
+lemma mul_sub_left_distrib (a b c : α) : a * (b - c) = a * b - a * c :=
+by simpa only [sub_eq_add_neg, neg_mul_eq_mul_neg] using mul_add a b (-c)
+
+alias mul_sub_left_distrib ← mul_sub
+
+lemma mul_sub_right_distrib (a b c : α) : (a - b) * c = a * c - b * c :=
+by simpa only [sub_eq_add_neg, neg_mul_eq_neg_mul] using add_mul a (-b) c
+
+alias mul_sub_right_distrib ← sub_mul
+
+variables {a b c d e : α}
+
+/-- An iff statement following from right distributivity in rings and the definition
+  of subtraction. -/
+theorem mul_add_eq_mul_add_iff_sub_mul_add_eq : a * e + c = b * e + d ↔ (a - b) * e + c = d :=
+calc
+  a * e + c = b * e + d ↔ a * e + c = d + b * e : by simp [add_comm]
+    ... ↔ a * e + c - b * e = d : iff.intro (λ h, begin rw h, simp end) (λ h,
+                                                  begin rw ← h, simp end)
+    ... ↔ (a - b) * e + c = d   : begin simp [sub_mul, sub_add_eq_add_sub] end
+
+/-- A simplification of one side of an equation exploiting right distributivity in rings
+  and the definition of subtraction. -/
+theorem sub_mul_add_eq_of_mul_add_eq_mul_add : a * e + c = b * e + d → (a - b) * e + c = d :=
+assume h,
+calc
+  (a - b) * e + c = (a * e + c) - b * e : begin simp [sub_mul, sub_add_eq_add_sub] end
+              ... = d                   : begin rw h, simp [@add_sub_cancel α] end
+
+end non_unital_non_assoc_ring
+
+
+section non_assoc_ring
+variables [non_assoc_ring α]
+
+lemma sub_one_mul (a b : α) : (a - 1) * b = a * b - b :=
+by rw [sub_mul, one_mul]
+lemma mul_sub_one (a b : α) : a * (b - 1) = a * b - a :=
+by rw [mul_sub, mul_one]
+lemma one_sub_mul (a b : α) : (1 - a) * b = b - a * b :=
+by rw [sub_mul, one_mul]
+lemma mul_one_sub (a b : α) : a * (1 - b) = a - a * b :=
+by rw [mul_sub, mul_one]
+
+end non_assoc_ring
 
 section ring
 variables [ring α] {a b c d e : α}

--- a/src/algebra/ring/defs.lean
+++ b/src/algebra/ring/defs.lean
@@ -1,0 +1,361 @@
+/-
+Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
+-/
+import algebra.group_with_zero.defs
+import data.int.cast.defs
+
+/-!
+# Semirings and rings
+
+This file defines semirings, rings and domains. This is analogous to `algebra.group.defs` and
+`algebra.group.basic`, the difference being that the former is about `+` and `*` separately, while
+the present file is about their interaction.
+
+## Main definitions
+
+* `distrib`: Typeclass for distributivity of multiplication over addition.
+* `has_distrib_neg`: Typeclass for commutativity of negation and multiplication. This is useful when
+  dealing with multiplicative submonoids which are closed under negation without being closed under
+  addition, for example `units`.
+* `(non_unital_)(non_assoc_)(semi)ring`: Typeclasses for possibly non-unital or non-associative
+  rings and semirings. Some combinations are not defined yet because they haven't found use.
+
+## Tags
+
+`semiring`, `comm_semiring`, `ring`, `comm_ring`, `domain`, `is_domain`, `nonzero`, `units`
+-/
+universes u v w x
+variables {α : Type u} {β : Type v} {γ : Type w} {R : Type x}
+
+set_option old_structure_cmd true
+open function
+
+/-!
+### `distrib` class
+-/
+
+/-- A typeclass stating that multiplication is left and right distributive
+over addition. -/
+@[protect_proj, ancestor has_mul has_add]
+class distrib (R : Type*) extends has_mul R, has_add R :=
+(left_distrib : ∀ a b c : R, a * (b + c) = a * b + a * c)
+(right_distrib : ∀ a b c : R, (a + b) * c = a * c + b * c)
+
+/-- A typeclass stating that multiplication is left distributive over addition. -/
+@[protect_proj]
+class left_distrib_class (R : Type*) [has_mul R] [has_add R] :=
+(left_distrib : ∀ a b c : R, a * (b + c) = a * b + a * c)
+
+/-- A typeclass stating that multiplication is right distributive over addition. -/
+@[protect_proj]
+class right_distrib_class (R : Type*) [has_mul R] [has_add R] :=
+(right_distrib : ∀ a b c : R, (a + b) * c = a * c + b * c)
+
+@[priority 100] -- see Note [lower instance priority]
+instance distrib.left_distrib_class (R : Type*) [distrib R] : left_distrib_class R :=
+⟨distrib.left_distrib⟩
+
+@[priority 100] -- see Note [lower instance priority]
+instance distrib.right_distrib_class (R : Type*) [distrib R] : right_distrib_class R :=
+⟨distrib.right_distrib⟩
+
+lemma left_distrib [has_mul R] [has_add R] [left_distrib_class R] (a b c : R) :
+  a * (b + c) = a * b + a * c :=
+left_distrib_class.left_distrib a b c
+
+alias left_distrib ← mul_add
+
+lemma right_distrib [has_mul R] [has_add R] [right_distrib_class R] (a b c : R) :
+  (a + b) * c = a * c + b * c :=
+right_distrib_class.right_distrib a b c
+
+alias right_distrib ← add_mul
+
+lemma distrib_three_right [has_mul R] [has_add R] [right_distrib_class R] (a b c d : R) :
+  (a + b + c) * d = a * d + b * d + c * d :=
+by simp [right_distrib]
+
+/-!
+### Semirings
+-/
+
+/-- A not-necessarily-unital, not-necessarily-associative semiring. -/
+@[protect_proj, ancestor add_comm_monoid distrib mul_zero_class]
+class non_unital_non_assoc_semiring (α : Type u) extends
+  add_comm_monoid α, distrib α, mul_zero_class α
+
+/-- An associative but not-necessarily unital semiring. -/
+@[protect_proj, ancestor non_unital_non_assoc_semiring semigroup_with_zero]
+class non_unital_semiring (α : Type u) extends
+  non_unital_non_assoc_semiring α, semigroup_with_zero α
+
+/-- A unital but not-necessarily-associative semiring. -/
+@[protect_proj, ancestor non_unital_non_assoc_semiring mul_zero_one_class]
+class non_assoc_semiring (α : Type u) extends
+  non_unital_non_assoc_semiring α, mul_zero_one_class α, add_comm_monoid_with_one α
+
+/-- A semiring is a type with the following structures: additive commutative monoid
+(`add_comm_monoid`), multiplicative monoid (`monoid`), distributive laws (`distrib`), and
+multiplication by zero law (`mul_zero_class`). The actual definition extends `monoid_with_zero`
+instead of `monoid` and `mul_zero_class`. -/
+@[protect_proj, ancestor non_unital_semiring non_assoc_semiring monoid_with_zero]
+class semiring (α : Type u) extends non_unital_semiring α, non_assoc_semiring α, monoid_with_zero α
+
+section has_one_has_add
+
+variables [has_one α] [has_add α]
+
+lemma one_add_one_eq_two : 1 + 1 = (2 : α) := rfl
+
+end has_one_has_add
+
+section distrib_mul_one_class
+variables [has_add α] [mul_one_class α]
+
+lemma add_one_mul [right_distrib_class α] (a b : α) : (a + 1) * b = a * b + b :=
+by rw [add_mul, one_mul]
+lemma mul_add_one [left_distrib_class α] (a b : α) : a * (b + 1) = a * b + a :=
+by rw [mul_add, mul_one]
+lemma one_add_mul [right_distrib_class α] (a b : α) : (1 + a) * b = b + a * b :=
+by rw [add_mul, one_mul]
+lemma mul_one_add [left_distrib_class α] (a b : α) : a * (1 + b) = a + a * b :=
+by rw [mul_add, mul_one]
+
+theorem two_mul [right_distrib_class α] (n : α) : 2 * n = n + n :=
+eq.trans (right_distrib 1 1 n) (by simp)
+
+theorem bit0_eq_two_mul [right_distrib_class α] (n : α) : bit0 n = 2 * n :=
+(two_mul _).symm
+
+theorem mul_two [left_distrib_class α] (n : α) : n * 2 = n + n :=
+(left_distrib n 1 1).trans (by simp)
+
+end distrib_mul_one_class
+
+section semiring
+variables [semiring α]
+
+@[to_additive] lemma mul_ite {α} [has_mul α] (P : Prop) [decidable P] (a b c : α) :
+  a * (if P then b else c) = if P then a * b else a * c :=
+by split_ifs; refl
+
+@[to_additive] lemma ite_mul {α} [has_mul α] (P : Prop) [decidable P] (a b c : α) :
+  (if P then a else b) * c = if P then a * c else b * c :=
+by split_ifs; refl
+
+-- We make `mul_ite` and `ite_mul` simp lemmas,
+-- but not `add_ite` or `ite_add`.
+-- The problem we're trying to avoid is dealing with
+-- summations of the form `∑ x in s, (f x + ite P 1 0)`,
+-- in which `add_ite` followed by `sum_ite` would needlessly slice up
+-- the `f x` terms according to whether `P` holds at `x`.
+-- There doesn't appear to be a corresponding difficulty so far with
+-- `mul_ite` and `ite_mul`.
+attribute [simp] mul_ite ite_mul
+
+@[simp] lemma mul_boole {α} [mul_zero_one_class α] (P : Prop) [decidable P] (a : α) :
+  a * (if P then 1 else 0) = if P then a else 0 :=
+by simp
+
+@[simp] lemma boole_mul {α} [mul_zero_one_class α] (P : Prop) [decidable P] (a : α) :
+  (if P then 1 else 0) * a = if P then a else 0 :=
+by simp
+
+lemma ite_mul_zero_left {α : Type*} [mul_zero_class α] (P : Prop) [decidable P] (a b : α) :
+  ite P (a * b) 0 = ite P a 0 * b :=
+by { by_cases h : P; simp [h], }
+
+lemma ite_mul_zero_right {α : Type*} [mul_zero_class α] (P : Prop) [decidable P] (a b : α) :
+  ite P (a * b) 0 = a * ite P b 0 :=
+by { by_cases h : P; simp [h], }
+
+lemma ite_and_mul_zero {α : Type*} [mul_zero_class α]
+  (P Q : Prop) [decidable P] [decidable Q] (a b : α) :
+  ite (P ∧ Q) (a * b) 0 = ite P a 0 * ite Q b 0 :=
+by simp only [←ite_and, ite_mul, mul_ite, mul_zero, zero_mul, and_comm]
+
+end semiring
+
+/-- A non-unital commutative semiring is a `non_unital_semiring` with commutative multiplication.
+In other words, it is a type with the following structures: additive commutative monoid
+(`add_comm_monoid`), commutative semigroup (`comm_semigroup`), distributive laws (`distrib`), and
+multiplication by zero law (`mul_zero_class`). -/
+@[protect_proj, ancestor non_unital_semiring comm_semigroup]
+class non_unital_comm_semiring (α : Type u) extends non_unital_semiring α, comm_semigroup α
+
+/-- A commutative semiring is a `semiring` with commutative multiplication. In other words, it is a
+type with the following structures: additive commutative monoid (`add_comm_monoid`), multiplicative
+commutative monoid (`comm_monoid`), distributive laws (`distrib`), and multiplication by zero law
+(`mul_zero_class`). -/
+@[protect_proj, ancestor semiring comm_monoid]
+class comm_semiring (α : Type u) extends semiring α, comm_monoid α
+
+@[priority 100] -- see Note [lower instance priority]
+instance comm_semiring.to_non_unital_comm_semiring [comm_semiring α] : non_unital_comm_semiring α :=
+{ .. comm_semiring.to_comm_monoid α, .. comm_semiring.to_semiring α }
+
+@[priority 100] -- see Note [lower instance priority]
+instance comm_semiring.to_comm_monoid_with_zero [comm_semiring α] : comm_monoid_with_zero α :=
+{ .. comm_semiring.to_comm_monoid α, .. comm_semiring.to_semiring α }
+
+section comm_semiring
+variables [comm_semiring α] {a b c : α}
+
+lemma add_mul_self_eq (a b : α) : (a + b) * (a + b) = a*a + 2*a*b + b*b :=
+by simp only [two_mul, add_mul, mul_add, add_assoc, mul_comm b]
+
+end comm_semiring
+
+section has_distrib_neg
+
+/-- Typeclass for a negation operator that distributes across multiplication.
+
+This is useful for dealing with submonoids of a ring that contain `-1` without having to duplicate
+lemmas. -/
+class has_distrib_neg (α : Type*) [has_mul α] extends has_involutive_neg α :=
+(neg_mul : ∀ x y : α, -x * y = -(x * y))
+(mul_neg : ∀ x y : α, x * -y = -(x * y))
+
+section has_mul
+variables [has_mul α] [has_distrib_neg α]
+
+@[simp] lemma neg_mul (a b : α) : - a * b = - (a * b) :=
+has_distrib_neg.neg_mul _ _
+
+@[simp] lemma mul_neg (a b : α) : a * - b = - (a * b) :=
+has_distrib_neg.mul_neg _ _
+
+lemma neg_mul_neg (a b : α) : -a * -b = a * b :=
+by simp
+
+lemma neg_mul_eq_neg_mul (a b : α) : -(a * b) = -a * b :=
+(neg_mul _ _).symm
+
+lemma neg_mul_eq_mul_neg (a b : α) : -(a * b) = a * -b :=
+(mul_neg _ _).symm
+
+lemma neg_mul_comm (a b : α) : -a * b = a * -b :=
+by simp
+
+end has_mul
+
+section mul_one_class
+variables [mul_one_class α] [has_distrib_neg α]
+
+theorem neg_eq_neg_one_mul (a : α) : -a = -1 * a :=
+by simp
+
+/-- An element of a ring multiplied by the additive inverse of one is the element's additive
+  inverse. -/
+lemma mul_neg_one (a : α) : a * -1 = -a := by simp
+
+/-- The additive inverse of one multiplied by an element of a ring is the element's additive
+  inverse. -/
+lemma neg_one_mul (a : α) : -1 * a = -a := by simp
+
+end mul_one_class
+
+section mul_zero_class
+variables [mul_zero_class α] [has_distrib_neg α]
+
+@[priority 100]
+instance mul_zero_class.neg_zero_class : neg_zero_class α :=
+{ neg_zero := by rw [←zero_mul (0 : α), ←neg_mul, mul_zero, mul_zero],
+  ..mul_zero_class.to_has_zero α,
+  ..has_distrib_neg.to_has_involutive_neg α }
+
+end mul_zero_class
+
+end has_distrib_neg
+
+/-!
+### Rings
+-/
+
+/-- A not-necessarily-unital, not-necessarily-associative ring. -/
+@[protect_proj, ancestor add_comm_group non_unital_non_assoc_semiring]
+class non_unital_non_assoc_ring (α : Type u) extends
+  add_comm_group α, non_unital_non_assoc_semiring α
+
+-- We defer the instance `non_unital_non_assoc_ring.to_has_distrib_neg` to `algebra.ring.basic`
+-- as it relies on the lemma `eq_neg_of_add_eq_zero_left`.
+
+/-- An associative but not-necessarily unital ring. -/
+@[protect_proj, ancestor non_unital_non_assoc_ring non_unital_semiring]
+class non_unital_ring (α : Type*) extends
+  non_unital_non_assoc_ring α, non_unital_semiring α
+
+/-- A unital but not-necessarily-associative ring. -/
+@[protect_proj, ancestor non_unital_non_assoc_ring non_assoc_semiring]
+class non_assoc_ring (α : Type*) extends
+  non_unital_non_assoc_ring α, non_assoc_semiring α, add_group_with_one α
+
+/-- A ring is a type with the following structures: additive commutative group (`add_comm_group`),
+multiplicative monoid (`monoid`), and distributive laws (`distrib`).  Equivalently, a ring is a
+`semiring` with a negation operation making it an additive group.  -/
+@[protect_proj, ancestor add_comm_group monoid distrib]
+class ring (α : Type u) extends add_comm_group_with_one α, monoid α, distrib α
+
+section ring
+variables [ring α] {a b c d e : α}
+
+/- A (unital, associative) ring is a not-necessarily-unital ring -/
+@[priority 100] -- see Note [lower instance priority]
+instance ring.to_non_unital_ring :
+  non_unital_ring α :=
+{ zero_mul := λ a, add_left_cancel $ show 0 * a + 0 * a = 0 * a + 0,
+    by rw [← add_mul, zero_add, add_zero],
+  mul_zero := λ a, add_left_cancel $ show a * 0 + a * 0 = a * 0 + 0,
+    by rw [← mul_add, add_zero, add_zero],
+  ..‹ring α› }
+
+/- A (unital, associative) ring is a not-necessarily-associative ring -/
+@[priority 100] -- see Note [lower instance priority]
+instance ring.to_non_assoc_ring :
+  non_assoc_ring α :=
+{ zero_mul := λ a, add_left_cancel $ show 0 * a + 0 * a = 0 * a + 0,
+    by rw [← add_mul, zero_add, add_zero],
+  mul_zero := λ a, add_left_cancel $ show a * 0 + a * 0 = a * 0 + 0,
+    by rw [← mul_add, add_zero, add_zero],
+  ..‹ring α› }
+
+/- The instance from `ring` to `semiring` happens often in linear algebra, for which all the basic
+definitions are given in terms of semirings, but many applications use rings or fields. We increase
+a little bit its priority above 100 to try it quickly, but remaining below the default 1000 so that
+more specific instances are tried first. -/
+@[priority 200]
+instance ring.to_semiring : semiring α :=
+{ ..‹ring α›, .. ring.to_non_unital_ring }
+
+end ring
+
+/-- A non-unital commutative ring is a `non_unital_ring` with commutative multiplication. -/
+@[protect_proj, ancestor non_unital_ring comm_semigroup]
+class non_unital_comm_ring (α : Type u) extends non_unital_ring α, comm_semigroup α
+
+@[priority 100] -- see Note [lower instance priority]
+instance non_unital_comm_ring.to_non_unital_comm_semiring [s : non_unital_comm_ring α] :
+  non_unital_comm_semiring α :=
+{ ..s }
+
+/-- A commutative ring is a `ring` with commutative multiplication. -/
+@[protect_proj, ancestor ring comm_semigroup]
+class comm_ring (α : Type u) extends ring α, comm_monoid α
+
+@[priority 100] -- see Note [lower instance priority]
+instance comm_ring.to_comm_semiring [s : comm_ring α] : comm_semiring α :=
+{ mul_zero := mul_zero, zero_mul := zero_mul, ..s }
+
+@[priority 100] -- see Note [lower instance priority]
+instance comm_ring.to_non_unital_comm_ring [s : comm_ring α] : non_unital_comm_ring α :=
+{ mul_zero := mul_zero, zero_mul := zero_mul, ..s }
+
+/-- A domain is a nontrivial ring with no zero divisors, i.e. satisfying
+  the condition `a * b = 0 ↔ a = 0 ∨ b = 0`.
+
+  This is implemented as a mixin for `ring α`.
+  To obtain an integral domain use `[comm_ring α] [is_domain α]`. -/
+@[protect_proj] class is_domain (α : Type u) [ring α]
+  extends no_zero_divisors α, nontrivial α : Prop

--- a/src/algebra/ring/inj_surj.lean
+++ b/src/algebra/ring/inj_surj.lean
@@ -1,0 +1,455 @@
+/-
+Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
+-/
+import algebra.ring.defs
+import algebra.group_with_zero.basic
+
+/-!
+# Pulling back rings along injective maps, and pushing them forward along surjective maps.
+
+-/
+universes u v w x
+variables {α : Type u} {β : Type v} {γ : Type w} {R : Type x}
+
+open function
+
+/-!
+### `distrib` class
+-/
+
+/-- Pullback a `distrib` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.distrib {S} [has_mul R] [has_add R] [distrib S]
+  (f : R → S) (hf : injective f) (add : ∀ x y, f (x + y) = f x + f y)
+  (mul : ∀ x y, f (x * y) = f x * f y) :
+  distrib R :=
+{ mul := (*),
+  add := (+),
+  left_distrib := λ x y z, hf $ by simp only [*, left_distrib],
+  right_distrib := λ x y z, hf $ by simp only [*, right_distrib] }
+
+/-- Pushforward a `distrib` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.distrib {S} [distrib R] [has_add S] [has_mul S]
+  (f : R → S) (hf : surjective f) (add : ∀ x y, f (x + y) = f x + f y)
+  (mul : ∀ x y, f (x * y) = f x * f y) :
+  distrib S :=
+{ mul := (*),
+  add := (+),
+  left_distrib := hf.forall₃.2 $ λ x y z, by simp only [← add, ← mul, left_distrib],
+  right_distrib := hf.forall₃.2 $ λ x y z, by simp only [← add, ← mul, right_distrib] }
+
+section injective_surjective_maps
+
+/-!
+### Semirings
+-/
+
+variables [has_zero β] [has_add β] [has_mul β] [has_smul ℕ β]
+
+/-- Pullback a `non_unital_non_assoc_semiring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.non_unital_non_assoc_semiring
+  {α : Type u} [non_unital_non_assoc_semiring α]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
+  non_unital_non_assoc_semiring β :=
+{ .. hf.mul_zero_class f zero mul, .. hf.add_comm_monoid f zero add nsmul, .. hf.distrib f add mul }
+
+/-- Pullback a `non_unital_semiring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.non_unital_semiring
+  {α : Type u} [non_unital_semiring α]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
+  non_unital_semiring β :=
+{ .. hf.non_unital_non_assoc_semiring f zero add mul nsmul, .. hf.semigroup_with_zero f zero mul }
+
+/-- Pullback a `non_assoc_semiring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.non_assoc_semiring
+  {α : Type u} [non_assoc_semiring α]
+  {β : Type v} [has_zero β] [has_one β] [has_mul β] [has_add β]
+  [has_smul ℕ β] [has_nat_cast β]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x)
+  (nat_cast : ∀ n : ℕ, f n = n) :
+  non_assoc_semiring β :=
+{ .. hf.add_monoid_with_one f zero one add nsmul nat_cast,
+  .. hf.non_unital_non_assoc_semiring f zero add mul nsmul,
+  .. hf.mul_one_class f one mul }
+
+/-- Pullback a `semiring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.semiring
+  {α : Type u} [semiring α]
+  {β : Type v} [has_zero β] [has_one β] [has_add β] [has_mul β] [has_pow β ℕ]
+  [has_smul ℕ β] [has_nat_cast β]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
+  (nat_cast : ∀ n : ℕ, f n = n) :
+  semiring β :=
+{ .. hf.non_assoc_semiring f zero one add mul nsmul nat_cast,
+  .. hf.monoid_with_zero f zero one mul npow,
+  .. hf.distrib f add mul }
+
+/-- Pushforward a `non_unital_non_assoc_semiring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.non_unital_non_assoc_semiring
+  {α : Type u} [non_unital_non_assoc_semiring α]
+  (f : α → β) (hf : surjective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
+  non_unital_non_assoc_semiring β :=
+{ .. hf.mul_zero_class f zero mul, .. hf.add_comm_monoid f zero add nsmul, .. hf.distrib f add mul }
+
+/-- Pushforward a `non_unital_semiring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.non_unital_semiring
+  {α : Type u} [non_unital_semiring α]
+  (f : α → β) (hf : surjective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
+  non_unital_semiring β :=
+{ .. hf.non_unital_non_assoc_semiring f zero add mul nsmul, .. hf.semigroup_with_zero f zero mul }
+
+/-- Pushforward a `non_assoc_semiring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.non_assoc_semiring
+  {α : Type u} [non_assoc_semiring α]
+  {β : Type v} [has_zero β] [has_one β] [has_add β] [has_mul β]
+  [has_smul ℕ β] [has_nat_cast β]
+  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x)
+  (nat_cast : ∀ n : ℕ, f n = n) :
+  non_assoc_semiring β :=
+{ .. hf.add_monoid_with_one f zero one add nsmul nat_cast,
+  .. hf.non_unital_non_assoc_semiring f zero add mul nsmul, .. hf.mul_one_class f one mul }
+
+/-- Pushforward a `semiring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.semiring
+  {α : Type u} [semiring α]
+  {β : Type v} [has_zero β] [has_one β] [has_add β] [has_mul β] [has_pow β ℕ]
+  [has_smul ℕ β] [has_nat_cast β]
+  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
+  (nat_cast : ∀ n : ℕ, f n = n) :
+  semiring β :=
+{ .. hf.non_assoc_semiring f zero one add mul nsmul nat_cast,
+  .. hf.monoid_with_zero f zero one mul npow, .. hf.add_comm_monoid f zero add nsmul,
+  .. hf.distrib f add mul }
+
+end injective_surjective_maps
+
+section non_unital_comm_semiring
+variables [non_unital_comm_semiring α] [non_unital_comm_semiring β] {a b c : α}
+
+/-- Pullback a `non_unital_semiring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.non_unital_comm_semiring [has_zero γ] [has_add γ] [has_mul γ]
+  [has_smul ℕ γ] (f : γ → α) (hf : injective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
+  non_unital_comm_semiring γ :=
+{ .. hf.non_unital_semiring f zero add mul nsmul, .. hf.comm_semigroup f mul }
+
+/-- Pushforward a `non_unital_semiring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.non_unital_comm_semiring [has_zero γ] [has_add γ] [has_mul γ]
+  [has_smul ℕ γ] (f : α → γ) (hf : surjective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) :
+  non_unital_comm_semiring γ :=
+{ .. hf.non_unital_semiring f zero add mul nsmul, .. hf.comm_semigroup f mul }
+
+end non_unital_comm_semiring
+
+section comm_semiring
+variables [comm_semiring α] [comm_semiring β] {a b c : α}
+
+/-- Pullback a `semiring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.comm_semiring
+  [has_zero γ] [has_one γ] [has_add γ] [has_mul γ] [has_smul ℕ γ] [has_nat_cast γ]
+  [has_pow γ ℕ] (f : γ → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
+  (nat_cast : ∀ n : ℕ, f n = n) :
+  comm_semiring γ :=
+{ .. hf.semiring f zero one add mul nsmul npow nat_cast, .. hf.comm_semigroup f mul }
+
+/-- Pushforward a `semiring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.comm_semiring
+  [has_zero γ] [has_one γ] [has_add γ] [has_mul γ] [has_smul ℕ γ] [has_nat_cast γ]
+  [has_pow γ ℕ] (f : α → γ) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
+  (nat_cast : ∀ n : ℕ, f n = n) :
+  comm_semiring γ :=
+{ .. hf.semiring f zero one add mul nsmul npow nat_cast, .. hf.comm_semigroup f mul }
+
+end comm_semiring
+
+section has_distrib_neg
+
+section has_mul
+variables [has_mul α] [has_distrib_neg α]
+
+/-- A type endowed with `-` and `*` has distributive negation, if it admits an injective map that
+preserves `-` and `*` to a type which has distributive negation. -/
+@[reducible] -- See note [reducible non-instances]
+protected def function.injective.has_distrib_neg [has_neg β] [has_mul β] (f : β → α)
+  (hf : injective f) (neg : ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
+  has_distrib_neg β :=
+{ neg_mul := λ x y, hf $ by erw [neg, mul, neg, neg_mul, mul],
+  mul_neg := λ x y, hf $ by erw [neg, mul, neg, mul_neg, mul],
+  ..hf.has_involutive_neg _ neg, ..‹has_mul β› }
+
+/-- A type endowed with `-` and `*` has distributive negation, if it admits a surjective map that
+preserves `-` and `*` from a type which has distributive negation. -/
+@[reducible] -- See note [reducible non-instances]
+protected def function.surjective.has_distrib_neg [has_neg β] [has_mul β] (f : α → β)
+  (hf : surjective f) (neg : ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
+  has_distrib_neg β :=
+{ neg_mul := hf.forall₂.2 $ λ x y, by { erw [←neg, ← mul, neg_mul, neg, mul], refl },
+  mul_neg := hf.forall₂.2 $ λ x y, by { erw [←neg, ← mul, mul_neg, neg, mul], refl },
+  ..hf.has_involutive_neg _ neg, ..‹has_mul β› }
+
+end has_mul
+
+end has_distrib_neg
+
+/-!
+### Rings
+-/
+
+section non_unital_non_assoc_ring
+variables [non_unital_non_assoc_ring α]
+
+/-- Pullback a `non_unital_non_assoc_ring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.non_unital_non_assoc_ring
+  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β] [has_smul ℕ β] [has_smul ℤ β]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
+  non_unital_non_assoc_ring β :=
+{ .. hf.add_comm_group f zero add neg sub nsmul zsmul, ..hf.mul_zero_class f zero mul,
+  .. hf.distrib f add mul }
+
+/-- Pushforward a `non_unital_non_assoc_ring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.non_unital_non_assoc_ring
+  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β] [has_smul ℕ β] [has_smul ℤ β]
+  (f : α → β) (hf : surjective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
+  non_unital_non_assoc_ring β :=
+{ .. hf.add_comm_group f zero add neg sub nsmul zsmul, .. hf.mul_zero_class f zero mul,
+  .. hf.distrib f add mul }
+
+end non_unital_non_assoc_ring
+
+section non_unital_ring
+variables [non_unital_ring α]
+
+/-- Pullback a `non_unital_ring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.non_unital_ring
+  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β] [has_smul ℕ β] [has_smul ℤ β]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (gsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
+  non_unital_ring β :=
+{ .. hf.add_comm_group f zero add neg sub nsmul gsmul, ..hf.mul_zero_class f zero mul,
+  .. hf.distrib f add mul, .. hf.semigroup f mul }
+
+/-- Pushforward a `non_unital_ring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.non_unital_ring
+  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β] [has_smul ℕ β] [has_smul ℤ β]
+  (f : α → β) (hf : surjective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (gsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
+  non_unital_ring β :=
+{ .. hf.add_comm_group f zero add neg sub nsmul gsmul, .. hf.mul_zero_class f zero mul,
+  .. hf.distrib f add mul, .. hf.semigroup f mul }
+
+end non_unital_ring
+
+section non_assoc_ring
+variables [non_assoc_ring α]
+
+/-- Pullback a `non_assoc_ring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.non_assoc_ring
+  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
+  [has_smul ℕ β] [has_smul ℤ β] [has_nat_cast β] [has_int_cast β]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (gsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
+  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
+  non_assoc_ring β :=
+{ .. hf.add_comm_group f zero add neg sub nsmul gsmul,
+  .. hf.add_group_with_one f zero one add neg sub nsmul gsmul nat_cast int_cast,
+  .. hf.mul_zero_class f zero mul, .. hf.distrib f add mul,
+  .. hf.mul_one_class f one mul }
+
+/-- Pushforward a `non_unital_ring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.non_assoc_ring
+  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
+  [has_smul ℕ β] [has_smul ℤ β] [has_nat_cast β] [has_int_cast β]
+  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (gsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
+  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
+  non_assoc_ring β :=
+{ .. hf.add_comm_group f zero add neg sub nsmul gsmul, .. hf.mul_zero_class f zero mul,
+  .. hf.add_group_with_one f zero one add neg sub nsmul gsmul nat_cast int_cast,
+  .. hf.distrib f add mul, .. hf.mul_one_class f one mul }
+
+end non_assoc_ring
+
+section ring
+variables [ring α] {a b c d e : α}
+
+/-- Pullback a `ring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.ring
+  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
+  [has_smul ℕ β] [has_smul ℤ β] [has_pow β ℕ] [has_nat_cast β] [has_int_cast β]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
+  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
+  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
+  ring β :=
+{ .. hf.add_group_with_one f zero one add neg sub nsmul zsmul nat_cast int_cast,
+  .. hf.add_comm_group f zero add neg sub nsmul zsmul,
+  .. hf.monoid f one mul npow, .. hf.distrib f add mul }
+
+/-- Pushforward a `ring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.ring
+  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
+  [has_smul ℕ β] [has_smul ℤ β] [has_pow β ℕ] [has_nat_cast β] [has_int_cast β]
+  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
+  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
+  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
+  ring β :=
+{ .. hf.add_group_with_one f zero one add neg sub nsmul zsmul nat_cast int_cast,
+  .. hf.add_comm_group f zero add neg sub nsmul zsmul,
+  .. hf.monoid f one mul npow, .. hf.distrib f add mul }
+
+end ring
+
+section non_unital_comm_ring
+variables [non_unital_comm_ring α] {a b c : α}
+
+/-- Pullback a `comm_ring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.non_unital_comm_ring
+  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
+  [has_smul ℕ β] [has_smul ℤ β]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
+  non_unital_comm_ring β :=
+{ .. hf.non_unital_ring f zero add mul neg sub nsmul zsmul, .. hf.comm_semigroup f mul }
+
+/-- Pushforward a `non_unital_comm_ring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.non_unital_comm_ring
+  [has_zero β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
+  [has_smul ℕ β] [has_smul ℤ β]
+  (f : α → β) (hf : surjective f) (zero : f 0 = 0)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x) :
+  non_unital_comm_ring β :=
+{ .. hf.non_unital_ring f zero add mul neg sub nsmul zsmul, .. hf.comm_semigroup f mul }
+
+end non_unital_comm_ring
+
+section comm_ring
+variables [comm_ring α] {a b c : α}
+
+/-- Pullback a `comm_ring` instance along an injective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.comm_ring
+  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
+  [has_smul ℕ β] [has_smul ℤ β] [has_pow β ℕ] [has_nat_cast β] [has_int_cast β]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
+  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
+  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
+  comm_ring β :=
+{ .. hf.ring f zero one add mul neg sub nsmul zsmul npow nat_cast int_cast,
+  .. hf.comm_semigroup f mul }
+
+/-- Pushforward a `comm_ring` instance along a surjective function.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.comm_ring
+  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
+  [has_smul ℕ β] [has_smul ℤ β] [has_pow β ℕ] [has_nat_cast β] [has_int_cast β]
+  (f : α → β) (hf : surjective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
+  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n)
+  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
+  comm_ring β :=
+{ .. hf.ring f zero one add mul neg sub nsmul zsmul npow nat_cast int_cast,
+  .. hf.comm_semigroup f mul }
+
+end comm_ring

--- a/src/algebra/ring/prod.lean
+++ b/src/algebra/ring/prod.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl, Chris Hughes, Mario Carneiro, Yury Kudryashov
 -/
 import algebra.group.prod
 import algebra.order.group.prod
-import algebra.ring.basic
 import algebra.ring.equiv
 
 /-!

--- a/src/ring_theory/coprime/basic.lean
+++ b/src/ring_theory/coprime/basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Ken Lee, Chris Hughes
 -/
 import tactic.ring
-import algebra.ring.basic
 import group_theory.group_action.units
 
 /-!


### PR DESCRIPTION
This split is better suited to successfully refactoring `algebra.order.ring.basic`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
