### PR TITLE
[Merged by Bors] - feat(analysis/convex/between): more transitivity variants

### DIFF
--- a/src/analysis/convex/between.lean
+++ b/src/analysis/convex/between.lean
@@ -378,6 +378,28 @@ lemma sbtw.trans_right [no_zero_smul_divisors R V] {w x y z : P} (h₁ : sbtw R 
   (h₂ : sbtw R x y z) : sbtw R w y z :=
 h₁.wbtw.trans_sbtw_right h₂
 
+lemma wbtw.trans_left_ne [no_zero_smul_divisors R V] {w x y z : P} (h₁ : wbtw R w y z)
+  (h₂ : wbtw R w x y) (h : y ≠ z) : x ≠ z :=
+begin
+  rintro rfl,
+  exact h (h₁.swap_right_iff.1 h₂)
+end
+
+lemma wbtw.trans_right_ne [no_zero_smul_divisors R V] {w x y z : P} (h₁ : wbtw R w x z)
+  (h₂ : wbtw R x y z) (h : w ≠ x) : w ≠ y :=
+begin
+  rintro rfl,
+  exact h (h₁.swap_left_iff.1 h₂)
+end
+
+lemma sbtw.trans_wbtw_left_ne [no_zero_smul_divisors R V] {w x y z : P} (h₁ : sbtw R w y z)
+  (h₂ : wbtw R w x y) : x ≠ z :=
+h₁.wbtw.trans_left_ne h₂ h₁.ne_right
+
+lemma sbtw.trans_wbtw_right_ne [no_zero_smul_divisors R V] {w x y z : P} (h₁ : sbtw R w x z)
+  (h₂ : wbtw R x y z) : w ≠ y :=
+h₁.wbtw.trans_right_ne h₂ h₁.left_ne
+
 end ordered_ring
 
 section strict_ordered_comm_ring


### PR DESCRIPTION
Add more variants of transitivity lemmas, giving that one endpoint is not equal to the middle point in cases where the hypotheses imply weak betweenness (and we already have the corresponding transitivity lemmas for that), and that one endpoint is not equal to the middle point, but don't imply strict betweenness.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
