### PR TITLE
[Merged by Bors] - feat(data/int/basic): add lemmas for w*z = -1

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -557,7 +557,7 @@ begin
   tauto,
 end
 
-lemma eq_one_or_neg_one_iff_mul_eq_one {z w : ℤ} :
+lemma mul_eq_one_iff_eq_one_or_neg_one {z w : ℤ} :
   z * w = 1 ↔ z = 1 ∧ w = 1 ∨ z = -1 ∧ w = -1 :=
 begin
   refine ⟨eq_one_or_neg_one_of_mul_eq_one', λ h, or.elim h (λ H, _) (λ H, _)⟩;
@@ -573,7 +573,7 @@ begin
   { exact or.inr ⟨rfl, neg_inj.mp (neg_one_mul w ▸ h)⟩, }
 end
 
-lemma eq_one_or_neg_one_iff_mul_eq_neg_one {z w : ℤ} :
+lemma mul_eq_neg_one_iff_eq_one_or_neg_one {z w : ℤ} :
   z * w = -1 ↔ z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1 :=
 begin
   refine ⟨eq_one_or_neg_one_of_mul_eq_neg_one', λ h, or.elim h (λ H, _) (λ H, _)⟩;

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -561,7 +561,7 @@ lemma eq_one_or_neg_one_of_mul_eq_neg_one' {z w : ℤ} (h : z * w = -1) :
   z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1 :=
 begin
   rcases is_unit_eq_one_or (is_unit.mul_iff.mp (int.is_unit_iff.mpr (or.inr h))).1 with rfl | rfl,
-  { rw one_mul at h, exact or.inl ⟨rfl, h⟩, },
+  { exact or.inl ⟨rfl, one_mul w ▸ h⟩, },
   { rw [neg_one_mul, neg_inj] at h, exact or.inr ⟨rfl, h⟩, }
 end
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -557,6 +557,18 @@ begin
   tauto,
 end
 
+lemma eq_one_or_neg_one_of_mul_eq_neg_one' {z w : ℤ} (h : z * w = -1) :
+z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1 :=
+begin
+  obtain ⟨h₁, h₂⟩ := is_unit.mul_iff.mp (int.is_unit_iff.mpr (or.inr h)),
+  rcases is_unit_eq_one_or h₁ with (rfl | rfl),
+  { rw one_mul at h, exact or.inl ⟨rfl, h⟩, },
+  { rw [neg_one_mul, neg_inj] at h, exact or.inr ⟨rfl, h⟩, }
+end
+
+lemma eq_one_or_neg_one_of_mul_eq_neg_one {z w : ℤ} (h : z * w = -1) : z = 1 ∨ z = -1 :=
+or.elim (eq_one_or_neg_one_of_mul_eq_neg_one' h) (λ H, or.inl H.1) (λ H, or.inr H.1)
+
 theorem is_unit_iff_nat_abs_eq {n : ℤ} : is_unit n ↔ n.nat_abs = 1 :=
 by simp [nat_abs_eq_iff, is_unit_iff, nat.cast_zero]
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -557,6 +557,14 @@ begin
   tauto,
 end
 
+lemma eq_one_or_neg_one_iff_mul_eq_one {z w : ℤ} :
+  z * w = 1 ↔ z = 1 ∧ w = 1 ∨ z = -1 ∧ w = -1 :=
+begin
+  refine ⟨eq_one_or_neg_one_of_mul_eq_one', λ h, or.elim h (λ H, _) (λ H, _)⟩;
+  rcases H with ⟨rfl, rfl⟩;
+  refl,
+end
+
 lemma eq_one_or_neg_one_of_mul_eq_neg_one' {z w : ℤ} (h : z * w = -1) :
   z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1 :=
 begin
@@ -569,8 +577,8 @@ lemma eq_one_or_neg_one_iff_mul_eq_neg_one {z w : ℤ} :
   z * w = -1 ↔ z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1 :=
 begin
   refine ⟨eq_one_or_neg_one_of_mul_eq_neg_one', λ h, or.elim h (λ H, _) (λ H, _)⟩;
-  rcases H with ⟨rfl, rfl⟩,
-  exacts [one_mul _, mul_one _],
+  rcases H with ⟨rfl, rfl⟩;
+  refl,
 end
 
 lemma eq_one_or_neg_one_of_mul_eq_neg_one {z w : ℤ} (h : z * w = -1) : z = 1 ∨ z = -1 :=

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -558,7 +558,7 @@ begin
 end
 
 lemma eq_one_or_neg_one_of_mul_eq_neg_one' {z w : ℤ} (h : z * w = -1) :
-z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1 :=
+  z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1 :=
 begin
   obtain ⟨h₁, h₂⟩ := is_unit.mul_iff.mp (int.is_unit_iff.mpr (or.inr h)),
   rcases is_unit_eq_one_or h₁ with (rfl | rfl),

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -560,7 +560,7 @@ end
 lemma eq_one_or_neg_one_of_mul_eq_neg_one' {z w : ℤ} (h : z * w = -1) :
   z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1 :=
 begin
-  rcases is_unit_eq_one_or (is_unit.mul_iff.mp (int.is_unit_iff.mpr (or.inr h))).1 with (rfl|rfl),
+  rcases is_unit_eq_one_or (is_unit.mul_iff.mp (int.is_unit_iff.mpr (or.inr h))).1 with rfl | rfl,
   { rw one_mul at h, exact or.inl ⟨rfl, h⟩, },
   { rw [neg_one_mul, neg_inj] at h, exact or.inr ⟨rfl, h⟩, }
 end

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -560,8 +560,7 @@ end
 lemma eq_one_or_neg_one_of_mul_eq_neg_one' {z w : ℤ} (h : z * w = -1) :
   z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1 :=
 begin
-  obtain ⟨h₁, h₂⟩ := is_unit.mul_iff.mp (int.is_unit_iff.mpr (or.inr h)),
-  rcases is_unit_eq_one_or h₁ with (rfl | rfl),
+  rcases is_unit_eq_one_or (is_unit.mul_iff.mp (int.is_unit_iff.mpr (or.inr h))).1 with (rfl|rfl),
   { rw one_mul at h, exact or.inl ⟨rfl, h⟩, },
   { rw [neg_one_mul, neg_inj] at h, exact or.inr ⟨rfl, h⟩, }
 end

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -562,7 +562,7 @@ lemma eq_one_or_neg_one_of_mul_eq_neg_one' {z w : ℤ} (h : z * w = -1) :
 begin
   rcases is_unit_eq_one_or (is_unit.mul_iff.mp (int.is_unit_iff.mpr (or.inr h))).1 with rfl | rfl,
   { exact or.inl ⟨rfl, one_mul w ▸ h⟩, },
-  { rw [neg_one_mul, neg_inj] at h, exact or.inr ⟨rfl, h⟩, }
+  { exact or.inr ⟨rfl, neg_inj.mp (neg_one_mul w ▸ h)⟩, }
 end
 
 lemma eq_one_or_neg_one_of_mul_eq_neg_one {z w : ℤ} (h : z * w = -1) : z = 1 ∨ z = -1 :=

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -565,6 +565,14 @@ begin
   { exact or.inr ⟨rfl, neg_inj.mp (neg_one_mul w ▸ h)⟩, }
 end
 
+lemma eq_one_or_neg_one_iff_mul_eq_neg_one {z w : ℤ} :
+  z * w = -1 ↔ z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1 :=
+begin
+  refine ⟨eq_one_or_neg_one_of_mul_eq_neg_one', λ h, or.elim h (λ H, _) (λ H, _)⟩;
+  rcases H with ⟨rfl, rfl⟩,
+  exacts [one_mul _, mul_one _],
+end
+
 lemma eq_one_or_neg_one_of_mul_eq_neg_one {z w : ℤ} (h : z * w = -1) : z = 1 ∨ z = -1 :=
 or.elim (eq_one_or_neg_one_of_mul_eq_neg_one' h) (λ H, or.inl H.1) (λ H, or.inr H.1)
 


### PR DESCRIPTION
This small PR adds two lemmas:
```lean
lemma eq_one_or_neg_one_of_mul_eq_neg_one {z w : ℤ} (h : z * w = -1) : z = 1 ∨ z = -1
lemma eq_one_or_neg_one_of_mul_eq_neg_one' {z w : ℤ} (h : z * w = -1) : z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1
```
that are analogous to the existing `eq_one_or_neg_one_of_mul_eq_one` and `eq_one_or_neg_one_of_mul_eq_one'`.

On request by Eric Wieser, this also adds
```lean
lemma mul_eq_neg_one_iff_eq_one_or_neg_one {z w : ℤ} : z * w = -1 ↔ z = 1 ∧ w = -1 ∨ z = -1 ∧ w = 1
```
and its analogue
```lean
lemma mul_eq_one_iff_eq_one_or_neg_one {z w : ℤ} : z * w = 1 ↔ z = 1 ∧ w = 1 ∨ z = -1 ∧ w = -1
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
