### PR TITLE
[Merged by Bors] - perf(analysis/complex/circle): fix a slow `@[simps]`

### DIFF
--- a/src/analysis/complex/circle.lean
+++ b/src/analysis/complex/circle.lean
@@ -66,6 +66,7 @@ circle.subtype.map_div z w
 /-- The elements of the circle embed into the units. -/
 def circle.to_units : circle →* units ℂ := unit_sphere_to_units ℂ
 
+-- written manually because `@[simps]` was slow and generated the wrong lemma
 @[simp] lemma circle.to_units_apply (z : circle) :
   circle.to_units z = units.mk0 z (ne_zero_of_mem_circle z) := rfl
 

--- a/src/analysis/complex/circle.lean
+++ b/src/analysis/complex/circle.lean
@@ -64,7 +64,10 @@ by rw [coe_inv_circle, inv_def, norm_sq_eq_of_mem_circle, inv_one, of_real_one, 
 circle.subtype.map_div z w
 
 /-- The elements of the circle embed into the units. -/
-@[simps apply] def circle.to_units : circle →* units ℂ := unit_sphere_to_units ℂ
+def circle.to_units : circle →* units ℂ := unit_sphere_to_units ℂ
+
+@[simp] lemma circle.to_units_apply (z : circle) :
+  circle.to_units z = units.mk0 z (ne_zero_of_mem_circle z) := rfl
 
 instance : compact_space circle := metric.sphere.compact_space _ _
 


### PR DESCRIPTION
This `@[simps]` is really slow on master and caused me a timeout in #17164, and moreover it generated a bad `simp` lemma (it used `↥(metric.sphere 0 1)` instead of `↥circle`), so I just wrote the lemma by hand.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
