### PR TITLE
[Merged by Bors] - feat(topology/algebra/module/finite_dimension): add `linear_map.is_open_map_of_finite_dimensional`

### DIFF
--- a/src/analysis/normed_space/add_torsor_bases.lean
+++ b/src/analysis/normed_space/add_torsor_bases.lean
@@ -27,19 +27,21 @@ This file contains results about bases in normed affine spaces.
 section barycentric
 
 variables {ι 𝕜 E P : Type*} [nontrivially_normed_field 𝕜] [complete_space 𝕜]
-variables [normed_add_comm_group E] [normed_space 𝕜 E] [finite_dimensional 𝕜 E]
+variables [normed_add_comm_group E] [normed_space 𝕜 E]
 variables [metric_space P] [normed_add_torsor E P]
-variables (b : affine_basis ι 𝕜 P)
+
+include E
+
+lemma is_open_map_barycentric_coord [nontrivial ι] (b : affine_basis ι 𝕜 P) (i : ι) :
+  is_open_map (b.coord i) :=
+affine_map.is_open_map_linear_iff.mp $ (b.coord i).linear.is_open_map_of_finite_dimensional $
+  (b.coord i).surjective_iff_linear_surjective.mpr (b.surjective_coord i)
+
+variables [finite_dimensional 𝕜 E] (b : affine_basis ι 𝕜 P)
 
 @[continuity]
 lemma continuous_barycentric_coord (i : ι) : continuous (b.coord i) :=
 (b.coord i).continuous_of_finite_dimensional
-
-local attribute [instance] finite_dimensional.complete
-
-lemma is_open_map_barycentric_coord [nontrivial ι] (i : ι) :
-  is_open_map (b.coord i) :=
-(b.coord i).is_open_map (continuous_barycentric_coord b i) (b.surjective_coord i)
 
 lemma smooth_barycentric_coord (b : affine_basis ι 𝕜 E) (i : ι) : cont_diff 𝕜 ⊤ (b.coord i) :=
 (⟨b.coord i, continuous_barycentric_coord b i⟩ : E →A[𝕜] 𝕜).cont_diff

--- a/src/topology/algebra/module/finite_dimension.lean
+++ b/src/topology/algebra/module/finite_dimension.lean
@@ -334,6 +334,18 @@ rfl
   range f.to_continuous_linear_map = range f :=
 rfl
 
+/-- A surjective linear map `f` with finite dimensional codomain is an open map. -/
+lemma is_open_map_of_finite_dimensional (f : F →ₗ[𝕜] E) (hf : function.surjective f) :
+  is_open_map f :=
+begin
+  rcases f.exists_right_inverse_of_surjective (linear_map.range_eq_top.2 hf) with ⟨g, hg⟩,
+  refine is_open_map.of_sections (λ x, ⟨λ y, g (y - f x) + x, _, _, λ y, _⟩),
+  { exact ((g.continuous_of_finite_dimensional.comp $ continuous_id.sub continuous_const).add
+      continuous_const).continuous_at },
+  { rw [sub_self, map_zero, zero_add] },
+  { simp only [map_sub, map_add, ← comp_apply f g, hg, id_apply, sub_add_cancel] }
+end
+
 end linear_map
 
 namespace linear_equiv


### PR DESCRIPTION
Also use it to prove `is_open_map_barycentric_coord` without assuming `[finite_dimensional 𝕜 E]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
