### PR TITLE
[Merged by Bors] - perf(analysis/complex/conformal): squeeze simps

### DIFF
--- a/src/analysis/complex/conformal.lean
+++ b/src/analysis/complex/conformal.lean
@@ -46,7 +46,7 @@ lemma is_conformal_map_complex_linear {map : ℂ →L[ℂ] E} (nonzero : map ≠
   is_conformal_map (map.restrict_scalars ℝ) :=
 begin
   have minor₁ : ‖map 1‖ ≠ 0,
-  { simpa [ext_ring_iff] using nonzero },
+  { simpa only [ext_ring_iff, ne.def, norm_eq_zero] using nonzero},
   refine ⟨‖map 1‖, minor₁, ⟨‖map 1‖⁻¹ • map, _⟩, _⟩,
   { intros x,
     simp only [linear_map.smul_apply],
@@ -54,9 +54,12 @@ begin
     nth_rewrite 0 [this],
     rw [_root_.coe_coe map, linear_map.coe_coe_is_scalar_tower],
     simp only [map.coe_coe, map.map_smul, norm_smul, norm_inv, norm_norm],
-    field_simp [minor₁], },
+    field_simp only [one_mul] },
   { ext1,
-    simp [minor₁] },
+    simp only [minor₁, linear_map.smul_apply, _root_.coe_coe, linear_map.coe_coe_is_scalar_tower,
+      continuous_linear_map.coe_coe, coe_restrict_scalars', coe_smul',
+      linear_isometry.coe_to_continuous_linear_map, linear_isometry.coe_mk, pi.smul_apply,
+      smul_inv_smul₀, ne.def, not_false_iff] },
 end
 
 lemma is_conformal_map_complex_linear_conj
@@ -105,14 +108,15 @@ begin
   { rintros ⟨⟨map, rfl⟩ | ⟨map, hmap⟩, h₂⟩,
     { refine is_conformal_map_complex_linear _,
       contrapose! h₂ with w,
-      simp [w] },
+      simp only [w, restrict_scalars_zero]},
     { have minor₁ : g = (map.restrict_scalars ℝ) ∘L ↑conj_cle,
       { ext1,
-        simp [hmap] },
+        simp only [hmap, coe_comp', continuous_linear_equiv.coe_coe, function.comp_app,
+          conj_cle_apply, star_ring_end_self_apply]},
       rw minor₁ at ⊢ h₂,
       refine is_conformal_map_complex_linear_conj _,
       contrapose! h₂ with w,
-      simp [w] } }
+      simp only [w, restrict_scalars_zero, zero_comp]} }
 end
 
 end conformal_into_complex_plane


### PR DESCRIPTION
This file has been causing arbitrary Bors and CI timeouts, so I squeezed the `simp`s in the slow declarations, especially `is_conformal_map_complex_linear`. Elaboration of that declaration went from 23.8 s to 5.69 s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
