### PR TITLE
[Merged by Bors] - feat(measure_theory/integral/lebesgue): Add Markov inequalities for tsum and card using counting measure.

### DIFF
--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2289,7 +2289,7 @@ begin
   { have obs : {i : α | ε ≤ a i} = ∅,
     { rw eq_empty_iff_forall_not_mem,
       intros i hi,
-      have infty_le_ai : ∞ ≤ a i, by simpa only [mem_set_of_eq] using hi,
+      have infty_le_ai : ∞ ≤ a i, by simpa only [h, mem_set_of_eq] using hi,
       refine (lt_of_le_of_lt infty_le_ai (ennreal.lt_top_of_tsum_ne_top _ i)).ne rfl,
       exact (lt_of_le_of_lt tsum_le_c c_ne_top.lt_top).ne, },
     simp only [obs, finite_empty, finite_empty_to_finset, finset.card_empty,
@@ -2298,8 +2298,7 @@ begin
   have hf : {i : α | ε ≤ a i}.finite,
     from finite_const_le_of_tsum_lt_top (lt_of_le_of_lt tsum_le_c c_ne_top.lt_top).ne ε_ne_zero,
   use hf,
-  have obs := @ennreal.count_const_le_le_of_tsum_le α ⊤ _ _ a_mble c
-    tsum_le_c _ ε_ne_zero ε_ne_top,
+  have obs := @ennreal.count_const_le_le_of_tsum_le α ⊤ _ _ a_mble c tsum_le_c _ ε_ne_zero h,
   simpa [← @measure.count_apply_finite _ ⊤ _ _ hf] using obs,
 end
 

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2261,47 +2261,6 @@ begin
   exact ennreal.div_le_div tsum_le_c rfl.le,
 end
 
-/-- A sum of extended nonnegative reals which is finite can have only finitely many terms
-above any positive threshold.-/
-lemma _root_.ennreal.finite_const_le_of_tsum_lt_top {α : Type*} {a : α → ℝ≥0∞}
-  (tsum_ne_top : ∑' i, a i ≠ ∞) {ε : ℝ≥0∞} (ε_ne_zero : ε ≠ 0) :
-  {i : α | ε ≤ a i}.finite :=
-begin
-  by_cases ε = ∞,
-  { by_contra con,
-    rcases set.infinite.nonempty con with ⟨i, hi⟩,
-    have infty_le_ai : ∞ ≤ a i, by simpa only [h, mem_set_of_eq] using hi,
-    exact (lt_of_le_of_lt infty_le_ai (ennreal.lt_top_of_tsum_ne_top tsum_ne_top i)).ne rfl, },
-  apply (measure.count_apply_lt_top' measurable_space.measurable_set_top).mp,
-  have key := @ennreal.count_const_le_le_of_tsum_le α ⊤ _
-                a (measurable_space.top.measurable a) _ rfl.le _ ε_ne_zero h,
-  exact lt_of_le_of_lt key (ennreal.div_lt_top tsum_ne_top ε_ne_zero),
-end
-
-/-- Markov's inequality for `finset.card` and `tsum` in `ℝ≥0∞`. -/
-lemma _root_.ennreal.finset_card_const_le_le_of_tsum_le {α : Type*} {a : α → ℝ≥0∞}
-  {c : ℝ≥0∞} (c_ne_top : c ≠ ∞) (tsum_le_c : ∑' i, a i ≤ c)
-  {ε : ℝ≥0∞} (ε_ne_zero : ε ≠ 0) :
-  ∃ hf : {i : α | ε ≤ a i}.finite, ↑hf.to_finset.card ≤ c / ε :=
-begin
-  by_cases ε = ∞,
-  { have obs : {i : α | ε ≤ a i} = ∅,
-    { rw eq_empty_iff_forall_not_mem,
-      intros i hi,
-      have infty_le_ai : ∞ ≤ a i, by simpa only [h, mem_set_of_eq] using hi,
-      refine (lt_of_le_of_lt infty_le_ai (ennreal.lt_top_of_tsum_ne_top _ i)).ne rfl,
-      exact (lt_of_le_of_lt tsum_le_c c_ne_top.lt_top).ne, },
-    simp only [obs, finite_empty, finite_empty_to_finset, finset.card_empty,
-               algebra_map.coe_zero, zero_le', exists_true_left], },
-  have hf : {i : α | ε ≤ a i}.finite,
-    from ennreal.finite_const_le_of_tsum_lt_top
-          (lt_of_le_of_lt tsum_le_c c_ne_top.lt_top).ne ε_ne_zero,
-  use hf,
-  simpa [← @measure.count_apply_finite _ ⊤ _ _ hf]
-    using @ennreal.count_const_le_le_of_tsum_le α ⊤ _
-            a (measurable_space.top.measurable a) c tsum_le_c ε ε_ne_zero h,
-end
-
 /-- Markov's inequality for counting measure with hypothesis using `tsum` in `ℝ≥0`. -/
 lemma _root_.nnreal.count_const_le_le_of_tsum_le [measurable_singleton_class α]
   {a : α → ℝ≥0} (a_mble : measurable a) (a_summable : summable a)
@@ -2314,31 +2273,6 @@ begin
           _ (by exact_mod_cast ε_ne_zero) (@ennreal.coe_ne_top ε),
   convert ennreal.coe_le_coe.mpr tsum_le_c,
   rw ennreal.tsum_coe_eq a_summable.has_sum,
-end
-
-/-- If a sum of nonnegative reals is summable, then it can only have finitely many terms
-above any positive threshold. -/
-lemma _root_.nnreal.finite_const_le_of_summable {α : Type*} {a : α → ℝ≥0} (a_summable : summable a)
-  {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
-  {i : α | ε ≤ a i}.finite :=
-begin
-  apply (measure.count_apply_lt_top' measurable_space.measurable_set_top).mp,
-  have key := @nnreal.count_const_le_le_of_tsum_le α ⊤ _
-                a (measurable_space.top.measurable a) a_summable _ rfl.le _ ε_ne_zero,
-  exact lt_of_le_of_lt key (by simp only [← ennreal.coe_div ε_ne_zero, ennreal.coe_lt_top]),
-end
-
-/-- Markov's inequality for `finset.card` and `tsum` in `ℝ≥0`. -/
-lemma _root_.nnreal.finset_card_const_le_le_of_tsum_nnreal_le {α : Type*} {a : α → ℝ≥0}
-  (a_summable : summable a) {c : ℝ≥0} (tsum_le_c : ∑' i, a i ≤ c) {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
-  ∃ hf : {i : α | ε ≤ a i}.finite, ↑hf.to_finset.card ≤ c / ε :=
-begin
-  have hf : {i : α | ε ≤ a i}.finite, from nnreal.finite_const_le_of_summable a_summable ε_ne_zero,
-  use hf,
-  have key := @nnreal.count_const_le_le_of_tsum_le α ⊤ _
-                a (measurable_space.top.measurable a) a_summable c tsum_le_c ε ε_ne_zero,
-  rw @measure.count_apply_finite _ ⊤ _ _ hf at key,
-  exact_mod_cast key,
 end
 
 end dirac_and_count

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2240,26 +2240,12 @@ begin
   exact funext (λ a, lintegral_dirac a f),
 end
 
-lemma measurable_space.top.measurable {α β : Type*} [measurable_space β] (f : α → β) :
-  @measurable α β ⊤ _ f :=
-λ s hs, measurable_space.measurable_set_top
-
 -- Q: Is this instance a bad idea? It is certainly always the correct one, but does it
 -- affect performance?
 @[priority 100]
 instance measurable_space.top.measurable_singleton_class {α : Type*} :
   @measurable_singleton_class α (⊤ : measurable_space α) :=
 { measurable_set_singleton := λ i, measurable_space.measurable_set_top, }
-
--- Place near `ennreal.tsum_eq_top_of_eq_top`?
-lemma _root_.ennreal.lt_top_of_tsum_ne_top {α : Type*} {a : α → ℝ≥0∞}
-  (tsum_ne_top : ∑' i, a i ≠ ∞) (j : α) :
-  a j < ⊤ :=
-begin
-  have key := not_imp_not.mpr ennreal.tsum_eq_top_of_eq_top,
-  simp only [not_exists] at key,
-  exact lt_top_iff_ne_top.mpr (key tsum_ne_top j),
-end
 
 lemma _root_.ennreal.tsum_const_eq [measurable_singleton_class α] (c : ℝ≥0∞) :
   (∑' (i : α), c) = (measure.count (univ : set α)) * c :=
@@ -2345,14 +2331,15 @@ begin
 end
 
 /-- Markov's inequality for `finset.card` and `tsum` in `ℝ≥0`. -/
-lemma finset_card_const_le_le_of_tsum_nnreal_le
-  {a : α → ℝ≥0} (a_summable : summable a) {c : ℝ≥0} (tsum_le_c : ∑' i, a i ≤ c) {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
+lemma finset_card_const_le_le_of_tsum_nnreal_le {a : α → ℝ≥0} (a_summable : summable a)
+  {c : ℝ≥0} (tsum_le_c : ∑' i, a i ≤ c) {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
   ∃ hf : {i : α | ε ≤ a i}.finite, ↑hf.to_finset.card ≤ c / ε :=
 begin
   have a_mble : @measurable _ _ ⊤ _ a, from measurable_space.top.measurable a,
   have hf : {i : α | ε ≤ a i}.finite, from finite_const_le_of_summable a_summable ε_ne_zero,
   use hf,
-  have obs := @nnreal.count_const_le_le_of_tsum_le α ⊤ _ _ a_mble a_summable c tsum_le_c ε ε_ne_zero,
+  have obs := @nnreal.count_const_le_le_of_tsum_le α ⊤ _ _ a_mble a_summable c tsum_le_c
+                ε ε_ne_zero,
   rw @measure.count_apply_finite _ ⊤ _ _ hf at obs,
   exact_mod_cast obs,
 end

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2240,6 +2240,123 @@ begin
   exact funext (λ a, lintegral_dirac a f),
 end
 
+lemma measurable_space.top.measurable {α β : Type*} [measurable_space β] (f : α → β) :
+  @measurable α β ⊤ _ f :=
+λ s hs, measurable_space.measurable_set_top
+
+-- Q: Is this instance a bad idea? It is certainly always the correct one, but does it
+-- affect performance?
+@[priority 100]
+instance measurable_space.top.measurable_singleton_class {α : Type*} :
+  @measurable_singleton_class α (⊤ : measurable_space α) :=
+{ measurable_set_singleton := λ i, measurable_space.measurable_set_top, }
+
+-- Place near `ennreal.tsum_eq_top_of_eq_top`?
+lemma _root_.ennreal.lt_top_of_tsum_ne_top {α : Type*} {a : α → ℝ≥0∞}
+  (tsum_ne_top : ∑' i, a i ≠ ∞) (j : α) :
+  a j < ⊤ :=
+begin
+  have key := not_imp_not.mpr ennreal.tsum_eq_top_of_eq_top,
+  simp only [not_exists] at key,
+  exact lt_top_iff_ne_top.mpr (key tsum_ne_top j),
+end
+
+lemma _root_.ennreal.tsum_const_eq [measurable_singleton_class α] (c : ℝ≥0∞) :
+  (∑' (i : α), c) = (measure.count (univ : set α)) * c :=
+by rw [← lintegral_count, lintegral_const, mul_comm]
+
+/-- Markov's inequality for the counting measure with hypothesis using `tsum` in `ℝ≥0∞`. -/
+lemma _root_.ennreal.count_const_le_le_of_tsum_le [measurable_singleton_class α]
+  {a : α → ℝ≥0∞} (a_mble : measurable a) {c : ℝ≥0∞} (tsum_le_c : ∑' i, a i ≤ c)
+  {ε : ℝ≥0∞} (ε_ne_zero : ε ≠ 0) (ε_ne_top : ε ≠ ∞) :
+  measure.count {i : α | ε ≤ a i} ≤ c / ε :=
+begin
+  rw ← lintegral_count at tsum_le_c,
+  apply (measure_theory.meas_ge_le_lintegral_div a_mble.ae_measurable ε_ne_zero ε_ne_top).trans,
+  exact ennreal.div_le_div tsum_le_c rfl.le,
+end
+
+/-- A sum of extended nonnegative reals which is finite can have only finitely many terms
+above any positive threshold.-/
+lemma finite_const_le_of_tsum_lt_top {a : α → ℝ≥0∞}
+  (tsum_ne_top : ∑' i, a i ≠ ∞) {ε : ℝ≥0∞} (ε_ne_zero : ε ≠ 0) :
+  {i : α | ε ≤ a i}.finite :=
+begin
+  have a_mble : @measurable _ _ ⊤ _ a, from measurable_space.top.measurable a,
+  by_cases ε = ∞,
+  { by_contra con,
+    rcases set.infinite.nonempty con with ⟨i, hi⟩,
+    have infty_le_ai : ∞ ≤ a i, by simpa only [h, mem_set_of_eq] using hi,
+    exact (lt_of_le_of_lt infty_le_ai (ennreal.lt_top_of_tsum_ne_top tsum_ne_top i)).ne rfl, },
+  apply (measure.count_apply_lt_top' measurable_space.measurable_set_top).mp,
+  have obs := @ennreal.count_const_le_le_of_tsum_le α ⊤ _ a a_mble _ rfl.le _ ε_ne_zero h,
+  exact lt_of_le_of_lt obs (ennreal.div_lt_top tsum_ne_top ε_ne_zero),
+end
+
+/-- Markov's inequality for `finset.card` and `tsum` in `ℝ≥0∞`. -/
+lemma finset_card_const_le_le_of_tsum_le {a : α → ℝ≥0∞}
+  {c : ℝ≥0∞} (c_ne_top : c ≠ ∞) (tsum_le_c : ∑' i, a i ≤ c)
+  {ε : ℝ≥0∞} (ε_ne_zero : ε ≠ 0) (ε_ne_top : ε ≠ ∞) :
+  ∃ hf : {i : α | ε ≤ a i}.finite, ↑hf.to_finset.card ≤ c / ε :=
+begin
+  by_cases ε = ∞,
+  { have obs : {i : α | ε ≤ a i} = ∅,
+    { rw eq_empty_iff_forall_not_mem,
+      intros i hi,
+      have infty_le_ai : ∞ ≤ a i, by simpa only [mem_set_of_eq] using hi,
+      refine (lt_of_le_of_lt infty_le_ai (ennreal.lt_top_of_tsum_ne_top _ i)).ne rfl,
+      exact (lt_of_le_of_lt tsum_le_c c_ne_top.lt_top).ne, },
+    simp only [obs, finite_empty, finite_empty_to_finset, finset.card_empty,
+               algebra_map.coe_zero, zero_le', exists_true_left], },
+  have a_mble : @measurable _ _ ⊤ _ a, from measurable_space.top.measurable a,
+  have hf : {i : α | ε ≤ a i}.finite,
+    from finite_const_le_of_tsum_lt_top (lt_of_le_of_lt tsum_le_c c_ne_top.lt_top).ne ε_ne_zero,
+  use hf,
+  have obs := @ennreal.count_const_le_le_of_tsum_le α ⊤ _ _ a_mble c
+    tsum_le_c _ ε_ne_zero ε_ne_top,
+  simpa [← @measure.count_apply_finite _ ⊤ _ _ hf] using obs,
+end
+
+/-- Markov's inequality for counting measure with hypothesis using `tsum` in `ℝ≥0`. -/
+lemma _root_.nnreal.count_const_le_le_of_tsum_le [measurable_singleton_class α]
+  {a : α → ℝ≥0} (a_mble : measurable a) (a_summable : summable a)
+  {c : ℝ≥0} (tsum_le_c : ∑' i, a i ≤ c) {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
+  measure.count {i : α | ε ≤ a i} ≤ c / ε :=
+begin
+  rw [show (λ i, ε ≤ a i) = (λ i, (ε : ℝ≥0∞) ≤ (coe ∘ a) i),
+        by { funext i, simp only [ennreal.coe_le_coe], }],
+  apply ennreal.count_const_le_le_of_tsum_le (measurable_coe_nnreal_ennreal.comp a_mble)
+          _ (by exact_mod_cast ε_ne_zero) (@ennreal.coe_ne_top ε),
+  convert ennreal.coe_le_coe.mpr tsum_le_c,
+  rw ennreal.tsum_coe_eq a_summable.has_sum,
+end
+
+/-- If a sum of nonnegative reals is summable, then it can only have finitely many terms
+above any positive threshold. -/
+lemma finite_const_le_of_summable {a : α → ℝ≥0} (a_summable : summable a)
+  {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
+  {i : α | ε ≤ a i}.finite :=
+begin
+  have a_mble : @measurable _ _ ⊤ _ a, from measurable_space.top.measurable a,
+  apply (measure.count_apply_lt_top' measurable_space.measurable_set_top).mp,
+  have obs := @nnreal.count_const_le_le_of_tsum_le α ⊤ _ a a_mble a_summable _ rfl.le _ ε_ne_zero,
+  refine lt_of_le_of_lt obs _,
+  simp only [← ennreal.coe_div ε_ne_zero, ennreal.coe_lt_top],
+end
+
+/-- Markov's inequality for `finset.card` and `tsum` in `ℝ≥0`. -/
+lemma finset_card_const_le_le_of_tsum_nnreal_le
+  {a : α → ℝ≥0} (a_summable : summable a) {c : ℝ≥0} (tsum_le_c : ∑' i, a i ≤ c) {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
+  ∃ hf : {i : α | ε ≤ a i}.finite, ↑hf.to_finset.card ≤ c / ε :=
+begin
+  have a_mble : @measurable _ _ ⊤ _ a, from measurable_space.top.measurable a,
+  have hf : {i : α | ε ≤ a i}.finite, from finite_const_le_of_summable a_summable ε_ne_zero,
+  use hf,
+  have obs := @nnreal.count_const_le_le_of_tsum_le α ⊤ _ _ a_mble a_summable c tsum_le_c ε ε_ne_zero,
+  rw @measure.count_apply_finite _ ⊤ _ _ hf at obs,
+  exact_mod_cast obs,
+end
+
 end dirac_and_count
 
 section countable

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2215,7 +2215,7 @@ by rw [← hg.set_lintegral_comp_preimage_emb hge, preimage_image_eq _ hge.injec
 
 section dirac_and_count
 
-@[priority 100]
+@[priority 10]
 instance _root_.measurable_space.top.measurable_singleton_class {α : Type*} :
   @measurable_singleton_class α (⊤ : measurable_space α) :=
 { measurable_set_singleton := λ i, measurable_space.measurable_set_top, }

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2282,7 +2282,7 @@ end
 /-- Markov's inequality for `finset.card` and `tsum` in `ℝ≥0∞`. -/
 lemma finset_card_const_le_le_of_tsum_le {a : α → ℝ≥0∞}
   {c : ℝ≥0∞} (c_ne_top : c ≠ ∞) (tsum_le_c : ∑' i, a i ≤ c)
-  {ε : ℝ≥0∞} (ε_ne_zero : ε ≠ 0) (ε_ne_top : ε ≠ ∞) :
+  {ε : ℝ≥0∞} (ε_ne_zero : ε ≠ 0) :
   ∃ hf : {i : α | ε ≤ a i}.finite, ↑hf.to_finset.card ≤ c / ε :=
 begin
   by_cases ε = ∞,

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2318,7 +2318,7 @@ end
 
 /-- If a sum of nonnegative reals is summable, then it can only have finitely many terms
 above any positive threshold. -/
-lemma _root_.finite_const_le_of_summable {α : Type*} {a : α → ℝ≥0} (a_summable : summable a)
+lemma _root_.nnreal.finite_const_le_of_summable {α : Type*} {a : α → ℝ≥0} (a_summable : summable a)
   {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
   {i : α | ε ≤ a i}.finite :=
 begin
@@ -2329,11 +2329,11 @@ begin
 end
 
 /-- Markov's inequality for `finset.card` and `tsum` in `ℝ≥0`. -/
-lemma finset_card_const_le_le_of_tsum_nnreal_le {α : Type*} {a : α → ℝ≥0} (a_summable : summable a)
-  {c : ℝ≥0} (tsum_le_c : ∑' i, a i ≤ c) {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
+lemma _root_.nnreal.finset_card_const_le_le_of_tsum_nnreal_le {α : Type*} {a : α → ℝ≥0}
+  (a_summable : summable a) {c : ℝ≥0} (tsum_le_c : ∑' i, a i ≤ c) {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
   ∃ hf : {i : α | ε ≤ a i}.finite, ↑hf.to_finset.card ≤ c / ε :=
 begin
-  have hf : {i : α | ε ≤ a i}.finite, from finite_const_le_of_summable a_summable ε_ne_zero,
+  have hf : {i : α | ε ≤ a i}.finite, from nnreal.finite_const_le_of_summable a_summable ε_ne_zero,
   use hf,
   have key := @nnreal.count_const_le_le_of_tsum_le α ⊤ _
                 a (measurable_space.top.measurable a) a_summable c tsum_le_c ε ε_ne_zero,

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2263,7 +2263,7 @@ end
 
 /-- A sum of extended nonnegative reals which is finite can have only finitely many terms
 above any positive threshold.-/
-lemma finite_const_le_of_tsum_lt_top {a : α → ℝ≥0∞}
+lemma _root_.ennreal.finite_const_le_of_tsum_lt_top {α : Type*} {a : α → ℝ≥0∞}
   (tsum_ne_top : ∑' i, a i ≠ ∞) {ε : ℝ≥0∞} (ε_ne_zero : ε ≠ 0) :
   {i : α | ε ≤ a i}.finite :=
 begin
@@ -2279,7 +2279,7 @@ begin
 end
 
 /-- Markov's inequality for `finset.card` and `tsum` in `ℝ≥0∞`. -/
-lemma finset_card_const_le_le_of_tsum_le {a : α → ℝ≥0∞}
+lemma _root_.ennreal.finset_card_const_le_le_of_tsum_le {α : Type*} {a : α → ℝ≥0∞}
   {c : ℝ≥0∞} (c_ne_top : c ≠ ∞) (tsum_le_c : ∑' i, a i ≤ c)
   {ε : ℝ≥0∞} (ε_ne_zero : ε ≠ 0) :
   ∃ hf : {i : α | ε ≤ a i}.finite, ↑hf.to_finset.card ≤ c / ε :=
@@ -2294,7 +2294,8 @@ begin
     simp only [obs, finite_empty, finite_empty_to_finset, finset.card_empty,
                algebra_map.coe_zero, zero_le', exists_true_left], },
   have hf : {i : α | ε ≤ a i}.finite,
-    from finite_const_le_of_tsum_lt_top (lt_of_le_of_lt tsum_le_c c_ne_top.lt_top).ne ε_ne_zero,
+    from ennreal.finite_const_le_of_tsum_lt_top
+          (lt_of_le_of_lt tsum_le_c c_ne_top.lt_top).ne ε_ne_zero,
   use hf,
   simpa [← @measure.count_apply_finite _ ⊤ _ _ hf]
     using @ennreal.count_const_le_le_of_tsum_le α ⊤ _
@@ -2317,7 +2318,7 @@ end
 
 /-- If a sum of nonnegative reals is summable, then it can only have finitely many terms
 above any positive threshold. -/
-lemma finite_const_le_of_summable {a : α → ℝ≥0} (a_summable : summable a)
+lemma _root_.finite_const_le_of_summable {α : Type*} {a : α → ℝ≥0} (a_summable : summable a)
   {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
   {i : α | ε ≤ a i}.finite :=
 begin
@@ -2328,7 +2329,7 @@ begin
 end
 
 /-- Markov's inequality for `finset.card` and `tsum` in `ℝ≥0`. -/
-lemma finset_card_const_le_le_of_tsum_nnreal_le {a : α → ℝ≥0} (a_summable : summable a)
+lemma finset_card_const_le_le_of_tsum_nnreal_le {α : Type*} {a : α → ℝ≥0} (a_summable : summable a)
   {c : ℝ≥0} (tsum_le_c : ∑' i, a i ≤ c) {ε : ℝ≥0} (ε_ne_zero : ε ≠ 0) :
   ∃ hf : {i : α | ε ≤ a i}.finite, ↑hf.to_finset.card ≤ c / ε :=
 begin

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2243,7 +2243,7 @@ end
 -- Q: Is this instance a bad idea? It is certainly always the correct one, but does it
 -- affect performance?
 @[priority 100]
-instance measurable_space.top.measurable_singleton_class {α : Type*} :
+instance _root_.measurable_space.top.measurable_singleton_class {α : Type*} :
   @measurable_singleton_class α (⊤ : measurable_space α) :=
 { measurable_set_singleton := λ i, measurable_space.measurable_set_top, }
 

--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -469,4 +469,8 @@ lemma measurable.le {α} {m m0 : measurable_space α} {mb : measurable_space β}
   (hf : measurable[m] f) : measurable[m0] f :=
 λ s hs, hm _ (hf hs)
 
+lemma measurable_space.top.measurable {α β : Type*} [measurable_space β] (f : α → β) :
+  @measurable α β ⊤ _ f :=
+λ s hs, measurable_space.measurable_set_top
+
 end measurable_functions

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -985,7 +985,7 @@ begin
     by_contra maybe_infinite,
     obtain ⟨j, hj⟩ := set.infinite.nonempty maybe_infinite,
     exact tsum_ne_top (le_antisymm le_top (le_trans hj (le_tsum' (@ennreal.summable _ a) j))), },
-  have key := (summable_coe.mpr
+  have key := (nnreal.summable_coe.mpr
                (summable_to_nnreal_of_tsum_ne_top tsum_ne_top)).tendsto_cofinite_zero
                (Iio_mem_nhds (to_real_pos ε_ne_zero ε_infty)),
   simp only [filter.mem_map, filter.mem_cofinite, preimage] at key,
@@ -1018,7 +1018,8 @@ begin
   have at_least : ∀ i ∈ hf.to_finset, ε ≤ a i,
   { intros i hi,
     simpa only [finite.mem_to_finset, mem_set_of_eq] using hi, },
-  have partial_sum := @sum_le_tsum _ _ _ _ _ a hf.to_finset (λ _ _, zero_le') (@ennreal.summable _ a),
+  have partial_sum := @sum_le_tsum _ _ _ _ _ a
+                        hf.to_finset (λ _ _, zero_le') (@ennreal.summable _ a),
   have lower_bound := finset.sum_le_sum at_least,
   simp only [finset.sum_const, nsmul_eq_mul] at lower_bound,
   have key := (ennreal.le_div_iff_mul_le (or.inl ε_ne_zero) (or.inl h)).mpr lower_bound,

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -985,8 +985,9 @@ begin
     by_contra maybe_infinite,
     obtain ⟨j, hj⟩ := set.infinite.nonempty maybe_infinite,
     exact tsum_ne_top (le_antisymm le_top (le_trans hj (le_tsum' (@ennreal.summable _ a) j))), },
-  have key := (summable_coe.mpr (summable_to_nnreal_of_tsum_ne_top tsum_ne_top)).tendsto_cofinite_zero
-              (Iio_mem_nhds (to_real_pos ε_ne_zero ε_infty)),
+  have key := (summable_coe.mpr
+               (summable_to_nnreal_of_tsum_ne_top tsum_ne_top)).tendsto_cofinite_zero
+               (Iio_mem_nhds (to_real_pos ε_ne_zero ε_infty)),
   simp only [filter.mem_map, filter.mem_cofinite, preimage] at key,
   have obs : {i : ι | ↑((a i).to_nnreal) ∈ Iio ε.to_real}ᶜ = {i : ι | ε ≤ a i},
   { ext i,

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -978,7 +978,7 @@ end
 above any positive threshold.-/
 lemma finite_const_le_of_tsum_ne_top {ι : Type*} {a : ι → ℝ≥0∞}
   (tsum_ne_top : ∑' i, a i ≠ ∞) {ε : ℝ≥0∞} (ε_ne_zero : ε ≠ 0) :
-  {i : X | ε ≤ a i}.finite :=
+  {i : ι | ε ≤ a i}.finite :=
 begin
   by_cases ε_infty : ε = ∞,
   { rw ε_infty,
@@ -1011,7 +1011,7 @@ begin
       exact c_ne_top (le_antisymm le_top oops), },
     simp only [obs, finite_empty, finite_empty_to_finset, finset.card_empty,
                algebra_map.coe_zero, zero_le', exists_true_left], },
-  have hf : {i : X | ε ≤ a i}.finite,
+  have hf : {i : ι | ε ≤ a i}.finite,
     from ennreal.finite_const_le_of_tsum_ne_top
           (lt_of_le_of_lt tsum_le_c c_ne_top.lt_top).ne ε_ne_zero,
   use hf,

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -803,6 +803,14 @@ le_tsum' ennreal.summable a
 protected lemma tsum_eq_top_of_eq_top : (∃ a, f a = ∞) → ∑' a, f a = ∞
 | ⟨a, ha⟩ := top_unique $ ha ▸ ennreal.le_tsum a
 
+protected lemma lt_top_of_tsum_ne_top {a : α → ℝ≥0∞} (tsum_ne_top : ∑' i, a i ≠ ∞) (j : α) :
+  a j < ⊤ :=
+begin
+  have key := not_imp_not.mpr ennreal.tsum_eq_top_of_eq_top,
+  simp only [not_exists] at key,
+  exact lt_top_iff_ne_top.mpr (key tsum_ne_top j),
+end
+
 @[simp] protected lemma tsum_top [nonempty α] : ∑' a : α, ∞ = ∞ :=
 let ⟨a⟩ := ‹nonempty α› in ennreal.tsum_eq_top_of_eq_top ⟨a, rfl⟩
 

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -804,7 +804,7 @@ protected lemma tsum_eq_top_of_eq_top : (∃ a, f a = ∞) → ∑' a, f a = ∞
 | ⟨a, ha⟩ := top_unique $ ha ▸ ennreal.le_tsum a
 
 protected lemma lt_top_of_tsum_ne_top {a : α → ℝ≥0∞} (tsum_ne_top : ∑' i, a i ≠ ∞) (j : α) :
-  a j < ⊤ :=
+  a j < ∞ :=
 begin
   have key := not_imp_not.mpr ennreal.tsum_eq_top_of_eq_top,
   simp only [not_exists] at key,


### PR DESCRIPTION
Add Markov inequalities for `tsum` and `finset.card` using the counting measure to translate the Markov inequality from measure theory to these.

---

I don't know if it is considered bad to do cardinality proofs via importing measure theory. But I tend to believe the measure theory library is very convenient to use compared to cardinalities directly, so I'd prefer to allow this. Markov's inequality is an example of where I think there is a small advantage, but other tools including convergence theorems will be convenient to translate from `lintegral`s to `tsum`s.

Perhaps the reviewers can comment on whether this import-heavy approach is acceptable/desirable at all.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
