### PR TITLE
[Merged by Bors] - ci: run `add_port_comments.py` nightly

### DIFF
--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           script: |
             prs = await exec.getExecOutput("bash",
-              ['-c', "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\\+'"]);
+              ['-c', "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\\+' | sort -u"]);
             pr_bullets = prs.stdout.trim().split('\n').map(x => "* " + x).join('\n'); 
             console.log(pr_bullets);
             core.setOutput("PR_LIST", pr_bullets); 

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -30,7 +30,7 @@ jobs:
         id: message
         run: |
           PR_LIST="$(git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'  | awk '{print "* " $0}')"
-          echo "PR_LIST=$PR_LIST" >> $GITHUB_OUTPUT
+          echo "PR_LIST=$(printf "%q" "$PR_LIST")" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -37,10 +37,10 @@ jobs:
         id: generate-message
         with:
           script: |
-            let prs = exec.getExecOutput(
+            var prs = exec.getExecOutput(
               "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'");
-            console.log(prs.stdout)
-            console.log(prs.stderr)
+            console.log(prs.stdout);
+            console.log(prs.stderr);
             # Assuming we have a `content` environment variable or output of previous step
             core.setOutput("PR_LIST", prs.stdout); 
 

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -27,11 +27,22 @@ jobs:
           python ./scripts/add_port_comments.py
 
       - name: generate message
-        id: generate-message
+        id: generate-message-bad
         run: |
           PR_LIST="$(git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'  | awk '{print "* " $0}')"
           echo "PR_LIST=$(printf "%q" "$PR_LIST")" >> $GITHUB_OUTPUT
           echo "$PR_LIST"
+          
+      - uses: actions/github-script@v5
+        id: generate-message
+        with:
+          script: |
+            let prs = exec.getExecOutput(
+              "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'");
+            console.log(prs.stdout)
+            console.log(prs.stderr)
+            # Assuming we have a `content` environment variable or output of previous step
+            core.setOutput("PR_LIST", prs.stdout); 
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
-  pull_request:  # todo: remove
 
 jobs:
   build:

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -29,7 +29,7 @@ jobs:
       - name: generate message
         id: message
         run: |
-          PR_LIST="$(git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'  | awk '{print "* " $0}')
+          PR_LIST="$(git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'  | awk '{print "* " $0}')"
           echo "PR_LIST=$PR_LIST" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -1,17 +1,15 @@
-name: update nolints
+name: Add mathlib4 porting comments
 
 on:
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch
+  workflow_dispatch:
+  pull_request:  # todo: remove
 
 jobs:
   build:
-    name: Build, lint and update nolints
+    name: Update comments
     runs-on: ubuntu-latest
-    env:
-      # number of commits to check for olean cache
-      GIT_HISTORY_DEPTH: 20
     steps:
       - uses: actions/checkout@v3
 
@@ -32,3 +30,6 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "chore(*): add mathlibport comments"
+          title: "chore(*): add mathlibport comments"

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -38,10 +38,10 @@ jobs:
         with:
           script: |
             prs = exec.getExecOutput("bash",
-              ['-c', "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/\\d+'"]);
-            console.log(prs.stdout);
-            console.log(prs.stderr);
-            core.setOutput("PR_LIST", prs.stdout); 
+              ['-c', "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]+'"]);
+            pr_bullets = prs.stdout.split('\n').map(x => "* " + x).join('\n'); 
+            console.log(pr_bullets);
+            core.setOutput("PR_LIST", pr_bullets); 
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           script: |
             prs = await exec.getExecOutput("bash",
-              ['-c', "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]+'"]);
+              ['-c', "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\\+'"]);
             pr_bullets = prs.stdout.split('\n').map(x => "* " + x).join('\n'); 
             console.log(pr_bullets);
             core.setOutput("PR_LIST", pr_bullets); 

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -32,3 +32,6 @@ jobs:
           base: master
           commit-message: "chore(*): add mathlibport comments"
           title: "chore(*): add mathlibport comments"
+          body: |
+            Regenerated from the [port status wiki page](https://github.com/leanprover-community/mathlib/wiki/mathlib4-port-status) 
+          labels: [easy, mathlib4-synchronization]

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -35,5 +35,6 @@ jobs:
           body: |
             Regenerated from the [port status wiki page](https://github.com/leanprover-community/mathlib/wiki/mathlib4-port-status) 
           labels: |
-            easy,
+            easy
+            awaiting-review
             mathlib4-synchronization

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -37,11 +37,9 @@ jobs:
         id: generate-message
         with:
           script: |
-            var prs = exec.getExecOutput(
-              "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'");
+            prs = exec.getExecOutput("git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull'");
             console.log(prs.stdout);
             console.log(prs.stderr);
-            # Assuming we have a `content` environment variable or output of previous step
             core.setOutput("PR_LIST", prs.stdout); 
 
       - name: Create Pull Request

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -37,7 +37,8 @@ jobs:
         id: generate-message
         with:
           script: |
-            prs = exec.getExecOutput("git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull'");
+            prs = exec.getExecOutput("bash",
+              ['-c', "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/\\d+'"]);
             console.log(prs.stdout);
             console.log(prs.stderr);
             core.setOutput("PR_LIST", prs.stdout); 

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -19,12 +19,10 @@ jobs:
           python-version: 3.8
 
       - name: install latest mathlibtools
-        id: build
         run: |
           pip install git+https://github.com/leanprover-community/mathlib-tools
 
       - name: update docstrings
-        id: build
         run: |
           ./scripts/add_port_comments.py
 

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -34,4 +34,6 @@ jobs:
           title: "chore(*): add mathlibport comments"
           body: |
             Regenerated from the [port status wiki page](https://github.com/leanprover-community/mathlib/wiki/mathlib4-port-status) 
-          labels: [easy, mathlib4-synchronization]
+          labels: |
+            easy,
+            mathlib4-synchronization

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: update docstrings
         run: |
-          ./scripts/add_port_comments.py
+          python ./scripts/add_port_comments.py
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           PR_LIST="$(git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'  | awk '{print "* " $0}')"
           echo "PR_LIST=$(printf "%q" "$PR_LIST")" >> $GITHUB_OUTPUT
+          echo "$PR_LIST"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -29,5 +29,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
+          base: master
           commit-message: "chore(*): add mathlibport comments"
           title: "chore(*): add mathlibport comments"

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -37,7 +37,7 @@ jobs:
         id: generate-message
         with:
           script: |
-            prs = exec.getExecOutput("bash",
+            prs = await exec.getExecOutput("bash",
               ['-c', "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]+'"]);
             pr_bullets = prs.stdout.split('\n').map(x => "* " + x).join('\n'); 
             console.log(pr_bullets);

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -26,6 +26,12 @@ jobs:
         run: |
           python ./scripts/add_port_comments.py
 
+      - name: generate message
+        id: message
+        run: |
+          PR_LIST="$(git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'  | awk '{print "* " $0}')
+          echo "PR_LIST=$PR_LIST" >> $GITHUB_OUTPUT
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
@@ -33,7 +39,9 @@ jobs:
           commit-message: "chore(*): add mathlibport comments"
           title: "chore(*): add mathlibport comments"
           body: |
-            Regenerated from the [port status wiki page](https://github.com/leanprover-community/mathlib/wiki/mathlib4-port-status) 
+            Regenerated from the [port status wiki page](https://github.com/leanprover-community/mathlib/wiki/mathlib4-port-status).
+            Relates to the following PRs:
+            ${{ steps.message-generator.outputs.PR_LIST }}
           labels: |
             easy
             awaiting-review

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -25,21 +25,16 @@ jobs:
       - name: update docstrings
         run: |
           python ./scripts/add_port_comments.py
-
-      - name: generate message
-        id: generate-message-bad
-        run: |
-          PR_LIST="$(git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'  | awk '{print "* " $0}')"
-          echo "PR_LIST=$(printf "%q" "$PR_LIST")" >> $GITHUB_OUTPUT
-          echo "$PR_LIST"
           
-      - uses: actions/github-script@v5
+      # multiline outputs are only supported in javascript
+      - name: generate message
+        uses: actions/github-script@v5
         id: generate-message
         with:
           script: |
             prs = await exec.getExecOutput("bash",
               ['-c', "git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\\+'"]);
-            pr_bullets = prs.stdout.split('\n').map(x => "* " + x).join('\n'); 
+            pr_bullets = prs.stdout.trim().split('\n').map(x => "* " + x).join('\n'); 
             console.log(pr_bullets);
             core.setOutput("PR_LIST", pr_bullets); 
 

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -1,0 +1,34 @@
+name: update nolints
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch
+
+jobs:
+  build:
+    name: Build, lint and update nolints
+    runs-on: ubuntu-latest
+    env:
+      # number of commits to check for olean cache
+      GIT_HISTORY_DEPTH: 20
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: install latest mathlibtools
+        id: build
+        run: |
+          pip install git+https://github.com/leanprover-community/mathlib-tools
+
+      - name: update docstrings
+        id: build
+        run: |
+          ./scripts/add_port_comments.py
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -27,7 +27,7 @@ jobs:
           python ./scripts/add_port_comments.py
 
       - name: generate message
-        id: message
+        id: generate-message
         run: |
           PR_LIST="$(git diff HEAD -U0 | grep -o -e 'https://github.com/leanprover-community/mathlib4/pull/[0-9]\+'  | awk '{print "* " $0}')"
           echo "PR_LIST=$(printf "%q" "$PR_LIST")" >> $GITHUB_OUTPUT
@@ -42,7 +42,10 @@ jobs:
           body: |
             Regenerated from the [port status wiki page](https://github.com/leanprover-community/mathlib/wiki/mathlib4-port-status).
             Relates to the following PRs:
-            ${{ steps.message-generator.outputs.PR_LIST }}
+            ${{ steps.generate-message.outputs.PR_LIST }}
+
+            ---
+            I am a bot; please check that I have not put a comment in a bad place before running `bors merge`!
           labels: |
             easy
             awaiting-review


### PR DESCRIPTION
Since this is modifying lean files and more could go wrong, this does not trigger bors automatically; but instead creates a PR for a human to double-check.

The PR description links to the mathlib4 PRs mentioned in the comments.

If a previous PR is open and not merged, this bot will update that PR. It remains to be seen how this will interact with bors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


See an example PR at #17642

Before merging this we should remove the `pull_request` trigger.