### PR TITLE
[Merged by Bors] - feat(algebra/module/pi): Non-dependent shortcut

### DIFF
--- a/src/algebra/module/pi.lean
+++ b/src/algebra/module/pi.lean
@@ -88,4 +88,11 @@ instance (α) {r : semiring α} {m : Π i, add_comm_monoid $ f i}
 ⟨λ c x h, or_iff_not_imp_left.mpr (λ hc, funext
   (λ i, (smul_eq_zero.mp (congr_fun h i)).resolve_left hc))⟩
 
+/-- A special case of `pi.no_zero_smul_divisors` for non-dependent types. Lean struggles to
+synthesize this instance by itself elsewhere in the library. -/
+instance _root_.function.no_zero_smul_divisors {ι α β : Type*} {r : semiring α}
+  {m : add_comm_monoid β} [module α β] [no_zero_smul_divisors α β] :
+  no_zero_smul_divisors α (ι → β) :=
+pi.no_zero_smul_divisors _
+
 end pi


### PR DESCRIPTION
Without this special case instance, Lean can't synthesize `no_zero_smul_divisors ℝ (ι → ℝ)` in #2819.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
