### PR TITLE
[Merged by Bors] - feat(topology/subset_properties): Add `is_clopen.preimage`

### DIFF
--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1495,6 +1495,10 @@ lemma is_clopen_bInter_finset {β : Type*} {s : finset β} {f : β → set α}
   is_clopen (⋂ i ∈ s, f i) :=
 is_clopen_bInter s.finite_to_set h
 
+lemma is_clopen.preimage {f : α → β} (hf : continuous f) {s : set β} (h : is_clopen s) :
+  is_clopen (f ⁻¹' s) :=
+⟨h.1.preimage hf, h.2.preimage hf⟩
+
 lemma continuous_on.preimage_clopen_of_clopen
   {f : α → β} {s : set α} {t : set β} (hf : continuous_on f s) (hs : is_clopen s)
   (ht : is_clopen t) : is_clopen (s ∩ f⁻¹' t) :=

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1495,7 +1495,7 @@ lemma is_clopen_bInter_finset {β : Type*} {s : finset β} {f : β → set α}
   is_clopen (⋂ i ∈ s, f i) :=
 is_clopen_bInter s.finite_to_set h
 
-lemma is_clopen.preimage {f : α → β} (hf : continuous f) {s : set β} (h : is_clopen s) :
+lemma is_clopen.preimage {s : set β} (h : is_clopen s) {f : α → β} (hf : continuous f) :
   is_clopen (f ⁻¹' s) :=
 ⟨h.1.preimage hf, h.2.preimage hf⟩
 


### PR DESCRIPTION
Adds a lemma proving the pre-image of a clopen set under a continuous map is clopen.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
