### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/affine_subspace): induction principle

### DIFF
--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -1147,7 +1147,7 @@ local attribute [instance] affine_subspace.to_add_torsor
 
 /-- A set, considered as a subset of its spanned affine subspace, spans the whole subspace. -/
 lemma affine_span_affine_span_coe_preimage (A : set P) [nonempty A] :
-affine_span k ((coe : affine_span k A → P) ⁻¹' A) = ⊤ :=
+  affine_span k ((coe : affine_span k A → P) ⁻¹' A) = ⊤ :=
 begin
   rw [eq_top_iff],
   rintro ⟨x, hx⟩ -,

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -1137,7 +1137,6 @@ lemma affine_span_induction' {x : P} {s : set P} {p : Π x, x ∈ affine_span k 
 begin
   refine exists.elim _ (λ (hx : x ∈ affine_span k s) (hc : p x hx), hc),
   refine @affine_span_induction k V P _ _ _ _ _ _ _ h _ _,
-  -- Why can't I substitute the following goals into the `refine` expression?
   { exact (λ y hy, ⟨subset_affine_span _ _ hy, Hs y hy⟩) },
   { exact (λ c u v w hu hv hw, exists.elim hu $ λ hu' hu, exists.elim hv $ λ hv' hv,
       exists.elim hw $ λ hw' hw,

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -1129,11 +1129,11 @@ lemma affine_span_induction {x : P} {s : set P} {p : P → Prop} (h : x ∈ affi
 (@affine_span_le _ _ _ _ _ _ _ _ ⟨p, Hc⟩).mpr Hs h
 
 /-- A dependent version of `affine_span_induction`. -/
-lemma affine_span_induction' {x : P} {s : set P} {p : Π x, x ∈ affine_span k s → Prop}
-  (h : x ∈ affine_span k s)
+lemma affine_span_induction' {s : set P} {p : Π x, x ∈ affine_span k s → Prop}
   (Hs : ∀ y (hys : y ∈ s), p y (subset_affine_span k _ hys))
   (Hc : ∀ (c : k) u hu v hv w hw, p u hu → p v hv → p w hw →
-    p (c • (u -ᵥ v) +ᵥ w) (affine_subspace.smul_vsub_vadd_mem _ _ hu hv hw)) : p x h :=
+    p (c • (u -ᵥ v) +ᵥ w) (affine_subspace.smul_vsub_vadd_mem _ _ hu hv hw))
+  {x : P} (h : x ∈ affine_span k s) : p x h :=
 begin
   refine exists.elim _ (λ (hx : x ∈ affine_span k s) (hc : p x hx), hc),
   refine @affine_span_induction k V P _ _ _ _ _ _ _ h _ _,
@@ -1151,7 +1151,7 @@ lemma affine_span_affine_span_coe_preimage (A : set P) [nonempty A] :
 begin
   rw [eq_top_iff],
   rintro ⟨x, hx⟩ -,
-  refine affine_span_induction' hx (λ y hy, _) (λ c u hu v hv w hw, _),
+  refine affine_span_induction' (λ y hy, _) (λ c u hu v hv w hw, _) hx,
   { exact subset_affine_span _ _ hy },
   { exact affine_subspace.smul_vsub_vadd_mem _ _ },
 end

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -1148,7 +1148,7 @@ section with_local_instance
 local attribute [instance] affine_subspace.to_add_torsor
 
 /-- A set, considered as a subset of its spanned affine subspace, spans the whole subspace. -/
-lemma affine_span_affine_span_coe_preimage (A : set P) [nonempty A] :
+@[simp] lemma affine_span_coe_preimage_eq_top (A : set P) [nonempty A] :
   affine_span k ((coe : affine_span k A → P) ⁻¹' A) = ⊤ :=
 begin
   rw [eq_top_iff],

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -1143,6 +1143,8 @@ begin
         ⟨affine_subspace.smul_vsub_vadd_mem _ _ hu' hv' hw', Hc _ _ _ _ _ _ _ hu hv hw⟩) },
 end
 
+section with_local_instance
+
 local attribute [instance] affine_subspace.to_add_torsor
 
 /-- A set, considered as a subset of its spanned affine subspace, spans the whole subspace. -/
@@ -1155,6 +1157,8 @@ begin
   { exact subset_affine_span _ _ hy },
   { exact affine_subspace.smul_vsub_vadd_mem _ _ },
 end
+
+end with_local_instance
 
 /-- Suppose a set of vectors spans `V`.  Then a point `p`, together
 with those vectors added to `p`, spans `P`. -/


### PR DESCRIPTION
Proves affine analogues of `submodule.span_induction'`, `submodule.span_induction'` and `submodule.span_span_coe_preimage`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
