### PR TITLE
[Merged by Bors] - chore(algebra/order/ring/defs): make `strict_ordered_ring.to_ordered_ring'` choice-free

### DIFF
--- a/src/algebra/order/ring/defs.lean
+++ b/src/algebra/order/ring/defs.lean
@@ -573,8 +573,7 @@ instance strict_ordered_ring.to_strict_ordered_semiring : strict_ordered_semirin
 `int` lemmas. -/
 @[reducible] -- See note [reducible non-instances]
 def strict_ordered_ring.to_ordered_ring' [@decidable_rel α (≤)] : ordered_ring α :=
-{ zero_le_one := strict_ordered_ring.zero_le_one,
-  mul_nonneg := λ a b ha hb, begin
+{ mul_nonneg := λ a b ha hb, begin
     obtain ha | ha := decidable.eq_or_lt_of_le ha,
     { rw [←ha, zero_mul] },
     obtain hb | hb := decidable.eq_or_lt_of_le hb,

--- a/src/algebra/order/ring/defs.lean
+++ b/src/algebra/order/ring/defs.lean
@@ -573,15 +573,15 @@ instance strict_ordered_ring.to_strict_ordered_semiring : strict_ordered_semirin
 `int` lemmas. -/
 @[reducible] -- See note [reducible non-instances]
 def strict_ordered_ring.to_ordered_ring' [@decidable_rel α (≤)] : ordered_ring α :=
-{ mul_nonneg := λ a b ha hb, begin
-    cases decidable.eq_or_lt_of_le ha with ha ha,
+{ zero_le_one := strict_ordered_ring.zero_le_one,
+  mul_nonneg := λ a b ha hb, begin
+    obtain ha | ha := decidable.eq_or_lt_of_le ha,
     { rw [←ha, zero_mul] },
-    cases decidable.eq_or_lt_of_le hb with hb hb,
+    obtain hb | hb := decidable.eq_or_lt_of_le hb,
     { rw [←hb, mul_zero] },
-    { exact (mul_pos ha hb).le }
+    { exact (strict_ordered_ring.mul_pos _ _ ha hb).le }
   end,
   ..‹strict_ordered_ring α›,  ..ring.to_semiring }
-
 
 @[priority 100] -- see Note [lower instance priority]
 instance strict_ordered_ring.to_ordered_ring : ordered_ring α :=


### PR DESCRIPTION
Make `strict_ordered_ring.to_ordered_ring'` choice-free as docstring says.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
