### PR TITLE
[Merged by Bors] - feat(combinatorics/young): add equivalence between Young diagrams and lists of natural numbers

### DIFF
--- a/src/combinatorics/young/young_diagram.lean
+++ b/src/combinatorics/young/young_diagram.lean
@@ -308,7 +308,7 @@ end row_lens
 section equiv_list_row_lens
 /-! ### Equivalence between Young diagrams and lists of natural numbers
 
-This section defines the equivalence between Young diagrams `mu` and weakly decreasing lists `w`
+This section defines the equivalence between Young diagrams `μ` and weakly decreasing lists `w`
 of positive natural numbers, corresponding to row lengths of the diagram:
   `young_diagram.equiv_list_row_lens :`
   `young_diagram ≃ {w : list ℕ // w.sorted (≥) ∧ ∀ x ∈ w, 0 < x}`
@@ -319,10 +319,10 @@ The two directions are `young_diagram.row_lens` (defined above) and `young_diagr
 
 /-- The cells making up a `young_diagram` from a list of row lengths -/
 protected def cells_of_row_lens : list ℕ → finset (ℕ × ℕ)
-| [] := finset.empty
+| [] := ∅
 | (w :: ws) := (({0} : finset ℕ) ×ˢ finset.range w) ∪
                  (cells_of_row_lens ws).map
-                   (function.embedding.prod_map ⟨_, nat.succ_injective⟩ (by refl))
+                   (embedding.prod_map ⟨_, nat.succ_injective⟩ (embedding.refl ℕ)
 
 protected lemma mem_cells_of_row_lens {w : list ℕ} {c : ℕ × ℕ} :
   c ∈ young_diagram.cells_of_row_lens w ↔ ∃ (h : c.fst < w.length), c.snd < w.nth_le c.fst h :=
@@ -346,8 +346,8 @@ def of_row_lens (w : list ℕ) (hw : w.sorted (≥)) : young_diagram :=
     calc j1 ≤ j2            : hj
       ...   < w.nth_le i2 _ : h2
       ...   ≤ w.nth_le i1 _ : _,
-    cases eq_or_lt_of_le hi,
-    { subst h },
+    obtain (rfl | h) := eq_or_lt_of_le hi,
+    { refl },
     { apply list.pairwise_iff_nth_le.mp hw _ _ _ h }
   end }
 
@@ -393,6 +393,7 @@ end
 
 /-- Equivalence between Young diagrams and weakly decreasing lists of positive natural numbers.
 A Young diagram `μ` is equivalent to a list of row lengths. -/
+@[simps]
 def equiv_list_row_lens : young_diagram ≃ {w : list ℕ // w.sorted (≥) ∧ ∀ x ∈ w, 0 < x} :=
 { to_fun    := λ μ, ⟨μ.row_lens, μ.row_lens_sorted, μ.pos_of_mem_row_lens⟩,
   inv_fun   := λ ww, of_row_lens ww.1 ww.2.1,

--- a/src/combinatorics/young/young_diagram.lean
+++ b/src/combinatorics/young/young_diagram.lean
@@ -331,7 +331,7 @@ protected lemma mem_cells_of_row_lens {w : list ℕ} {c : ℕ × ℕ} :
 begin
   induction w generalizing c;
   rw young_diagram.cells_of_row_lens,
-  { change false ↔ ∃ (h : _ < 0), _, simp },
+  { simp [young_diagram.cells_of_row_lens] },
   { rcases c with ⟨⟨_, _⟩, _⟩,
     { simp },
     { simpa [w_ih, -finset.singleton_product, nat.succ_lt_succ_iff] } }

--- a/src/combinatorics/young/young_diagram.lean
+++ b/src/combinatorics/young/young_diagram.lean
@@ -47,6 +47,8 @@ Young diagram
 
 -/
 
+open function
+
 /-- A Young diagram is a finite collection of cells on the `ℕ × ℕ` grid such that whenever
 a cell is present, so are all the ones above and to the left of it. Like matrices, an `(i, j)` cell
 is a cell in row `i` and column `j`, where rows are enumerated downward and columns rightward.
@@ -322,7 +324,7 @@ protected def cells_of_row_lens : list ℕ → finset (ℕ × ℕ)
 | [] := ∅
 | (w :: ws) := (({0} : finset ℕ) ×ˢ finset.range w) ∪
                  (cells_of_row_lens ws).map
-                   (embedding.prod_map ⟨_, nat.succ_injective⟩ (embedding.refl ℕ)
+                   (embedding.prod_map ⟨_, nat.succ_injective⟩ (embedding.refl ℕ))
 
 protected lemma mem_cells_of_row_lens {w : list ℕ} {c : ℕ × ℕ} :
   c ∈ young_diagram.cells_of_row_lens w ↔ ∃ (h : c.fst < w.length), c.snd < w.nth_le c.fst h :=

--- a/src/combinatorics/young/young_diagram.lean
+++ b/src/combinatorics/young/young_diagram.lean
@@ -305,4 +305,99 @@ end
 
 end row_lens
 
+section equiv_list_row_lens
+/-! ### Equivalence between Young diagrams and lists of natural numbers
+
+This section defines the equivalence between Young diagrams `mu` and weakly decreasing lists `w`
+of positive natural numbers, corresponding to row lengths of the diagram:
+  `young_diagram.equiv_list_row_lens :`
+  `young_diagram ≃ {w : list ℕ // w.sorted (≥) ∧ ∀ x ∈ w, 0 < x}`
+
+The two directions are `young_diagram.row_lens` (defined above) and `young_diagram.of_row_lens`.
+
+-/
+
+protected def cells_of_row_lens : list ℕ → finset (ℕ × ℕ)
+| [] := finset.empty
+| (w :: ws) := (({0} : finset ℕ) ×ˢ finset.range w) ∪
+                 (cells_of_row_lens ws).map
+                   (function.embedding.prod_map ⟨_, nat.succ_injective⟩ (by refl))
+
+protected lemma mem_cells_of_row_lens {w : list ℕ} {c : ℕ × ℕ} :
+  c ∈ young_diagram.cells_of_row_lens w ↔ ∃ (h : c.fst < w.length), c.snd < w.nth_le c.fst h :=
+begin
+  induction w generalizing c;
+  rw young_diagram.cells_of_row_lens,
+  { change false ↔ ∃ (h : _ < 0), _, simp },
+  { rcases c with ⟨⟨_, _⟩, _⟩,
+    { simp },
+    { simpa [w_ih, -finset.singleton_product, nat.succ_lt_succ_iff] } }
+end
+
+/-- Young diagram from a sorted list -/
+def of_row_lens (w : list ℕ) (hw : w.sorted (≥)) : young_diagram :=
+{ cells        := young_diagram.cells_of_row_lens w,
+  is_lower_set := begin
+    rintros ⟨i2, j2⟩ ⟨i1, j1⟩ ⟨hi : i1 ≤ i2, hj : j1 ≤ j2⟩ hcell,
+    rw [finset.mem_coe, young_diagram.mem_cells_of_row_lens] at hcell ⊢,
+    obtain ⟨h1, h2⟩ := hcell,
+    refine ⟨hi.trans_lt h1, _⟩,
+    calc j1 ≤ j2            : hj
+      ...   < w.nth_le i2 _ : h2
+      ...   ≤ w.nth_le i1 _ : _,
+    cases eq_or_lt_of_le hi,
+    { subst h },
+    { apply list.pairwise_iff_nth_le.mp hw _ _ _ h }
+  end }
+
+lemma mem_of_row_lens {w : list ℕ} {hw : w.sorted (≥)} {c : ℕ × ℕ} :
+  c ∈ of_row_lens w hw ↔ ∃ (h : c.fst < w.length), c.snd < w.nth_le c.fst h :=
+young_diagram.mem_cells_of_row_lens
+
+/-- The number of rows in `of_row_lens w hw` is the length of `w` -/
+lemma row_lens_length_of_row_lens {w : list ℕ} {hw : w.sorted (≥)} (hpos : ∀ x ∈ w, 0 < x) :
+  (of_row_lens w hw).row_lens.length = w.length :=
+begin
+  simp only [length_row_lens, col_len, nat.find_eq_iff, mem_cells, mem_of_row_lens,
+             lt_self_iff_false, is_empty.exists_iff, not_not],
+  exact ⟨id, λ n hn, ⟨hn, hpos _ (list.nth_le_mem _ _ hn)⟩⟩,
+end
+
+/-- The length of the `i`th row in `of_row_lens w hw` is the `i`th entry of `w` -/
+lemma row_len_of_row_lens {w : list ℕ} {hw : w.sorted (≥)} (hpos : ∀ x ∈ w, 0 < x)
+  (i : ℕ) (hi : i < w.length) : (of_row_lens w hw).row_len i = w.nth_le i hi :=
+by simp [row_len, nat.find_eq_iff, mem_of_row_lens, hi]
+
+/-- The left_inv direction of the equivalence -/
+lemma of_row_lens_to_row_lens_eq_self {μ : young_diagram} :
+  of_row_lens _ (row_lens_sorted μ) = μ :=
+begin
+  ext ⟨i, j⟩,
+  simp only [mem_cells, mem_of_row_lens, length_row_lens, nth_le_row_lens],
+  simpa [← mem_iff_lt_col_len, mem_iff_lt_row_len] using j.zero_le.trans_lt,
+end
+
+/-- The right_inv direction of the equivalence -/
+lemma row_lens_of_row_lens_eq_self {w : list ℕ} {hw : w.sorted (≥)} (hpos : ∀ x ∈ w, 0 < x) :
+  (of_row_lens w hw).row_lens = w :=
+begin
+  ext i r,
+  cases lt_or_ge i w.length,
+  { simp only [option.mem_def, ← list.nth_le_eq_iff, h, row_lens_length_of_row_lens hpos],
+    revert r,
+    simpa only [eq_iff_eq_cancel_right, nth_le_row_lens] using row_len_of_row_lens hpos _ h },
+  { rw [list.nth_eq_none_iff.mpr h, list.nth_eq_none_iff.mpr],
+    rwa row_lens_length_of_row_lens hpos }
+end
+
+/-- Equivalence between Young diagrams and weakly decreasing lists of positive natural numbers.
+A Young diagram `μ` is equivalent to a list of row lengths. -/
+def equiv_list_row_lens : young_diagram ≃ {w : list ℕ // w.sorted (≥) ∧ ∀ x ∈ w, 0 < x} :=
+{ to_fun    := λ μ, ⟨μ.row_lens, μ.row_lens_sorted, μ.pos_of_mem_row_lens⟩,
+  inv_fun   := λ ww, of_row_lens ww.1 ww.2.1,
+  left_inv  := λ μ, of_row_lens_to_row_lens_eq_self,
+  right_inv := λ ⟨w, hw⟩, subtype.mk_eq_mk.mpr (row_lens_of_row_lens_eq_self hw.2) }
+
+end equiv_list_row_lens
+
 end young_diagram

--- a/src/combinatorics/young/young_diagram.lean
+++ b/src/combinatorics/young/young_diagram.lean
@@ -317,6 +317,7 @@ The two directions are `young_diagram.row_lens` (defined above) and `young_diagr
 
 -/
 
+/-- The cells making up a `young_diagram` from a list of row lengths -/
 protected def cells_of_row_lens : list ℕ → finset (ℕ × ℕ)
 | [] := finset.empty
 | (w :: ws) := (({0} : finset ℕ) ×ˢ finset.range w) ∪
@@ -364,7 +365,7 @@ begin
 end
 
 /-- The length of the `i`th row in `of_row_lens w hw` is the `i`th entry of `w` -/
-lemma row_len_of_row_lens {w : list ℕ} {hw : w.sorted (≥)} (hpos : ∀ x ∈ w, 0 < x)
+lemma row_len_of_row_lens {w : list ℕ} {hw : w.sorted (≥)}
   (i : ℕ) (hi : i < w.length) : (of_row_lens w hw).row_len i = w.nth_le i hi :=
 by simp [row_len, nat.find_eq_iff, mem_of_row_lens, hi]
 
@@ -385,7 +386,7 @@ begin
   cases lt_or_ge i w.length,
   { simp only [option.mem_def, ← list.nth_le_eq_iff, h, row_lens_length_of_row_lens hpos],
     revert r,
-    simpa only [eq_iff_eq_cancel_right, nth_le_row_lens] using row_len_of_row_lens hpos _ h },
+    simpa only [eq_iff_eq_cancel_right, nth_le_row_lens] using row_len_of_row_lens _ h },
   { rw [list.nth_eq_none_iff.mpr h, list.nth_eq_none_iff.mpr],
     rwa row_lens_length_of_row_lens hpos }
 end


### PR DESCRIPTION
Construct the equivalence between Young diagrams and weakly decreasing lists of positive natural numbers:
`equiv_list_row_lens : young_diagram ≃ {w : list ℕ // w.sorted (≥) ∧ ∀ x ∈ w, 0 < x}`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
