### PR TITLE
[Merged by Bors] - feat(group_theory/order_of_element): lemmas about orders of powers of group elements

### DIFF
--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -166,7 +166,7 @@ section group
 
 open subgroup
 
-variables {α : Type*} [group α] {a : α}
+variables {α : Type*} [group α] (a : α)
 
 /-- See also `order_eq_card_zpowers`. -/
 @[to_additive add_order_eq_card_zmultiples' "See also `add_order_eq_card_zmultiples`."]
@@ -175,6 +175,8 @@ begin
   have := nat.card_congr (mul_action.orbit_zpowers_equiv a (1 : α)),
   rwa [nat.card_zmod, orbit_subgroup_one_eq_self, eq_comm] at this,
 end
+
+variables {a}
 
 @[to_additive is_of_fin_add_order.finite_zmultiples]
 lemma is_of_fin_order.finite_zpowers (h : is_of_fin_order a) : finite $ zpowers a :=

--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -160,12 +160,27 @@ by rw [←fintype.of_equiv_card (orbit_zpowers_equiv a b), zmod.card]
   exact fintype.card_ne_zero,
 end⟩
 
+end mul_action
+
+section group
+
+open subgroup
+
+variables {α : Type*} [group α] {a : α}
+
 /-- See also `order_eq_card_zpowers`. -/
 @[to_additive add_order_eq_card_zmultiples' "See also `add_order_eq_card_zmultiples`."]
-lemma _root_.order_eq_card_zpowers' : order_of a = nat.card (zpowers a) :=
+lemma order_eq_card_zpowers' : order_of a = nat.card (zpowers a) :=
 begin
   have := nat.card_congr (mul_action.orbit_zpowers_equiv a (1 : α)),
   rwa [nat.card_zmod, orbit_subgroup_one_eq_self, eq_comm] at this,
 end
 
-end mul_action
+@[to_additive is_of_fin_add_order.finite_zmultiples]
+lemma is_of_fin_order.finite_zpowers (h : is_of_fin_order a) : finite $ zpowers a :=
+begin
+  rw [← order_of_pos_iff, order_eq_card_zpowers'] at h,
+  exact nat.finite_of_card_ne_zero h.ne.symm,
+end
+
+end group

--- a/src/dynamics/fixed_points/basic.lean
+++ b/src/dynamics/fixed_points/basic.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import data.set.function
 import logic.function.iterate
+import group_theory.perm.basic
 
 /-!
 # Fixed points of a self-map
@@ -23,7 +24,7 @@ fixed point
 
 universes u v
 
-variables {α : Type u} {β : Type v} {f fa g : α → α} {x y : α} {fb : β → β} {m n k : ℕ}
+variables {α : Type u} {β : Type v} {f fa g : α → α} {x y : α} {fb : β → β} {m n k : ℕ} {e : α ≃ α}
 
 namespace function
 
@@ -142,3 +143,20 @@ lemma commute.right_bij_on_fixed_pts_comp (h : commute f g) :
 by simpa only [h.comp_eq] using bij_on_fixed_pts_comp f g
 
 end function
+
+namespace equiv.is_fixed_pt
+
+protected lemma symm (h : function.is_fixed_pt e x) : function.is_fixed_pt e.symm x :=
+h.to_left_inverse e.left_inverse_symm
+
+protected lemma zpow (h : function.is_fixed_pt e x) (n : ℤ) : function.is_fixed_pt ⇑(e^n) x :=
+begin
+  cases n,
+  { rw [int.of_nat_eq_coe, zpow_coe_nat, ← equiv.perm.iterate_eq_pow],
+    exact h.iterate n, },
+  { change function.is_fixed_pt ⇑(e^(-(↑(n + 1) : ℤ))) x,
+    rw [zpow_neg, zpow_coe_nat, ← inv_pow, ← equiv.perm.iterate_eq_pow, equiv.perm.inv_def],
+    exact (equiv.is_fixed_pt.symm h).iterate (n + 1), },
+end
+
+end equiv.is_fixed_pt

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -423,6 +423,47 @@ begin
   exact ⟨pow_injective_of_lt_order_of _ (nat.mod_lt _ hx) (nat.mod_lt _ hx), λ h, congr_arg _ h⟩
 end
 
+@[simp, to_additive zsmul_smul_order_of]
+lemma zpow_pow_order_of : (x^i)^order_of x = 1 :=
+begin
+  by_cases h : is_of_fin_order x,
+  { rw [← zpow_coe_nat, ← zpow_mul, mul_comm, zpow_mul, zpow_coe_nat, pow_order_of_eq_one,
+      one_zpow], },
+  { rw [order_of_eq_zero h, pow_zero], },
+end
+
+@[to_additive is_of_fin_add_order.zsmul]
+lemma is_of_fin_order.zpow (h : is_of_fin_order x) {i : ℤ} : is_of_fin_order (x^i) :=
+(is_of_fin_order_iff_pow_eq_one _).mpr ⟨order_of x, order_of_pos' h, zpow_pow_order_of⟩
+
+@[to_additive is_of_fin_add_order.of_mem_zmultiples]
+lemma is_of_fin_order.of_mem_zpowers (h : is_of_fin_order x) (h' : y ∈ subgroup.zpowers x) :
+  is_of_fin_order y :=
+by { obtain ⟨k, rfl⟩ := subgroup.mem_zpowers_iff.mp h', exact h.zpow, }
+
+@[to_additive add_order_of_dvd_of_mem_zmultiples]
+lemma order_of_dvd_of_mem_zpowers (h : y ∈ subgroup.zpowers x) : order_of y ∣ order_of x :=
+begin
+  obtain ⟨k, rfl⟩ := subgroup.mem_zpowers_iff.mp h,
+  rw order_of_dvd_iff_pow_eq_one,
+  exact zpow_pow_order_of,
+end
+
+@[to_additive vadd_eq_self_of_mem_zmultiples]
+lemma smul_eq_self_of_mem_zpowers {α : Type*} [mul_action G α]
+  (hx : x ∈ subgroup.zpowers y) {a : α} (hs : y • a = a) : x • a = a :=
+begin
+  suffices : ∀ {g : G} {a' : α} (hs₀ : g • a' = a') (k : ℤ) (hk : 0 ≤ k), g^k • a' = a',
+  { obtain ⟨k, rfl⟩ := subgroup.mem_zpowers_iff.mp hx,
+    cases le_or_lt 0 k with hk hk, { exact this hs k hk, },
+    rw [← neg_neg k, ← inv_zpow'],
+    exact this (inv_smul_eq_iff.mpr hs.symm) (-k) (neg_nonneg.mpr hk.le), },
+  clear hx hs a y x,
+  intros g s hs k hk,
+  replace hs : (((•) g)^[k.nat_abs]) s = s := is_fixed_pt.iterate hs k.nat_abs,
+  rwa [smul_iterate, ← zpow_coe_nat, ← int.eq_nat_abs_of_zero_le hk] at hs,
+end
+
 end group
 
 section comm_monoid

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -449,20 +449,20 @@ begin
   exact zpow_pow_order_of,
 end
 
-@[to_additive vadd_eq_self_of_mem_zmultiples]
 lemma smul_eq_self_of_mem_zpowers {α : Type*} [mul_action G α]
   (hx : x ∈ subgroup.zpowers y) {a : α} (hs : y • a = a) : x • a = a :=
 begin
-  suffices : ∀ {g : G} {a' : α} (hs₀ : g • a' = a') (k : ℤ) (hk : 0 ≤ k), g^k • a' = a',
-  { obtain ⟨k, rfl⟩ := subgroup.mem_zpowers_iff.mp hx,
-    cases le_or_lt 0 k with hk hk, { exact this hs k hk, },
-    rw [← neg_neg k, ← inv_zpow'],
-    exact this (inv_smul_eq_iff.mpr hs.symm) (-k) (neg_nonneg.mpr hk.le), },
-  clear hx hs a y x,
-  intros g s hs k hk,
-  replace hs : (((•) g)^[k.nat_abs]) s = s := is_fixed_pt.iterate hs k.nat_abs,
-  rwa [smul_iterate, ← zpow_coe_nat, ← int.eq_nat_abs_of_zero_le hk] at hs,
+  obtain ⟨k, rfl⟩ := subgroup.mem_zpowers_iff.mp hx,
+  rw [← mul_action.to_perm_apply, ← mul_action.to_perm_hom_apply,
+    monoid_hom.map_zpow _ y k, mul_action.to_perm_hom_apply],
+  exact equiv.is_fixed_pt.zpow hs k,
 end
+
+lemma vadd_eq_self_of_mem_zmultiples {α G : Type*} [add_group G] [add_action G α] {x y : G}
+  (hx : x ∈ add_subgroup.zmultiples y) {a : α} (hs : y +ᵥ a = a) : x +ᵥ a = a :=
+@smul_eq_self_of_mem_zpowers (multiplicative G) _ _ _ α _ hx a hs
+
+attribute [to_additive vadd_eq_self_of_mem_zmultiples] smul_eq_self_of_mem_zpowers
 
 end group
 

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -556,6 +556,9 @@ instance has_zpow : has_pow H ℤ := ⟨λ a n, ⟨a ^ n, H.zpow_mem a.2 n⟩⟩
 @[simp, norm_cast, to_additive] lemma coe_pow (x : H) (n : ℕ) : ((x ^ n : H) : G) = x ^ n := rfl
 @[simp, norm_cast, to_additive] lemma coe_zpow (x : H) (n : ℤ) : ((x ^ n : H) : G) = x ^ n := rfl
 
+@[simp, to_additive] lemma mk_eq_one_iff {g : G} {h} : (⟨g, h⟩ : H) = 1 ↔ g = 1 :=
+show (⟨g, h⟩ : H) = (⟨1, H.one_mem⟩ : H) ↔ g = 1, by simp
+
 /-- A subgroup of a group inherits a group structure. -/
 @[to_additive "An `add_subgroup` of an `add_group` inherits an `add_group` structure."]
 instance to_group {G : Type*} [group G] (H : subgroup G) : group H :=


### PR DESCRIPTION
The lemma `subgroup.mk_eq_one_iff` is unrelated but convenient to include for dependent work.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
