### PR TITLE
[Merged by Bors] - fix(tactic/assert_exists): avoid name collisions in linter declarations

### DIFF
--- a/src/tactic/assert_exists.lean
+++ b/src/tactic/assert_exists.lean
@@ -16,7 +16,7 @@ These commands are used to enforce the independence of different parts of mathli
 This file provides two linters that verify that things we assert do not _yet_ exist do _eventually_
 exist. This works by creating declarations of the form:
 
-* `assert_not_exists._checked.foo : unit` for `assert_not_exists foo`
+* ``assert_not_exists._checked.<uniq> : name := `foo`` for `assert_not_exists foo`
 * `assert_no_instance._checked.<uniq> := t` for `assert_instance t`
 
 These declarations are then picked up by the linter and analyzed accordingly.
@@ -61,10 +61,10 @@ do
   decl ← ident,
   ff ← succeeds (get_decl decl) |
   fail format!"Declaration {decl} is not allowed to exist in this file.",
-  let marker := (`assert_not_exists._checked).append decl,
-  tt ← succeeds (get_decl marker) |
+  n ← tactic.mk_fresh_name,
+  let marker := (`assert_not_exists._checked).append n,
   add_decl
-    (declaration.defn marker [] `(unit) `(()) default tt),
+    (declaration.defn marker [] `(name) `(decl) default tt),
   pure ()
 
 /-- A linter for checking that the declarations marked `assert_not_exists` eventually exist. -/
@@ -72,7 +72,8 @@ meta def assert_not_exists.linter : linter :=
 { test := λ d, (do
     let n := d.to_name,
     tt ← pure ((`assert_not_exists._checked).is_prefix_of n) | pure none,
-    let n := n.replace_prefix `assert_not_exists._checked name.anonymous,
+    declaration.defn _ _ `(name) val _ _ ← pure d,
+    n ← tactic.eval_expr name val,
     tt ← succeeds (get_decl n) | pure (some (format!"`{n}` does not ever exist").to_string),
     pure none),
   auto_decls := tt,

--- a/test/assert_exists/test_linter.lean
+++ b/test/assert_exists/test_linter.lean
@@ -1,0 +1,28 @@
+import tactic.assert_exists
+import tactic.lint
+
+/-! ### Test `assert_not_exists` -/
+
+assert_not_exists foo
+
+def foo : nat := 1
+
+assert_not_exists bar
+
+run_cmd do
+  (_, s) ← lint tt lint_verbosity.medium [`assert_not_exists.linter] tt,
+  guard $ "/- `bar` does not ever exist -/\n".is_suffix_of s.to_string
+
+/-! ### Test `assert_no_instance` -/
+
+class some_class (t : Type*).
+
+assert_no_instance (some_class ℕ)
+
+instance : some_class ℕ := {}
+
+assert_no_instance (some_class ℤ)
+
+run_cmd do
+  (_, s) ← lint tt lint_verbosity.medium [`assert_no_instance.linter] tt,
+  guard $ "/- No instance of `some_class ℤ` -/\n".is_suffix_of s.to_string


### PR DESCRIPTION
Previously there was a check to avoid adding a declaration if it already existed. This didn't really solve the problem though, as likely the definition would be provided by two files that were unaware of each other, and the collision would only occur when both are imported simultaneously.

I also forgot to `git add` the test last time.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
