### PR TITLE
[Merged by Bors] - feat(algebraic_topology/dold_kan): a few basic lemmas and a property of P_infty

### DIFF
--- a/src/algebraic_topology/dold_kan/p_infty.lean
+++ b/src/algebraic_topology/dold_kan/p_infty.lean
@@ -61,15 +61,29 @@ def P_infty : K[X] ⟶ K[X] := chain_complex.of_hom _ _ _ _ _ _
   (λ n, by simpa only [← P_is_eventually_constant (show n ≤ n, by refl),
     alternating_face_map_complex.obj_d_eq] using (P (n+1)).comm (n+1) n)
 
+/-- The endomorphism `Q_infty : K[X] ⟶ K[X]` obtained from the `Q q` by passing to the limit. -/
+def Q_infty : K[X] ⟶ K[X] := 𝟙 _ - P_infty
+
 @[simp]
 lemma P_infty_f_0 : (P_infty.f 0 : X _[0] ⟶ X _[0]) = 𝟙 _ := rfl
 
 lemma P_infty_f (n : ℕ) : (P_infty.f n : X _[n] ⟶  X _[n] ) = (P n).f n := rfl
 
+@[simp]
+lemma Q_infty_f_0 : (Q_infty.f 0 : X _[0] ⟶ X _[0]) = 0 :=
+by { dsimp [Q_infty], simp only [sub_self], }
+
+lemma Q_infty_f (n : ℕ) : (Q_infty.f n : X _[n] ⟶  X _[n] ) = (Q n).f n := rfl
+
 @[simp, reassoc]
 lemma P_infty_f_naturality (n : ℕ) {X Y : simplicial_object C} (f : X ⟶ Y) :
   f.app (op [n]) ≫ P_infty.f n = P_infty.f n ≫ f.app (op [n]) :=
 P_f_naturality n n f
+
+@[simp, reassoc]
+lemma Q_infty_f_naturality (n : ℕ) {X Y : simplicial_object C} (f : X ⟶ Y) :
+  f.app (op [n]) ≫ Q_infty.f n = Q_infty.f n ≫ f.app (op [n]) :=
+Q_f_naturality n n f
 
 @[simp, reassoc]
 lemma P_infty_f_idem (n : ℕ) :
@@ -79,6 +93,52 @@ by simp only [P_infty_f, P_f_idem]
 @[simp, reassoc]
 lemma P_infty_idem : (P_infty : K[X] ⟶ _) ≫ P_infty = P_infty :=
 by { ext n, exact P_infty_f_idem n, }
+
+@[simp, reassoc]
+lemma Q_infty_f_idem (n : ℕ) :
+  (Q_infty.f n : X _[n] ⟶ _) ≫ (Q_infty.f n) = Q_infty.f n :=
+Q_f_idem _ _
+
+@[simp, reassoc]
+lemma Q_infty_idem : (Q_infty : K[X] ⟶ _) ≫ Q_infty = Q_infty :=
+by { ext n, exact Q_infty_f_idem n, }
+
+@[simp, reassoc]
+lemma P_infty_f_comp_Q_infty_f (n : ℕ) :
+  (P_infty.f n : X _[n] ⟶ _) ≫ Q_infty.f n = 0 :=
+begin
+  dsimp only [Q_infty],
+  simp only [homological_complex.sub_f_apply, homological_complex.id_f, comp_sub, comp_id,
+    P_infty_f_idem, sub_self],
+end
+
+@[simp, reassoc]
+lemma P_infty_comp_Q_infty :
+  (P_infty : K[X] ⟶ _) ≫ Q_infty = 0 :=
+by { ext n, apply P_infty_f_comp_Q_infty_f, }
+
+@[simp, reassoc]
+lemma Q_infty_f_comp_P_infty_f (n : ℕ) :
+  (Q_infty.f n : X _[n] ⟶ _) ≫ P_infty.f n = 0 :=
+begin
+  dsimp only [Q_infty],
+  simp only [homological_complex.sub_f_apply, homological_complex.id_f, sub_comp, id_comp,
+    P_infty_f_idem, sub_self],
+end
+
+@[simp, reassoc]
+lemma Q_infty_comp_P_infty :
+  (Q_infty : K[X] ⟶ _) ≫ P_infty = 0 :=
+by { ext n, apply Q_infty_f_comp_P_infty_f, }
+
+@[simp]
+lemma P_infty_add_Q_infty :
+  (P_infty : K[X] ⟶ _) + Q_infty = 𝟙 _ :=
+by { dsimp only [Q_infty], simp only [add_sub_cancel'_right], }
+
+lemma P_infty_f_add_Q_infty_f (n : ℕ) :
+  (P_infty.f n : X _[n] ⟶ _ ) + Q_infty.f n = 𝟙 _ :=
+homological_complex.congr_hom (P_infty_add_Q_infty) n
 
 variable (C)
 

--- a/src/algebraic_topology/dold_kan/projections.lean
+++ b/src/algebraic_topology/dold_kan/projections.lean
@@ -5,6 +5,7 @@ Authors: Joël Riou
 -/
 
 import algebraic_topology.dold_kan.faces
+import category_theory.idempotents.basic
 
 /-!
 
@@ -28,12 +29,9 @@ strategy of proof of the Dold-Kan equivalence.
 
 -/
 
-open category_theory
-open category_theory.category
-open category_theory.limits
-open category_theory.preadditive
-open category_theory.simplicial_object
-open opposite
+open category_theory category_theory.category category_theory.limits
+  category_theory.preadditive category_theory.simplicial_object opposite
+  category_theory.idempotents
 open_locale simplicial dold_kan
 
 noncomputable theory
@@ -132,10 +130,20 @@ begin
 end
 
 @[simp, reassoc]
+lemma Q_f_idem (q n : ℕ) :
+  ((Q q).f n : X _[n] ⟶ _) ≫ ((Q q).f n) = (Q q).f n :=
+idem_of_id_sub_idem _ (P_f_idem q n)
+
+@[simp, reassoc]
 lemma P_idem (q : ℕ) : (P q : K[X] ⟶ K[X]) ≫ P q = P q :=
 by { ext n, exact P_f_idem q n, }
 
+@[simp, reassoc]
+lemma Q_idem (q : ℕ) : (Q q : K[X] ⟶ K[X]) ≫ Q q = Q q :=
+by { ext n, exact Q_f_idem q n, }
+
 /-- For each `q`, `P q` is a natural transformation. -/
+@[simps]
 def nat_trans_P (q : ℕ) :
   alternating_face_map_complex C ⟶ alternating_face_map_complex C :=
 { app := λ X, P q,
@@ -157,6 +165,22 @@ lemma P_f_naturality (q n : ℕ) {X Y : simplicial_object C} (f : X ⟶ Y) :
   f.app (op [n]) ≫ (P q).f n = (P q).f n ≫ f.app (op [n]) :=
 homological_complex.congr_hom ((nat_trans_P q).naturality f) n
 
+@[simp, reassoc]
+lemma Q_f_naturality (q n : ℕ) {X Y : simplicial_object C} (f : X ⟶ Y) :
+  f.app (op [n]) ≫ (Q q).f n = (Q q).f n ≫ f.app (op [n]) :=
+begin
+  simp only [Q, homological_complex.sub_f_apply, homological_complex.id_f,
+    comp_sub, P_f_naturality, sub_comp, sub_left_inj],
+  dsimp,
+  simp only [comp_id, id_comp],
+end
+
+/-- For each `q`, `Q q` is a natural transformation. -/
+@[simps]
+def nat_trans_Q (q : ℕ) :
+  alternating_face_map_complex C ⟶ alternating_face_map_complex C :=
+{ app := λ X, Q q, }
+
 lemma map_P {D : Type*} [category D] [preadditive D]
   (G : C ⥤ D) [G.additive] (X : simplicial_object C) (q n : ℕ) :
   G.map ((P q : K[X] ⟶ _).f n) = (P q : K[((whiskering C D).obj G).obj X] ⟶ _).f n :=
@@ -167,6 +191,15 @@ begin
   { unfold P,
     simp only [comp_add, homological_complex.comp_f, homological_complex.add_f_apply,
       comp_id, functor.map_add, functor.map_comp, hq, map_Hσ], }
+end
+
+lemma map_Q {D : Type*} [category D] [preadditive D]
+  (G : C ⥤ D) [G.additive] (X : simplicial_object C) (q n : ℕ) :
+  G.map ((Q q : K[X] ⟶ _).f n) = (Q q : K[((whiskering C D).obj G).obj X] ⟶ _).f n :=
+begin
+  rw [← add_right_inj (G.map ((P q : K[X] ⟶ _).f n)), ← G.map_add, map_P G X q n,
+    P_add_Q_f, P_add_Q_f],
+  apply G.map_id,
 end
 
 end dold_kan

--- a/src/algebraic_topology/dold_kan/split_simplicial_object.lean
+++ b/src/algebraic_topology/dold_kan/split_simplicial_object.lean
@@ -6,6 +6,7 @@ Authors: Joël Riou
 
 import algebraic_topology.split_simplicial_object
 import category_theory.preadditive
+import algebraic_topology.dold_kan.degeneracies
 
 /-!
 
@@ -20,7 +21,7 @@ when `C` is a preadditive category, and get an isomorphism
 noncomputable theory
 
 open category_theory category_theory.limits category_theory.category
-  category_theory.preadditive opposite
+  category_theory.preadditive opposite algebraic_topology.dold_kan
 
 open_locale big_operators simplicial
 
@@ -92,6 +93,20 @@ begin
   have h := simplex_category.len_le_of_epi (infer_instance : epi A.e),
   dsimp at ⊢ h,
   linarith,
+end
+
+/-- If a simplicial object `X` in an additive category is split,
+then `P_infty` vanishes on all the summands of `X _[n]` which do
+not correspond to the identity of `[n]`. -/
+lemma ι_summand_comp_P_infty_eq_zero {X : simplicial_object C} [has_finite_coproducts C]
+  (s : simplicial_object.splitting X)
+  {n : ℕ} (A : simplicial_object.splitting.index_set (op [n]))
+  (hA : ¬ A.eq_id) :
+  s.ι_summand A ≫ P_infty.f n = 0 :=
+begin
+  rw simplicial_object.splitting.index_set.eq_id_iff_mono at hA,
+  rw [simplicial_object.splitting.ι_summand_eq, assoc,
+    degeneracy_comp_P_infty X n A.e hA, comp_zero],
 end
 
 end splitting

--- a/src/algebraic_topology/dold_kan/split_simplicial_object.lean
+++ b/src/algebraic_topology/dold_kan/split_simplicial_object.lean
@@ -98,7 +98,7 @@ end
 /-- If a simplicial object `X` in an additive category is split,
 then `P_infty` vanishes on all the summands of `X _[n]` which do
 not correspond to the identity of `[n]`. -/
-lemma ι_summand_comp_P_infty_eq_zero {X : simplicial_object C} [has_finite_coproducts C]
+lemma ι_summand_comp_P_infty_eq_zero {X : simplicial_object C}
   (s : simplicial_object.splitting X)
   {n : ℕ} (A : simplicial_object.splitting.index_set (op [n]))
   (hA : ¬ A.eq_id) :

--- a/src/algebraic_topology/split_simplicial_object.lean
+++ b/src/algebraic_topology/split_simplicial_object.lean
@@ -34,10 +34,8 @@ Simplicial objects equipped with a splitting form a category
 
 noncomputable theory
 
-open category_theory
-open category_theory.category
-open category_theory.limits
-open opposite
+open category_theory category_theory.category category_theory.limits
+  opposite simplex_category
 open_locale simplicial
 
 universe u
@@ -82,7 +80,7 @@ end
 instance : fintype (index_set Δ) :=
 fintype.of_injective
   ((λ A, ⟨⟨A.1.unop.len, nat.lt_succ_iff.mpr
-    (simplex_category.len_le_of_epi (infer_instance : epi A.e))⟩, A.e.to_order_hom⟩) :
+    (len_le_of_epi (infer_instance : epi A.e))⟩, A.e.to_order_hom⟩) :
     index_set Δ → (sigma (λ (k : fin (Δ.unop.len+1)), (fin (Δ.unop.len+1) → fin (k+1)))))
 begin
   rintros ⟨Δ₁, α₁⟩ ⟨Δ₂, α₂⟩ h₁,
@@ -125,7 +123,7 @@ begin
     refine ext _ _ rfl _,
     { haveI := hf,
       simp only [eq_to_hom_refl, comp_id],
-      exact simplex_category.eq_id_of_epi f, }, },
+      exact eq_id_of_epi f, }, },
 end
 
 lemma eq_id_iff_len_eq : A.eq_id ↔ A.1.unop.len = Δ.unop.len :=
@@ -138,6 +136,28 @@ begin
     rw ← unop_inj_iff,
     ext,
     exact h, },
+end
+
+lemma eq_id_iff_len_le : A.eq_id ↔ Δ.unop.len ≤ A.1.unop.len :=
+begin
+  rw eq_id_iff_len_eq,
+  split,
+  { intro h,
+    rw h, },
+  { exact le_antisymm (len_le_of_epi (infer_instance : epi A.e)), },
+end
+
+lemma eq_id_iff_mono : A.eq_id ↔ mono A.e :=
+begin
+  split,
+  { intro h,
+    dsimp at h,
+    subst h,
+    dsimp only [id, e],
+    apply_instance, },
+  { intro h,
+    rw eq_id_iff_len_le,
+    exact len_le_of_mono h, }
 end
 
 /-- Given `A : index_set Δ₁`, if `p.unop : unop Δ₂ ⟶ unop Δ₁` is an epi, this


### PR DESCRIPTION
This PR introduces some very basic lemmas for the complement projection `Q` of `P`. We also obtain the lemma  `ι_summand_comp_P_infty_eq_zero`  which states that in a given degree, `P_infty` vanishes on all the summands of a split simplicial object except one.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
