### PR TITLE
[Merged by Bors] - feat(scripts/port_status): output `git diff` command

### DIFF
--- a/scripts/port_status.py
+++ b/scripts/port_status.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import_re = re.compile(r"^import ([^ ]*)")
 synchronized_re = re.compile(r".*SYNCHRONIZED WITH MATHLIB4.*")
 hash_re = re.compile(r"[0-9a-f]*")
-output_git_command = 1 < len(argv)
 
 def mk_label(path: Path) -> str:
     rel = path.relative_to(Path('src'))
@@ -125,5 +124,5 @@ for node in graph.nodes:
 if len(touched) > 0:
     print()
     print('# The following files have been modified since the commit at which they were verified.')
-    for (n, v) in touched.items():
-        print(' '.join(v) if output_git_command else n)
+    for v in touched.values():
+        print(' '.join(v))


### PR DESCRIPTION
We modify the `port_status` script to instead of listing files that have been modified, outputting the `git diff` command required to see the file at the current moment vs the commit that it is officially ported towards.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
