### PR TITLE
[Merged by Bors] - chore(*): add mathlib4 synchronization labels

### DIFF
--- a/src/algebra/group/commutator.lean
+++ b/src/algebra/group/commutator.lean
@@ -9,6 +9,10 @@ import data.bracket
 
 /-!
 # The bracket on a group given by commutator.
+
+> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
+> https://github.com/leanprover-community/mathlib4/pull/582
+> Any changes to this file require a corresponding PR to mathlib4.
 -/
 
 /-- The commutator of two elements `g₁` and `g₂`. -/

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -9,6 +9,10 @@ import data.nat.basic
 /-!
 # Basic instances on the integers
 
+> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
+> https://github.com/leanprover-community/mathlib4/pull/584
+> Any changes to this file require a corresponding PR to mathlib4.
+
 This file contains:
 * instances on `ℤ`. The stronger one is `int.comm_ring`.
   See `data/int/defs/order` for `int.linear_ordered_comm_ring`.

--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -8,6 +8,10 @@ import logic.function.conjugate
 /-!
 # Iterations of a function
 
+> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
+> https://github.com/leanprover-community/mathlib4/pull/585
+> Any changes to this file require a corresponding PR to mathlib4.
+
 In this file we prove simple properties of `nat.iterate f n` a.k.a. `f^[n]`:
 
 * `iterate_zero`, `iterate_succ`, `iterate_succ'`, `iterate_add`, `iterate_mul`:

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -9,6 +9,10 @@ import data.subtype
 /-!
 # Basic definitions about `≤` and `<`
 
+> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
+> https://github.com/leanprover-community/mathlib4/pull/556
+> Any changes to this file require a corresponding PR to mathlib4.
+
 This file proves basic results about orders, provides extensive dot notation, defines useful order
 classes and allows to transfer order instances.
 


### PR DESCRIPTION
This adds synchronization labels for the following files:

* logic.function.iterate     --  PR mathlib4#585
* order.basic     -- mathlib4#556
* data.int.basic     -- mathlib4#584
* algebra.group.commutator     -- mathlib4#582

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
