### PR TITLE
[Merged by Bors] - feat(tactic/assert_exists): add a linter to protect against typos

### DIFF
--- a/src/data/rat/order.lean
+++ b/src/data/rat/order.lean
@@ -222,4 +222,5 @@ assert_not_exists set.Icc
 assert_not_exists galois_connection
 -- These are less significant, but should not be relaxed until at least after port to Lean 4.
 assert_not_exists linear_ordered_comm_group_with_zero
-assert_not_exists positive.add_comm_semigroup
+-- This one doesn't exist anywhere!
+-- assert_not_exists positive.add_comm_semigroup

--- a/src/data/rat/order.lean
+++ b/src/data/rat/order.lean
@@ -222,4 +222,4 @@ assert_not_exists set.Icc
 assert_not_exists galois_connection
 -- These are less significant, but should not be relaxed until at least after port to Lean 4.
 assert_not_exists linear_ordered_comm_group_with_zero
-assert_not_exists positive.add_comm_monoid
+assert_not_exists positive.add_comm_semigroup

--- a/src/tactic/assert_exists.lean
+++ b/src/tactic/assert_exists.lean
@@ -68,7 +68,7 @@ do
   pure ()
 
 /-- A linter for checking that the declarations marked `assert_not_exists` eventually exist. -/
-@[linter] meta def assert_not_exists.linter : linter :=
+meta def assert_not_exists.linter : linter :=
 { test := λ d, do {
     let n := d.to_name,
     tt ← pure ((`assert_not_exists._checked).is_prefix_of n) | pure none,
@@ -136,7 +136,7 @@ do
   end
 
 /-- A linter for checking that the declarations marked `assert_no_instance` eventually exist. -/
-@[linter] meta def assert_no_instance.linter : linter :=
+meta def assert_no_instance.linter : linter :=
 { test := λ d, do {
     let n := d.to_name,
     tt ← pure ((`assert_no_instance._checked).is_prefix_of n) | pure none,
@@ -152,3 +152,5 @@ do
   is_fast := ff }
 
 end
+
+#eval (`fo«o.f»ar).length

--- a/src/tactic/assert_exists.lean
+++ b/src/tactic/assert_exists.lean
@@ -4,16 +4,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Scott Morrison
 -/
 import tactic.core
+import tactic.lint.basic
 
 /-!
 # User commands for assert the (non-)existence of declaration or instances.
 
 These commands are used to enforce the independence of different parts of mathlib.
 
-## Future work
-We should have a linter that collects all `assert_not_exists` and `assert_no_instance` commands,
-and checks that they are eventually satisfied when importing all of mathlib.
-This will protect against typos.
+## Implementation notes
+
+This file provides two linters that verify that things we assert do not _yet_ exist do _eventually_
+exist. This works by creating declarations of the form:
+
+* `assert_not_exists._checked.foo : unit` for `assert_not_exists foo`
+* `assert_no_instance._checked.<uniq> := t` for `assert_instance t`
+
+These declarations are then picked up by the linter and analyzed accordingly.
+The `_` in the `_checked` prefix should hide them from doc-gen.
 -/
 
 section
@@ -50,9 +57,29 @@ You should *not* delete the `assert_not_exists` statement without careful discus
 -/
 @[user_command]
 meta def assert_not_exists (_ : parse $ tk "assert_not_exists")  : lean.parser unit :=
-do decl ← ident,
-   success_if_fail (get_decl decl) <|>
-   fail format!"Declaration {decl} is not allowed to exist in this file."
+do
+  decl ← ident,
+  ff ← succeeds (get_decl decl) |
+  fail format!"Declaration {decl} is not allowed to exist in this file.",
+  let marker := (`assert_not_exists._checked).append decl,
+  tt ← succeeds (get_decl marker) |
+  add_decl
+    (declaration.defn marker [] `(unit) `(()) default tt),
+  pure ()
+
+/-- A linter for checking that the declarations marked `assert_not_exists` eventually exist. -/
+@[linter] meta def assert_not_exists.linter : linter :=
+{ test := λ d, do {
+    let n := d.to_name,
+    tt ← pure ((`assert_not_exists._checked).is_prefix_of n) | pure none,
+    let n := n.replace_prefix `assert_not_exists._checked name.anonymous,
+    tt ← succeeds (get_decl n) | pure (some (format!"`{n}` does not ever exist").to_string),
+    pure none },
+  auto_decls := tt,
+  no_errors_found := "All `assert_not_exists` declarations eventually exist.",
+  errors_found :=
+    "The following declarations used in `assert_not_exists` never exist; perhaps there is a typo.",
+  is_fast := tt }
 
 /--
 `assert_instance e` is a user command that asserts that an instance `e` is available
@@ -91,13 +118,37 @@ assert_no_instance linear_ordered_field ℚ
 -/
 @[user_command]
 meta def assert_no_instance (_ : parse $ tk "assert_no_instance")  : lean.parser unit :=
-do q ← texpr,
-   e ← i_to_expr q,
-   i ← try_core (mk_instance e),
-   match i with
-   | none := skip -- TODO: record for the linter
-   | some i := 
-    (fail!"Instance `{i} : {e}` is not allowed to be found in this file." : tactic unit)
-   end
+do
+  q ← texpr,
+  e ← i_to_expr q,
+  i ← try_core (mk_instance e),
+  match i with
+  | none := do
+      n ← tactic.mk_fresh_name,
+      let marker := (`assert_no_instance._checked).append n,
+      et ← infer_type e,
+      tt ← succeeds (get_decl marker) |
+      add_decl
+          (declaration.defn marker [] et e default tt),
+      pure ()
+  | some i :=
+   (fail!"Instance `{i} : {e}` is not allowed to be found in this file." : tactic unit)
+  end
+
+/-- A linter for checking that the declarations marked `assert_no_instance` eventually exist. -/
+@[linter] meta def assert_no_instance.linter : linter :=
+{ test := λ d, do {
+    let n := d.to_name,
+    tt ← pure ((`assert_no_instance._checked).is_prefix_of n) | pure none,
+    declaration.defn _ _ _ val _ _ ← pure d,
+    tt ← succeeds (tactic.mk_instance val)
+      | (some ∘ format.to_string) <$> pformat!"No instance of `{val}`",
+    pure none },
+  auto_decls := tt,
+  no_errors_found := "All `assert_no_instance` instances eventually exist.",
+  errors_found :=
+    "The following typeclass instances used in `assert_no_instance` never exist; perhaps they " ++
+    "are missing?",
+  is_fast := ff }
 
 end

--- a/src/tactic/assert_exists.lean
+++ b/src/tactic/assert_exists.lean
@@ -152,5 +152,3 @@ meta def assert_no_instance.linter : linter :=
   is_fast := ff }
 
 end
-
-#eval (`fo«o.f»ar).length

--- a/src/tactic/assert_exists.lean
+++ b/src/tactic/assert_exists.lean
@@ -69,12 +69,12 @@ do
 
 /-- A linter for checking that the declarations marked `assert_not_exists` eventually exist. -/
 meta def assert_not_exists.linter : linter :=
-{ test := λ d, do {
+{ test := λ d, (do
     let n := d.to_name,
     tt ← pure ((`assert_not_exists._checked).is_prefix_of n) | pure none,
     let n := n.replace_prefix `assert_not_exists._checked name.anonymous,
     tt ← succeeds (get_decl n) | pure (some (format!"`{n}` does not ever exist").to_string),
-    pure none },
+    pure none),
   auto_decls := tt,
   no_errors_found := "All `assert_not_exists` declarations eventually exist.",
   errors_found :=

--- a/src/tactic/assert_exists.lean
+++ b/src/tactic/assert_exists.lean
@@ -137,13 +137,13 @@ do
 
 /-- A linter for checking that the declarations marked `assert_no_instance` eventually exist. -/
 meta def assert_no_instance.linter : linter :=
-{ test := λ d, do {
+{ test := λ d, (do
     let n := d.to_name,
     tt ← pure ((`assert_no_instance._checked).is_prefix_of n) | pure none,
     declaration.defn _ _ _ val _ _ ← pure d,
     tt ← succeeds (tactic.mk_instance val)
       | (some ∘ format.to_string) <$> pformat!"No instance of `{val}`",
-    pure none },
+    pure none),
   auto_decls := tt,
   no_errors_found := "All `assert_no_instance` instances eventually exist.",
   errors_found :=

--- a/src/tactic/lint/default.lean
+++ b/src/tactic/lint/default.lean
@@ -99,5 +99,6 @@ add_tactic_doc
 /-- The default linters used in mathlib CI. -/
 meta def mathlib_linters : list name := by do
 ls ← get_checks tt [] ff,
-let ls := ls.map (λ ⟨n, _⟩, `linter ++ n),
+let ls := ls.map (λ ⟨n, _⟩, `linter ++ n) ++
+  [`assert_not_exists.linter, `assert_no_instance.linter],
 exact (reflect ls)


### PR DESCRIPTION
Since this later can fail if not run in `all.lean`, we do not tag these declarations with `@[linter]`; instead they are added manually to the list of linters mathlib uses in CI.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)