### PR TITLE
[Merged by Bors] - refactor(topology/{fiber,vector}_bundle): make `vector_bundle` a mixin

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -205,7 +205,8 @@ Topology:
     connectedness: 'connected_space'
     compact open topology: 'continuous_map.compact_open'
     Stone-Cech compactification: 'stone_cech'
-    topological fiber bundle: 'is_topological_fiber_bundle'
+    topological fiber bundle: 'fiber_bundle'
+    topological vector bundle: 'vector_bundle'
     Urysohn's lemma: 'exists_continuous_zero_one_of_closed'
     Stone-Weierstrass theorem: 'continuous_map.subalgebra_topological_closure_eq_top_of_separates_points'
   Uniform notions:

--- a/src/analysis/complex/re_im_topology.lean
+++ b/src/analysis/complex/re_im_topology.lean
@@ -16,7 +16,7 @@ topological properties of `complex.re` and `complex.im`.
 
 Each statement about `complex.re` listed below has a counterpart about `complex.im`.
 
-* `complex.is_trivial_topological_fiber_bundle_re`: `complex.re` turns `ℂ` into a trivial
+* `complex.is_trivial_fiber_bundle_re`: `complex.re` turns `ℂ` into a trivial
   topological fiber bundle over `ℝ`;
 * `complex.is_open_map_re`, `complex.quotient_map_re`: in particular, `complex.re` is an open map
   and is a quotient map;
@@ -37,24 +37,18 @@ noncomputable theory
 namespace complex
 
 /-- `complex.re` turns `ℂ` into a trivial topological fiber bundle over `ℝ`. -/
-lemma is_trivial_topological_fiber_bundle_re : is_trivial_topological_fiber_bundle ℝ re :=
+lemma is_trivial_fiber_bundle_re : is_trivial_fiber_bundle ℝ re :=
 ⟨equiv_real_prodₗ.to_homeomorph, λ z, rfl⟩
 
 /-- `complex.im` turns `ℂ` into a trivial topological fiber bundle over `ℝ`. -/
-lemma is_trivial_topological_fiber_bundle_im : is_trivial_topological_fiber_bundle ℝ im :=
+lemma is_trivial_fiber_bundle_im : is_trivial_fiber_bundle ℝ im :=
 ⟨equiv_real_prodₗ.to_homeomorph.trans (homeomorph.prod_comm ℝ ℝ), λ z, rfl⟩
 
-lemma is_topological_fiber_bundle_re : is_topological_fiber_bundle ℝ re :=
-is_trivial_topological_fiber_bundle_re.is_topological_fiber_bundle
+lemma is_open_map_re : is_open_map re := is_trivial_fiber_bundle_re.is_open_map_proj
+lemma is_open_map_im : is_open_map im := is_trivial_fiber_bundle_im.is_open_map_proj
 
-lemma is_topological_fiber_bundle_im : is_topological_fiber_bundle ℝ im :=
-is_trivial_topological_fiber_bundle_im.is_topological_fiber_bundle
-
-lemma is_open_map_re : is_open_map re := is_topological_fiber_bundle_re.is_open_map_proj
-lemma is_open_map_im : is_open_map im := is_topological_fiber_bundle_im.is_open_map_proj
-
-lemma quotient_map_re : quotient_map re := is_topological_fiber_bundle_re.quotient_map_proj
-lemma quotient_map_im : quotient_map im := is_topological_fiber_bundle_im.quotient_map_proj
+lemma quotient_map_re : quotient_map re := is_trivial_fiber_bundle_re.quotient_map_proj
+lemma quotient_map_im : quotient_map im := is_trivial_fiber_bundle_im.quotient_map_proj
 
 lemma interior_preimage_re (s : set ℝ) : interior (re ⁻¹' s) = re ⁻¹' (interior s) :=
 (is_open_map_re.preimage_interior_eq_interior_preimage continuous_re _).symm

--- a/src/analysis/complex/re_im_topology.lean
+++ b/src/analysis/complex/re_im_topology.lean
@@ -16,7 +16,7 @@ topological properties of `complex.re` and `complex.im`.
 
 Each statement about `complex.re` listed below has a counterpart about `complex.im`.
 
-* `complex.is_trivial_fiber_bundle_re`: `complex.re` turns `ℂ` into a trivial
+* `complex.is_homeomorphic_trivial_fiber_bundle_re`: `complex.re` turns `ℂ` into a trivial
   topological fiber bundle over `ℝ`;
 * `complex.is_open_map_re`, `complex.quotient_map_re`: in particular, `complex.re` is an open map
   and is a quotient map;
@@ -37,18 +37,18 @@ noncomputable theory
 namespace complex
 
 /-- `complex.re` turns `ℂ` into a trivial topological fiber bundle over `ℝ`. -/
-lemma is_trivial_fiber_bundle_re : is_trivial_fiber_bundle ℝ re :=
+lemma is_homeomorphic_trivial_fiber_bundle_re : is_homeomorphic_trivial_fiber_bundle ℝ re :=
 ⟨equiv_real_prodₗ.to_homeomorph, λ z, rfl⟩
 
 /-- `complex.im` turns `ℂ` into a trivial topological fiber bundle over `ℝ`. -/
-lemma is_trivial_fiber_bundle_im : is_trivial_fiber_bundle ℝ im :=
+lemma is_homeomorphic_trivial_fiber_bundle_im : is_homeomorphic_trivial_fiber_bundle ℝ im :=
 ⟨equiv_real_prodₗ.to_homeomorph.trans (homeomorph.prod_comm ℝ ℝ), λ z, rfl⟩
 
-lemma is_open_map_re : is_open_map re := is_trivial_fiber_bundle_re.is_open_map_proj
-lemma is_open_map_im : is_open_map im := is_trivial_fiber_bundle_im.is_open_map_proj
+lemma is_open_map_re : is_open_map re := is_homeomorphic_trivial_fiber_bundle_re.is_open_map_proj
+lemma is_open_map_im : is_open_map im := is_homeomorphic_trivial_fiber_bundle_im.is_open_map_proj
 
-lemma quotient_map_re : quotient_map re := is_trivial_fiber_bundle_re.quotient_map_proj
-lemma quotient_map_im : quotient_map im := is_trivial_fiber_bundle_im.quotient_map_proj
+lemma quotient_map_re : quotient_map re := is_homeomorphic_trivial_fiber_bundle_re.quotient_map_proj
+lemma quotient_map_im : quotient_map im := is_homeomorphic_trivial_fiber_bundle_im.quotient_map_proj
 
 lemma interior_preimage_re (s : set ℝ) : interior (re ⁻¹' s) = re ⁻¹' (interior s) :=
 (is_open_map_re.preimage_interior_eq_interior_preimage continuous_re _).symm

--- a/src/geometry/manifold/cont_mdiff_mfderiv.lean
+++ b/src/geometry/manifold/cont_mdiff_mfderiv.lean
@@ -443,30 +443,30 @@ variables (Z : basic_smooth_vector_bundle_core I M E')
 
 /-- A version of `cont_mdiff_at_iff_target` when the codomain is the total space of
   a `basic_smooth_vector_bundle_core`. The continuity condition in the RHS is weaker. -/
-lemma cont_mdiff_at_iff_target {f : N → Z.to_topological_vector_bundle_core.total_space}
+lemma cont_mdiff_at_iff_target {f : N → Z.to_vector_bundle_core.total_space}
   {x : N} {n : ℕ∞} :
   cont_mdiff_at J (I.prod 𝓘(𝕜, E')) n f x ↔ continuous_at (bundle.total_space.proj ∘ f) x ∧
     cont_mdiff_at J 𝓘(𝕜, E × E') n (ext_chart_at (I.prod 𝓘(𝕜, E')) (f x) ∘ f) x :=
 begin
-  let Z' := Z.to_topological_vector_bundle_core,
+  let Z' := Z.to_vector_bundle_core,
   rw [cont_mdiff_at_iff_target, and.congr_left_iff],
   refine λ hf, ⟨λ h, Z'.continuous_proj.continuous_at.comp h, λ h, _⟩,
   exact (Z'.local_triv ⟨chart_at _ (f x).1, chart_mem_atlas _ _⟩)
     .continuous_at_of_comp_left h (mem_chart_source _ _) (h.prod hf.continuous_at.snd)
 end
 
-lemma smooth_iff_target {f : N → Z.to_topological_vector_bundle_core.total_space} :
+lemma smooth_iff_target {f : N → Z.to_vector_bundle_core.total_space} :
   smooth J (I.prod 𝓘(𝕜, E')) f ↔ continuous (bundle.total_space.proj ∘ f) ∧
   ∀ x, smooth_at J 𝓘(𝕜, E × E') (ext_chart_at (I.prod 𝓘(𝕜, E')) (f x) ∘ f) x :=
 by simp_rw [smooth, smooth_at, cont_mdiff, Z.cont_mdiff_at_iff_target, forall_and_distrib,
   continuous_iff_continuous_at]
 
 lemma cont_mdiff_proj :
-  cont_mdiff (I.prod 𝓘(𝕜, E')) I n Z.to_topological_vector_bundle_core.proj :=
+  cont_mdiff (I.prod 𝓘(𝕜, E')) I n Z.to_vector_bundle_core.proj :=
 begin
   assume x,
   rw [cont_mdiff_at, cont_mdiff_within_at_iff'],
-  refine ⟨Z.to_topological_vector_bundle_core.continuous_proj.continuous_within_at, _⟩,
+  refine ⟨Z.to_vector_bundle_core.continuous_proj.continuous_within_at, _⟩,
   simp only [(∘), chart_at, chart] with mfld_simps,
   apply cont_diff_within_at_fst.congr,
   { rintros ⟨a, b⟩ hab,
@@ -476,39 +476,39 @@ begin
 end
 
 lemma smooth_proj :
-  smooth (I.prod 𝓘(𝕜, E')) I Z.to_topological_vector_bundle_core.proj :=
+  smooth (I.prod 𝓘(𝕜, E')) I Z.to_vector_bundle_core.proj :=
 cont_mdiff_proj Z
 
-lemma cont_mdiff_on_proj {s : set (Z.to_topological_vector_bundle_core.total_space)} :
+lemma cont_mdiff_on_proj {s : set (Z.to_vector_bundle_core.total_space)} :
   cont_mdiff_on (I.prod 𝓘(𝕜, E')) I n
-    Z.to_topological_vector_bundle_core.proj s :=
+    Z.to_vector_bundle_core.proj s :=
 Z.cont_mdiff_proj.cont_mdiff_on
 
-lemma smooth_on_proj {s : set (Z.to_topological_vector_bundle_core.total_space)} :
-  smooth_on (I.prod 𝓘(𝕜, E')) I Z.to_topological_vector_bundle_core.proj s :=
+lemma smooth_on_proj {s : set (Z.to_vector_bundle_core.total_space)} :
+  smooth_on (I.prod 𝓘(𝕜, E')) I Z.to_vector_bundle_core.proj s :=
 cont_mdiff_on_proj Z
 
-lemma cont_mdiff_at_proj {p : Z.to_topological_vector_bundle_core.total_space} :
+lemma cont_mdiff_at_proj {p : Z.to_vector_bundle_core.total_space} :
   cont_mdiff_at (I.prod 𝓘(𝕜, E')) I n
-    Z.to_topological_vector_bundle_core.proj p :=
+    Z.to_vector_bundle_core.proj p :=
 Z.cont_mdiff_proj.cont_mdiff_at
 
-lemma smooth_at_proj {p : Z.to_topological_vector_bundle_core.total_space} :
-  smooth_at (I.prod 𝓘(𝕜, E')) I Z.to_topological_vector_bundle_core.proj p :=
+lemma smooth_at_proj {p : Z.to_vector_bundle_core.total_space} :
+  smooth_at (I.prod 𝓘(𝕜, E')) I Z.to_vector_bundle_core.proj p :=
 Z.cont_mdiff_at_proj
 
 lemma cont_mdiff_within_at_proj
-  {s : set (Z.to_topological_vector_bundle_core.total_space)}
-  {p : Z.to_topological_vector_bundle_core.total_space} :
+  {s : set (Z.to_vector_bundle_core.total_space)}
+  {p : Z.to_vector_bundle_core.total_space} :
   cont_mdiff_within_at (I.prod 𝓘(𝕜, E')) I n
-    Z.to_topological_vector_bundle_core.proj s p :=
+    Z.to_vector_bundle_core.proj s p :=
 Z.cont_mdiff_at_proj.cont_mdiff_within_at
 
 lemma smooth_within_at_proj
-  {s : set (Z.to_topological_vector_bundle_core.total_space)}
-  {p : Z.to_topological_vector_bundle_core.total_space} :
+  {s : set (Z.to_vector_bundle_core.total_space)}
+  {p : Z.to_vector_bundle_core.total_space} :
   smooth_within_at (I.prod 𝓘(𝕜, E')) I
-    Z.to_topological_vector_bundle_core.proj s p :=
+    Z.to_vector_bundle_core.proj s p :=
 Z.cont_mdiff_within_at_proj
 
 /-- If an element of `E'` is invariant under all coordinate changes, then one can define a
@@ -518,24 +518,24 @@ section of the endomorphism bundle of a vector bundle. -/
 lemma smooth_const_section (v : E')
   (h : ∀ (i j : atlas H M), ∀ x ∈ i.1.source ∩ j.1.source, Z.coord_change i j (i.1 x) v = v) :
   smooth I (I.prod 𝓘(𝕜, E'))
-    (show M → Z.to_topological_vector_bundle_core.total_space, from λ x, ⟨x, v⟩) :=
+    (show M → Z.to_vector_bundle_core.total_space, from λ x, ⟨x, v⟩) :=
 begin
   assume x,
   rw [cont_mdiff_at, cont_mdiff_within_at_iff'],
   split,
   { apply continuous.continuous_within_at,
-    apply topological_fiber_bundle_core.continuous_const_section,
+    apply fiber_bundle_core.continuous_const_section,
     assume i j y hy,
     exact h _ _ _ hy },
   { have : cont_diff 𝕜 ⊤ (λ (y : E), (y, v)) := cont_diff_id.prod cont_diff_const,
     apply this.cont_diff_within_at.congr,
     { assume y hy,
       simp only with mfld_simps at hy,
-      simp only [chart, hy, chart_at, prod.mk.inj_iff, to_topological_vector_bundle_core]
+      simp only [chart, hy, chart_at, prod.mk.inj_iff, to_vector_bundle_core]
         with mfld_simps,
       apply h,
       simp only [hy, subtype.val_eq_coe] with mfld_simps },
-    { simp only [chart, chart_at, prod.mk.inj_iff, to_topological_vector_bundle_core]
+    { simp only [chart, chart_at, prod.mk.inj_iff, to_vector_bundle_core]
         with mfld_simps,
       apply h,
       simp only [subtype.val_eq_coe] with mfld_simps } }
@@ -634,7 +634,7 @@ begin
     { exact differentiable_at_id'.prod (differentiable_at_const _) } },
   simp only [tangent_bundle.zero_section, tangent_map, mfderiv,
     A, dif_pos, chart_at, basic_smooth_vector_bundle_core.chart,
-    basic_smooth_vector_bundle_core.to_topological_vector_bundle_core, tangent_bundle_core,
+    basic_smooth_vector_bundle_core.to_vector_bundle_core, tangent_bundle_core,
     function.comp, continuous_linear_map.map_zero] with mfld_simps,
   rw ← fderiv_within_inter N (I.unique_diff (I ((chart_at H x) x)) (set.mem_range_self _)) at B,
   rw [← fderiv_within_inter N (I.unique_diff (I ((chart_at H x) x)) (set.mem_range_self _)), ← B],

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -1349,7 +1349,7 @@ begin
   -- a trivial instance is needed after the rewrite, handle it right now.
   rotate, { apply_instance },
   simp only [continuous_linear_map.coe_coe, basic_smooth_vector_bundle_core.chart, h,
-    tangent_bundle_core, basic_smooth_vector_bundle_core.to_topological_vector_bundle_core,
+    tangent_bundle_core, basic_smooth_vector_bundle_core.to_vector_bundle_core,
     chart_at, sigma.mk.inj_iff] with mfld_simps,
 end
 
@@ -1619,7 +1619,7 @@ variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
 /-- In a smooth fiber bundle constructed from core, the preimage under the projection of a set with
 unique differential in the basis also has unique differential. -/
 lemma unique_mdiff_on.smooth_bundle_preimage (hs : unique_mdiff_on I s) :
-  unique_mdiff_on (I.prod (𝓘(𝕜, F))) (Z.to_topological_vector_bundle_core.proj ⁻¹' s) :=
+  unique_mdiff_on (I.prod (𝓘(𝕜, F))) (Z.to_vector_bundle_core.proj ⁻¹' s) :=
 begin
   /- Using a chart (and the fact that unique differentiability is invariant under charts), we
   reduce the situation to the model space, where we can use the fact that products respect
@@ -1630,14 +1630,14 @@ begin
   let e := chart_at (model_prod H F) p,
   -- It suffices to prove unique differentiability in a chart
   suffices h : unique_mdiff_on (I.prod (𝓘(𝕜, F)))
-    (e.target ∩ e.symm⁻¹' (Z.to_topological_vector_bundle_core.proj ⁻¹' s)),
+    (e.target ∩ e.symm⁻¹' (Z.to_vector_bundle_core.proj ⁻¹' s)),
   { have A : unique_mdiff_on (I.prod (𝓘(𝕜, F))) (e.symm.target ∩
-      e.symm.symm ⁻¹' (e.target ∩ e.symm⁻¹' (Z.to_topological_vector_bundle_core.proj ⁻¹' s))),
+      e.symm.symm ⁻¹' (e.target ∩ e.symm⁻¹' (Z.to_vector_bundle_core.proj ⁻¹' s))),
     { apply h.unique_mdiff_on_preimage,
       exact (mdifferentiable_of_mem_atlas _ (chart_mem_atlas _ _)).symm,
       apply_instance },
     have : p ∈ e.symm.target ∩
-      e.symm.symm ⁻¹' (e.target ∩ e.symm⁻¹' (Z.to_topological_vector_bundle_core.proj ⁻¹' s)),
+      e.symm.symm ⁻¹' (e.target ∩ e.symm⁻¹' (Z.to_vector_bundle_core.proj ⁻¹' s)),
         by simp only [e, hp] with mfld_simps,
     apply (A _ this).mono,
     assume q hq,

--- a/src/geometry/manifold/tangent_bundle.lean
+++ b/src/geometry/manifold/tangent_bundle.lean
@@ -39,8 +39,8 @@ specifying the changes in the fiber when one goes from one coordinate chart to a
   bundle with fiber `F` over `M`.
 
 Let `Z` be a basic smooth bundle core over `M` with fiber `F`. We define
-`Z.to_topological_vector_bundle_core`, the (topological) vector bundle core associated to `Z`. From
-it, we get a space `Z.to_topological_vector_bundle_core.total_space` (which as a Type is just
+`Z.to_vector_bundle_core`, the (topological) vector bundle core associated to `Z`. From
+it, we get a space `Z.to_vector_bundle_core.total_space` (which as a Type is just
 `Σ (x : M), F`), with the fiber bundle topology. It inherits a manifold structure (where the
 charts are in bijection with the charts of the basis). We show that this manifold is smooth.
 
@@ -183,7 +183,7 @@ end
 
 /-- Vector bundle core associated to a basic smooth bundle core -/
 @[simps coord_change index_at]
-def to_topological_vector_bundle_core : topological_vector_bundle_core 𝕜 M F (atlas H M) :=
+def to_vector_bundle_core : vector_bundle_core 𝕜 M F (atlas H M) :=
 { base_set := λ i, i.1.source,
   is_open_base_set := λ i, i.1.open_source,
   index_at := achart H,
@@ -204,24 +204,24 @@ def to_topological_vector_bundle_core : topological_vector_bundle_core 𝕜 M F 
   end }
 
 @[simp, mfld_simps] lemma base_set (i : atlas H M) :
-  (Z.to_topological_vector_bundle_core.local_triv i).base_set = i.1.source := rfl
+  (Z.to_vector_bundle_core.local_triv i).base_set = i.1.source := rfl
 
 @[simp, mfld_simps] lemma target (i : atlas H M) :
-  (Z.to_topological_vector_bundle_core.local_triv i).target = i.1.source ×ˢ univ := rfl
+  (Z.to_vector_bundle_core.local_triv i).target = i.1.source ×ˢ univ := rfl
 
 /-- Local chart for the total space of a basic smooth bundle -/
 def chart {e : local_homeomorph M H} (he : e ∈ atlas H M) :
-  local_homeomorph (Z.to_topological_vector_bundle_core.total_space) (model_prod H F) :=
-(Z.to_topological_vector_bundle_core.local_triv ⟨e, he⟩).to_local_homeomorph.trans
+  local_homeomorph (Z.to_vector_bundle_core.total_space) (model_prod H F) :=
+(Z.to_vector_bundle_core.local_triv ⟨e, he⟩).to_local_homeomorph.trans
   (local_homeomorph.prod e (local_homeomorph.refl F))
 
-lemma chart_apply {x : M} (z : Z.to_topological_vector_bundle_core.total_space) :
+lemma chart_apply {x : M} (z : Z.to_vector_bundle_core.total_space) :
   Z.chart (chart_mem_atlas H x) z = (chart_at H x z.proj,
     Z.coord_change (achart H z.proj) (achart H x) (achart H z.proj z.proj) z.2) :=
 rfl
 
 @[simp, mfld_simps] lemma chart_source (e : local_homeomorph M H) (he : e ∈ atlas H M) :
-  (Z.chart he).source = Z.to_topological_vector_bundle_core.proj ⁻¹' e.source :=
+  (Z.chart he).source = Z.to_vector_bundle_core.proj ⁻¹' e.source :=
 by { simp only [chart, mem_prod], mfld_set_tac }
 
 @[simp, mfld_simps] lemma chart_target (e : local_homeomorph M H) (he : e ∈ atlas H M) :
@@ -232,7 +232,7 @@ by { simp only [chart], mfld_set_tac }
 charts are in bijection with the charts of the basis. -/
 @[simps chart_at (lemmas_only)]
 instance to_charted_space :
-  charted_space (model_prod H F) Z.to_topological_vector_bundle_core.total_space :=
+  charted_space (model_prod H F) Z.to_vector_bundle_core.total_space :=
 { atlas := ⋃(e : local_homeomorph M H) (he : e ∈ atlas H M), {Z.chart he},
   chart_at := λ p, Z.chart (chart_mem_atlas H p.1),
   mem_chart_source := λ p, by simp [mem_chart_source],
@@ -242,31 +242,31 @@ instance to_charted_space :
   end }
 
 lemma mem_atlas_iff
-  (f : local_homeomorph Z.to_topological_vector_bundle_core.total_space (model_prod H F)) :
-  f ∈ atlas (model_prod H F) Z.to_topological_vector_bundle_core.total_space ↔
+  (f : local_homeomorph Z.to_vector_bundle_core.total_space (model_prod H F)) :
+  f ∈ atlas (model_prod H F) Z.to_vector_bundle_core.total_space ↔
   ∃(e : local_homeomorph M H) (he : e ∈ atlas H M), f = Z.chart he :=
 by simp only [atlas, mem_Union, mem_singleton_iff]
 
 @[simp, mfld_simps] lemma mem_chart_source_iff
-  (p q : Z.to_topological_vector_bundle_core.total_space) :
+  (p q : Z.to_vector_bundle_core.total_space) :
   p ∈ (chart_at (model_prod H F) q).source ↔ p.1 ∈ (chart_at H q.1).source :=
 by simp only [chart_at] with mfld_simps
 
 @[simp, mfld_simps] lemma mem_chart_target_iff
-  (p : H × F) (q : Z.to_topological_vector_bundle_core.total_space) :
+  (p : H × F) (q : Z.to_vector_bundle_core.total_space) :
   p ∈ (chart_at (model_prod H F) q).target ↔ p.1 ∈ (chart_at H q.1).target :=
 by simp only [chart_at] with mfld_simps
 
-@[simp, mfld_simps] lemma coe_chart_at_fst (p q : Z.to_topological_vector_bundle_core.total_space) :
+@[simp, mfld_simps] lemma coe_chart_at_fst (p q : Z.to_vector_bundle_core.total_space) :
   ((chart_at (model_prod H F) q) p).1 = chart_at H q.1 p.1 := rfl
 
 @[simp, mfld_simps] lemma coe_chart_at_symm_fst
-  (p : H × F) (q : Z.to_topological_vector_bundle_core.total_space) :
+  (p : H × F) (q : Z.to_vector_bundle_core.total_space) :
   ((chart_at (model_prod H F) q).symm p).1 = ((chart_at H q.1).symm : H → M) p.1 := rfl
 
 /-- Smooth manifold structure on the total space of a basic smooth bundle -/
 instance to_smooth_manifold :
-  smooth_manifold_with_corners (I.prod (𝓘(𝕜, F))) Z.to_topological_vector_bundle_core.total_space :=
+  smooth_manifold_with_corners (I.prod (𝓘(𝕜, F))) Z.to_vector_bundle_core.total_space :=
 begin
   /- We have to check that the charts belong to the smooth groupoid, i.e., they are smooth on their
   source, and their inverses are smooth on the target. Since both objects are of the same kind, it
@@ -500,7 +500,7 @@ variable {M}
 include I
 
 /-- The tangent space at a point of the manifold `M`. It is just `E`. We could use instead
-`(tangent_bundle_core I M).to_topological_vector_bundle_core.fiber x`, but we use `E` to help the
+`(tangent_bundle_core I M).to_vector_bundle_core.fiber x`, but we use `E` to help the
 kernel.
 -/
 @[nolint unused_arguments]
@@ -550,7 +550,7 @@ end
 variable (M)
 
 instance : topological_space TM :=
-(tangent_bundle_core I M).to_topological_vector_bundle_core.to_topological_space (atlas H M)
+(tangent_bundle_core I M).to_vector_bundle_core.to_topological_space (atlas H M)
 
 instance : charted_space (model_prod H E) TM :=
 (tangent_bundle_core I M).to_charted_space
@@ -558,9 +558,11 @@ instance : charted_space (model_prod H E) TM :=
 instance : smooth_manifold_with_corners I.tangent TM :=
 (tangent_bundle_core I M).to_smooth_manifold
 
-instance : topological_vector_bundle 𝕜 E (tangent_space I : M → Type*) :=
-topological_vector_bundle_core.fiber.topological_vector_bundle
-  (tangent_bundle_core I M).to_topological_vector_bundle_core
+instance : fiber_bundle E (tangent_space I : M → Type*) :=
+(tangent_bundle_core I M).to_vector_bundle_core.fiber_bundle
+
+instance : vector_bundle 𝕜 E (tangent_space I : M → Type*) :=
+(tangent_bundle_core I M).to_vector_bundle_core.vector_bundle
 
 end tangent_bundle_instances
 
@@ -568,11 +570,11 @@ variable (M)
 
 /-- The tangent bundle projection on the basis is a continuous map. -/
 lemma tangent_bundle_proj_continuous : continuous (tangent_bundle.proj I M) :=
-((tangent_bundle_core I M).to_topological_vector_bundle_core).continuous_proj
+((tangent_bundle_core I M).to_vector_bundle_core).continuous_proj
 
 /-- The tangent bundle projection on the basis is an open map. -/
 lemma tangent_bundle_proj_open : is_open_map (tangent_bundle.proj I M) :=
-((tangent_bundle_core I M).to_topological_vector_bundle_core).is_open_map_proj
+((tangent_bundle_core I M).to_vector_bundle_core).is_open_map_proj
 
 /-- In the tangent bundle to the model space, the charts are just the canonical identification
 between a product type and a sigma type, a.k.a. `equiv.sigma_equiv_prod`. -/
@@ -591,12 +593,12 @@ begin
     (equiv.sigma_equiv_prod H E) x,
   { cases x,
     simp only [chart_at, basic_smooth_vector_bundle_core.chart, tangent_bundle_core,
-      basic_smooth_vector_bundle_core.to_topological_vector_bundle_core, A, prod.mk.inj_iff,
+      basic_smooth_vector_bundle_core.to_vector_bundle_core, A, prod.mk.inj_iff,
       continuous_linear_map.coe_id'] with mfld_simps },
   show ∀ x, ((chart_at (model_prod H E) p).to_local_equiv).symm x =
     (equiv.sigma_equiv_prod H E).symm x,
   { rintros ⟨x_fst, x_snd⟩,
-    simp only [basic_smooth_vector_bundle_core.to_topological_vector_bundle_core,
+    simp only [basic_smooth_vector_bundle_core.to_vector_bundle_core,
       tangent_bundle_core, A, continuous_linear_map.coe_id', basic_smooth_vector_bundle_core.chart,
       chart_at, continuous_linear_map.coe_coe, sigma.mk.inj_iff] with mfld_simps, },
   show ((chart_at (model_prod H E) p).to_local_equiv).source = univ,

--- a/src/topology/covering.lean
+++ b/src/topology/covering.lean
@@ -21,6 +21,8 @@ This file defines covering maps.
   assumed to be surjective, so the fibers are even allowed to be empty.
 -/
 
+open_locale bundle
+
 variables {E X : Type*} [topological_space E] [topological_space X] (f : E → X) (s : set X)
 
 /-- A point `x : X` is evenly covered by `f : E → X` if `x` has an evenly covered neighborhood. -/
@@ -150,6 +152,13 @@ end is_covering_map
 
 variables {f}
 
-protected lemma is_topological_fiber_bundle.is_covering_map {F : Type*} [topological_space F]
-  [discrete_topology F] (hf : is_topological_fiber_bundle F f) : is_covering_map f :=
+protected lemma is_fiber_bundle.is_covering_map {F : Type*} [topological_space F]
+  [discrete_topology F] (hf : ∀ x : X, ∃ e : trivialization F f, x ∈ e.base_set) :
+  is_covering_map f :=
 is_covering_map.mk f (λ x, F) (λ x, classical.some (hf x)) (λ x, classical.some_spec (hf x))
+
+protected lemma fiber_bundle.is_covering_map {F : Type*} {E : X → Type*} [topological_space F]
+  [discrete_topology F] [topological_space (bundle.total_space E)] [Π x, topological_space (E x)]
+  [hf : fiber_bundle F E] : is_covering_map (π E) :=
+is_fiber_bundle.is_covering_map
+  (λ x, ⟨trivialization_at F E x, mem_base_set_trivialization_at F E x ⟩)

--- a/src/topology/fiber_bundle/basic.lean
+++ b/src/topology/fiber_bundle/basic.lean
@@ -353,58 +353,6 @@ instance [t₁ : topological_space B] [t₂ : topological_space F] :
   topological_space (total_space (trivial B F)) :=
 induced total_space.proj t₁ ⊓ induced (trivial.proj_snd B F) t₂
 
-namespace trivial
-variables (B F) [topological_space B] [topological_space F]
-
-/-- Local trivialization for trivial bundle. -/
-def trivialization : trivialization F (π (bundle.trivial B F)) :=
-{ to_fun := λ x, (x.fst, x.snd),
-  inv_fun := λ y, ⟨y.fst, y.snd⟩,
-  source := univ,
-  target := univ,
-  map_source' := λ x h, mem_univ (x.fst, x.snd),
-  map_target' := λ y h,  mem_univ ⟨y.fst, y.snd⟩,
-  left_inv' := λ x h, sigma.eq rfl rfl,
-  right_inv' := λ x h, prod.ext rfl rfl,
-  open_source := is_open_univ,
-  open_target := is_open_univ,
-  continuous_to_fun := by { rw [←continuous_iff_continuous_on_univ, continuous_iff_le_induced],
-    simp only [prod.topological_space, induced_inf, induced_compose], exact le_rfl, },
-  continuous_inv_fun := by { rw [←continuous_iff_continuous_on_univ, continuous_iff_le_induced],
-    simp only [bundle.total_space.topological_space, induced_inf, induced_compose],
-    exact le_rfl, },
-  base_set := univ,
-  open_base_set := is_open_univ,
-  source_eq := rfl,
-  target_eq := by simp only [univ_prod_univ],
-  proj_to_fun := λ y hy, rfl }
-
-@[simp]
-lemma trivialization_source : (trivialization B F).source = univ := rfl
-
-@[simp]
-lemma trivialization_target : (trivialization B F).target = univ := rfl
-
-/-- Fiber bundle instance on the trivial bundle. -/
-instance fiber_bundle : fiber_bundle F (bundle.trivial B F) :=
-{ trivialization_atlas := {bundle.trivial.trivialization B F},
-  trivialization_at := λ x, bundle.trivial.trivialization B F,
-  mem_base_set_trivialization_at := mem_univ,
-  trivialization_mem_atlas := λ x, mem_singleton _,
-  total_space_mk_inducing := λ b, ⟨begin
-    have : (λ (x : trivial B F b), x) = @id F, by { ext x, refl },
-    simp only [total_space.topological_space, induced_inf, induced_compose, function.comp,
-      total_space.proj, induced_const, top_inf_eq, trivial.proj_snd, id.def,
-      trivial.topological_space, this, induced_id],
-  end⟩ }
-
-lemma eq_trivialization (e : _root_.trivialization F (π (bundle.trivial B F)))
-  [i : mem_trivialization_atlas e] :
-  e = trivialization B F :=
-i.out
-
-end trivial
-
 end bundle
 
 /-- Core data defining a locally trivial bundle with fiber `F` over a topological
@@ -532,7 +480,7 @@ def local_triv_as_local_equiv (i : ι) : local_equiv Z.total_space (B × F) :=
     { simp only [hx, mem_inter_iff, and_self, mem_base_set_at] }
   end }
 
-variables (i : ι)
+variable (i : ι)
 
 lemma mem_local_triv_as_local_equiv_source (p : Z.total_space) :
   p ∈ (Z.local_triv_as_local_equiv i).source ↔ p.1 ∈ Z.base_set i :=

--- a/src/topology/fiber_bundle/basic.lean
+++ b/src/topology/fiber_bundle/basic.lean
@@ -8,10 +8,28 @@ import topology.fiber_bundle.trivialization
 /-!
 # Fiber bundles
 
-A (topological) fiber bundle with fiber `F` over a base `B` is a space projecting on `B` for which the
-fibers are all homeomorphic to `F`, such that the local situation around each point is a direct
-product. We define a structure `fiber_bundle F E` saying that `E : B → Type*` is a
-fiber bundle with fiber `F`.
+Mathematically, a (topological) fiber bundle with fiber `F` over a base `B` is a space projecting on
+`B` for which the fibers are all homeomorphic to `F`, such that the local situation around each point
+is a direct product.
+
+In our formalism, a fiber bundle is by definition the type
+`bundle.total_space E` where `E : B → Type*` is a function associating to
+`x : B` the fiber over `x`. This type `bundle.total_space E` is just a type synonym for
+`Σ (x : B), E x`, with the interest that one can put another topology than on `Σ (x : B), E x`
+which has the disjoint union topology.
+
+To have a fiber bundle structure on `bundle.total_space E`, one should
+additionally have the following data:
+
+* `F` should be a topological space;
+* There should be a topology on `bundle.total_space E`, for which the projection to `B` is
+a fiber bundle with fiber `F` (in particular, each fiber `E x` is homeomorphic to `F`);
+* For each `x`, the fiber `E x` should be a topological space, and the injection
+from `E x` to `bundle.total_space F E` should be an embedding;
+* There should be a distinguished set of bundle trivializations, the "trivialization atlas"
+* There should be a choice of bundle trivialization at each point, which belongs to this atlas.
+
+If all these conditions are satisfied, we register the typeclass `fiber_bundle F E`.
 
 It is in general nontrivial to construct a fiber bundle. A way is to start from the knowledge of
 how changes of local trivializations act on the fiber. From this, one can construct the total space
@@ -359,10 +377,7 @@ instance fiber_bundle : fiber_bundle F (bundle.trivial B F) :=
 lemma eq_trivialization (e : _root_.trivialization F (π (bundle.trivial B F)))
   [i : mem_trivialization_atlas e] :
   e = trivialization B F :=
-begin
-  unfreezingI { cases i },
-  exact i,
-end
+i.out
 
 end trivial
 
@@ -827,11 +842,11 @@ begin
   exact (a.inducing_total_space_mk b).continuous
 end
 
-/-- Make a `topological_vector_bundle` from a `topological_vector_prebundle`.  Concretely this means
-that, given a `topological_vector_prebundle` structure for a sigma-type `E` -- which consists of a
+/-- Make a `fiber_bundle` from a `fiber_prebundle`.  Concretely this means
+that, given a `fiber_prebundle` structure for a sigma-type `E` -- which consists of a
 number of "pretrivializations" identifying parts of `E` with product spaces `U × F` -- one
 establishes that for the topology constructed on the sigma-type using
-`topological_vector_prebundle.total_space_topology`, these "pretrivializations" are actually
+`fiber_prebundle.total_space_topology`, these "pretrivializations" are actually
 "trivializations" (i.e., homeomorphisms with respect to the constructed topology). -/
 def to_fiber_bundle :
   @fiber_bundle B F _ _ E a.total_space_topology a.fiber_topology :=
@@ -851,9 +866,9 @@ begin
   exact continuous_proj F E,
 end
 
-/-- For a fiber bundle `Z` over `B` constructed using the `fiber_prebundle` mechanism,
-continuity of a function `Z → X` on an open set `s` can be checked by precomposing at each point
-with the pretrivialization used for the construction at that point. -/
+/-- For a fiber bundle `E` over `B` constructed using the `fiber_prebundle` mechanism,
+continuity of a function `total_space E → X` on an open set `s` can be checked by precomposing at
+each point with the pretrivialization used for the construction at that point. -/
 lemma continuous_on_of_comp_right {X : Type*} [topological_space X] {f : total_space E → X}
   {s : set B} (hs : is_open s)
   (hf : ∀ b ∈ s, continuous_on (f ∘ (a.pretrivialization_at b).to_local_equiv.symm)

--- a/src/topology/fiber_bundle/basic.lean
+++ b/src/topology/fiber_bundle/basic.lean
@@ -9,8 +9,8 @@ import topology.fiber_bundle.trivialization
 # Fiber bundles
 
 Mathematically, a (topological) fiber bundle with fiber `F` over a base `B` is a space projecting on
-`B` for which the fibers are all homeomorphic to `F`, such that the local situation around each point
-is a direct product.
+`B` for which the fibers are all homeomorphic to `F`, such that the local situation around each
+point is a direct product.
 
 In our formalism, a fiber bundle is by definition the type
 `bundle.total_space E` where `E : B → Type*` is a function associating to
@@ -190,19 +190,10 @@ def is_trivial_fiber_bundle {Z : Type*} [topological_space Z] (proj : Z → B) :
 
 variables {F}
 
-/-- A `fiber_bundle` structure on a sigma-type `E` satisfying `is_trivial_fiber_bundle F (π E)`,
-consisting of the single global trivialization given by that hypothesis. -/
-noncomputable def is_trivial_fiber_bundle.fiber_bundle (h : is_trivial_fiber_bundle F (π E)) :
-  fiber_bundle F E :=
-let e := h.some in
-let he := h.some_spec in
-let a : trivialization F (π E) :=
-  ⟨e.to_local_homeomorph, univ, is_open_univ, rfl, univ_prod_univ.symm, λ x _, he x⟩ in
-{ total_space_mk_inducing := sorry,
-  trivialization_atlas := {a},
-  trivialization_at := λ x, a,
-  mem_base_set_trivialization_at := mem_univ,
-  trivialization_mem_atlas := λ x, rfl }
+lemma is_trivial_fiber_bundle.proj_eq {Z : Type*} [topological_space Z] {proj : Z → B}
+  (h : is_trivial_fiber_bundle F proj) :
+  ∃ e : Z ≃ₜ (B × F), proj = prod.fst ∘ e :=
+⟨h.some, (funext h.some_spec).symm⟩
 
 namespace fiber_bundle
 variables (F) {E} [fiber_bundle F E]
@@ -237,6 +228,39 @@ lemma continuous_total_space_mk (x : B) : continuous (@total_space_mk B E x) :=
 (total_space_mk_inducing F E x).continuous
 
 end fiber_bundle
+
+variables {F}
+
+/-- The projection from a trivial fiber bundle to its base is surjective. -/
+lemma is_trivial_fiber_bundle.surjective_proj [nonempty F] {Z : Type*} [topological_space Z]
+  {proj : Z → B} (h : is_trivial_fiber_bundle F proj) : function.surjective proj :=
+begin
+  obtain ⟨e, rfl⟩ := h.proj_eq,
+  exact prod.fst_surjective.comp e.surjective,
+end
+
+/-- The projection from a trivial fiber bundle to its base is continuous. -/
+lemma is_trivial_fiber_bundle.continuous_proj {Z : Type*} [topological_space Z] {proj : Z → B}
+  (h : is_trivial_fiber_bundle F proj) : continuous proj :=
+begin
+  obtain ⟨e, rfl⟩ := h.proj_eq,
+  exact continuous_fst.comp e.continuous,
+end
+
+/-- The projection from a trivial fiber bundle to its base is open. -/
+lemma is_trivial_fiber_bundle.is_open_map_proj {Z : Type*} [topological_space Z] {proj : Z → B}
+  (h : is_trivial_fiber_bundle F proj) : is_open_map proj :=
+begin
+  obtain ⟨e, rfl⟩ := h.proj_eq,
+  exact is_open_map_fst.comp e.is_open_map,
+end
+
+/-- The projection from a trivial fiber bundle to its base is open. -/
+lemma is_trivial_fiber_bundle.quotient_map_proj [nonempty F] {Z : Type*} [topological_space Z]
+  {proj : Z → B} (h : is_trivial_fiber_bundle F proj) : quotient_map proj :=
+h.is_open_map_proj.to_quotient_map h.continuous_proj h.surjective_proj
+
+variables (F)
 
 /-- The first projection in a product is a trivial fiber bundle. -/
 lemma is_trivial_fiber_bundle_fst :

--- a/src/topology/fiber_bundle/basic.lean
+++ b/src/topology/fiber_bundle/basic.lean
@@ -1,56 +1,46 @@
 /-
 Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sébastien Gouëzel
+Authors: Sébastien Gouëzel, Floris van Doorn, Heather Macbeth
 -/
 import topology.fiber_bundle.trivialization
 
 /-!
 # Fiber bundles
 
-A topological fiber bundle with fiber `F` over a base `B` is a space projecting on `B` for which the
+A (topological) fiber bundle with fiber `F` over a base `B` is a space projecting on `B` for which the
 fibers are all homeomorphic to `F`, such that the local situation around each point is a direct
-product. We define a predicate `is_topological_fiber_bundle F p` saying that `p : Z → B` is a
-topological fiber bundle with fiber `F`.
+product. We define a structure `fiber_bundle F E` saying that `E : B → Type*` is a
+fiber bundle with fiber `F`.
 
 It is in general nontrivial to construct a fiber bundle. A way is to start from the knowledge of
 how changes of local trivializations act on the fiber. From this, one can construct the total space
 of the bundle and its topology by a suitable gluing construction. The main content of this file is
 an implementation of this construction: starting from an object of type
-`topological_fiber_bundle_core` registering the trivialization changes, one gets the corresponding
+`fiber_bundle_core` registering the trivialization changes, one gets the corresponding
 fiber bundle and projection.
 
-Similarly we implement the object `topological_fiber_prebundle` which allows to define a topological
+Similarly we implement the object `fiber_prebundle` which allows to define a topological
 fiber bundle from trivializations given as local equivalences with minimum additional properties.
 
 ## Main definitions
 
 ### Basic definitions
 
-* `is_topological_fiber_bundle F p` : Prop saying that the map `p` between topological spaces is a
-                  fiber bundle with fiber `F`.
+* `fiber_bundle F E` : Structure saying that `E : B → Type*` is a fiber bundle with fiber `F`.
 
-* `is_trivial_topological_fiber_bundle F p` : Prop saying that the map `p : Z → B` between
-  topological spaces is a trivial topological fiber bundle, i.e., there exists a homeomorphism
+* `is_trivial_fiber_bundle F p` : Prop saying that the map `p : Z → B` between
+  topological spaces is a trivial fiber bundle, i.e., there exists a homeomorphism
   `h : Z ≃ₜ B × F` such that `proj x = (h x).1`.
-
-### Operations on bundles
-
-* `is_topological_fiber_bundle.comap`: if `p : Z → B` is a topological fiber bundle, then its
-  pullback along a continuous map `f : B' → B` is a topological fiber bundle as well.
-
-* `is_topological_fiber_bundle.comp_homeomorph`: if `p : Z → B` is a topological fiber bundle
-  and `h : Z' ≃ₜ Z` is a homeomorphism, then `p ∘ h : Z' → B` is a topological fiber bundle with
-  the same fiber.
 
 ### Construction of a bundle from trivializations
 
 * `bundle.total_space E` is a type synonym for `Σ (x : B), E x`, that we can endow with a suitable
   topology.
-* `topological_fiber_bundle_core ι B F` : structure registering how changes of coordinates act
+* `fiber_bundle_core ι B F` : structure registering how changes of coordinates act
   on the fiber `F` above open subsets of `B`, where local trivializations are indexed by `ι`.
 
-Let `Z : topological_fiber_bundle_core ι B F`. Then we define
+Let `Z : fiber_bundle_core ι B F`. Then we define
 
 * `Z.fiber x`     : the fiber above `x`, homeomorphic to `F` (and defeq to `F` as a type).
 * `Z.total_space` : the total space of `Z`, defined as a `Type` as `Σ (b : B), F`, but with a
@@ -60,16 +50,16 @@ Let `Z : topological_fiber_bundle_core ι B F`. Then we define
 * `Z.local_triv i`: for `i : ι`, bundle trivialization above the set `Z.base_set i`, which is an
                     open set in `B`.
 
-* `topological_fiber_prebundle F proj` : structure registering a cover of prebundle trivializations
+* `fiber_prebundle F E` : structure registering a cover of prebundle trivializations
   and requiring that the relative transition maps are local homeomorphisms.
-* `topological_fiber_prebundle.total_space_topology a` : natural topology of the total space, making
+* `fiber_prebundle.total_space_topology a` : natural topology of the total space, making
   the prebundle into a bundle.
 
 ## Implementation notes
 
 ### Core construction
 
-A topological fiber bundle with fiber `F` over a base `B` is a family of spaces isomorphic to `F`,
+A fiber bundle with fiber `F` over a base `B` is a family of spaces isomorphic to `F`,
 indexed by `B`, which is locally trivial in the following sense: there is a covering of `B` by open
 sets such that, on each such open set `s`, the bundle is isomorphic to `s × F`.
 
@@ -81,7 +71,7 @@ belong to some subgroup, preserving some structure (the "structure group of the 
 these structures are inherited by the fibers of the bundle.
 
 Given such trivialization change data (encoded below in a structure called
-`topological_fiber_bundle_core`), one can construct the fiber bundle. The intrinsic canonical
+`fiber_bundle_core`), one can construct the fiber bundle. The intrinsic canonical
 mathematical construction is the following.
 The fiber above `x` is the disjoint union of `F` over all trivializations, modulo the gluing
 identifications: one gets a fiber which is isomorphic to `F`, but non-canonically
@@ -112,9 +102,9 @@ each other, one can express that the composition of their derivatives is the ide
 as it does not know that `g (f x) = x`). As these types are the same to Lean (equal to `F`), there
 are in fact no dependent type difficulties here!
 
-For this construction of a fiber bundle from a `topological_fiber_bundle_core`, we should thus
+For this construction of a fiber bundle from a `fiber_bundle_core`, we should thus
 choose for each `x` one specific trivialization around it. We include this choice in the definition
-of the `topological_fiber_bundle_core`, as it makes some constructions more
+of the `fiber_bundle_core`, as it makes some constructions more
 functorial and it is a nice way to say that the trivializations cover the whole space `B`.
 
 With this definition, the type of the fiber bundle space constructed from the core data is just
@@ -124,7 +114,7 @@ We also take the indexing type (indexing all the trivializations) as a parameter
 core: it could always be taken as a subtype of all the maps from open subsets of `B` to continuous
 maps of `F`, but in practice it will sometimes be something else. For instance, on a manifold, one
 will use the set of charts as a good parameterization for the trivializations of the tangent bundle.
-Or for the pullback of a `topological_fiber_bundle_core`, the indexing type will be the same as
+Or for the pullback of a `fiber_bundle_core`, the indexing type will be the same as
 for the initial bundle.
 
 ## Tags
@@ -134,117 +124,126 @@ Fiber bundle, topological bundle, structure group
 variables {ι : Type*} {B : Type*} {F : Type*}
 
 open topological_space filter set bundle
-open_locale topological_space classical
+open_locale topological_space classical bundle
 
-/-! ### General definition of topological fiber bundles -/
+/-! ### General definition of fiber bundles -/
 
-section topological_fiber_bundle
+section fiber_bundle
 
-variables (F) {Z : Type*} [topological_space B] [topological_space F] {proj : Z → B}
-variable [topological_space Z]
+variables (F) [topological_space B] [topological_space F] (E : B → Type*)
 
-/-- A topological fiber bundle with fiber `F` over a base `B` is a space projecting on `B`
+/-! ### Fiber bundles -/
+
+variables [topological_space (total_space E)] [∀ b, topological_space (E b)]
+
+/-- A (topological) fiber bundle with fiber `F` over a base `B` is a space projecting on `B`
 for which the fibers are all homeomorphic to `F`, such that the local situation around each point
 is a direct product. -/
-def is_topological_fiber_bundle (proj : Z → B) : Prop :=
-∀ x : B, ∃e : trivialization F proj, x ∈ e.base_set
+class fiber_bundle :=
+(total_space_mk_inducing [] : ∀ (b : B), inducing (@total_space_mk B E b))
+(trivialization_atlas [] : set (trivialization F (π E)))
+(trivialization_at [] : B → trivialization F (π E))
+(mem_base_set_trivialization_at [] : ∀ b : B, b ∈ (trivialization_at b).base_set)
+(trivialization_mem_atlas [] : ∀ b : B, trivialization_at b ∈ trivialization_atlas)
 
-/-- A trivial topological fiber bundle with fiber `F` over a base `B` is a space `Z`
+export fiber_bundle
+
+variables {F E}
+
+/-- Given a type `E` equipped with a fiber bundle structure, this is a `Prop` typeclass
+for trivializations of `E`, expressing that a trivialization is in the designated atlas for the
+bundle.  This is needed because lemmas about the linearity of trivializations or the continuity (as
+functions to `F →L[R] F`, where `F` is the model fibre) of the transition functions are only
+expected to hold for trivializations in the designated atlas. -/
+@[mk_iff]
+class mem_trivialization_atlas [fiber_bundle F E] (e : trivialization F (π E)) : Prop :=
+(out : e ∈ trivialization_atlas F E)
+
+instance [fiber_bundle F E] (b : B) : mem_trivialization_atlas (trivialization_at F E b) :=
+{ out := trivialization_mem_atlas F E b }
+
+variables (F E)
+
+/-- A trivial fiber bundle with fiber `F` over a base `B` is a space `Z`
 projecting on `B` for which there exists a homeomorphism to `B × F` that sends `proj`
 to `prod.fst`. -/
-def is_trivial_topological_fiber_bundle (proj : Z → B) : Prop :=
+def is_trivial_fiber_bundle {Z : Type*} [topological_space Z] (proj : Z → B) : Prop :=
 ∃ e : Z ≃ₜ (B × F), ∀ x, (e x).1 = proj x
 
 variables {F}
 
-lemma is_trivial_topological_fiber_bundle.is_topological_fiber_bundle
-  (h : is_trivial_topological_fiber_bundle F proj) :
-  is_topological_fiber_bundle F proj :=
-let ⟨e, he⟩ := h in λ x,
-⟨⟨e.to_local_homeomorph, univ, is_open_univ, rfl, univ_prod_univ.symm, λ x _, he x⟩, mem_univ x⟩
+/-- A `fiber_bundle` structure on a sigma-type `E` satisfying `is_trivial_fiber_bundle F (π E)`,
+consisting of the single global trivialization given by that hypothesis. -/
+noncomputable def is_trivial_fiber_bundle.fiber_bundle (h : is_trivial_fiber_bundle F (π E)) :
+  fiber_bundle F E :=
+let e := h.some in
+let he := h.some_spec in
+let a : trivialization F (π E) :=
+  ⟨e.to_local_homeomorph, univ, is_open_univ, rfl, univ_prod_univ.symm, λ x _, he x⟩ in
+{ total_space_mk_inducing := sorry,
+  trivialization_atlas := {a},
+  trivialization_at := λ x, a,
+  mem_base_set_trivialization_at := mem_univ,
+  trivialization_mem_atlas := λ x, rfl }
 
-lemma is_topological_fiber_bundle.map_proj_nhds (h : is_topological_fiber_bundle F proj) (x : Z) :
-  map proj (𝓝 x) = 𝓝 (proj x) :=
-let ⟨e, ex⟩ := h (proj x) in e.map_proj_nhds $ e.mem_source.2 ex
+namespace fiber_bundle
+variables (F) {E} [fiber_bundle F E]
 
-/-- The projection from a topological fiber bundle to its base is continuous. -/
-lemma is_topological_fiber_bundle.continuous_proj (h : is_topological_fiber_bundle F proj) :
-  continuous proj :=
-continuous_iff_continuous_at.2 $ λ x, (h.map_proj_nhds _).le
+lemma map_proj_nhds (x : total_space E) :
+  map (π E) (𝓝 x) = 𝓝 x.proj :=
+(trivialization_at F E x.proj).map_proj_nhds $
+  (trivialization_at F E x.proj).mem_source.2 $ mem_base_set_trivialization_at F E x.proj
 
-/-- The projection from a topological fiber bundle to its base is an open map. -/
-lemma is_topological_fiber_bundle.is_open_map_proj (h : is_topological_fiber_bundle F proj) :
-  is_open_map proj :=
-is_open_map.of_nhds_le $ λ x, (h.map_proj_nhds x).ge
+variables (E)
 
-/-- The projection from a topological fiber bundle with a nonempty fiber to its base is a surjective
+/-- The projection from a fiber bundle to its base is continuous. -/
+@[continuity] lemma continuous_proj : continuous (π E) :=
+continuous_iff_continuous_at.2 $ λ x, (map_proj_nhds F x).le
+
+/-- The projection from a fiber bundle to its base is an open map. -/
+lemma is_open_map_proj : is_open_map (π E) :=
+is_open_map.of_nhds_le $ λ x, (map_proj_nhds F x).ge
+
+/-- The projection from a fiber bundle with a nonempty fiber to its base is a surjective
 map. -/
-lemma is_topological_fiber_bundle.surjective_proj [nonempty F]
-  (h : is_topological_fiber_bundle F proj) :
-  function.surjective proj :=
-λ b, let ⟨e, eb⟩ := h b, ⟨x, _, hx⟩ := e.proj_surj_on_base_set eb in ⟨x, hx⟩
+lemma surjective_proj [nonempty F] : function.surjective (π E) :=
+λ b, let ⟨p, _, hpb⟩ :=
+  (trivialization_at F E b).proj_surj_on_base_set (mem_base_set_trivialization_at F E b) in ⟨p, hpb⟩
 
-/-- The projection from a topological fiber bundle with a nonempty fiber to its base is a quotient
+/-- The projection from a fiber bundle with a nonempty fiber to its base is a quotient
 map. -/
-lemma is_topological_fiber_bundle.quotient_map_proj [nonempty F]
-  (h : is_topological_fiber_bundle F proj) :
-  quotient_map proj :=
-h.is_open_map_proj.to_quotient_map h.continuous_proj h.surjective_proj
+lemma quotient_map_proj [nonempty F] : quotient_map (π E) :=
+(is_open_map_proj F E).to_quotient_map (continuous_proj F E) (surjective_proj F E)
 
-/-- The first projection in a product is a trivial topological fiber bundle. -/
-lemma is_trivial_topological_fiber_bundle_fst :
-  is_trivial_topological_fiber_bundle F (prod.fst : B × F → B) :=
+lemma continuous_total_space_mk (x : B) : continuous (@total_space_mk B E x) :=
+(total_space_mk_inducing F E x).continuous
+
+end fiber_bundle
+
+/-- The first projection in a product is a trivial fiber bundle. -/
+lemma is_trivial_fiber_bundle_fst :
+  is_trivial_fiber_bundle F (prod.fst : B × F → B) :=
 ⟨homeomorph.refl _, λ x, rfl⟩
 
-/-- The first projection in a product is a topological fiber bundle. -/
-lemma is_topological_fiber_bundle_fst : is_topological_fiber_bundle F (prod.fst : B × F → B) :=
-is_trivial_topological_fiber_bundle_fst.is_topological_fiber_bundle
-
-/-- The second projection in a product is a trivial topological fiber bundle. -/
-lemma is_trivial_topological_fiber_bundle_snd :
-  is_trivial_topological_fiber_bundle F (prod.snd : F × B → B) :=
+/-- The second projection in a product is a trivial fiber bundle. -/
+lemma is_trivial_fiber_bundle_snd :
+  is_trivial_fiber_bundle F (prod.snd : F × B → B) :=
 ⟨homeomorph.prod_comm _ _, λ x, rfl⟩
 
-/-- The second projection in a product is a topological fiber bundle. -/
-lemma is_topological_fiber_bundle_snd : is_topological_fiber_bundle F (prod.snd : F × B → B) :=
-is_trivial_topological_fiber_bundle_snd.is_topological_fiber_bundle
-
-lemma is_topological_fiber_bundle.comp_homeomorph {Z' : Type*} [topological_space Z']
-  (e : is_topological_fiber_bundle F proj) (h : Z' ≃ₜ Z) :
-  is_topological_fiber_bundle F (proj ∘ h) :=
-λ x, let ⟨e, he⟩ := e x in
-⟨e.comp_homeomorph h, by simpa [trivialization.comp_homeomorph] using he⟩
-
-section comap
-
-open_locale classical
-
-variables {B' : Type*} [topological_space B']
-
-/-- If `proj : Z → B` is a topological fiber bundle with fiber `F` and `f : B' → B` is a continuous
-map, then the pullback bundle (a.k.a. induced bundle) is the topological bundle with the total space
-`{(x, y) : B' × Z | f x = proj y}` given by `λ ⟨(x, y), h⟩, x`. -/
-lemma is_topological_fiber_bundle.comap (h : is_topological_fiber_bundle F proj)
-  {f : B' → B} (hf : continuous f) :
-  is_topological_fiber_bundle F (λ x : {p : B' × Z | f p.1 = proj p.2}, (x : B' × Z).1) :=
-λ x, let ⟨e, he⟩ := h (f x) in ⟨e.comap f hf x he, he⟩
-
-end comap
-
-/-- If `h` is a topological fiber bundle over a conditionally complete linear order,
+/-- If `E` is a fiber bundle over a conditionally complete linear order,
 then it is trivial over any closed interval. -/
-lemma is_topological_fiber_bundle.exists_trivialization_Icc_subset
-  [conditionally_complete_linear_order B] [order_topology B]
-  (h : is_topological_fiber_bundle F proj) (a b : B) :
-  ∃ e : trivialization F proj, Icc a b ⊆ e.base_set :=
+lemma fiber_bundle.exists_trivialization_Icc_subset
+  [conditionally_complete_linear_order B] [order_topology B] [fiber_bundle F E] (a b : B) :
+  ∃ e : trivialization F (π E), Icc a b ⊆ e.base_set :=
 begin
   classical,
-  obtain ⟨ea, hea⟩ : ∃ ea : trivialization F proj, a ∈ ea.base_set := h a,
+  obtain ⟨ea, hea⟩ : ∃ ea : trivialization F (π E), a ∈ ea.base_set :=
+    ⟨trivialization_at F E a, mem_base_set_trivialization_at F E a⟩,
   -- If `a < b`, then `[a, b] = ∅`, and the statement is trivial
   cases le_or_lt a b with hab hab; [skip, exact ⟨ea, by simp *⟩],
-  /- Let `s` be the set of points `x ∈ [a, b]` such that `proj` is trivializable over `[a, x]`.
+  /- Let `s` be the set of points `x ∈ [a, b]` such that `E` is trivializable over `[a, x]`.
   We need to show that `b ∈ s`. Let `c = Sup s`. We will show that `c ∈ s` and `c = b`. -/
-  set s : set B := {x ∈ Icc a b | ∃ e : trivialization F proj, Icc a x ⊆ e.base_set},
+  set s : set B := {x ∈ Icc a b | ∃ e : trivialization F (π E), Icc a x ⊆ e.base_set},
   have ha : a ∈ s, from ⟨left_mem_Icc.2 hab, ea, by simp [hea]⟩,
   have sne : s.nonempty := ⟨a, ha⟩,
   have hsb : b ∈ upper_bounds s, from λ x hx, hx.1.2,
@@ -252,12 +251,13 @@ begin
   set c := Sup s,
   have hsc : is_lub s c, from is_lub_cSup sne sbd,
   have hc : c ∈ Icc a b, from ⟨hsc.1 ha, hsc.2 hsb⟩,
-  obtain ⟨-, ec : trivialization F proj, hec : Icc a c ⊆ ec.base_set⟩ : c ∈ s,
+  obtain ⟨-, ec : trivialization F (π E), hec : Icc a c ⊆ ec.base_set⟩ : c ∈ s,
   { cases hc.1.eq_or_lt with heq hlt, { rwa ← heq },
     refine ⟨hc, _⟩,
     /- In order to show that `c ∈ s`, consider a trivialization `ec` of `proj` over a neighborhood
     of `c`. Its base set includes `(c', c]` for some `c' ∈ [a, c)`. -/
-    rcases h c with ⟨ec, hc⟩,
+    obtain ⟨ec, hc⟩ : ∃ ec : trivialization F (π E), c ∈ ec.base_set :=
+      ⟨trivialization_at F E c, mem_base_set_trivialization_at F E c⟩,
     obtain ⟨c', hc', hc'e⟩ : ∃ c' ∈ Ico a c, Ioc c' c ⊆ ec.base_set :=
       (mem_nhds_within_Iic_iff_exists_mem_Ico_Ioc_subset hlt).1
         (mem_nhds_within_of_mem_nhds $ is_open.mem_nhds ec.open_base_set hc),
@@ -270,7 +270,7 @@ begin
   done. Otherwise we show that `proj` can be trivialized over a larger interval `[a, d]`,
   `d ∈ (c, b]`, hence `c` is not an upper bound of `s`. -/
   cases hc.2.eq_or_lt with heq hlt, { exact ⟨ec, heq ▸ hec⟩ },
-  rsuffices ⟨d, hdcb, hd⟩ : ∃ (d ∈ Ioc c b) (e : trivialization F proj), Icc a d ⊆ e.base_set,
+  rsuffices ⟨d, hdcb, hd⟩ : ∃ (d ∈ Ioc c b) (e : trivialization F (π E)), Icc a d ⊆ e.base_set,
   { exact ((hsc.1 ⟨⟨hc.1.trans hdcb.1.le, hdcb.2⟩, hd⟩).not_lt hdcb.1).elim },
   /- Since the base set of `ec` is open, it includes `[c, d)` (hence, `[a, d)`) for some
   `d ∈ (c, b]`. -/
@@ -283,7 +283,8 @@ begin
   { /- If `(c, d) = ∅`, then let `ed` be a trivialization of `proj` over a neighborhood of `d`.
     Then the disjoint union of `ec` restricted to `(-∞, d)` and `ed` restricted to `(c, ∞)` is
     a trivialization over `[a, d]`. -/
-    rcases h d with ⟨ed, hed⟩,
+    obtain ⟨ed, hed⟩ : ∃ ed : trivialization F (π E), d ∈ ed.base_set :=
+      ⟨trivialization_at F E d, mem_base_set_trivialization_at F E d⟩,
     refine ⟨d, hdcb, (ec.restr_open (Iio d) is_open_Iio).disjoint_union
       (ed.restr_open (Ioi c) is_open_Ioi) (he.mono (inter_subset_right _ _)
         (inter_subset_right _ _)), λ x hx, _⟩,
@@ -295,13 +296,11 @@ begin
     exact ⟨d', ⟨hd'c, hdd'.le.trans hdcb.2⟩, ec, (Icc_subset_Ico_right hdd').trans had⟩ }
 end
 
-end topological_fiber_bundle
+end fiber_bundle
 
-/-! ### Constructing topological fiber bundles -/
+/-! ### Constructing fiber bundles -/
 
 namespace bundle
-
-variable (E : B → Type*)
 
 attribute [mfld_simps] total_space.proj total_space_mk coe_fst coe_snd coe_snd_map_apply
   coe_snd_map_smul total_space.mk_cast
@@ -312,9 +311,64 @@ instance [t₁ : topological_space B] [t₂ : topological_space F] :
   topological_space (total_space (trivial B F)) :=
 induced total_space.proj t₁ ⊓ induced (trivial.proj_snd B F) t₂
 
+namespace trivial
+variables (B F) [topological_space B] [topological_space F]
+
+/-- Local trivialization for trivial bundle. -/
+def trivialization : trivialization F (π (bundle.trivial B F)) :=
+{ to_fun := λ x, (x.fst, x.snd),
+  inv_fun := λ y, ⟨y.fst, y.snd⟩,
+  source := univ,
+  target := univ,
+  map_source' := λ x h, mem_univ (x.fst, x.snd),
+  map_target' := λ y h,  mem_univ ⟨y.fst, y.snd⟩,
+  left_inv' := λ x h, sigma.eq rfl rfl,
+  right_inv' := λ x h, prod.ext rfl rfl,
+  open_source := is_open_univ,
+  open_target := is_open_univ,
+  continuous_to_fun := by { rw [←continuous_iff_continuous_on_univ, continuous_iff_le_induced],
+    simp only [prod.topological_space, induced_inf, induced_compose], exact le_rfl, },
+  continuous_inv_fun := by { rw [←continuous_iff_continuous_on_univ, continuous_iff_le_induced],
+    simp only [bundle.total_space.topological_space, induced_inf, induced_compose],
+    exact le_rfl, },
+  base_set := univ,
+  open_base_set := is_open_univ,
+  source_eq := rfl,
+  target_eq := by simp only [univ_prod_univ],
+  proj_to_fun := λ y hy, rfl }
+
+@[simp]
+lemma trivialization_source : (trivialization B F).source = univ := rfl
+
+@[simp]
+lemma trivialization_target : (trivialization B F).target = univ := rfl
+
+/-- Fiber bundle instance on the trivial bundle. -/
+instance fiber_bundle : fiber_bundle F (bundle.trivial B F) :=
+{ trivialization_atlas := {bundle.trivial.trivialization B F},
+  trivialization_at := λ x, bundle.trivial.trivialization B F,
+  mem_base_set_trivialization_at := mem_univ,
+  trivialization_mem_atlas := λ x, mem_singleton _,
+  total_space_mk_inducing := λ b, ⟨begin
+    have : (λ (x : trivial B F b), x) = @id F, by { ext x, refl },
+    simp only [total_space.topological_space, induced_inf, induced_compose, function.comp,
+      total_space.proj, induced_const, top_inf_eq, trivial.proj_snd, id.def,
+      trivial.topological_space, this, induced_id],
+  end⟩ }
+
+lemma eq_trivialization (e : _root_.trivialization F (π (bundle.trivial B F)))
+  [i : mem_trivialization_atlas e] :
+  e = trivialization B F :=
+begin
+  unfreezingI { cases i },
+  exact i,
+end
+
+end trivial
+
 end bundle
 
-/-- Core data defining a locally trivial topological bundle with fiber `F` over a topological
+/-- Core data defining a locally trivial bundle with fiber `F` over a topological
 space `B`. Note that "bundle" is used in its mathematical sense. This is the (computer science)
 bundled version, i.e., all the relevant data is contained in the following structure. A family of
 local trivializations is indexed by a type `ι`, on open subsets `base_set i` for each `i : ι`.
@@ -323,7 +377,7 @@ Trivialization changes from `i` to `j` are given by continuous maps `coord_chang
 `B → F → F` and require continuity on `(base_set i ∩ base_set j) × F` to avoid the topology on the
 space of continuous maps on `F`. -/
 @[nolint has_nonempty_instance]
-structure topological_fiber_bundle_core (ι : Type*) (B : Type*) [topological_space B]
+structure fiber_bundle_core (ι : Type*) (B : Type*) [topological_space B]
   (F : Type*) [topological_space F] :=
 (base_set          : ι → set B)
 (is_open_base_set  : ∀ i, is_open (base_set i))
@@ -336,21 +390,21 @@ structure topological_fiber_bundle_core (ι : Type*) (B : Type*) [topological_sp
 (coord_change_comp : ∀ i j k, ∀ x ∈ (base_set i) ∩ (base_set j) ∩ (base_set k), ∀ v,
   (coord_change j k x) (coord_change i j x v) = coord_change i k x v)
 
-namespace topological_fiber_bundle_core
+namespace fiber_bundle_core
 
-variables [topological_space B] [topological_space F] (Z : topological_fiber_bundle_core ι B F)
+variables [topological_space B] [topological_space F] (Z : fiber_bundle_core ι B F)
 
 include Z
 
-/-- The index set of a topological fiber bundle core, as a convenience function for dot notation -/
+/-- The index set of a fiber bundle core, as a convenience function for dot notation -/
 @[nolint unused_arguments has_nonempty_instance]
 def index := ι
 
-/-- The base space of a topological fiber bundle core, as a convenience function for dot notation -/
+/-- The base space of a fiber bundle core, as a convenience function for dot notation -/
 @[nolint unused_arguments, reducible]
 def base := B
 
-/-- The fiber of a topological fiber bundle core, as a convenience function for dot notation and
+/-- The fiber of a fiber bundle core, as a convenience function for dot notation and
 typeclass inference -/
 @[nolint unused_arguments has_nonempty_instance]
 def fiber (x : B) := F
@@ -362,13 +416,13 @@ instance topological_space_fiber (x : B) : topological_space (Z.fiber x) := by a
 
 end fiber_instances
 
-/-- The total space of the topological fiber bundle, as a convenience function for dot notation.
+/-- The total space of the fiber bundle, as a convenience function for dot notation.
 It is by definition equal to `bundle.total_space Z.fiber`, a.k.a. `Σ x, Z.fiber x` but with a
 different name for typeclass inference. -/
 @[nolint unused_arguments, reducible]
 def total_space := bundle.total_space Z.fiber
 
-/-- The projection from the total space of a topological fiber bundle core, on its base. -/
+/-- The projection from the total space of a fiber bundle core, on its base. -/
 @[reducible, simp, mfld_simps] def proj : Z.total_space → B := bundle.total_space.proj
 
 /-- Local homeomorphism version of the trivialization change. -/
@@ -439,7 +493,7 @@ def local_triv_as_local_equiv (i : ι) : local_equiv Z.total_space (B × F) :=
     { simp only [hx, mem_inter_iff, and_self, mem_base_set_at] }
   end }
 
-variable (i : ι)
+variables (i : ι)
 
 lemma mem_local_triv_as_local_equiv_source (p : Z.total_space) :
   p ∈ (Z.local_triv_as_local_equiv i).source ↔ p.1 ∈ Z.base_set i :=
@@ -469,13 +523,13 @@ end
 
 variable (ι)
 
-/-- Topological structure on the total space of a topological bundle created from core, designed so
+/-- Topological structure on the total space of a fiber bundle created from core, designed so
 that all the local trivialization are continuous. -/
 instance to_topological_space : topological_space (bundle.total_space Z.fiber) :=
 topological_space.generate_from $ ⋃ (i : ι) (s : set (B × F)) (s_open : is_open s),
   {(Z.local_triv_as_local_equiv i).source ∩ (Z.local_triv_as_local_equiv i) ⁻¹' s}
 
-variable {ι}
+variables {ι} (b : B) (a : F)
 
 lemma open_source' (i : ι) : is_open (Z.local_triv_as_local_equiv i).source :=
 begin
@@ -526,21 +580,9 @@ def local_triv (i : ι) : trivialization F Z.proj :=
   end,
   to_local_equiv := Z.local_triv_as_local_equiv i }
 
-/-- A topological fiber bundle constructed from core is indeed a topological fiber bundle. -/
-protected theorem is_topological_fiber_bundle : is_topological_fiber_bundle F Z.proj :=
-λx, ⟨Z.local_triv (Z.index_at x), Z.mem_base_set_at x⟩
-
-/-- The projection on the base of a topological bundle created from core is continuous -/
-lemma continuous_proj : continuous Z.proj :=
-Z.is_topological_fiber_bundle.continuous_proj
-
-/-- The projection on the base of a topological bundle created from core is an open map -/
-lemma is_open_map_proj : is_open_map Z.proj :=
-Z.is_topological_fiber_bundle.is_open_map_proj
-
 /-- Preferred local trivialization of a fiber bundle constructed from core, at a given point, as
 a bundle trivialization -/
-def local_triv_at (b : B) : trivialization F Z.proj :=
+def local_triv_at (b : B) : trivialization F (π Z.fiber) :=
 Z.local_triv (Z.index_at b)
 
 @[simp, mfld_simps] lemma local_triv_at_def (b : B) :
@@ -598,6 +640,9 @@ Z.local_triv_at_apply _
 @[simp, mfld_simps] lemma mem_local_triv_at_source (p : Z.total_space) (b : B) :
   p ∈ (Z.local_triv_at b).source ↔ p.1 ∈ (Z.local_triv_at b).base_set := iff.rfl
 
+@[simp, mfld_simps] lemma mem_source_at : (⟨b, a⟩ : Z.total_space) ∈ (Z.local_triv_at b).source :=
+by { rw [local_triv_at, mem_local_triv_source], exact Z.mem_base_set_at b }
+
 @[simp, mfld_simps] lemma mem_local_triv_target (p : B × F) :
   p ∈ (Z.local_triv i).target ↔ p.1 ∈ (Z.local_triv i).base_set :=
 trivialization.mem_target _
@@ -619,7 +664,7 @@ by { rw [local_triv_at, ←base_set_at], exact Z.mem_base_set_at b, }
 lemma continuous_total_space_mk (b : B) :
   continuous (total_space_mk b : Z.fiber b → bundle.total_space Z.fiber) :=
 begin
-  rw [continuous_iff_le_induced, topological_fiber_bundle_core.to_topological_space],
+  rw [continuous_iff_le_induced, fiber_bundle_core.to_topological_space],
   apply le_induced_generate_from,
   simp only [total_space_mk, mem_Union, mem_singleton_iff, local_triv_as_local_equiv_source,
     local_triv_as_local_equiv_coe],
@@ -643,30 +688,57 @@ begin
       exact is_open_empty, }}
 end
 
-end topological_fiber_bundle_core
+/-- A fiber bundle constructed from core is indeed a fiber bundle. -/
+instance fiber_bundle : fiber_bundle F Z.fiber :=
+{ total_space_mk_inducing := λ b, ⟨ begin refine le_antisymm _ (λ s h, _),
+    { rw ←continuous_iff_le_induced,
+      exact continuous_total_space_mk Z b, },
+    { refine is_open_induced_iff.mpr ⟨(Z.local_triv_at b).source ∩ (Z.local_triv_at b) ⁻¹'
+        ((Z.local_triv_at b).base_set ×ˢ s), (continuous_on_open_iff
+        (Z.local_triv_at b).open_source).mp (Z.local_triv_at b).continuous_to_fun _
+        ((Z.local_triv_at b).open_base_set.prod h), _⟩,
+      rw [preimage_inter, ←preimage_comp, function.comp],
+      simp only [total_space_mk],
+      refine ext_iff.mpr (λ a, ⟨λ ha, _, λ ha, ⟨Z.mem_base_set_at b, _⟩⟩),
+      { simp only [mem_prod, mem_preimage, mem_inter_iff, local_triv_at_apply_mk] at ha,
+        exact ha.2.2, },
+      { simp only [mem_prod, mem_preimage, mem_inter_iff, local_triv_at_apply_mk],
+        exact ⟨Z.mem_base_set_at b, ha⟩, } } end⟩,
+  trivialization_atlas := set.range Z.local_triv,
+  trivialization_at := Z.local_triv_at,
+  mem_base_set_trivialization_at := Z.mem_base_set_at,
+  trivialization_mem_atlas := λ b, ⟨Z.index_at b, rfl⟩ }
 
-variables (F) {Z : Type*} [topological_space B] [topological_space F] {proj : Z → B}
+/-- The projection on the base of a fiber bundle created from core is continuous -/
+lemma continuous_proj : continuous Z.proj := continuous_proj F Z.fiber
+
+/-- The projection on the base of a fiber bundle created from core is an open map -/
+lemma is_open_map_proj : is_open_map Z.proj := is_open_map_proj F Z.fiber
+
+end fiber_bundle_core
+
+variables (F) (E : B → Type*) [topological_space B] [topological_space F]
 
 /-- This structure permits to define a fiber bundle when trivializations are given as local
 equivalences but there is not yet a topology on the total space. The total space is hence given a
 topology in such a way that there is a fiber bundle structure for which the local equivalences
 are also local homeomorphism and hence local trivializations. -/
 @[nolint has_nonempty_instance]
-structure topological_fiber_prebundle (proj : Z → B) :=
-(pretrivialization_atlas : set (pretrivialization F proj))
-(pretrivialization_at : B → pretrivialization F proj)
+structure fiber_prebundle :=
+(pretrivialization_atlas : set (pretrivialization F (π E)))
+(pretrivialization_at : B → pretrivialization F (π E))
 (mem_base_pretrivialization_at : ∀ x : B, x ∈ (pretrivialization_at x).base_set)
 (pretrivialization_mem_atlas : ∀ x : B, pretrivialization_at x ∈ pretrivialization_atlas)
 (continuous_triv_change : ∀ e e' ∈ pretrivialization_atlas,
   continuous_on (e ∘ e'.to_local_equiv.symm) (e'.target ∩ (e'.to_local_equiv.symm ⁻¹' e.source)))
 
-namespace topological_fiber_prebundle
+namespace fiber_prebundle
 
-variables {F} (a : topological_fiber_prebundle F proj) {e : pretrivialization F proj}
+variables {F E} (a : fiber_prebundle F E) {e : pretrivialization F (π E)}
 
 /-- Topology on the total space that will make the prebundle into a bundle. -/
-def total_space_topology (a : topological_fiber_prebundle F proj) : topological_space Z :=
-⨆ (e : pretrivialization F proj) (he : e ∈ a.pretrivialization_atlas),
+def total_space_topology (a : fiber_prebundle F E) : topological_space (total_space E) :=
+⨆ (e : pretrivialization F (π E)) (he : e ∈ a.pretrivialization_atlas),
   coinduced e.set_symm (subtype.topological_space)
 
 lemma continuous_symm_of_mem_pretrivialization_atlas (he : e ∈ a.pretrivialization_atlas) :
@@ -678,7 +750,7 @@ begin
   exact le_supr₂ e he,
 end
 
-lemma is_open_source (e : pretrivialization F proj) : @is_open _ a.total_space_topology e.source :=
+lemma is_open_source (e : pretrivialization F (π E)) : @is_open _ a.total_space_topology e.source :=
 begin
   letI := a.total_space_topology,
   refine is_open_supr_iff.mpr (λ e', _),
@@ -690,7 +762,7 @@ begin
     pretrivialization.preimage_symm_proj_inter],
 end
 
-lemma is_open_target_of_mem_pretrivialization_atlas_inter (e e' : pretrivialization F proj)
+lemma is_open_target_of_mem_pretrivialization_atlas_inter (e e' : pretrivialization F (π E))
   (he' : e' ∈ a.pretrivialization_atlas) :
   is_open (e'.to_local_equiv.target ∩ e'.to_local_equiv.symm ⁻¹' e.source) :=
 begin
@@ -703,7 +775,7 @@ end
 
 /-- Promotion from a `pretrivialization` to a `trivialization`. -/
 def trivialization_of_mem_pretrivialization_atlas (he : e ∈ a.pretrivialization_atlas) :
-  @trivialization B F Z _ _ a.total_space_topology proj :=
+  @trivialization B F _ _ _ a.total_space_topology (π E) :=
 { open_source := a.is_open_source e,
   continuous_to_fun := begin
     letI := a.total_space_topology,
@@ -723,36 +795,84 @@ def trivialization_of_mem_pretrivialization_atlas (he : e ∈ a.pretrivializatio
   continuous_inv_fun := a.continuous_symm_of_mem_pretrivialization_atlas he,
   .. e }
 
-lemma is_topological_fiber_bundle :
-  @is_topological_fiber_bundle B F Z _ _ a.total_space_topology proj :=
-λ x, ⟨a.trivialization_of_mem_pretrivialization_atlas (a.pretrivialization_mem_atlas x),
-  a.mem_base_pretrivialization_at x ⟩
+lemma mem_trivialization_at_source (b : B) (x : E b) :
+  total_space_mk b x ∈ (a.pretrivialization_at b).source :=
+begin
+  simp only [(a.pretrivialization_at b).source_eq, mem_preimage, total_space.proj],
+  exact a.mem_base_pretrivialization_at b,
+end
 
-lemma continuous_proj : @continuous _ _ a.total_space_topology _ proj :=
-by { letI := a.total_space_topology, exact a.is_topological_fiber_bundle.continuous_proj, }
+@[simp] lemma total_space_mk_preimage_source (b : B) :
+  (total_space_mk b) ⁻¹' (a.pretrivialization_at b).source = univ :=
+begin
+  apply eq_univ_of_univ_subset,
+  rw [(a.pretrivialization_at b).source_eq, ←preimage_comp, function.comp],
+  simp only [total_space.proj],
+  rw preimage_const_of_mem _,
+  exact a.mem_base_pretrivialization_at b,
+end
 
-/-- For a fiber bundle `Z` over `B` constructed using the `topological_fiber_prebundle` mechanism,
+/-- Topology on the fibers `E b` induced by the map `E b → E.total_space`. -/
+def fiber_topology (b : B) : topological_space (E b) :=
+topological_space.induced (total_space_mk b) a.total_space_topology
+
+@[continuity] lemma inducing_total_space_mk (b : B) :
+  @inducing _ _ (a.fiber_topology b) a.total_space_topology (total_space_mk b) :=
+by { letI := a.total_space_topology, letI := a.fiber_topology b, exact ⟨rfl⟩ }
+
+@[continuity] lemma continuous_total_space_mk (b : B) :
+  @continuous _ _ (a.fiber_topology b) a.total_space_topology (total_space_mk b) :=
+begin
+  letI := a.total_space_topology, letI := a.fiber_topology b,
+  exact (a.inducing_total_space_mk b).continuous
+end
+
+/-- Make a `topological_vector_bundle` from a `topological_vector_prebundle`.  Concretely this means
+that, given a `topological_vector_prebundle` structure for a sigma-type `E` -- which consists of a
+number of "pretrivializations" identifying parts of `E` with product spaces `U × F` -- one
+establishes that for the topology constructed on the sigma-type using
+`topological_vector_prebundle.total_space_topology`, these "pretrivializations" are actually
+"trivializations" (i.e., homeomorphisms with respect to the constructed topology). -/
+def to_fiber_bundle :
+  @fiber_bundle B F _ _ E a.total_space_topology a.fiber_topology :=
+{ total_space_mk_inducing := a.inducing_total_space_mk,
+  trivialization_atlas := {e | ∃ e₀ (he₀ : e₀ ∈ a.pretrivialization_atlas),
+    e = a.trivialization_of_mem_pretrivialization_atlas he₀},
+  trivialization_at := λ x, a.trivialization_of_mem_pretrivialization_atlas
+    (a.pretrivialization_mem_atlas x),
+  mem_base_set_trivialization_at := a.mem_base_pretrivialization_at,
+  trivialization_mem_atlas := λ x, ⟨_, a.pretrivialization_mem_atlas x, rfl⟩ }
+
+lemma continuous_proj : @continuous _ _ a.total_space_topology _ (π E) :=
+begin
+  letI := a.total_space_topology,
+  letI := a.fiber_topology,
+  letI := a.to_fiber_bundle,
+  exact continuous_proj F E,
+end
+
+/-- For a fiber bundle `Z` over `B` constructed using the `fiber_prebundle` mechanism,
 continuity of a function `Z → X` on an open set `s` can be checked by precomposing at each point
 with the pretrivialization used for the construction at that point. -/
-lemma continuous_on_of_comp_right {X : Type*} [topological_space X] {f : Z → X} {s : set B}
-  (hs : is_open s)
+lemma continuous_on_of_comp_right {X : Type*} [topological_space X] {f : total_space E → X}
+  {s : set B} (hs : is_open s)
   (hf : ∀ b ∈ s, continuous_on (f ∘ (a.pretrivialization_at b).to_local_equiv.symm)
     ((s ∩ (a.pretrivialization_at b).base_set) ×ˢ (set.univ : set F))) :
-  @continuous_on _ _ a.total_space_topology _ f (proj ⁻¹' s) :=
+  @continuous_on _ _ a.total_space_topology _ f ((π E) ⁻¹' s) :=
 begin
   letI := a.total_space_topology,
   intros z hz,
-  let e : trivialization F proj :=
-  a.trivialization_of_mem_pretrivialization_atlas (a.pretrivialization_mem_atlas (proj z)),
+  let e : trivialization F (π E) :=
+  a.trivialization_of_mem_pretrivialization_atlas (a.pretrivialization_mem_atlas z.proj),
   refine (e.continuous_at_of_comp_right _
-    ((hf (proj z) hz).continuous_at (is_open.mem_nhds _ _))).continuous_within_at,
-  { exact a.mem_base_pretrivialization_at (proj z) },
-  { exact ((hs.inter (a.pretrivialization_at (proj z)).open_base_set).prod is_open_univ) },
+    ((hf z.proj hz).continuous_at (is_open.mem_nhds _ _))).continuous_within_at,
+  { exact a.mem_base_pretrivialization_at z.proj },
+  { exact ((hs.inter (a.pretrivialization_at z.proj).open_base_set).prod is_open_univ) },
   refine ⟨_, mem_univ _⟩,
   rw e.coe_fst,
-  { exact ⟨hz, a.mem_base_pretrivialization_at (proj z)⟩ },
+  { exact ⟨hz, a.mem_base_pretrivialization_at z.proj⟩ },
   { rw e.mem_source,
-    exact a.mem_base_pretrivialization_at (proj z) },
+    exact a.mem_base_pretrivialization_at z.proj },
 end
 
-end topological_fiber_prebundle
+end fiber_prebundle

--- a/src/topology/fiber_bundle/basic.lean
+++ b/src/topology/fiber_bundle/basic.lean
@@ -77,26 +77,26 @@ Let `Z : fiber_bundle_core ι B F`. Then we define
 
 ### Data vs mixins
 
-For both fiber and vector bundles, one faces a choice: should the definition state the *existence* of
-local trivializations (a propositional typeclass), or specify a fixed atlas of trivializations (a
+For both fiber and vector bundles, one faces a choice: should the definition state the *existence*
+of local trivializations (a propositional typeclass), or specify a fixed atlas of trivializations (a
 typeclass containing data)?
 
-In their initial mathlib implementations, both fiber and vector bundles were defined propositionally.
-For vector bundles, this turns out to be mathematically wrong: in infinite dimension, the transition
-function between two trivializations is not automatically continuous as a map from the base `B` to
-the endomorphisms `F →L[R] F` of the fibre (considered with the operator-norm topology), and so the
-definition needs to be modified by restricting consideration to a family of trivializations
-(constituting the data) which are all mutually-compatible in this sense.  The PRs #13052 and #13175
-implemented this change.
+In their initial mathlib implementations, both fiber and vector bundles were defined
+propositionally. For vector bundles, this turns out to be mathematically wrong: in infinite
+dimension, the transition function between two trivializations is not automatically continuous as a
+map from the base `B` to the endomorphisms `F →L[R] F` of the fibre (considered with the
+operator-norm topology), and so the definition needs to be modified by restricting consideration to
+a family of trivializations (constituting the data) which are all mutually-compatible in this sense.
+The PRs #13052 and #13175 implemented this change.
 
 There is still the choice about whether to hold this data at the level of fiber bundles or of vector
 bundles. As of PR #17505, the data is all held in `fiber_bundle`, with `vector_bundle` a
 (propositional) mixin stating fibrewise-linearity.
 
-This allows bundles to carry instances of typeclasses in which the scalar field, `R`, does not appear
-as a parameter. Notably, we would like a vector bundle over `R` with fibre `F` over base `B` to be a
-`charted_space (B × F)`, with the trivializations providing the charts. This would be a dangerous
-instance for typeclass inference, because `R` does not appear as a parameter in
+This allows bundles to carry instances of typeclasses in which the scalar field, `R`, does not
+appear as a parameter. Notably, we would like a vector bundle over `R` with fibre `F` over base `B`
+to be a `charted_space (B × F)`, with the trivializations providing the charts. This would be a
+dangerous instance for typeclass inference, because `R` does not appear as a parameter in
 `charted_space (B × F)`. But if the data of the trivializations is held in `fiber_bundle`, then a
 fibre bundle with fibre `F` over base `B` can be a `charted_space (B × F)`, and this is safe for
 typeclass inference.

--- a/src/topology/fiber_bundle/basic.lean
+++ b/src/topology/fiber_bundle/basic.lean
@@ -75,6 +75,35 @@ Let `Z : fiber_bundle_core ι B F`. Then we define
 
 ## Implementation notes
 
+### Data vs mixins
+
+For both fiber and vector bundles, one faces a choice: should the definition state the *existence* of
+local trivializations (a propositional typeclass), or specify a fixed atlas of trivializations (a
+typeclass containing data)?
+
+In their initial mathlib implementations, both fiber and vector bundles were defined propositionally.
+For vector bundles, this turns out to be mathematically wrong: in infinite dimension, the transition
+function between two trivializations is not automatically continuous as a map from the base `B` to
+the endomorphisms `F →L[R] F` of the fibre (considered with the operator-norm topology), and so the
+definition needs to be modified by restricting consideration to a family of trivializations
+(constituting the data) which are all mutually-compatible in this sense.  The PRs #13052 and #13175
+implemented this change.
+
+There is still the choice about whether to hold this data at the level of fiber bundles or of vector
+bundles. As of PR #17505, the data is all held in `fiber_bundle`, with `vector_bundle` a
+(propositional) mixin stating fibrewise-linearity.
+
+This allows bundles to carry instances of typeclasses in which the scalar field, `R`, does not appear
+as a parameter. Notably, we would like a vector bundle over `R` with fibre `F` over base `B` to be a
+`charted_space (B × F)`, with the trivializations providing the charts. This would be a dangerous
+instance for typeclass inference, because `R` does not appear as a parameter in
+`charted_space (B × F)`. But if the data of the trivializations is held in `fiber_bundle`, then a
+fibre bundle with fibre `F` over base `B` can be a `charted_space (B × F)`, and this is safe for
+typeclass inference.
+
+We expect that this choice of definition will also streamline constructions of fibre bundles with
+similar underlying structure (e.g., the same bundle being both a real and complex vector bundle).
+
 ### Core construction
 
 A fiber bundle with fiber `F` over a base `B` is a family of spaces isomorphic to `F`,

--- a/src/topology/fiber_bundle/basic.lean
+++ b/src/topology/fiber_bundle/basic.lean
@@ -47,7 +47,7 @@ fiber bundle from trivializations given as local equivalences with minimum addit
 
 * `fiber_bundle F E` : Structure saying that `E : B → Type*` is a fiber bundle with fiber `F`.
 
-* `is_trivial_fiber_bundle F p` : Prop saying that the map `p : Z → B` between
+* `is_homeomorphic_trivial_fiber_bundle F p` : Prop saying that the map `p : Z → B` between
   topological spaces is a trivial fiber bundle, i.e., there exists a homeomorphism
   `h : Z ≃ₜ B × F` such that `proj x = (h x).1`.
 
@@ -214,13 +214,13 @@ variables (F E)
 /-- A trivial fiber bundle with fiber `F` over a base `B` is a space `Z`
 projecting on `B` for which there exists a homeomorphism to `B × F` that sends `proj`
 to `prod.fst`. -/
-def is_trivial_fiber_bundle {Z : Type*} [topological_space Z] (proj : Z → B) : Prop :=
+def is_homeomorphic_trivial_fiber_bundle {Z : Type*} [topological_space Z] (proj : Z → B) : Prop :=
 ∃ e : Z ≃ₜ (B × F), ∀ x, (e x).1 = proj x
 
 variables {F}
 
-lemma is_trivial_fiber_bundle.proj_eq {Z : Type*} [topological_space Z] {proj : Z → B}
-  (h : is_trivial_fiber_bundle F proj) :
+lemma is_homeomorphic_trivial_fiber_bundle.proj_eq {Z : Type*} [topological_space Z] {proj : Z → B}
+  (h : is_homeomorphic_trivial_fiber_bundle F proj) :
   ∃ e : Z ≃ₜ (B × F), proj = prod.fst ∘ e :=
 ⟨h.some, (funext h.some_spec).symm⟩
 
@@ -261,44 +261,48 @@ end fiber_bundle
 variables {F}
 
 /-- The projection from a trivial fiber bundle to its base is surjective. -/
-lemma is_trivial_fiber_bundle.surjective_proj [nonempty F] {Z : Type*} [topological_space Z]
-  {proj : Z → B} (h : is_trivial_fiber_bundle F proj) : function.surjective proj :=
+lemma is_homeomorphic_trivial_fiber_bundle.surjective_proj [nonempty F] {Z : Type*}
+  [topological_space Z] {proj : Z → B} (h : is_homeomorphic_trivial_fiber_bundle F proj) :
+  function.surjective proj :=
 begin
   obtain ⟨e, rfl⟩ := h.proj_eq,
   exact prod.fst_surjective.comp e.surjective,
 end
 
 /-- The projection from a trivial fiber bundle to its base is continuous. -/
-lemma is_trivial_fiber_bundle.continuous_proj {Z : Type*} [topological_space Z] {proj : Z → B}
-  (h : is_trivial_fiber_bundle F proj) : continuous proj :=
+lemma is_homeomorphic_trivial_fiber_bundle.continuous_proj {Z : Type*} [topological_space Z]
+  {proj : Z → B} (h : is_homeomorphic_trivial_fiber_bundle F proj) :
+  continuous proj :=
 begin
   obtain ⟨e, rfl⟩ := h.proj_eq,
   exact continuous_fst.comp e.continuous,
 end
 
 /-- The projection from a trivial fiber bundle to its base is open. -/
-lemma is_trivial_fiber_bundle.is_open_map_proj {Z : Type*} [topological_space Z] {proj : Z → B}
-  (h : is_trivial_fiber_bundle F proj) : is_open_map proj :=
+lemma is_homeomorphic_trivial_fiber_bundle.is_open_map_proj {Z : Type*} [topological_space Z]
+  {proj : Z → B} (h : is_homeomorphic_trivial_fiber_bundle F proj) :
+  is_open_map proj :=
 begin
   obtain ⟨e, rfl⟩ := h.proj_eq,
   exact is_open_map_fst.comp e.is_open_map,
 end
 
 /-- The projection from a trivial fiber bundle to its base is open. -/
-lemma is_trivial_fiber_bundle.quotient_map_proj [nonempty F] {Z : Type*} [topological_space Z]
-  {proj : Z → B} (h : is_trivial_fiber_bundle F proj) : quotient_map proj :=
+lemma is_homeomorphic_trivial_fiber_bundle.quotient_map_proj [nonempty F] {Z : Type*}
+  [topological_space Z] {proj : Z → B} (h : is_homeomorphic_trivial_fiber_bundle F proj) :
+  quotient_map proj :=
 h.is_open_map_proj.to_quotient_map h.continuous_proj h.surjective_proj
 
 variables (F)
 
 /-- The first projection in a product is a trivial fiber bundle. -/
-lemma is_trivial_fiber_bundle_fst :
-  is_trivial_fiber_bundle F (prod.fst : B × F → B) :=
+lemma is_homeomorphic_trivial_fiber_bundle_fst :
+  is_homeomorphic_trivial_fiber_bundle F (prod.fst : B × F → B) :=
 ⟨homeomorph.refl _, λ x, rfl⟩
 
 /-- The second projection in a product is a trivial fiber bundle. -/
-lemma is_trivial_fiber_bundle_snd :
-  is_trivial_fiber_bundle F (prod.snd : F × B → B) :=
+lemma is_homeomorphic_trivial_fiber_bundle_snd :
+  is_homeomorphic_trivial_fiber_bundle F (prod.snd : F × B → B) :=
 ⟨homeomorph.prod_comm _ _, λ x, rfl⟩
 
 /-- If `E` is a fiber bundle over a conditionally complete linear order,

--- a/src/topology/vector_bundle/basic.lean
+++ b/src/topology/vector_bundle/basic.lean
@@ -301,7 +301,7 @@ variables [nontrivially_normed_field R] [∀ x, add_comm_monoid (E x)] [∀ x, m
   [topological_space (total_space E)] [∀ x, topological_space (E x)] [fiber_bundle F E]
 
 /-- The space `total_space E` (for `E : B → Type*` such that each `E x` is a topological vector
-space) has a (topological) vector space structure with fiber `F` (denoted with
+space) has a topological vector space structure with fiber `F` (denoted with
 `vector_bundle R F E`) if around every point there is a fiber bundle trivialization
 which is linear in the fibers. -/
 class vector_bundle : Prop :=
@@ -439,6 +439,55 @@ by { ext v, rw [coord_changeL_apply e e' hb], refl }
 end trivialization
 
 namespace bundle.trivial
+variables (B) (F' : Type*) [topological_space B] [topological_space F']
+
+/-- Local trivialization for trivial bundle. -/
+def trivialization : trivialization F' (π (bundle.trivial B F')) :=
+{ to_fun := λ x, (x.fst, x.snd),
+  inv_fun := λ y, ⟨y.fst, y.snd⟩,
+  source := univ,
+  target := univ,
+  map_source' := λ x h, mem_univ (x.fst, x.snd),
+  map_target' := λ y h,  mem_univ ⟨y.fst, y.snd⟩,
+  left_inv' := λ x h, sigma.eq rfl rfl,
+  right_inv' := λ x h, prod.ext rfl rfl,
+  open_source := is_open_univ,
+  open_target := is_open_univ,
+  continuous_to_fun := by { rw [←continuous_iff_continuous_on_univ, continuous_iff_le_induced],
+    simp only [prod.topological_space, induced_inf, induced_compose], exact le_rfl, },
+  continuous_inv_fun := by { rw [←continuous_iff_continuous_on_univ, continuous_iff_le_induced],
+    simp only [bundle.total_space.topological_space, induced_inf, induced_compose],
+    exact le_rfl, },
+  base_set := univ,
+  open_base_set := is_open_univ,
+  source_eq := rfl,
+  target_eq := by simp only [univ_prod_univ],
+  proj_to_fun := λ y hy, rfl }
+
+@[simp]
+lemma trivialization_source : (trivialization B F').source = univ := rfl
+
+@[simp]
+lemma trivialization_target : (trivialization B F').target = univ := rfl
+
+/-- Fiber bundle instance on the trivial bundle. -/
+instance fiber_bundle : fiber_bundle F' (bundle.trivial B F') :=
+{ trivialization_atlas := {bundle.trivial.trivialization B F'},
+  trivialization_at := λ x, bundle.trivial.trivialization B F',
+  mem_base_set_trivialization_at := mem_univ,
+  trivialization_mem_atlas := λ x, mem_singleton _,
+  total_space_mk_inducing := λ b, ⟨begin
+    have : (λ (x : trivial B F' b), x) = @id F', by { ext x, refl },
+    simp only [total_space.topological_space, induced_inf, induced_compose, function.comp,
+      total_space.proj, induced_const, top_inf_eq, trivial.proj_snd, id.def,
+      trivial.topological_space, this, induced_id],
+  end⟩ }
+
+lemma eq_trivialization (e : _root_.trivialization F' (π (bundle.trivial B F')))
+  [i : mem_trivialization_atlas e] :
+  e = trivialization B F' :=
+i.out
+
 variables (R B F)
 
 instance trivialization.is_linear : (trivialization B F).is_linear R :=

--- a/src/topology/vector_bundle/basic.lean
+++ b/src/topology/vector_bundle/basic.lean
@@ -439,7 +439,7 @@ by { ext v, rw [coord_changeL_apply e e' hb], refl }
 end trivialization
 
 namespace bundle.trivial
-variables (B) (F' : Type*) [topological_space B] [topological_space F']
+variables (R B) (F' : Type*) [topological_space B] [topological_space F']
 
 /-- Local trivialization for trivial bundle. -/
 def trivialization : trivialization F' (π (bundle.trivial B F')) :=
@@ -463,6 +463,19 @@ def trivialization : trivialization F' (π (bundle.trivial B F')) :=
   source_eq := rfl,
   target_eq := by simp only [univ_prod_univ],
   proj_to_fun := λ y hy, rfl }
+
+instance trivialization.is_linear : (trivialization B F).is_linear R :=
+{ linear := λ x hx, ⟨λ y z, rfl, λ c y, rfl⟩ }
+
+variables {R}
+
+lemma trivialization.coord_changeL (b : B) :
+  (trivialization B F).coord_changeL R (trivialization B F) b = continuous_linear_equiv.refl R F :=
+begin
+  ext v,
+  rw [trivialization.coord_changeL_apply'],
+  exacts [rfl, ⟨mem_univ _, mem_univ _⟩]
+end
 
 @[simp]
 lemma trivialization_source : (trivialization B F').source = univ := rfl
@@ -488,20 +501,7 @@ lemma eq_trivialization (e : _root_.trivialization F' (π (bundle.trivial B F'))
   e = trivialization B F' :=
 i.out
 
-variables (R B F)
-
-instance trivialization.is_linear : (trivialization B F).is_linear R :=
-{ linear := λ x hx, ⟨λ y z, rfl, λ c y, rfl⟩ }
-
-variables {R}
-
-lemma trivialization.coord_changeL (b : B) :
-  (trivialization B F).coord_changeL R (trivialization B F) b = continuous_linear_equiv.refl R F :=
-begin
-  ext v,
-  rw [trivialization.coord_changeL_apply'],
-  exacts [rfl, ⟨mem_univ _, mem_univ _⟩]
-end
+variables (R)
 
 instance vector_bundle : vector_bundle R F (bundle.trivial B F) :=
 { trivialization_linear' := begin

--- a/src/topology/vector_bundle/basic.lean
+++ b/src/topology/vector_bundle/basic.lean
@@ -12,28 +12,20 @@ import topology.fiber_bundle.basic
 
 In this file we define (topological) vector bundles.
 
-Let `B` be the base space. In our formalism, a vector bundle is by definition the type
-`bundle.total_space E` where `E : B → Type*` is a function associating to
-`x : B` the fiber over `x`. This type `bundle.total_space E` is just a type synonym for
-`Σ (x : B), E x`, with the interest that one can put another topology than on `Σ (x : B), E x`
-which has the disjoint union topology.
+Let `B` be the base space, let `F` be a normed space over a normed field `R`, and let `E : B → Type*`
+be a `fiber_bundle` with fiber `F`, in which, for each `x`, the fiber `E x` is a topological vector
+space over `R`.
 
-To have a vector bundle structure on `bundle.total_space E`, one should
-additionally have the following data:
+To have a vector bundle structure on `bundle.total_space E`, one should additionally have the
+following properties:
 
-* `F` should be a normed space over a normed field `R`;
-* There should be a topology on `bundle.total_space E`, for which the projection to `B` is
-a fiber bundle with fiber `F` (in particular, each fiber `E x` is homeomorphic to `F`);
-* For each `x`, the fiber `E x` should be a topological vector space over `R`, and the injection
-from `E x` to `bundle.total_space F E` should be an embedding;
-* There should be a distinguished set of bundle trivializations (which are continuous linear equivs
-in the fibres), the "trivialization atlas"
-* There should be a choice of bundle trivialization at each point, which belongs to this atlas.
+* The bundle trivializations in the trivialization atlas should be continuous linear equivs in the
+fibres;
+* For any two trivializations `e`, `e'` in the atlas the transition function considered as a map
+from `B` into `F →L[R] F` is continuous on `e.base_set ∩ e'.base_set` with respect to the operator
+norm topology on `F →L[R] F`.
 
-If all these conditions are satisfied, and if moreover for any two trivializations `e`, `e'` in the
-atlas the transition function considered as a map from `B` into `F →L[R] F` is continuous on
-`e.base_set ∩ e'.base_set` with respect to the operator norm topology on `F →L[R] F`, we register
-the typeclass `vector_bundle R F E`.
+If these conditions are satisfied, we register the typeclass `vector_bundle R F E`.
 
 We define constructions on vector bundles like pullbacks and direct sums in other files.
 Only the trivial bundle is defined in this file.
@@ -309,7 +301,7 @@ variables [nontrivially_normed_field R] [∀ x, add_comm_monoid (E x)] [∀ x, m
   [topological_space (total_space E)] [∀ x, topological_space (E x)] [fiber_bundle F E]
 
 /-- The space `total_space E` (for `E : B → Type*` such that each `E x` is a topological vector
-space) has a topological vector space structure with fiber `F` (denoted with
+space) has a (topological) vector space structure with fiber `F` (denoted with
 `vector_bundle R F E`) if around every point there is a fiber bundle trivialization
 which is linear in the fibers. -/
 class vector_bundle : Prop :=
@@ -455,8 +447,7 @@ instance trivialization.is_linear : (trivialization B F).is_linear R :=
 variables {R}
 
 lemma trivialization.coord_changeL (b : B) :
-  (trivialization B F).coord_changeL R
-    (trivialization B F) b = continuous_linear_equiv.refl R F :=
+  (trivialization B F).coord_changeL R (trivialization B F) b = continuous_linear_equiv.refl R F :=
 begin
   ext v,
   rw [trivialization.coord_changeL_apply'],

--- a/src/topology/vector_bundle/basic.lean
+++ b/src/topology/vector_bundle/basic.lean
@@ -12,9 +12,9 @@ import topology.fiber_bundle.basic
 
 In this file we define (topological) vector bundles.
 
-Let `B` be the base space, let `F` be a normed space over a normed field `R`, and let `E : B → Type*`
-be a `fiber_bundle` with fiber `F`, in which, for each `x`, the fiber `E x` is a topological vector
-space over `R`.
+Let `B` be the base space, let `F` be a normed space over a normed field `R`, and let
+`E : B → Type*` be a `fiber_bundle` with fiber `F`, in which, for each `x`, the fiber `E x` is a
+topological vector space over `R`.
 
 To have a vector bundle structure on `bundle.total_space E`, one should additionally have the
 following properties:

--- a/src/topology/vector_bundle/basic.lean
+++ b/src/topology/vector_bundle/basic.lean
@@ -439,7 +439,7 @@ by { ext v, rw [coord_changeL_apply e e' hb], refl }
 end trivialization
 
 namespace bundle.trivial
-variables (R B) (F' : Type*) [topological_space B] [topological_space F']
+variables (R B) (F' : Type*) [topological_space F']
 
 /-- Local trivialization for trivial bundle. -/
 def trivialization : trivialization F' (π (bundle.trivial B F')) :=

--- a/src/topology/vector_bundle/basic.lean
+++ b/src/topology/vector_bundle/basic.lean
@@ -8,22 +8,22 @@ import analysis.normed_space.bounded_linear_maps
 import topology.fiber_bundle.basic
 
 /-!
-# Topological vector bundles
+# Vector bundles
 
-In this file we define topological vector bundles.
+In this file we define (topological) vector bundles.
 
-Let `B` be the base space. In our formalism, a topological vector bundle is by definition the type
+Let `B` be the base space. In our formalism, a vector bundle is by definition the type
 `bundle.total_space E` where `E : B → Type*` is a function associating to
 `x : B` the fiber over `x`. This type `bundle.total_space E` is just a type synonym for
 `Σ (x : B), E x`, with the interest that one can put another topology than on `Σ (x : B), E x`
 which has the disjoint union topology.
 
-To have a topological vector bundle structure on `bundle.total_space E`, one should
+To have a vector bundle structure on `bundle.total_space E`, one should
 additionally have the following data:
 
 * `F` should be a normed space over a normed field `R`;
 * There should be a topology on `bundle.total_space E`, for which the projection to `B` is
-a topological fiber bundle with fiber `F` (in particular, each fiber `E x` is homeomorphic to `F`);
+a fiber bundle with fiber `F` (in particular, each fiber `E x` is homeomorphic to `F`);
 * For each `x`, the fiber `E x` should be a topological vector space over `R`, and the injection
 from `E x` to `bundle.total_space F E` should be an embedding;
 * There should be a distinguished set of bundle trivializations (which are continuous linear equivs
@@ -33,7 +33,7 @@ in the fibres), the "trivialization atlas"
 If all these conditions are satisfied, and if moreover for any two trivializations `e`, `e'` in the
 atlas the transition function considered as a map from `B` into `F →L[R] F` is continuous on
 `e.base_set ∩ e'.base_set` with respect to the operator norm topology on `F →L[R] F`, we register
-the typeclass `topological_vector_bundle R F E`.
+the typeclass `vector_bundle R F E`.
 
 We define constructions on vector bundles like pullbacks and direct sums in other files.
 Only the trivial bundle is defined in this file.
@@ -82,7 +82,7 @@ begin
   { rw [e.coe_symm_of_not_mem hb], exact (0 : F →ₗ[R] E b).is_linear }
 end
 
-/-- A pretrivialization for a topological vector bundle defines linear equivalences between the
+/-- A pretrivialization for a vector bundle defines linear equivalences between the
 fibers and the model space. -/
 @[simps {fully_applied := ff}] def linear_equiv_at (e : pretrivialization F (π E)) [e.is_linear R]
   (b : B) (hb : b ∈ e.base_set) :
@@ -164,7 +164,7 @@ instance to_pretrivialization.is_linear [add_comm_monoid F] [module R F]
 
 variables [add_comm_monoid F] [module R F] [∀ x, add_comm_monoid (E x)] [∀ x, module R (E x)]
 
-/-- A trivialization for a topological vector bundle defines linear equivalences between the
+/-- A trivialization for a vector bundle defines linear equivalences between the
 fibers and the model space. -/
 def linear_equiv_at (e : trivialization F (π E)) [e.is_linear R] (b : B) (hb : b ∈ e.base_set) :
   E b ≃ₗ[R] F :=
@@ -306,55 +306,34 @@ section
 
 variables [nontrivially_normed_field R] [∀ x, add_comm_monoid (E x)] [∀ x, module R (E x)]
   [normed_add_comm_group F] [normed_space R F] [topological_space B]
-  [topological_space (total_space E)] [∀ x, topological_space (E x)]
+  [topological_space (total_space E)] [∀ x, topological_space (E x)] [fiber_bundle F E]
 
 /-- The space `total_space E` (for `E : B → Type*` such that each `E x` is a topological vector
 space) has a topological vector space structure with fiber `F` (denoted with
-`topological_vector_bundle R F E`) if around every point there is a fiber bundle trivialization
+`vector_bundle R F E`) if around every point there is a fiber bundle trivialization
 which is linear in the fibers. -/
-class topological_vector_bundle :=
-(total_space_mk_inducing [] : ∀ (b : B), inducing (@total_space_mk B E b))
-(trivialization_atlas [] : set (trivialization F (π E)))
-(trivialization_linear' : ∀ (e : trivialization F (π E)) (he : e ∈ trivialization_atlas),
+class vector_bundle : Prop :=
+(trivialization_linear' : ∀ (e : trivialization F (π E)) [mem_trivialization_atlas e],
   e.is_linear R)
-(trivialization_at [] : B → trivialization F (π E))
-(mem_base_set_trivialization_at [] : ∀ b : B, b ∈ (trivialization_at b).base_set)
-(trivialization_mem_atlas [] : ∀ b : B, trivialization_at b ∈ trivialization_atlas)
-(continuous_on_coord_change' [] : ∀ (e e' : trivialization F (π E)) (he : e ∈ trivialization_atlas)
-  (he' : e' ∈ trivialization_atlas),
-  have _ := trivialization_linear' e he,
-  have _ := trivialization_linear' e' he',
+(continuous_on_coord_change' [] : ∀ (e e' : trivialization F (π E)) [mem_trivialization_atlas e]
+  [mem_trivialization_atlas e'],
   continuous_on
   (λ b, by exactI trivialization.coord_changeL R e e' b : B → F →L[R] F) (e.base_set ∩ e'.base_set))
 
-export topological_vector_bundle (trivialization_atlas trivialization_at
-  mem_base_set_trivialization_at trivialization_mem_atlas)
-
-variables {F E} [topological_vector_bundle R F E]
-
-/-- Given a type `E` equipped with a topological vector bundle structure, this is a `Prop` typeclass
-for trivializations of `E`, expressing that a trivialization is in the designated atlas for the
-bundle.  This is needed because lemmas about the linearity of trivializations or the continuity (as
-functions to `F →L[R] F`, where `F` is the model fibre) of the transition functions are only
-expected to hold for trivializations in the designated atlas. -/
-@[mk_iff]
-class mem_trivialization_atlas (e : trivialization F (π E)) : Prop :=
-(out : e ∈ trivialization_atlas R F E)
-
-instance (b : B) : mem_trivialization_atlas R (trivialization_at R F E b) :=
-{ out := topological_vector_bundle.trivialization_mem_atlas R F E b }
+variables {F E}
 
 @[priority 100]
-instance trivialization_linear (e : trivialization F (π E)) [he : mem_trivialization_atlas R e] :
+instance trivialization_linear [vector_bundle R F E] (e : trivialization F (π E))
+  [mem_trivialization_atlas e] :
   e.is_linear R :=
-topological_vector_bundle.trivialization_linear' e he.out
+vector_bundle.trivialization_linear' e
 
-lemma continuous_on_coord_change (e e' : trivialization F (π E))
-  [he : mem_trivialization_atlas R e]
-  [he' : mem_trivialization_atlas R e'] :
+lemma continuous_on_coord_change [vector_bundle R F E] (e e' : trivialization F (π E))
+  [he : mem_trivialization_atlas e]
+  [he' : mem_trivialization_atlas e'] :
   continuous_on
   (λ b, trivialization.coord_changeL R e e' b : B → F →L[R] F) (e.base_set ∩ e'.base_set) :=
-topological_vector_bundle.continuous_on_coord_change' e e' he.out he'.out
+vector_bundle.continuous_on_coord_change' R e e'
 
 namespace trivialization
 
@@ -369,7 +348,7 @@ def continuous_linear_map_at (e : trivialization F (π E)) [e.is_linear R] (b : 
     rw [e.coe_linear_map_at b],
     refine continuous_if_const _ (λ hb, _) (λ _, continuous_zero),
     exact continuous_snd.comp (e.to_local_homeomorph.continuous_on.comp_continuous
-      (topological_vector_bundle.total_space_mk_inducing R F E b).continuous
+      (fiber_bundle.total_space_mk_inducing F E b).continuous
       (λ x, e.mem_source.mpr hb))
   end,
   .. e.linear_map_at R b }
@@ -380,7 +359,7 @@ def symmL (e : trivialization F (π E)) [e.is_linear R] (b : B) : F →L[R] E b 
 { to_fun := e.symm b, -- given explicitly to help `simps`
   cont := begin
     by_cases hb : b ∈ e.base_set,
-    { rw (topological_vector_bundle.total_space_mk_inducing R F E b).continuous_iff,
+    { rw (fiber_bundle.total_space_mk_inducing F E b).continuous_iff,
       exact e.continuous_on_symm.comp_continuous (continuous_const.prod_mk continuous_id)
         (λ x, mk_mem_prod hb (mem_univ x)) },
     { refine continuous_zero.congr (λ x, (e.symm_apply_of_not_mem hb x).symm) },
@@ -401,7 +380,7 @@ e.linear_map_at_symmₗ hb y
 
 variables (R)
 
-/-- In a topological vector bundle, a trivialization in the fiber (which is a priori only linear)
+/-- In a vector bundle, a trivialization in the fiber (which is a priori only linear)
 is in fact a continuous linear equiv between the fibers and the model fiber. -/
 @[simps apply symm_apply {fully_applied := ff}]
 def continuous_linear_equiv_at (e : trivialization F (π E)) [e.is_linear R] (b : B)
@@ -409,7 +388,7 @@ def continuous_linear_equiv_at (e : trivialization F (π E)) [e.is_linear R] (b 
 { to_fun := λ y, (e (total_space_mk b y)).2, -- given explicitly to help `simps`
   inv_fun := e.symm b, -- given explicitly to help `simps`
   continuous_to_fun := continuous_snd.comp (e.to_local_homeomorph.continuous_on.comp_continuous
-    (topological_vector_bundle.total_space_mk_inducing R F E b).continuous
+    (fiber_bundle.total_space_mk_inducing F E b).continuous
     (λ x, e.mem_source.mpr hb)),
   continuous_inv_fun := (e.symmL R b).continuous,
   .. e.to_pretrivialization.linear_equiv_at R b hb }
@@ -467,31 +446,8 @@ by { ext v, rw [coord_changeL_apply e e' hb], refl }
 
 end trivialization
 
-namespace trivial_topological_vector_bundle
+namespace bundle.trivial
 variables (R B F)
-
-/-- Local trivialization for trivial bundle. -/
-def trivialization : trivialization F (π (bundle.trivial B F)) :=
-{ to_fun := λ x, (x.fst, x.snd),
-  inv_fun := λ y, ⟨y.fst, y.snd⟩,
-  source := univ,
-  target := univ,
-  map_source' := λ x h, mem_univ (x.fst, x.snd),
-  map_target' := λ y h,  mem_univ ⟨y.fst, y.snd⟩,
-  left_inv' := λ x h, sigma.eq rfl rfl,
-  right_inv' := λ x h, prod.ext rfl rfl,
-  open_source := is_open_univ,
-  open_target := is_open_univ,
-  continuous_to_fun := by { rw [←continuous_iff_continuous_on_univ, continuous_iff_le_induced],
-    simp only [prod.topological_space, induced_inf, induced_compose], exact le_rfl, },
-  continuous_inv_fun := by { rw [←continuous_iff_continuous_on_univ, continuous_iff_le_induced],
-    simp only [bundle.total_space.topological_space, induced_inf, induced_compose],
-    exact le_rfl, },
-  base_set := univ,
-  open_base_set := is_open_univ,
-  source_eq := rfl,
-  target_eq := by simp only [univ_prod_univ],
-  proj_to_fun := λ y hy, rfl }
 
 instance trivialization.is_linear : (trivialization B F).is_linear R :=
 { linear := λ x hx, ⟨λ y z, rfl, λ c y, rfl⟩ }
@@ -507,71 +463,32 @@ begin
   exacts [rfl, ⟨mem_univ _, mem_univ _⟩]
 end
 
-@[simp]
-lemma trivialization_source : (trivialization B F).source = univ := rfl
-
-@[simp]
-lemma trivialization_target : (trivialization B F).target = univ := rfl
-
-instance topological_vector_bundle :
-  topological_vector_bundle R F (bundle.trivial B F) :=
-{ trivialization_atlas := {trivial_topological_vector_bundle.trivialization B F},
-  trivialization_linear' := begin
-    intros e he,
-    rw mem_singleton_iff at he,
-    subst he,
+instance vector_bundle : vector_bundle R F (bundle.trivial B F) :=
+{ trivialization_linear' := begin
+    introsI e he,
+    rw eq_trivialization B F e,
     apply_instance
   end,
-  trivialization_at := λ x, trivial_topological_vector_bundle.trivialization B F,
-  mem_base_set_trivialization_at := mem_univ,
-  trivialization_mem_atlas := λ x, mem_singleton _,
-  total_space_mk_inducing := λ b, ⟨begin
-    have : (λ (x : trivial B F b), x) = @id F, by { ext x, refl },
-    simp only [total_space.topological_space, induced_inf, induced_compose, function.comp,
-      total_space.proj, induced_const, top_inf_eq, trivial.proj_snd, id.def,
-      trivial.topological_space, this, induced_id],
-  end⟩,
   continuous_on_coord_change' := begin
-    intros e e' he he',
-    rw mem_singleton_iff at he he',
-    subst he,
-    subst he',
+    introsI e e' he he',
+    unfreezingI { obtain rfl := eq_trivialization B F e },
+    unfreezingI { obtain rfl := eq_trivialization B F e' },
     simp_rw trivialization.coord_changeL,
     exact continuous_const.continuous_on
   end }
 
-end trivial_topological_vector_bundle
-
-/- Not registered as an instance because of a metavariable. -/
-lemma is_topological_vector_bundle_is_topological_fiber_bundle :
-  is_topological_fiber_bundle F (@total_space.proj B E) :=
-λ x, ⟨trivialization_at R F E x, mem_base_set_trivialization_at R F E x⟩
+end bundle.trivial
 
 include R F
 
-namespace topological_vector_bundle
-
-lemma continuous_total_space_mk (x : B) : continuous (@total_space_mk B E x) :=
-(topological_vector_bundle.total_space_mk_inducing R F E x).continuous
+/-! ### Constructing vector bundles -/
 
 variables (R B F)
 
-@[continuity] lemma continuous_proj : continuous (@total_space.proj B E) :=
-begin
-  apply @is_topological_fiber_bundle.continuous_proj B F,
-  apply @is_topological_vector_bundle_is_topological_fiber_bundle R,
-end
-
-end topological_vector_bundle
-
-/-! ### Constructing topological vector bundles -/
-
-variables (R B F)
-
-/-- Analogous construction of `topological_fiber_bundle_core` for vector bundles. This
+/-- Analogous construction of `fiber_bundle_core` for vector bundles. This
 construction gives a way to construct vector bundles from a structure registering how
 trivialization changes act on fibers. -/
-structure topological_vector_bundle_core (ι : Type*) :=
+structure vector_bundle_core (ι : Type*) :=
 (base_set          : ι → set B)
 (is_open_base_set  : ∀ i, is_open (base_set i))
 (index_at          : B → ι)
@@ -582,10 +499,10 @@ structure topological_vector_bundle_core (ι : Type*) :=
 (coord_change_comp : ∀ i j k, ∀ x ∈ (base_set i) ∩ (base_set j) ∩ (base_set k), ∀ v,
   (coord_change j k x) (coord_change i j x v) = coord_change i k x v)
 
-/-- The trivial topological vector bundle core, in which all the changes of coordinates are the
+/-- The trivial vector bundle core, in which all the changes of coordinates are the
 identity. -/
-def trivial_topological_vector_bundle_core (ι : Type*) [inhabited ι] :
-  topological_vector_bundle_core R B F ι :=
+def trivial_vector_bundle_core (ι : Type*) [inhabited ι] :
+  vector_bundle_core R B F ι :=
 { base_set := λ ι, univ,
   is_open_base_set := λ i, is_open_univ,
   index_at := default,
@@ -595,22 +512,22 @@ def trivial_topological_vector_bundle_core (ι : Type*) [inhabited ι] :
   coord_change_comp := λ i j k x hx v, rfl,
   coord_change_continuous := λ i j, continuous_on_const }
 
-instance (ι : Type*) [inhabited ι] : inhabited (topological_vector_bundle_core R B F ι) :=
-⟨trivial_topological_vector_bundle_core R B F ι⟩
+instance (ι : Type*) [inhabited ι] : inhabited (vector_bundle_core R B F ι) :=
+⟨trivial_vector_bundle_core R B F ι⟩
 
-namespace topological_vector_bundle_core
+namespace vector_bundle_core
 
-variables {R B F} {ι : Type*} (Z : topological_vector_bundle_core R B F ι)
+variables {R B F} {ι : Type*} (Z : vector_bundle_core R B F ι)
 
-/-- Natural identification to a `topological_fiber_bundle_core`. -/
-def to_topological_fiber_bundle_core : topological_fiber_bundle_core ι B F :=
+/-- Natural identification to a `fiber_bundle_core`. -/
+def to_fiber_bundle_core : fiber_bundle_core ι B F :=
 { coord_change := λ i j b, Z.coord_change i j b,
   coord_change_continuous := λ i j, is_bounded_bilinear_map_apply.continuous.comp_continuous_on
       ((Z.coord_change_continuous i j).prod_map continuous_on_id),
   ..Z }
 
-instance to_topological_fiber_bundle_core_coe : has_coe (topological_vector_bundle_core R B F ι)
-  (topological_fiber_bundle_core ι B F) := ⟨to_topological_fiber_bundle_core⟩
+instance to_fiber_bundle_core_coe : has_coe (vector_bundle_core R B F ι)
+  (fiber_bundle_core ι B F) := ⟨to_fiber_bundle_core⟩
 
 include Z
 
@@ -618,32 +535,32 @@ lemma coord_change_linear_comp (i j k : ι): ∀ x ∈ (Z.base_set i) ∩ (Z.bas
   (Z.coord_change j k x).comp (Z.coord_change i j x) = Z.coord_change i k x :=
 λ x hx, by { ext v, exact Z.coord_change_comp i j k x hx v }
 
-/-- The index set of a topological vector bundle core, as a convenience function for dot notation -/
+/-- The index set of a vector bundle core, as a convenience function for dot notation -/
 @[nolint unused_arguments has_nonempty_instance]
 def index := ι
 
-/-- The base space of a topological vector bundle core, as a convenience function for dot notation-/
+/-- The base space of a vector bundle core, as a convenience function for dot notation-/
 @[nolint unused_arguments, reducible]
 def base := B
 
-/-- The fiber of a topological vector bundle core, as a convenience function for dot notation and
+/-- The fiber of a vector bundle core, as a convenience function for dot notation and
 typeclass inference -/
 @[nolint unused_arguments has_nonempty_instance]
-def fiber : B → Type* := Z.to_topological_fiber_bundle_core.fiber
+def fiber : B → Type* := Z.to_fiber_bundle_core.fiber
 
 instance topological_space_fiber (x : B) : topological_space (Z.fiber x) :=
-by delta_instance topological_vector_bundle_core.fiber
+by delta_instance vector_bundle_core.fiber
 instance add_comm_monoid_fiber : ∀ (x : B), add_comm_monoid (Z.fiber x) :=
-by dsimp [topological_vector_bundle_core.fiber]; delta_instance topological_fiber_bundle_core.fiber
+by dsimp [vector_bundle_core.fiber]; delta_instance fiber_bundle_core.fiber
 instance module_fiber : ∀ (x : B), module R (Z.fiber x) :=
-by dsimp [topological_vector_bundle_core.fiber];  delta_instance topological_fiber_bundle_core.fiber
+by dsimp [vector_bundle_core.fiber];  delta_instance fiber_bundle_core.fiber
 instance add_comm_group_fiber [add_comm_group F] : ∀ (x : B), add_comm_group (Z.fiber x) :=
-by dsimp [topological_vector_bundle_core.fiber];  delta_instance topological_fiber_bundle_core.fiber
+by dsimp [vector_bundle_core.fiber];  delta_instance fiber_bundle_core.fiber
 
-/-- The projection from the total space of a topological fiber bundle core, on its base. -/
+/-- The projection from the total space of a fiber bundle core, on its base. -/
 @[reducible, simp, mfld_simps] def proj : total_space Z.fiber → B := total_space.proj
 
-/-- The total space of the topological vector bundle, as a convenience function for dot notation.
+/-- The total space of the vector bundle, as a convenience function for dot notation.
 It is by definition equal to `bundle.total_space Z.fiber`, a.k.a. `Σ x, Z.fiber x` but with a
 different name for typeclass inference. -/
 @[nolint unused_arguments, reducible]
@@ -651,33 +568,33 @@ def total_space := bundle.total_space Z.fiber
 
 /-- Local homeomorphism version of the trivialization change. -/
 def triv_change (i j : ι) : local_homeomorph (B × F) (B × F) :=
-topological_fiber_bundle_core.triv_change ↑Z i j
+fiber_bundle_core.triv_change ↑Z i j
 
 @[simp, mfld_simps] lemma mem_triv_change_source (i j : ι) (p : B × F) :
   p ∈ (Z.triv_change i j).source ↔ p.1 ∈ Z.base_set i ∩ Z.base_set j :=
-topological_fiber_bundle_core.mem_triv_change_source ↑Z i j p
+fiber_bundle_core.mem_triv_change_source ↑Z i j p
 
 variable (ι)
 
-/-- Topological structure on the total space of a topological bundle created from core, designed so
+/-- Topological structure on the total space of a vector bundle created from core, designed so
 that all the local trivialization are continuous. -/
 instance to_topological_space : topological_space Z.total_space :=
-topological_fiber_bundle_core.to_topological_space ι ↑Z
+fiber_bundle_core.to_topological_space ι ↑Z
 
 variables {ι} (b : B) (a : F)
 
 @[simp, mfld_simps] lemma coe_coord_change (i j : ι) :
-  Z.to_topological_fiber_bundle_core.coord_change i j b = Z.coord_change i j b := rfl
+  Z.to_fiber_bundle_core.coord_change i j b = Z.coord_change i j b := rfl
 
 /-- One of the standard local trivializations of a vector bundle constructed from core, taken by
 considering this in particular as a fiber bundle constructed from core. -/
 def local_triv (i : ι) : trivialization F (π Z.fiber) :=
-by dsimp [topological_vector_bundle_core.total_space, topological_vector_bundle_core.fiber];
-  exact Z.to_topological_fiber_bundle_core.local_triv i
+by dsimp [vector_bundle_core.total_space, vector_bundle_core.fiber];
+  exact Z.to_fiber_bundle_core.local_triv i
 
 /-- The standard local trivializations of a vector bundle constructed from core are linear. -/
 instance local_triv.is_linear (i : ι) : (Z.local_triv i).is_linear R :=
-{ linear := λ x hx, by dsimp [topological_vector_bundle_core.local_triv]; exact
+{ linear := λ x hx, by dsimp [vector_bundle_core.local_triv]; exact
   { map_add := λ v w, by simp only [continuous_linear_map.map_add] with mfld_simps,
     map_smul := λ r v, by simp only [continuous_linear_map.map_smul] with mfld_simps} }
 
@@ -685,7 +602,7 @@ variables (i j : ι)
 
 @[simp, mfld_simps] lemma mem_local_triv_source (p : Z.total_space) :
   p ∈ (Z.local_triv i).source ↔ p.1 ∈ Z.base_set i :=
-by dsimp [topological_vector_bundle_core.fiber]; exact iff.rfl
+by dsimp [vector_bundle_core.fiber]; exact iff.rfl
 
 @[simp, mfld_simps] lemma base_set_at : Z.base_set i = (Z.local_triv i).base_set := rfl
 
@@ -694,7 +611,7 @@ by dsimp [topological_vector_bundle_core.fiber]; exact iff.rfl
 
 @[simp, mfld_simps] lemma mem_local_triv_target (p : B × F) :
   p ∈ (Z.local_triv i).target ↔ p.1 ∈ (Z.local_triv i).base_set :=
-Z.to_topological_fiber_bundle_core.mem_local_triv_target i p
+Z.to_fiber_bundle_core.mem_local_triv_target i p
 
 @[simp, mfld_simps] lemma local_triv_symm_fst (p : B × F) :
   (Z.local_triv i).to_local_homeomorph.symm p =
@@ -726,7 +643,7 @@ by { rw [local_triv_at, mem_local_triv_source], exact Z.mem_base_set_at b }
 
 @[simp, mfld_simps] lemma local_triv_at_apply (p : Z.total_space) :
   ((Z.local_triv_at p.1) p) = ⟨p.1, p.2⟩ :=
-topological_fiber_bundle_core.local_triv_at_apply Z p
+fiber_bundle_core.local_triv_at_apply Z p
 
 @[simp, mfld_simps] lemma local_triv_at_apply_mk (b : B) (a : F) :
   ((Z.local_triv_at b) ⟨b, a⟩) = ⟨b, a⟩ :=
@@ -734,51 +651,35 @@ Z.local_triv_at_apply _
 
 @[simp, mfld_simps] lemma mem_local_triv_at_base_set :
   b ∈ (Z.local_triv_at b).base_set :=
-topological_fiber_bundle_core.mem_local_triv_at_base_set Z b
+fiber_bundle_core.mem_local_triv_at_base_set Z b
 
-instance : topological_vector_bundle R F Z.fiber :=
-{ total_space_mk_inducing := λ b, ⟨ begin refine le_antisymm _ (λ s h, _),
-    { rw ←continuous_iff_le_induced,
-      exact topological_fiber_bundle_core.continuous_total_space_mk Z b, },
-    { refine is_open_induced_iff.mpr ⟨(Z.local_triv_at b).source ∩ (Z.local_triv_at b) ⁻¹'
-        ((Z.local_triv_at b).base_set ×ˢ s), (continuous_on_open_iff
-        (Z.local_triv_at b).open_source).mp (Z.local_triv_at b).continuous_to_fun _
-        ((Z.local_triv_at b).open_base_set.prod h), _⟩,
-      rw [preimage_inter, ←preimage_comp, function.comp],
-      simp only [total_space_mk],
-      refine ext_iff.mpr (λ a, ⟨λ ha, _, λ ha, ⟨Z.mem_base_set_at b, _⟩⟩),
-      { simp only [mem_prod, mem_preimage, mem_inter_iff, local_triv_at_apply_mk] at ha,
-        exact ha.2.2, },
-      { simp only [mem_prod, mem_preimage, mem_inter_iff, local_triv_at_apply_mk],
-        exact ⟨Z.mem_base_set_at b, ha⟩, } } end⟩,
-  trivialization_atlas := set.range Z.local_triv,
-  trivialization_linear' := begin
+instance fiber_bundle : fiber_bundle F Z.fiber := Z.to_fiber_bundle_core.fiber_bundle
+
+instance vector_bundle : vector_bundle R F Z.fiber :=
+{ trivialization_linear' := begin
     rintros _ ⟨i, rfl⟩,
-    apply_instance
+    apply local_triv.is_linear,
   end,
-  trivialization_at := Z.local_triv_at,
-  mem_base_set_trivialization_at := Z.mem_base_set_at,
-  trivialization_mem_atlas := λ b, ⟨Z.index_at b, rfl⟩,
   continuous_on_coord_change' := begin
     rintros _ _ ⟨i, rfl⟩ ⟨i', rfl⟩,
     refine (Z.coord_change_continuous i i').congr (λ b hb, _),
     ext v,
-    simp_rw [continuous_linear_equiv.coe_coe, Z.local_triv_coord_change_eq i i' hb],
+    exact Z.local_triv_coord_change_eq i i' hb v,
   end }
 
-/-- The projection on the base of a topological vector bundle created from core is continuous -/
+/-- The projection on the base of a vector bundle created from core is continuous -/
 @[continuity] lemma continuous_proj : continuous Z.proj :=
-topological_fiber_bundle_core.continuous_proj Z
+fiber_bundle_core.continuous_proj Z
 
-/-- The projection on the base of a topological vector bundle created from core is an open map -/
+/-- The projection on the base of a vector bundle created from core is an open map -/
 lemma is_open_map_proj : is_open_map Z.proj :=
-topological_fiber_bundle_core.is_open_map_proj Z
+fiber_bundle_core.is_open_map_proj Z
 
-end topological_vector_bundle_core
+end vector_bundle_core
 
 end
 
-/-! ### Topological vector prebundle -/
+/-! ### Vector prebundle -/
 
 section
 variables [nontrivially_normed_field R] [∀ x, add_comm_monoid (E x)] [∀ x, module R (E x)]
@@ -786,7 +687,7 @@ variables [nontrivially_normed_field R] [∀ x, add_comm_monoid (E x)] [∀ x, m
 
 open topological_space
 
-open topological_vector_bundle
+open vector_bundle
 /-- This structure permits to define a vector bundle when trivializations are given as local
 equivalences but there is not yet a topology on the total space or the fibers.
 The total space is hence given a topology in such a way that there is a fiber bundle structure for
@@ -796,9 +697,9 @@ The topology on the fibers is induced from the one on the total space.
 The field `exists_coord_change` is stated as an existential statement (instead of 3 separate
 fields), since it depends on propositional information (namely `e e' ∈ pretrivialization_atlas`).
 This makes it inconvenient to explicitly define a `coord_change` function when constructing a
-`topological_vector_prebundle`. -/
+`vector_prebundle`. -/
 @[nolint has_nonempty_instance]
-structure topological_vector_prebundle :=
+structure vector_prebundle :=
 (pretrivialization_atlas : set (pretrivialization F (π E)))
 (pretrivialization_linear' : ∀ (e : pretrivialization F (π E)) (he : e ∈ pretrivialization_atlas),
   e.is_linear R)
@@ -810,30 +711,30 @@ structure topological_vector_prebundle :=
   ∀ (b : B) (hb : b ∈ e.base_set ∩ e'.base_set) (v : F),
     f b v = (e' (total_space_mk b (e.symm b v))).2)
 
-namespace topological_vector_prebundle
+namespace vector_prebundle
 
 variables {R E F}
 
-/-- A randomly chosen coordinate change on a `topological_vector_prebundle`, given by
+/-- A randomly chosen coordinate change on a `vector_prebundle`, given by
   the field `exists_coord_change`. -/
-def coord_change (a : topological_vector_prebundle R F E)
+def coord_change (a : vector_prebundle R F E)
   {e e' : pretrivialization F (π E)} (he : e ∈ a.pretrivialization_atlas)
   (he' : e' ∈ a.pretrivialization_atlas) (b : B) : F →L[R] F :=
 classical.some (a.exists_coord_change e he e' he') b
 
-lemma continuous_on_coord_change (a : topological_vector_prebundle R F E)
+lemma continuous_on_coord_change (a : vector_prebundle R F E)
   {e e' : pretrivialization F (π E)} (he : e ∈ a.pretrivialization_atlas)
   (he' : e' ∈ a.pretrivialization_atlas) :
   continuous_on (a.coord_change he he') (e.base_set ∩ e'.base_set) :=
 (classical.some_spec (a.exists_coord_change e he e' he')).1
 
-lemma coord_change_apply (a : topological_vector_prebundle R F E)
+lemma coord_change_apply (a : vector_prebundle R F E)
   {e e' : pretrivialization F (π E)} (he : e ∈ a.pretrivialization_atlas)
   (he' : e' ∈ a.pretrivialization_atlas) {b : B} (hb : b ∈ e.base_set ∩ e'.base_set) (v : F) :
   a.coord_change he he' b v = (e' (total_space_mk b (e.symm b v))).2 :=
 (classical.some_spec (a.exists_coord_change e he e' he')).2 b hb v
 
-lemma mk_coord_change (a : topological_vector_prebundle R F E)
+lemma mk_coord_change (a : vector_prebundle R F E)
   {e e' : pretrivialization F (π E)} (he : e ∈ a.pretrivialization_atlas)
   (he' : e' ∈ a.pretrivialization_atlas) {b : B} (hb : b ∈ e.base_set ∩ e'.base_set) (v : F) :
   (b, a.coord_change he he' b v) = e' (total_space_mk b (e.symm b v)) :=
@@ -844,13 +745,10 @@ begin
   { exact a.coord_change_apply he he' hb v }
 end
 
-/-- Natural identification of `topological_vector_prebundle` as a `topological_fiber_prebundle`. -/
-def to_topological_fiber_prebundle (a : topological_vector_prebundle R F E) :
-  topological_fiber_prebundle F (@total_space.proj B E) :=
-{ pretrivialization_atlas := a.pretrivialization_atlas,
-  pretrivialization_at := a.pretrivialization_at,
-  pretrivialization_mem_atlas := a.pretrivialization_mem_atlas,
-  continuous_triv_change := begin
+/-- Natural identification of `vector_prebundle` as a `fiber_prebundle`. -/
+def to_fiber_prebundle (a : vector_prebundle R F E) :
+  fiber_prebundle F E :=
+{ continuous_triv_change := begin
     intros e he e' he',
     have := is_bounded_bilinear_map_apply.continuous.comp_continuous_on
       ((a.continuous_on_coord_change he' he).prod_map continuous_on_id),
@@ -870,76 +768,62 @@ def to_topological_fiber_prebundle (a : topological_vector_prebundle R F E) :
   .. a }
 
 /-- Topology on the total space that will make the prebundle into a bundle. -/
-def total_space_topology (a : topological_vector_prebundle R F E) :
+def total_space_topology (a : vector_prebundle R F E) :
   topological_space (total_space E) :=
-a.to_topological_fiber_prebundle.total_space_topology
+a.to_fiber_prebundle.total_space_topology
 
 /-- Promotion from a `trivialization` in the `pretrivialization_atlas` of a
-`topological_vector_prebundle` to a `trivialization`. -/
-def trivialization_of_mem_pretrivialization_atlas (a : topological_vector_prebundle R F E)
+`vector_prebundle` to a `trivialization`. -/
+def trivialization_of_mem_pretrivialization_atlas (a : vector_prebundle R F E)
   {e : pretrivialization F (π E)} (he : e ∈ a.pretrivialization_atlas) :
   @trivialization B F _ _ _ a.total_space_topology (π E) :=
-a.to_topological_fiber_prebundle.trivialization_of_mem_pretrivialization_atlas he
+a.to_fiber_prebundle.trivialization_of_mem_pretrivialization_atlas he
 
-lemma linear_of_mem_pretrivialization_atlas (a : topological_vector_prebundle R F E)
+lemma linear_of_mem_pretrivialization_atlas (a : vector_prebundle R F E)
   {e : pretrivialization F (π E)} (he : e ∈ a.pretrivialization_atlas) :
   @trivialization.is_linear R B F _ _ _ _ a.total_space_topology _ _ _ _
     (trivialization_of_mem_pretrivialization_atlas a he) :=
 { linear := (a.pretrivialization_linear' e he).linear }
 
-variable (a : topological_vector_prebundle R F E)
+variable (a : vector_prebundle R F E)
 
 lemma mem_trivialization_at_source (b : B) (x : E b) :
   total_space_mk b x ∈ (a.pretrivialization_at b).source :=
-begin
-  simp only [(a.pretrivialization_at b).source_eq, mem_preimage, total_space.proj],
-  exact a.mem_base_pretrivialization_at b,
-end
+a.to_fiber_prebundle.mem_trivialization_at_source b x
 
 @[simp] lemma total_space_mk_preimage_source (b : B) :
   (total_space_mk b) ⁻¹' (a.pretrivialization_at b).source = univ :=
-begin
-  apply eq_univ_of_univ_subset,
-  rw [(a.pretrivialization_at b).source_eq, ←preimage_comp, function.comp],
-  simp only [total_space.proj],
-  rw preimage_const_of_mem _,
-  exact a.mem_base_pretrivialization_at b,
-end
+a.to_fiber_prebundle.total_space_mk_preimage_source b
 
 /-- Topology on the fibers `E b` induced by the map `E b → E.total_space`. -/
 def fiber_topology (b : B) : topological_space (E b) :=
-topological_space.induced (total_space_mk b) a.total_space_topology
+a.to_fiber_prebundle.fiber_topology b
 
 @[continuity] lemma inducing_total_space_mk (b : B) :
   @inducing _ _ (a.fiber_topology b) a.total_space_topology (total_space_mk b) :=
-by { letI := a.total_space_topology, letI := a.fiber_topology b, exact ⟨rfl⟩ }
+a.to_fiber_prebundle.inducing_total_space_mk b
 
 @[continuity] lemma continuous_total_space_mk (b : B) :
   @continuous _ _ (a.fiber_topology b) a.total_space_topology (total_space_mk b) :=
-begin
-  letI := a.total_space_topology, letI := a.fiber_topology b,
-  exact (a.inducing_total_space_mk b).continuous
-end
+a.to_fiber_prebundle.continuous_total_space_mk b
 
-/-- Make a `topological_vector_bundle` from a `topological_vector_prebundle`.  Concretely this means
-that, given a `topological_vector_prebundle` structure for a sigma-type `E` -- which consists of a
+/-- Make a `fiber_bundle` from a `vector_prebundle`; auxiliary construction for
+`vector_prebundle.vector_bundle`. -/
+def to_fiber_bundle : @fiber_bundle B F _ _ _ a.total_space_topology a.fiber_topology :=
+a.to_fiber_prebundle.to_fiber_bundle
+
+/-- Make a `vector_bundle` from a `vector_prebundle`.  Concretely this means
+that, given a `vector_prebundle` structure for a sigma-type `E` -- which consists of a
 number of "pretrivializations" identifying parts of `E` with product spaces `U × F` -- one
 establishes that for the topology constructed on the sigma-type using
-`topological_vector_prebundle.total_space_topology`, these "pretrivializations" are actually
+`vector_prebundle.total_space_topology`, these "pretrivializations" are actually
 "trivializations" (i.e., homeomorphisms with respect to the constructed topology). -/
-def to_topological_vector_bundle :
-  @topological_vector_bundle R _ F E _ _ _ _ _ _ a.total_space_topology a.fiber_topology :=
-{ total_space_mk_inducing := a.inducing_total_space_mk,
-  trivialization_atlas := {e | ∃ e₀ (he₀ : e₀ ∈ a.pretrivialization_atlas),
-    e = a.trivialization_of_mem_pretrivialization_atlas he₀},
-  trivialization_linear' := begin
+lemma to_vector_bundle :
+  @vector_bundle R _ F E _ _ _ _ _ _ a.total_space_topology a.fiber_topology a.to_fiber_bundle :=
+{ trivialization_linear' := begin
     rintros _ ⟨e, he, rfl⟩,
     apply linear_of_mem_pretrivialization_atlas,
   end,
-  trivialization_at := λ x, a.trivialization_of_mem_pretrivialization_atlas
-    (a.pretrivialization_mem_atlas x),
-  mem_base_set_trivialization_at := a.mem_base_pretrivialization_at,
-  trivialization_mem_atlas := λ x, ⟨_, a.pretrivialization_mem_atlas x, rfl⟩,
   continuous_on_coord_change' := begin
     rintros _ _ ⟨e, he, rfl⟩ ⟨e', he', rfl⟩,
     refine (a.continuous_on_coord_change he he').congr _,
@@ -950,6 +834,6 @@ def to_topological_vector_bundle :
     exacts [rfl, hb]
   end }
 
-end topological_vector_prebundle
+end vector_prebundle
 
 end

--- a/src/topology/vector_bundle/hom.lean
+++ b/src/topology/vector_bundle/hom.lean
@@ -83,8 +83,6 @@ variables (F₂ : Type*) [normed_add_comm_group F₂][normed_space 𝕜₂ F₂]
   (E₂ : B → Type*) [Π x, add_comm_monoid (E₂ x)] [Π x, module 𝕜₂ (E₂ x)]
   [topological_space (total_space E₂)]
 
--- open vector_bundle
-
 variables {F₁ E₁ F₂ E₂} (e₁ e₁' : trivialization F₁ (π E₁)) (e₂ e₂' : trivialization F₂ (π E₂))
 
 namespace pretrivialization

--- a/src/topology/vector_bundle/hom.lean
+++ b/src/topology/vector_bundle/hom.lean
@@ -101,10 +101,11 @@ def continuous_linear_map_coord_change
   (F₁ →SL[σ] F₂) ≃L[𝕜₂] F₁ →SL[σ] F₂)
 
 variables {σ e₁ e₁' e₂ e₂'}
-variables [Π x : B, topological_space (E₁ x)] [fiber_bundle F₁ E₁] [vector_bundle 𝕜₁ F₁ E₁]
-variables [Π x : B, topological_space (E₂ x)] [fiber_bundle F₂ E₂] [vector_bundle 𝕜₂ F₂ E₂]
+variables [Π x : B, topological_space (E₁ x)] [fiber_bundle F₁ E₁]
+variables [Π x : B, topological_space (E₂ x)] [fiber_bundle F₂ E₂]
 
 lemma continuous_on_continuous_linear_map_coord_change
+  [vector_bundle 𝕜₁ F₁ E₁] [vector_bundle 𝕜₂ F₂ E₂]
   [mem_trivialization_atlas e₁] [mem_trivialization_atlas e₁']
   [mem_trivialization_atlas e₂] [mem_trivialization_atlas e₂'] :
   continuous_on (continuous_linear_map_coord_change σ e₁ e₁' e₂ e₂')

--- a/src/topology/vector_bundle/hom.lean
+++ b/src/topology/vector_bundle/hom.lean
@@ -21,7 +21,7 @@ topology on continuous linear maps between general topological vector spaces.
 
 ## Main Definitions
 
-* `bundle.continuous_linear_map.topological_vector_bundle`: continuous semilinear maps between
+* `bundle.continuous_linear_map.vector_bundle`: continuous semilinear maps between
   vector bundles form a vector bundle.
 
 -/
@@ -83,7 +83,7 @@ variables (F₂ : Type*) [normed_add_comm_group F₂][normed_space 𝕜₂ F₂]
   (E₂ : B → Type*) [Π x, add_comm_monoid (E₂ x)] [Π x, module 𝕜₂ (E₂ x)]
   [topological_space (total_space E₂)]
 
-open topological_vector_bundle
+-- open vector_bundle
 
 variables {F₁ E₁ F₂ E₂} (e₁ e₁' : trivialization F₁ (π E₁)) (e₂ e₂' : trivialization F₂ (π E₂))
 
@@ -103,12 +103,12 @@ def continuous_linear_map_coord_change
   (F₁ →SL[σ] F₂) ≃L[𝕜₂] F₁ →SL[σ] F₂)
 
 variables {σ e₁ e₁' e₂ e₂'}
-variables [Π x : B, topological_space (E₁ x)] [topological_vector_bundle 𝕜₁ F₁ E₁]
-variables [Π x : B, topological_space (E₂ x)] [topological_vector_bundle 𝕜₂ F₂ E₂]
+variables [Π x : B, topological_space (E₁ x)] [fiber_bundle F₁ E₁] [vector_bundle 𝕜₁ F₁ E₁]
+variables [Π x : B, topological_space (E₂ x)] [fiber_bundle F₂ E₂] [vector_bundle 𝕜₂ F₂ E₂]
 
 lemma continuous_on_continuous_linear_map_coord_change
-  [mem_trivialization_atlas 𝕜₁ e₁] [mem_trivialization_atlas 𝕜₁ e₁']
-  [mem_trivialization_atlas 𝕜₂ e₂] [mem_trivialization_atlas 𝕜₂ e₂'] :
+  [mem_trivialization_atlas e₁] [mem_trivialization_atlas e₁']
+  [mem_trivialization_atlas e₂] [mem_trivialization_atlas e₂'] :
   continuous_on (continuous_linear_map_coord_change σ e₁ e₁' e₂ e₂')
     ((e₁.base_set ∩ e₂.base_set) ∩ (e₁'.base_set ∩ e₂'.base_set)) :=
 begin
@@ -222,31 +222,31 @@ end pretrivialization
 
 open pretrivialization
 variables (F₁ E₁ F₂ E₂) [ring_hom_isometric σ]
-variables [Π x : B, topological_space (E₁ x)] [topological_vector_bundle 𝕜₁ F₁ E₁]
-variables [Π x : B, topological_space (E₂ x)] [topological_vector_bundle 𝕜₂ F₂ E₂]
+variables [Π x : B, topological_space (E₁ x)] [fiber_bundle F₁ E₁] [vector_bundle 𝕜₁ F₁ E₁]
+variables [Π x : B, topological_space (E₂ x)] [fiber_bundle F₂ E₂] [vector_bundle 𝕜₂ F₂ E₂]
 variables [Π x, has_continuous_add (E₂ x)] [Π x, has_continuous_smul 𝕜₂ (E₂ x)]
 
 /-- The continuous `σ`-semilinear maps between two topological vector bundles form a
-`topological_vector_prebundle` (this is an auxiliary construction for the
-`topological_vector_bundle` instance, in which the pretrivializations are collated but no topology
+`vector_prebundle` (this is an auxiliary construction for the
+`vector_bundle` instance, in which the pretrivializations are collated but no topology
 on the total space is yet provided). -/
-def _root_.bundle.continuous_linear_map.topological_vector_prebundle :
-  topological_vector_prebundle 𝕜₂ (F₁ →SL[σ] F₂)
+def _root_.bundle.continuous_linear_map.vector_prebundle :
+  vector_prebundle 𝕜₂ (F₁ →SL[σ] F₂)
   (bundle.continuous_linear_map σ F₁ E₁ F₂ E₂) :=
 { pretrivialization_atlas :=
     {e |  ∃ (e₁ : trivialization F₁ (π E₁)) (e₂ : trivialization F₂ (π E₂))
-    [mem_trivialization_atlas 𝕜₁ e₁] [mem_trivialization_atlas 𝕜₂ e₂], by exactI
+    [mem_trivialization_atlas e₁] [mem_trivialization_atlas e₂], by exactI
     e = pretrivialization.continuous_linear_map σ e₁ e₂},
   pretrivialization_linear' := begin
     rintro _ ⟨e₁, he₁, e₂, he₂, rfl⟩,
     apply_instance
   end,
   pretrivialization_at := λ x, pretrivialization.continuous_linear_map σ
-    (trivialization_at 𝕜₁ F₁ E₁ x) (trivialization_at 𝕜₂ F₂ E₂ x),
+    (trivialization_at F₁ E₁ x) (trivialization_at F₂ E₂ x),
   mem_base_pretrivialization_at := λ x,
-    ⟨mem_base_set_trivialization_at 𝕜₁ F₁ E₁ x, mem_base_set_trivialization_at 𝕜₂ F₂ E₂ x⟩,
+    ⟨mem_base_set_trivialization_at F₁ E₁ x, mem_base_set_trivialization_at F₂ E₂ x⟩,
   pretrivialization_mem_atlas := λ x,
-    ⟨trivialization_at 𝕜₁ F₁ E₁ x, trivialization_at 𝕜₂ F₂ E₂ x, _, _, rfl⟩,
+    ⟨trivialization_at F₁ E₁ x, trivialization_at F₂ E₂ x, _, _, rfl⟩,
   exists_coord_change := by { rintro _ ⟨e₁, e₂, he₁, he₂, rfl⟩ _ ⟨e₁', e₂', he₁', he₂', rfl⟩,
     resetI,
     exact ⟨continuous_linear_map_coord_change σ e₁ e₁' e₂ e₂',
@@ -258,22 +258,28 @@ def _root_.bundle.continuous_linear_map.topological_vector_prebundle :
 modelled on normed spaces `F₁`, `F₂` respectively.  The topology we put on the continuous
 `σ`-semilinear_maps is the topology coming from the operator norm on maps from `F₁` to `F₂`. -/
 instance (x : B) : topological_space (bundle.continuous_linear_map σ F₁ E₁ F₂ E₂ x) :=
-(bundle.continuous_linear_map.topological_vector_prebundle σ F₁ E₁ F₂ E₂).fiber_topology x
+(bundle.continuous_linear_map.vector_prebundle σ F₁ E₁ F₂ E₂).fiber_topology x
 
 /-- Topology on the total space of the continuous `σ`-semilinear_maps between two "normable" vector
 bundles over the same base. -/
 instance bundle.continuous_linear_map.topological_space_total_space :
   topological_space (total_space (bundle.continuous_linear_map σ F₁ E₁ F₂ E₂)) :=
-(bundle.continuous_linear_map.topological_vector_prebundle
+(bundle.continuous_linear_map.vector_prebundle
   σ F₁ E₁ F₂ E₂).total_space_topology
 
-/-- The continuous `σ`-semilinear_maps between two vector bundles form a vector bundle. -/
-instance _root_.bundle.continuous_linear_map.topological_vector_bundle :
-  topological_vector_bundle 𝕜₂ (F₁ →SL[σ] F₂) (bundle.continuous_linear_map σ F₁ E₁ F₂ E₂) :=
-(bundle.continuous_linear_map.topological_vector_prebundle
-  σ F₁ E₁ F₂ E₂).to_topological_vector_bundle
+/-- The continuous `σ`-semilinear_maps between two vector bundles form a fiber bundle. -/
+instance _root_.bundle.continuous_linear_map.fiber_bundle :
+  fiber_bundle (F₁ →SL[σ] F₂) (bundle.continuous_linear_map σ F₁ E₁ F₂ E₂) :=
+(bundle.continuous_linear_map.vector_prebundle
+  σ F₁ E₁ F₂ E₂).to_fiber_bundle
 
-variables (e₁ e₂) [he₁ : mem_trivialization_atlas 𝕜₁ e₁] [he₂ : mem_trivialization_atlas 𝕜₂ e₂]
+/-- The continuous `σ`-semilinear_maps between two vector bundles form a vector bundle. -/
+instance _root_.bundle.continuous_linear_map.vector_bundle :
+  vector_bundle 𝕜₂ (F₁ →SL[σ] F₂) (bundle.continuous_linear_map σ F₁ E₁ F₂ E₂) :=
+(bundle.continuous_linear_map.vector_prebundle
+  σ F₁ E₁ F₂ E₂).to_vector_bundle
+
+variables (e₁ e₂) [he₁ : mem_trivialization_atlas e₁] [he₂ : mem_trivialization_atlas e₂]
   {F₁ E₁ F₂ E₂}
 
 include he₁ he₂
@@ -283,10 +289,10 @@ the induced trivialization for the continuous `σ`-semilinear maps from `E₁` t
 whose base set is `e₁.base_set ∩ e₂.base_set`. -/
 def trivialization.continuous_linear_map :
   trivialization (F₁ →SL[σ] F₂) (π (bundle.continuous_linear_map σ F₁ E₁ F₂ E₂)) :=
-topological_vector_prebundle.trivialization_of_mem_pretrivialization_atlas _ ⟨e₁, e₂, he₁, he₂, rfl⟩
+vector_prebundle.trivialization_of_mem_pretrivialization_atlas _ ⟨e₁, e₂, he₁, he₂, rfl⟩
 
 instance _root_.bundle.continuous_linear_map.mem_trivialization_atlas :
-  mem_trivialization_atlas 𝕜₂ (e₁.continuous_linear_map σ e₂ :
+  mem_trivialization_atlas (e₁.continuous_linear_map σ e₂ :
     trivialization (F₁ →SL[σ] F₂) (π (bundle.continuous_linear_map σ F₁ E₁ F₂ E₂))) :=
 { out := ⟨_, ⟨e₁, e₂, by apply_instance, by apply_instance, rfl⟩, rfl⟩ }
 

--- a/src/topology/vector_bundle/prod.lean
+++ b/src/topology/vector_bundle/prod.lean
@@ -7,12 +7,13 @@ Authors: Heather Macbeth, Floris van Doorn
 import topology.vector_bundle.basic
 
 /-!
-# Direct sum of two vector bundles
+# Fiberwise product of two vector bundles
 
-If `E₁ : B → Type*` and `E₂ : B → Type*` define two topological vector bundles over `R` with fiber
-models `F₁` and `F₂`, we define the bundle of direct sums `E₁ ×ᵇ E₂ := λ x, E₁ x × E₂ x`.
-We can endow `E₁ ×ᵇ E₂` with a topological vector bundle structure:
-`bundle.prod.vector_bundle`.
+If `E₁ : B → Type*` and `E₂ : B → Type*` define two fiber bundles over `R` with fiber
+models `F₁` and `F₂`, we define the bundle of fibrewise products `E₁ ×ᵇ E₂ := λ x, E₁ x × E₂ x`.
+
+If moreover `E₁` and `E₂` are vector bundles over `R`, we can endow `E₁ ×ᵇ E₂` with a vector bundle
+structure: `bundle.prod.vector_bundle`, the direct sum of the two vector bundles.
 
 A similar construction (which is yet to be formalized) can be done for the vector bundle of
 continuous linear maps from `E₁ x` to `E₂ x` with fiber a type synonym
@@ -23,7 +24,7 @@ products of topological vector bundles, exterior algebras, and so on, where the 
 defined using a norm on the fiber model if this helps.
 
 ## Tags
-Vector bundle
+Vector bundle, fiberwise product, direct sum
 -/
 
 noncomputable theory
@@ -37,147 +38,160 @@ section defs
 variables (E₁ : B → Type*) (E₂ : B → Type*)
 variables [topological_space (total_space E₁)] [topological_space (total_space E₂)]
 
-/-- Equip the total space of the fibrewise product of two topological vector bundles `E₁`, `E₂` with
+/-- Equip the total space of the fibrewise product of two fiber bundles `E₁`, `E₂` with
 the induced topology from the diagonal embedding into `total_space E₁ × total_space E₂`. -/
-instance vector_bundle.prod.topological_space :
+instance fiber_bundle.prod.topological_space :
   topological_space (total_space (E₁ ×ᵇ E₂)) :=
 topological_space.induced
   (λ p, ((⟨p.1, p.2.1⟩ : total_space E₁), (⟨p.1, p.2.2⟩ : total_space E₂)))
   (by apply_instance : topological_space (total_space E₁ × total_space E₂))
 
-/-- The diagonal map from the total space of the fibrewise product of two topological vector bundles
+/-- The diagonal map from the total space of the fibrewise product of two fiber bundles
 `E₁`, `E₂` into `total_space E₁ × total_space E₂` is `inducing`. -/
-lemma vector_bundle.prod.inducing_diag : inducing
+lemma fiber_bundle.prod.inducing_diag : inducing
   (λ p, (⟨p.1, p.2.1⟩, ⟨p.1, p.2.2⟩) :
     total_space (E₁ ×ᵇ E₂) → total_space E₁ × total_space E₂) :=
 ⟨rfl⟩
 
 end defs
 
-open vector_bundle
+open fiber_bundle
 
 variables [nontrivially_normed_field R] [topological_space B]
 
-variables (F₁ : Type*) [normed_add_comm_group F₁] [normed_space R F₁]
+variables (F₁' : Type*) [topological_space F₁']
+  (F₁ : Type*) [normed_add_comm_group F₁] [normed_space R F₁]
   (E₁ : B → Type*) [topological_space (total_space E₁)]
 
-variables (F₂ : Type*) [normed_add_comm_group F₂] [normed_space R F₂]
+variables (F₂' : Type*) [topological_space F₂']
+  (F₂ : Type*) [normed_add_comm_group F₂] [normed_space R F₂]
   (E₂ : B → Type*) [topological_space (total_space E₂)]
 
 namespace trivialization
+variables (ε₁ : trivialization F₁' (π E₁)) (ε₂ : trivialization F₂' (π E₂))
 variables (e₁ : trivialization F₁ (π E₁)) (e₂ : trivialization F₂ (π E₂))
-include e₁ e₂
-variables {R F₁ E₁ F₂ E₂}
+include ε₁ ε₂
+variables {R F₁' F₁ E₁ F₂' F₂ E₂}
 
-/-- Given trivializations `e₁`, `e₂` for vector bundles `E₁`, `E₂` over a base `B`, the forward
-function for the construction `vector_bundle.trivialization.prod`, the induced
-trivialization for the direct sum of `E₁` and `E₂`. -/
-def prod.to_fun' : total_space (E₁ ×ᵇ E₂) → B × (F₁ × F₂) :=
-λ p, ⟨p.1, (e₁ ⟨p.1, p.2.1⟩).2, (e₂ ⟨p.1, p.2.2⟩).2⟩
+/-- Given trivializations `e₁`, `e₂` for fiber bundles `E₁`, `E₂` over a base `B`, the forward
+function for the construction `trivialization.prod`, the induced
+trivialization for the fibrewise product of `E₁` and `E₂`. -/
+def prod.to_fun' : total_space (E₁ ×ᵇ E₂) → B × (F₁' × F₂') :=
+λ p, ⟨p.1, (ε₁ ⟨p.1, p.2.1⟩).2, (ε₂ ⟨p.1, p.2.2⟩).2⟩
 
-variables {e₁ e₂}
+variables {ε₁ ε₂}
 
-lemma prod.continuous_to_fun : continuous_on (prod.to_fun' e₁ e₂)
-  (@total_space.proj B (E₁ ×ᵇ E₂) ⁻¹' (e₁.base_set ∩ e₂.base_set)) :=
+lemma prod.continuous_to_fun : continuous_on (prod.to_fun' ε₁ ε₂)
+  (@total_space.proj B (E₁ ×ᵇ E₂) ⁻¹' (ε₁.base_set ∩ ε₂.base_set)) :=
 begin
   let f₁ : total_space (E₁ ×ᵇ E₂) → total_space E₁ × total_space E₂ :=
     λ p, ((⟨p.1, p.2.1⟩ : total_space E₁), (⟨p.1, p.2.2⟩ : total_space E₂)),
-  let f₂ : total_space E₁ × total_space E₂ → (B × F₁) × (B × F₂) := λ p, ⟨e₁ p.1, e₂ p.2⟩,
-  let f₃ : (B × F₁) × (B × F₂) → B × F₁ × F₂ := λ p, ⟨p.1.1, p.1.2, p.2.2⟩,
+  let f₂ : total_space E₁ × total_space E₂ → (B × F₁') × (B × F₂') := λ p, ⟨ε₁ p.1, ε₂ p.2⟩,
+  let f₃ : (B × F₁') × (B × F₂') → B × F₁' × F₂' := λ p, ⟨p.1.1, p.1.2, p.2.2⟩,
   have hf₁ : continuous f₁ := (prod.inducing_diag E₁ E₂).continuous,
-  have hf₂ : continuous_on f₂ (e₁.source ×ˢ e₂.source) :=
-    e₁.to_local_homeomorph.continuous_on.prod_map e₂.to_local_homeomorph.continuous_on,
+  have hf₂ : continuous_on f₂ (ε₁.source ×ˢ ε₂.source) :=
+    ε₁.to_local_homeomorph.continuous_on.prod_map ε₂.to_local_homeomorph.continuous_on,
   have hf₃ : continuous f₃ :=
     (continuous_fst.comp continuous_fst).prod_mk (continuous_snd.prod_map continuous_snd),
   refine ((hf₃.comp_continuous_on hf₂).comp hf₁.continuous_on _).congr _,
-  { rw [e₁.source_eq, e₂.source_eq],
+  { rw [ε₁.source_eq, ε₂.source_eq],
     exact maps_to_preimage _ _ },
   rintros ⟨b, v₁, v₂⟩ ⟨hb₁, hb₂⟩,
   simp only [prod.to_fun', prod.mk.inj_iff, eq_self_iff_true, and_true],
-  rw e₁.coe_fst,
-  rw [e₁.source_eq, mem_preimage],
+  rw ε₁.coe_fst,
+  rw [ε₁.source_eq, mem_preimage],
   exact hb₁,
 end
 
-variables (e₁ e₂)
-  [Π x, add_comm_monoid (E₁ x)] [Π x, module R (E₁ x)]
-  [Π x, add_comm_monoid (E₂ x)] [Π x, module R (E₂ x)]
+variables (ε₁ ε₂) [nz₁ : Π x, has_zero (E₁ x)] [nz₂ : ∀ x, has_zero (E₂ x)]
+  [mnd₁ : Π x, add_comm_monoid (E₁ x)] [mdl₁ : Π x, module R (E₁ x)]
+  [mnd₂ : Π x, add_comm_monoid (E₂ x)] [mdl₂ : Π x, module R (E₂ x)]
 
+include nz₁ nz₂
 
-/-- Given trivializations `e₁`, `e₂` for vector bundles `E₁`, `E₂` over a base `B`, the inverse
-function for the construction `vector_bundle.trivialization.prod`, the induced
-trivialization for the direct sum of `E₁` and `E₂`. -/
-def prod.inv_fun' (p : B × (F₁ × F₂)) : total_space (E₁ ×ᵇ E₂) :=
-⟨p.1, e₁.symm p.1 p.2.1, e₂.symm p.1 p.2.2⟩
+/-- Given trivializations `ε₁`, `ε₂` for fiber bundles `E₁`, `E₂` over a base `B`, the inverse
+function for the construction `trivialization.prod`, the induced
+trivialization for the fibrewise product of `E₁` and `E₂`. -/
+def prod.inv_fun' (p : B × (F₁' × F₂')) : total_space (E₁ ×ᵇ E₂) :=
+⟨p.1, ε₁.symm p.1 p.2.1, ε₂.symm p.1 p.2.2⟩
 
-variables {e₁ e₂}
+variables {ε₁ ε₂}
 
 lemma prod.left_inv {x : total_space (E₁ ×ᵇ E₂)}
-  (h : x ∈ @total_space.proj B (E₁ ×ᵇ E₂) ⁻¹' (e₁.base_set ∩ e₂.base_set)) :
-  prod.inv_fun' e₁ e₂ (prod.to_fun' e₁ e₂ x) = x :=
+  (h : x ∈ @total_space.proj B (E₁ ×ᵇ E₂) ⁻¹' (ε₁.base_set ∩ ε₂.base_set)) :
+  prod.inv_fun' ε₁ ε₂ (prod.to_fun' ε₁ ε₂ x) = x :=
 begin
   obtain ⟨x, v₁, v₂⟩ := x,
-  obtain ⟨h₁ : x ∈ e₁.base_set, h₂ : x ∈ e₂.base_set⟩ := h,
+  obtain ⟨h₁ : x ∈ ε₁.base_set, h₂ : x ∈ ε₂.base_set⟩ := h,
   simp only [prod.to_fun', prod.inv_fun', symm_apply_apply_mk, h₁, h₂]
 end
 
-lemma prod.right_inv {x : B × F₁ × F₂}
-  (h : x ∈ (e₁.base_set ∩ e₂.base_set) ×ˢ (univ : set (F₁ × F₂))) :
-  prod.to_fun' e₁ e₂ (prod.inv_fun' e₁ e₂ x) = x :=
+lemma prod.right_inv {x : B × F₁' × F₂'}
+  (h : x ∈ (ε₁.base_set ∩ ε₂.base_set) ×ˢ (univ : set (F₁' × F₂'))) :
+  prod.to_fun' ε₁ ε₂ (prod.inv_fun' ε₁ ε₂ x) = x :=
 begin
   obtain ⟨x, w₁, w₂⟩ := x,
-  obtain ⟨⟨h₁ : x ∈ e₁.base_set, h₂ : x ∈ e₂.base_set⟩, -⟩ := h,
+  obtain ⟨⟨h₁ : x ∈ ε₁.base_set, h₂ : x ∈ ε₂.base_set⟩, -⟩ := h,
   simp only [prod.to_fun', prod.inv_fun', apply_mk_symm, h₁, h₂]
 end
 
 lemma prod.continuous_inv_fun :
-  continuous_on (prod.inv_fun' e₁ e₂) ((e₁.base_set ∩ e₂.base_set) ×ˢ univ) :=
+  continuous_on (prod.inv_fun' ε₁ ε₂) ((ε₁.base_set ∩ ε₂.base_set) ×ˢ univ) :=
 begin
   rw (prod.inducing_diag E₁ E₂).continuous_on_iff,
-  have H₁ : continuous (λ p : B × F₁ × F₂, ((p.1, p.2.1), (p.1, p.2.2))) :=
+  have H₁ : continuous (λ p : B × F₁' × F₂', ((p.1, p.2.1), (p.1, p.2.2))) :=
     (continuous_id.prod_map continuous_fst).prod_mk (continuous_id.prod_map continuous_snd),
-  refine (e₁.continuous_on_symm.prod_map e₂.continuous_on_symm).comp H₁.continuous_on _,
+  refine (ε₁.continuous_on_symm.prod_map ε₂.continuous_on_symm).comp H₁.continuous_on _,
   exact λ x h, ⟨⟨h.1.1, mem_univ _⟩, ⟨h.1.2, mem_univ _⟩⟩
 end
 
-variables (e₁ e₂ R)
+variables (e₁ e₂ ε₁ ε₂ R)
 variables [Π x : B, topological_space (E₁ x)] [Π x : B, topological_space (E₂ x)]
-  [fiber_bundle F₁ E₁] [fiber_bundle F₂ E₂]
+  [fiber_bundle F₁' E₁] [fiber_bundle F₂' E₂] [fiber_bundle F₁ E₁] [fiber_bundle F₂ E₂]
 
-/-- Given trivializations `e₁`, `e₂` for fiber bundles `E₁`, `E₂` over a base `B`, the induced
-trivialization for the direct sum of `E₁` and `E₂`, whose base set is `e₁.base_set ∩ e₂.base_set`.
--/
+/-- Given trivializations `ε₁`, `ε₂` for fiber bundles `E₁`, `E₂` over a base `B`, the induced
+trivialization for the fibrewise product of `E₁` and `E₂`, whose base set is
+`ε₁.base_set ∩ ε₂.base_set`. -/
 @[nolint unused_arguments]
-def prod : trivialization (F₁ × F₂) (π (E₁ ×ᵇ E₂)) :=
-{ to_fun := prod.to_fun' e₁ e₂,
-  inv_fun := prod.inv_fun' e₁ e₂,
-  source := (@total_space.proj B (E₁ ×ᵇ E₂)) ⁻¹' (e₁.base_set ∩ e₂.base_set),
-  target := (e₁.base_set ∩ e₂.base_set) ×ˢ set.univ,
+def prod : trivialization (F₁' × F₂') (π (E₁ ×ᵇ E₂)) :=
+{ to_fun := prod.to_fun' ε₁ ε₂,
+  inv_fun := prod.inv_fun' ε₁ ε₂,
+  source := (@total_space.proj B (E₁ ×ᵇ E₂)) ⁻¹' (ε₁.base_set ∩ ε₂.base_set),
+  target := (ε₁.base_set ∩ ε₂.base_set) ×ˢ set.univ,
   map_source' := λ x h, ⟨h, set.mem_univ _⟩,
   map_target' := λ x h, h.1,
   left_inv' := λ x, prod.left_inv,
   right_inv' := λ x, prod.right_inv,
   open_source := begin
-    refine (e₁.open_base_set.inter e₂.open_base_set).preimage _,
-    have : continuous (@total_space.proj B E₁) := continuous_proj F₁ E₁,
+    refine (ε₁.open_base_set.inter ε₂.open_base_set).preimage _,
+    have : continuous (@total_space.proj B E₁) := continuous_proj F₁' E₁,
     exact this.comp (prod.inducing_diag E₁ E₂).continuous.fst,
   end,
-  open_target := (e₁.open_base_set.inter e₂.open_base_set).prod is_open_univ,
+  open_target := (ε₁.open_base_set.inter ε₂.open_base_set).prod is_open_univ,
   continuous_to_fun := prod.continuous_to_fun,
   continuous_inv_fun := prod.continuous_inv_fun,
-  base_set := e₁.base_set ∩ e₂.base_set,
-  open_base_set := e₁.open_base_set.inter e₂.open_base_set,
+  base_set := ε₁.base_set ∩ ε₂.base_set,
+  open_base_set := ε₁.open_base_set.inter ε₂.open_base_set,
   source_eq := rfl,
   target_eq := rfl,
   proj_to_fun := λ x h, rfl }
 
+omit nz₁ nz₂ ε₁ ε₂
+include mnd₁ mdl₁ mnd₂ mdl₂
+
 instance prod.is_linear [e₁.is_linear R] [e₂.is_linear R] : (e₁.prod e₂).is_linear R :=
 { linear := λ x ⟨h₁, h₂⟩, (((e₁.linear R h₁).mk' _).prod_map ((e₂.linear R h₂).mk' _)).is_linear }
 
-@[simp] lemma base_set_prod : (prod e₁ e₂).base_set = e₁.base_set ∩ e₂.base_set :=
+omit mnd₁ mdl₁ mnd₂ mdl₂
+include nz₁ nz₂
+
+@[simp] lemma base_set_prod : (prod ε₁ ε₂).base_set = ε₁.base_set ∩ ε₂.base_set :=
 rfl
 
-variables {e₁ e₂}
+omit nz₁ nz₂
+include mnd₁ mdl₁ mnd₂ mdl₂
+
+variables {e₁ e₂ ε₁ ε₂}
 
 variables (R)
 
@@ -188,38 +202,46 @@ lemma prod_apply
   = ⟨x, e₁.continuous_linear_equiv_at R x hx₁ v₁, e₂.continuous_linear_equiv_at R x hx₂ v₂⟩ :=
 rfl
 
-variables {R}
+omit mnd₁ mdl₁ mnd₂ mdl₂
+include nz₁ nz₂
 
-lemma prod_symm_apply (x : B) (w₁ : F₁) (w₂ : F₂) : (prod e₁ e₂).to_local_equiv.symm (x, w₁, w₂)
-  = ⟨x, e₁.symm x w₁, e₂.symm x w₂⟩ :=
+lemma prod_symm_apply (x : B) (w₁ : F₁') (w₂ : F₂') : (prod ε₁ ε₂).to_local_equiv.symm (x, w₁, w₂)
+  = ⟨x, ε₁.symm x w₁, ε₂.symm x w₂⟩ :=
 rfl
 
 end trivialization
 
 open trivialization
 
-variables [Π x, add_comm_monoid (E₁ x)] [Π x, module R (E₁ x)]
-  [Π x, add_comm_monoid (E₂ x)] [Π x, module R (E₂ x)]
+variables [nz₁ : Π x, has_zero (E₁ x)] [nz₂ : ∀ x, has_zero (E₂ x)]
+  [mnd₁ : Π x, add_comm_monoid (E₁ x)] [mdl₁ : Π x, module R (E₁ x)]
+  [mnd₂ : Π x, add_comm_monoid (E₂ x)] [mdl₂ : Π x, module R (E₂ x)]
 
 variables [Π x : B, topological_space (E₁ x)] [Π x : B, topological_space (E₂ x)]
+  [fiber_bundle F₁' E₁] [fiber_bundle F₂' E₂]
   [fiber_bundle F₁ E₁] [fiber_bundle F₂ E₂]
 
+include nz₁ nz₂
+
 /-- The product of two fiber bundles is a fiber bundle. -/
-instance _root_.bundle.prod.fiber_bundle : fiber_bundle (F₁ × F₂) (E₁ ×ᵇ E₂) :=
+instance _root_.bundle.prod.fiber_bundle : fiber_bundle (F₁' × F₂') (E₁ ×ᵇ E₂) :=
 { total_space_mk_inducing := λ b,
   begin
     rw (prod.inducing_diag E₁ E₂).inducing_iff,
-    exact (total_space_mk_inducing F₁ E₁ b).prod_mk (total_space_mk_inducing F₂ E₂ b),
+    exact (total_space_mk_inducing F₁' E₁ b).prod_mk (total_space_mk_inducing F₂' E₂ b),
   end,
   trivialization_atlas :=
-    {e |  ∃ (e₁ : trivialization F₁ (π E₁)) (e₂ : trivialization F₂ (π E₂))
+    {e |  ∃ (e₁ : trivialization F₁' (π E₁)) (e₂ : trivialization F₂' (π E₂))
     [mem_trivialization_atlas e₁] [mem_trivialization_atlas e₂], by exactI
     e = trivialization.prod e₁ e₂},
-  trivialization_at := λ b, (trivialization_at F₁ E₁ b).prod (trivialization_at F₂ E₂ b),
+  trivialization_at := λ b, (trivialization_at F₁' E₁ b).prod (trivialization_at F₂' E₂ b),
   mem_base_set_trivialization_at :=
-    λ b, ⟨mem_base_set_trivialization_at F₁ E₁ b, mem_base_set_trivialization_at F₂ E₂ b⟩,
-  trivialization_mem_atlas := λ b, ⟨trivialization_at F₁ E₁ b, trivialization_at F₂ E₂ b,
+    λ b, ⟨mem_base_set_trivialization_at F₁' E₁ b, mem_base_set_trivialization_at F₂' E₂ b⟩,
+  trivialization_mem_atlas := λ b, ⟨trivialization_at F₁' E₁ b, trivialization_at F₂' E₂ b,
     by apply_instance, by apply_instance, rfl⟩ }
+
+omit nz₁ nz₂
+include mnd₁ mdl₁ mnd₂ mdl₂
 
 /-- The product of two vector bundles is a vector bundle. -/
 instance _root_.bundle.prod.vector_bundle  [vector_bundle R F₁ E₁] [vector_bundle R F₂ E₂] :
@@ -245,12 +267,18 @@ instance _root_.bundle.prod.vector_bundle  [vector_bundle R F₁ E₁] [vector_b
       exacts [rfl, hb, ⟨hb.1.2, hb.2.2⟩, ⟨hb.1.1, hb.2.1⟩] }
   end }
 
-instance _root_.bundle.prod.mem_trivialization_atlas {e₁ : trivialization F₁ (π E₁)}
-  {e₂ : trivialization F₂ (π E₂)} [mem_trivialization_atlas e₁] [mem_trivialization_atlas e₂] :
-  mem_trivialization_atlas (e₁.prod e₂ : trivialization (F₁ × F₂) (π (E₁ ×ᵇ E₂))) :=
+omit mnd₁ mdl₁ mnd₂ mdl₂
+include nz₁ nz₂
+
+instance _root_.bundle.prod.mem_trivialization_atlas {e₁ : trivialization F₁' (π E₁)}
+  {e₂ : trivialization F₂' (π E₂)} [mem_trivialization_atlas e₁] [mem_trivialization_atlas e₂] :
+  mem_trivialization_atlas (e₁.prod e₂ : trivialization (F₁' × F₂') (π (E₁ ×ᵇ E₂))) :=
 { out := ⟨e₁, e₂, by apply_instance, by apply_instance, rfl⟩ }
 
 variables {R F₁ E₁ F₂ E₂}
+
+omit nz₁ nz₂
+include mnd₁ mdl₁ mnd₂ mdl₂
 
 @[simp] lemma trivialization.continuous_linear_equiv_at_prod {e₁ : trivialization F₁ (π E₁)}
   {e₂ : trivialization F₂ (π E₂)} [e₁.is_linear R] [e₂.is_linear R] {x : B} (hx₁ : x ∈ e₁.base_set)

--- a/src/topology/vector_bundle/prod.lean
+++ b/src/topology/vector_bundle/prod.lean
@@ -12,7 +12,7 @@ import topology.vector_bundle.basic
 If `E₁ : B → Type*` and `E₂ : B → Type*` define two topological vector bundles over `R` with fiber
 models `F₁` and `F₂`, we define the bundle of direct sums `E₁ ×ᵇ E₂ := λ x, E₁ x × E₂ x`.
 We can endow `E₁ ×ᵇ E₂` with a topological vector bundle structure:
-`bundle.prod.topological_vector_bundle`.
+`bundle.prod.vector_bundle`.
 
 A similar construction (which is yet to be formalized) can be done for the vector bundle of
 continuous linear maps from `E₁ x` to `E₂ x` with fiber a type synonym
@@ -39,7 +39,7 @@ variables [topological_space (total_space E₁)] [topological_space (total_space
 
 /-- Equip the total space of the fibrewise product of two topological vector bundles `E₁`, `E₂` with
 the induced topology from the diagonal embedding into `total_space E₁ × total_space E₂`. -/
-instance topological_vector_bundle.prod.topological_space :
+instance vector_bundle.prod.topological_space :
   topological_space (total_space (E₁ ×ᵇ E₂)) :=
 topological_space.induced
   (λ p, ((⟨p.1, p.2.1⟩ : total_space E₁), (⟨p.1, p.2.2⟩ : total_space E₂)))
@@ -47,14 +47,14 @@ topological_space.induced
 
 /-- The diagonal map from the total space of the fibrewise product of two topological vector bundles
 `E₁`, `E₂` into `total_space E₁ × total_space E₂` is `inducing`. -/
-lemma topological_vector_bundle.prod.inducing_diag : inducing
+lemma vector_bundle.prod.inducing_diag : inducing
   (λ p, (⟨p.1, p.2.1⟩, ⟨p.1, p.2.2⟩) :
     total_space (E₁ ×ᵇ E₂) → total_space E₁ × total_space E₂) :=
 ⟨rfl⟩
 
 end defs
 
-open topological_vector_bundle
+open vector_bundle
 
 variables [nontrivially_normed_field R] [topological_space B]
 
@@ -70,7 +70,7 @@ include e₁ e₂
 variables {R F₁ E₁ F₂ E₂}
 
 /-- Given trivializations `e₁`, `e₂` for vector bundles `E₁`, `E₂` over a base `B`, the forward
-function for the construction `topological_vector_bundle.trivialization.prod`, the induced
+function for the construction `vector_bundle.trivialization.prod`, the induced
 trivialization for the direct sum of `E₁` and `E₂`. -/
 def prod.to_fun' : total_space (E₁ ×ᵇ E₂) → B × (F₁ × F₂) :=
 λ p, ⟨p.1, (e₁ ⟨p.1, p.2.1⟩).2, (e₂ ⟨p.1, p.2.2⟩).2⟩
@@ -105,7 +105,7 @@ variables (e₁ e₂)
 
 
 /-- Given trivializations `e₁`, `e₂` for vector bundles `E₁`, `E₂` over a base `B`, the inverse
-function for the construction `topological_vector_bundle.trivialization.prod`, the induced
+function for the construction `vector_bundle.trivialization.prod`, the induced
 trivialization for the direct sum of `E₁` and `E₂`. -/
 def prod.inv_fun' (p : B × (F₁ × F₂)) : total_space (E₁ ×ᵇ E₂) :=
 ⟨p.1, e₁.symm p.1 p.2.1, e₂.symm p.1 p.2.2⟩
@@ -142,11 +142,9 @@ end
 
 variables (e₁ e₂ R)
 variables [Π x : B, topological_space (E₁ x)] [Π x : B, topological_space (E₂ x)]
-  [topological_vector_bundle R F₁ E₁] [topological_vector_bundle R F₂ E₂]
+  [fiber_bundle F₁ E₁] [fiber_bundle F₂ E₂]
 
-include R
-
-/-- Given trivializations `e₁`, `e₂` for vector bundles `E₁`, `E₂` over a base `B`, the induced
+/-- Given trivializations `e₁`, `e₂` for fiber bundles `E₁`, `E₂` over a base `B`, the induced
 trivialization for the direct sum of `E₁` and `E₂`, whose base set is `e₁.base_set ∩ e₂.base_set`.
 -/
 @[nolint unused_arguments]
@@ -161,7 +159,7 @@ def prod : trivialization (F₁ × F₂) (π (E₁ ×ᵇ E₂)) :=
   right_inv' := λ x, prod.right_inv,
   open_source := begin
     refine (e₁.open_base_set.inter e₂.open_base_set).preimage _,
-    have : continuous (@total_space.proj B E₁) := continuous_proj R B F₁,
+    have : continuous (@total_space.proj B E₁) := continuous_proj F₁ E₁,
     exact this.comp (prod.inducing_diag E₁ E₂).continuous.fst,
   end,
   open_target := (e₁.open_base_set.inter e₂.open_base_set).prod is_open_univ,
@@ -173,27 +171,26 @@ def prod : trivialization (F₁ × F₂) (π (E₁ ×ᵇ E₂)) :=
   target_eq := rfl,
   proj_to_fun := λ x h, rfl }
 
-omit R
-
-instance prod.is_linear [e₁.is_linear R] [e₂.is_linear R] : (e₁.prod R e₂).is_linear R :=
+instance prod.is_linear [e₁.is_linear R] [e₂.is_linear R] : (e₁.prod e₂).is_linear R :=
 { linear := λ x ⟨h₁, h₂⟩, (((e₁.linear R h₁).mk' _).prod_map ((e₂.linear R h₂).mk' _)).is_linear }
 
-@[simp] lemma base_set_prod : (prod R e₁ e₂).base_set = e₁.base_set ∩ e₂.base_set :=
+@[simp] lemma base_set_prod : (prod e₁ e₂).base_set = e₁.base_set ∩ e₂.base_set :=
 rfl
 
 variables {e₁ e₂}
 
 variables (R)
 
-lemma prod_apply [e₁.is_linear R] [e₂.is_linear R] {x : B} (hx₁ : x ∈ e₁.base_set)
+lemma prod_apply [vector_bundle R F₁ E₁] [vector_bundle R F₂ E₂]
+  [e₁.is_linear R] [e₂.is_linear R] {x : B} (hx₁ : x ∈ e₁.base_set)
   (hx₂ : x ∈ e₂.base_set) (v₁ : E₁ x) (v₂ : E₂ x) :
-  prod R e₁ e₂ ⟨x, (v₁, v₂)⟩
+  prod e₁ e₂ ⟨x, (v₁, v₂)⟩
   = ⟨x, e₁.continuous_linear_equiv_at R x hx₁ v₁, e₂.continuous_linear_equiv_at R x hx₂ v₂⟩ :=
 rfl
 
 variables {R}
 
-lemma prod_symm_apply (x : B) (w₁ : F₁) (w₂ : F₂) : (prod R e₁ e₂).to_local_equiv.symm (x, w₁, w₂)
+lemma prod_symm_apply (x : B) (w₁ : F₁) (w₂ : F₂) : (prod e₁ e₂).to_local_equiv.symm (x, w₁, w₂)
   = ⟨x, e₁.symm x w₁, e₂.symm x w₂⟩ :=
 rfl
 
@@ -205,29 +202,32 @@ variables [Π x, add_comm_monoid (E₁ x)] [Π x, module R (E₁ x)]
   [Π x, add_comm_monoid (E₂ x)] [Π x, module R (E₂ x)]
 
 variables [Π x : B, topological_space (E₁ x)] [Π x : B, topological_space (E₂ x)]
-  [topological_vector_bundle R F₁ E₁] [topological_vector_bundle R F₂ E₂]
+  [fiber_bundle F₁ E₁] [fiber_bundle F₂ E₂]
+  [vector_bundle R F₁ E₁] [vector_bundle R F₂ E₂]
 
-/-- The product of two vector bundles is a vector bundle. -/
-instance _root_.bundle.prod.topological_vector_bundle :
-  topological_vector_bundle R (F₁ × F₂) (E₁ ×ᵇ E₂) :=
+/-- The product of two fiber bundles is a fiber bundle. -/
+instance _root_.bundle.prod.fiber_bundle : fiber_bundle (F₁ × F₂) (E₁ ×ᵇ E₂) :=
 { total_space_mk_inducing := λ b,
   begin
     rw (prod.inducing_diag E₁ E₂).inducing_iff,
-    exact (total_space_mk_inducing R F₁ E₁ b).prod_mk (total_space_mk_inducing R F₂ E₂ b),
+    exact (total_space_mk_inducing F₁ E₁ b).prod_mk (total_space_mk_inducing F₂ E₂ b),
   end,
   trivialization_atlas :=
     {e |  ∃ (e₁ : trivialization F₁ (π E₁)) (e₂ : trivialization F₂ (π E₂))
-    [mem_trivialization_atlas R e₁] [mem_trivialization_atlas R e₂], by exactI
-    e = trivialization.prod R e₁ e₂},
-  trivialization_linear' := begin
+    [mem_trivialization_atlas e₁] [mem_trivialization_atlas e₂], by exactI
+    e = trivialization.prod e₁ e₂},
+  trivialization_at := λ b, (trivialization_at F₁ E₁ b).prod (trivialization_at F₂ E₂ b),
+  mem_base_set_trivialization_at :=
+    λ b, ⟨mem_base_set_trivialization_at F₁ E₁ b, mem_base_set_trivialization_at F₂ E₂ b⟩,
+  trivialization_mem_atlas := λ b, ⟨trivialization_at F₁ E₁ b, trivialization_at F₂ E₂ b,
+    by apply_instance, by apply_instance, rfl⟩ }
+
+/-- The product of two vector bundles is a vector bundle. -/
+instance _root_.bundle.prod.vector_bundle : vector_bundle R (F₁ × F₂) (E₁ ×ᵇ E₂) :=
+{ trivialization_linear' := begin
     rintros _ ⟨e₁, e₂, he₁, he₂, rfl⟩, resetI,
     apply_instance
   end,
-  trivialization_at := λ b, (trivialization_at R F₁ E₁ b).prod R (trivialization_at R F₂ E₂ b),
-  mem_base_set_trivialization_at :=
-    λ b, ⟨mem_base_set_trivialization_at R F₁ E₁ b, mem_base_set_trivialization_at R F₂ E₂ b⟩,
-  trivialization_mem_atlas := λ b, ⟨trivialization_at R F₁ E₁ b, trivialization_at R F₂ E₂ b,
-    by apply_instance, by apply_instance, rfl⟩,
   continuous_on_coord_change' := begin
     rintros _ _ ⟨e₁, e₂, he₁, he₂, rfl⟩ ⟨e₁', e₂', he₁', he₂', rfl⟩, resetI,
     refine (((continuous_on_coord_change R e₁ e₁').mono _).prod_mapL R
@@ -238,16 +238,16 @@ instance _root_.bundle.prod.topological_vector_bundle :
     { rintro b hb,
       rw [continuous_linear_map.ext_iff],
       rintro ⟨v₁, v₂⟩,
-      show (e₁.prod R e₂).coord_changeL R (e₁'.prod R e₂') b (v₁, v₂) =
+      show (e₁.prod e₂).coord_changeL R (e₁'.prod e₂') b (v₁, v₂) =
         (e₁.coord_changeL R e₁' b v₁, e₂.coord_changeL R e₂' b v₂),
       rw [e₁.coord_changeL_apply e₁', e₂.coord_changeL_apply e₂',
-        (e₁.prod R e₂).coord_changeL_apply'],
+        (e₁.prod e₂).coord_changeL_apply'],
       exacts [rfl, hb, ⟨hb.1.2, hb.2.2⟩, ⟨hb.1.1, hb.2.1⟩] }
   end }
 
 instance _root_.bundle.prod.mem_trivialization_atlas {e₁ : trivialization F₁ (π E₁)}
-  {e₂ : trivialization F₂ (π E₂)} [mem_trivialization_atlas R e₁] [mem_trivialization_atlas R e₂] :
-  mem_trivialization_atlas R (e₁.prod R e₂ : trivialization (F₁ × F₂) (π (E₁ ×ᵇ E₂))) :=
+  {e₂ : trivialization F₂ (π E₂)} [mem_trivialization_atlas e₁] [mem_trivialization_atlas e₂] :
+  mem_trivialization_atlas (e₁.prod e₂ : trivialization (F₁ × F₂) (π (E₁ ×ᵇ E₂))) :=
 { out := ⟨e₁, e₂, by apply_instance, by apply_instance, rfl⟩ }
 
 variables {R F₁ E₁ F₂ E₂}
@@ -255,12 +255,14 @@ variables {R F₁ E₁ F₂ E₂}
 @[simp] lemma trivialization.continuous_linear_equiv_at_prod {e₁ : trivialization F₁ (π E₁)}
   {e₂ : trivialization F₂ (π E₂)} [e₁.is_linear R] [e₂.is_linear R] {x : B} (hx₁ : x ∈ e₁.base_set)
   (hx₂ : x ∈ e₂.base_set) :
-  (e₁.prod R e₂).continuous_linear_equiv_at R x ⟨hx₁, hx₂⟩
+  (e₁.prod e₂).continuous_linear_equiv_at R x ⟨hx₁, hx₂⟩
   = (e₁.continuous_linear_equiv_at R x hx₁).prod (e₂.continuous_linear_equiv_at R x hx₂) :=
 begin
   ext1,
   funext v,
   obtain ⟨v₁, v₂⟩ := v,
-  rw [(e₁.prod R e₂).continuous_linear_equiv_at_apply R, trivialization.prod],
+  rw [(e₁.prod e₂).continuous_linear_equiv_at_apply R, trivialization.prod],
   exact (congr_arg prod.snd (prod_apply R hx₁ hx₂ v₁ v₂) : _)
 end
+
+#lint

--- a/src/topology/vector_bundle/prod.lean
+++ b/src/topology/vector_bundle/prod.lean
@@ -181,7 +181,7 @@ variables {e₁ e₂}
 
 variables (R)
 
-lemma prod_apply [vector_bundle R F₁ E₁] [vector_bundle R F₂ E₂]
+lemma prod_apply
   [e₁.is_linear R] [e₂.is_linear R] {x : B} (hx₁ : x ∈ e₁.base_set)
   (hx₂ : x ∈ e₂.base_set) (v₁ : E₁ x) (v₂ : E₂ x) :
   prod e₁ e₂ ⟨x, (v₁, v₂)⟩
@@ -203,7 +203,6 @@ variables [Π x, add_comm_monoid (E₁ x)] [Π x, module R (E₁ x)]
 
 variables [Π x : B, topological_space (E₁ x)] [Π x : B, topological_space (E₂ x)]
   [fiber_bundle F₁ E₁] [fiber_bundle F₂ E₂]
-  [vector_bundle R F₁ E₁] [vector_bundle R F₂ E₂]
 
 /-- The product of two fiber bundles is a fiber bundle. -/
 instance _root_.bundle.prod.fiber_bundle : fiber_bundle (F₁ × F₂) (E₁ ×ᵇ E₂) :=
@@ -223,7 +222,8 @@ instance _root_.bundle.prod.fiber_bundle : fiber_bundle (F₁ × F₂) (E₁ ×�
     by apply_instance, by apply_instance, rfl⟩ }
 
 /-- The product of two vector bundles is a vector bundle. -/
-instance _root_.bundle.prod.vector_bundle : vector_bundle R (F₁ × F₂) (E₁ ×ᵇ E₂) :=
+instance _root_.bundle.prod.vector_bundle  [vector_bundle R F₁ E₁] [vector_bundle R F₂ E₂] :
+  vector_bundle R (F₁ × F₂) (E₁ ×ᵇ E₂) :=
 { trivialization_linear' := begin
     rintros _ ⟨e₁, e₂, he₁, he₂, rfl⟩, resetI,
     apply_instance
@@ -264,5 +264,3 @@ begin
   rw [(e₁.prod e₂).continuous_linear_equiv_at_apply R, trivialization.prod],
   exact (congr_arg prod.snd (prod_apply R hx₁ hx₂ v₁ v₂) : _)
 end
-
-#lint


### PR DESCRIPTION
Previously, `is_fiber_bundle`* was a propositional typeclass on a function `p : Z → B`, stating the existence of local trivializations covering `Z`.  Then `vector_bundle`* was a class with data on a type `E : X → Type*` (with the projection from `Σ x : B, E x` to `B` playing the role of `p`), giving a fixed atlas of fibrewise-linear local trivializations.

We change this definition so that 
(i) the data is all held in `fiber_bundle`, with `vector_bundle` a mixin stating fibrewise-linearity
(ii) only sigma-types can be fiber bundles, not general topological spaces

This allows bundles to carry instances of typeclasses in which the scalar field, `R`, does not appear as a parameter.  Notably, we would like a vector bundle over `R` with fibre `F` over base `B` to be a `charted_space (B × F)`, with the trivializations providing the charts.  This would be a dangerous instance for typeclass inference, because `R` does not appear as a parameter in `charted_space (B × F)`.  But if the data of the trivializations is held in `fiber_bundle`, then a *fibre* bundle with fibre `F` over base `B` can be a `charted_space (B × F)`, and this is safe for typeclass inference.

We expect that this refector will also streamline constructions of fibre bundles with similar underlying structure (e.g., the same bundle being both a real and complex vector bundle).

[Here](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Smooth.20vector.20bundles/near/306023372) is the relevant Zulip discussion.

*We take the opportunity to rename `topological_{fiber,vector}_bundle` to `{fiber,vector}_bundle`, since in the upcoming definition of smooth bundles, smoothness will be another mixin for `fiber_bundle`.

Co-authored-by: Floris van Doorn [fpvdoorn@gmail.com](mailto:fpvdoorn@gmail.com)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I tried to do things "in place" as much as possible, to make the diff a bit clearer, so there will be a follow-up PR moving around all the lemmas and instances which used to apply to vector bundles and now apply to fiber bundles.