### PR TITLE
[Merged by Bors] - feat(number_theory/modular_forms/slash_invariant_forms): define slash-invariant forms

### DIFF
--- a/src/linear_algebra/general_linear_group.lean
+++ b/src/linear_algebra/general_linear_group.lean
@@ -140,8 +140,7 @@ end
 
 @[simp] lemma mem_GL_pos (A : GL n R) : A ∈ GL_pos n R ↔ 0 < (A.det : R) := iff.rfl
 
-lemma GL_pos.det_ne_zero (A : GL_pos n R) : (A : matrix n n R).det ≠ 0 :=
-((mem_GL_pos (A : GL n R)).1 A.prop).ne'
+lemma GL_pos.det_ne_zero (A : GL_pos n R) : (A : matrix n n R).det ≠ 0 := ne_of_gt A.prop
 
 end
 

--- a/src/linear_algebra/general_linear_group.lean
+++ b/src/linear_algebra/general_linear_group.lean
@@ -139,6 +139,10 @@ def GL_pos : subgroup (GL n R) :=
 end
 
 @[simp] lemma mem_GL_pos (A : GL n R) : A ∈ GL_pos n R ↔ 0 < (A.det : R) := iff.rfl
+
+lemma GL_pos.det_ne_zero (A : GL_pos n R) : (A : matrix n n R).det ≠ 0 :=
+((mem_GL_pos (A : GL n R)).1 A.prop).ne'
+
 end
 
 section has_neg

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -26,8 +26,8 @@ local notation `SL(` n `, ` R `)` := matrix.special_linear_group (fin n) R
 
 /--A general version of the slash action of the space of modular forms.-/
 class slash_action (β G α γ : Type*) [group G] [has_zero α ]
-[has_one α ] [has_smul γ α ] [has_add α ] :=
-(map : β → G → α → α )
+[has_one α] [has_smul γ α] [has_add α] :=
+(map : β → G → α → α)
 (mul_zero : ∀ (k : β) (g : G), map k g 0 = 0)
 (one_mul : ∀ (k : β) (a : α) , map k 1 a = a)
 (right_action : ∀ (k : β) (g h : G) (a : α), map k h (map k g a) = map k (g * h) a )
@@ -36,14 +36,14 @@ class slash_action (β G α γ : Type*) [group G] [has_zero α ]
 
 /--Slash_action induced by a monoid homomorphism.-/
 def monoid_hom_slash_action {β G H α γ : Type*} [group G] [has_zero α]
-  [has_one α] [has_smul γ α ] [has_add α ] [group H] [slash_action β G α γ]
+  [has_one α] [has_smul γ α] [has_add α] [group H] [slash_action β G α γ]
   (h : H →* G) : slash_action β H α γ :=
-{ map := λ k g , slash_action.map γ k (h g) ,
-  mul_zero := by {intros k g, apply slash_action.mul_zero k (h g), },
-  one_mul := by {intros k a, simp only [map_one], apply slash_action.one_mul,},
-  right_action := by {simp only [map_mul], intros k g gg a, apply slash_action.right_action,},
-  smul_action := by {intros k g a z, apply slash_action.smul_action, },
-  add_action := by {intros k g a b, apply slash_action.add_action}}
+{ map := λ k g , slash_action.map γ k (h g),
+  mul_zero := λ k g, slash_action.mul_zero k (h g),
+  one_mul := by {intros k a, simp only [map_one], apply slash_action.one_mul},
+  right_action := by {simp only [map_mul], intros k g gg a, apply slash_action.right_action},
+  smul_action := λ _ _, slash_action.smul_action _ _,
+  add_action := λ _ g _ _, slash_action.add_action _ (h g) _ _,}
 
 namespace modular_form
 
@@ -108,11 +108,11 @@ end
 
 instance : slash_action ℤ GL(2, ℝ)⁺ (ℍ → ℂ) ℂ :=
 { map := slash,
-  mul_zero := by {intros k g, funext, simp only [slash, pi.zero_apply, zero_mul], },
-  one_mul := by {apply slash_one,},
-  right_action := by {apply slash_right_action},
-  smul_action := by {apply smul_slash},
-  add_action := by {apply slash_add}}
+  mul_zero := by {intros k g, funext, simp only [slash, pi.zero_apply, zero_mul]},
+  one_mul := slash_one,
+  right_action := slash_right_action,
+  smul_action := smul_slash,
+  add_action := slash_add }
 
 instance subgroup_action (Γ : subgroup SL(2, ℤ)) : slash_action ℤ Γ (ℍ → ℂ) ℂ :=
 monoid_hom_slash_action (monoid_hom.comp (matrix.special_linear_group.to_GL_pos)

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -6,7 +6,6 @@ Authors: Chris Birkbeck
 import analysis.complex.upper_half_plane.basic
 import linear_algebra.general_linear_group
 import linear_algebra.special_linear_group
-
 /-!
 # Slash actions
 
@@ -26,9 +25,9 @@ local notation `GL(` n `, ` R `)`⁺ := matrix.GL_pos (fin n) R
 local notation `SL(` n `, ` R `)` := matrix.special_linear_group (fin n) R
 
 /--A general version of the slash action of the space of modular forms.-/
-class slash_action (β : Type*) (G : Type*) (α : Type*) (γ : Type*) [group G] [ring α]
-  [has_smul γ α] :=
-(map : β → G → α → α)
+class slash_action (β G α γ : Type*) [group G] [has_zero α ]
+[has_one α ] [has_smul γ α ] [has_add α ] :=
+(map : β → G → α → α )
 (mul_zero : ∀ (k : β) (g : G), map k g 0 = 0)
 (one_mul : ∀ (k : β) (a : α) , map k 1 a = a)
 (right_action : ∀ (k : β) (g h : G) (a : α), map k h (map k g a) = map k (g * h) a )
@@ -36,28 +35,28 @@ class slash_action (β : Type*) (G : Type*) (α : Type*) (γ : Type*) [group G] 
 (add_action : ∀ (k : β) (g : G) (a b : α), map k g (a + b) = map k g a + map k g b)
 
 /--Slash_action induced by a monoid homomorphism.-/
-def monoid_hom_slash_action { β : Type*} {G : Type*} {H : Type*} {α : Type*} {γ : Type*}
-  [group G] [ring α] [has_smul γ α] [group H] [slash_action β G α γ] (h : H →* G) :
-  slash_action β H α γ:=
-{ map := (λ k g a, slash_action.map γ k (h(g)) a),
+def monoid_hom_slash_action {β G H α γ : Type*} [group G] [has_zero α]
+  [has_one α] [has_smul γ α ] [has_add α ] [group H] [slash_action β G α γ]
+  (h : H →* G) : slash_action β H α γ :=
+{ map := λ k g , slash_action.map γ k (h g) ,
   mul_zero := by {intros k g, apply slash_action.mul_zero k (h g), },
   one_mul := by {intros k a, simp only [map_one], apply slash_action.one_mul,},
   right_action := by {simp only [map_mul], intros k g gg a, apply slash_action.right_action,},
   smul_action := by {intros k g a z, apply slash_action.smul_action, },
-  add_action := by {intros k g a b, apply slash_action.add_action, }, }
+  add_action := by {intros k g a b, apply slash_action.add_action}}
 
-namespace modular_forms
+namespace modular_form
 
 noncomputable theory
 
 /--The weight `k` action of `GL(2, ℝ)⁺` on functions `f : ℍ → ℂ`. -/
-def slash : ℤ → GL(2, ℝ)⁺ → (ℍ → ℂ) → (ℍ → ℂ) := λ k γ f,
-  (λ (x : ℍ), f (γ • x) * (((↑ₘ γ).det) : ℝ)^(k-1) * (upper_half_plane.denom γ x)^(-k))
+def slash (k : ℤ) (γ : GL(2, ℝ)⁺) (f : ℍ → ℂ) (x : ℍ) : ℂ :=
+f (γ • x) * (((↑ₘ γ).det) : ℝ)^(k-1) * (upper_half_plane.denom γ x)^(-k)
 
-variables {Γ : subgroup SL(2,ℤ)} {k: ℤ} (f : (ℍ → ℂ))
+variables {Γ : subgroup SL(2, ℤ)} {k: ℤ} (f : ℍ → ℂ)
 
-localized "notation (name := modular_forms.slash) f ` ∣[`:100 k `]`:0 γ :100 :=
-  modular_forms.slash k γ f" in modular_forms
+localized "notation (name := modular_form.slash) f ` ∣[`:100 k `]`:0 γ :100 :=
+  modular_form.slash k γ f" in modular_form
 
 lemma slash_right_action (k : ℤ) (A B : GL(2, ℝ)⁺) (f : ℍ → ℂ) :
   (f ∣[k] A) ∣[k] B = f ∣[k] (A * B) :=
@@ -81,18 +80,15 @@ end
 lemma slash_add (k : ℤ) (A : GL(2, ℝ)⁺) (f g : ℍ → ℂ) :
   (f + g) ∣[k] A = (f ∣[k] A) + (g ∣[k] A) :=
 begin
-  simp only [slash, pi.add_apply, matrix.general_linear_group.coe_det_apply, subtype.val_eq_coe,
-    coe_coe],
   ext1,
-  simp only [pi.add_apply],
+  simp only [slash, pi.add_apply, denom, coe_coe, zpow_neg],
   ring,
 end
 
-lemma slash_mul_one (k : ℤ) (f : ℍ → ℂ) : (f ∣[k] 1) = f :=
+lemma slash_one (k : ℤ) (f : ℍ → ℂ) : (f ∣[k] 1) = f :=
 begin
- simp_rw slash,
  ext1,
- simp,
+ simp [slash],
 end
 
 lemma smul_slash (k : ℤ) (A : GL(2, ℝ)⁺) (f : ℍ → ℂ) (c : ℂ) : (c • f) ∣[k] A = c • (f ∣[k] A) :=
@@ -104,20 +100,92 @@ begin
   ring,
 end
 
+lemma neg_slash (k : ℤ) (A : GL(2, ℝ)⁺) (f : ℍ → ℂ) : (-f) ∣[k] A = - (f ∣[k] A) :=
+begin
+  ext1,
+  simp [slash],
+end
+
 instance : slash_action ℤ GL(2, ℝ)⁺ (ℍ → ℂ) ℂ :=
 { map := slash,
-  mul_zero := by {intros k g, rw slash, simp only [pi.zero_apply, zero_mul], refl, },
-  one_mul := by {apply slash_mul_one,},
+  mul_zero := by {intros k g, funext, simp only [slash, pi.zero_apply, zero_mul], },
+  one_mul := by {apply slash_one,},
   right_action := by {apply slash_right_action},
   smul_action := by {apply smul_slash},
-  add_action := by {apply slash_add},}
+  add_action := by {apply slash_add}}
 
-instance subgroup_action (Γ : subgroup SL(2,ℤ)) : slash_action ℤ Γ (ℍ → ℂ) ℂ :=
+instance subgroup_action (Γ : subgroup SL(2, ℤ)) : slash_action ℤ Γ (ℍ → ℂ) ℂ :=
 monoid_hom_slash_action (monoid_hom.comp (matrix.special_linear_group.to_GL_pos)
   (monoid_hom.comp (matrix.special_linear_group.map (int.cast_ring_hom ℝ)) (subgroup.subtype Γ)))
 
-instance SL_action : slash_action ℤ SL(2,ℤ) (ℍ → ℂ) ℂ :=
+@[simp] lemma subgroup_slash (Γ : subgroup SL(2, ℤ)) (γ : Γ):
+  (slash_action.map ℂ k γ f) = slash k (γ : GL(2,ℝ)⁺) f := rfl
+
+instance SL_action : slash_action ℤ SL(2, ℤ) (ℍ → ℂ) ℂ :=
 monoid_hom_slash_action (monoid_hom.comp (matrix.special_linear_group.to_GL_pos)
   (matrix.special_linear_group.map (int.cast_ring_hom ℝ)))
 
-end modular_forms
+@[simp] lemma SL_slash (γ : SL(2, ℤ)):
+  (slash_action.map ℂ k γ f) = slash k (γ : GL(2,ℝ)⁺) f := rfl
+
+local notation f `∣[`:73 k:0, A `]` :72 := slash_action.map ℂ k A f
+
+/-- The constant function 1 is invariant under any subgroup of `SL(2, ℤ)`. -/
+lemma is_invariant_one (A : SL(2, ℤ)) : (1 : ℍ → ℂ) ∣[(0 : ℤ), A] = (1 : ℍ → ℂ) :=
+begin
+  rw [SL_slash],
+  have : (((↑ₘ(A : GL(2,ℝ)⁺)).det) : ℝ) = 1,
+  { simp only [coe_coe,
+      matrix.special_linear_group.coe_GL_pos_coe_GL_coe_matrix,
+      matrix.special_linear_group.det_coe], },
+  funext,
+  rw [slash, zero_sub, this],
+  simp,
+end
+
+/-- A function `f : ℍ → ℂ` is weakly modular, of weight `k ∈ ℤ` and level `Γ`, if for every matrix .
+ `γ ∈ Γ` we have `f(γ • z)= (c*z+d)^k f(z)` where `γ= ![![a, b], ![c, d]]`, and it acts on `ℍ`
+  via Möbius transformations. -/
+lemma slash_action_eq'_iff (k : ℤ) (Γ : subgroup SL(2, ℤ)) (f : ℍ → ℂ) (γ : Γ) :
+  ∀ z : ℍ, f ∣[k, γ] z = f z ↔ f (γ • z) = ((↑ₘγ 1 0 : ℝ) * z +(↑ₘγ 1 1 : ℝ))^k * f z :=
+begin
+  intro z,
+  simp only [subgroup_slash, modular_form.slash],
+  convert inv_mul_eq_iff_eq_mul₀ _ using 2,
+  { rw mul_comm,
+    simp [-matrix.special_linear_group.coe_matrix_coe] },
+  { exact zpow_ne_zero _ (denom_ne_zero _ _) },
+end
+
+lemma mul_slash (k1 k2 : ℤ) (A : GL(2, ℝ)⁺) (f g : ℍ → ℂ) :
+  (f * g) ∣[k1 + k2, A] = (((↑ₘ A).det) : ℝ) • (f ∣[k1, A]) * (g ∣[k2, A]) :=
+begin
+  ext1,
+  simp only [slash_action.map, slash, matrix.general_linear_group.coe_det_apply, subtype.val_eq_coe,
+    pi.mul_apply, pi.smul_apply, algebra.smul_mul_assoc, real_smul],
+  set d : ℂ := ↑((↑ₘ A).det : ℝ),
+  have h1 : d ^ (k1 + k2 - 1) = d * d ^ (k1 - 1) * d ^ (k2 - 1),
+  { have : d ≠ 0,
+    { dsimp [d],
+      norm_cast,
+      exact matrix.GL_pos.det_ne_zero A },
+    rw [← zpow_one_add₀ this, ← zpow_add₀ this],
+    ring_exp },
+  have h22 : denom A x ^ (- (k1 + k2)) = denom A x ^ (- k1) * denom A x ^ (- k2),
+  { rw [int.neg_add, zpow_add₀],
+    exact upper_half_plane.denom_ne_zero A x, },
+  rw [h1, h22],
+  ring,
+end
+
+lemma mul_slash_SL2 (k1 k2 : ℤ) (A : SL(2, ℤ)) (f g : ℍ → ℂ) :
+  (f * g) ∣[k1 + k2, A] = (f ∣[k1, A]) * (g ∣[k2, A]) :=
+calc (f * g) ∣[k1 + k2, (A : GL(2, ℝ)⁺)] = _ • (f ∣[k1, A]) * (g ∣[k2, A]) : mul_slash _ _ _ _ _
+... = (1:ℝ) • (f ∣[k1, A]) * (g ∣[k2, A]) : by simp [-matrix.special_linear_group.coe_matrix_coe]
+... = (f ∣[k1, A]) * (g ∣[k2, A]) : by simp
+
+lemma mul_slash_subgroup (k1 k2 : ℤ) (Γ : subgroup SL(2, ℤ)) (A : Γ) (f g : ℍ → ℂ) :
+  (f * g) ∣[k1 + k2, A] = (f ∣[k1, A]) * (g ∣[k2, A]) :=
+mul_slash_SL2 k1 k2 A f g
+
+end modular_form

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -25,8 +25,8 @@ local notation `GL(` n `, ` R `)`⁺ := matrix.GL_pos (fin n) R
 local notation `SL(` n `, ` R `)` := matrix.special_linear_group (fin n) R
 
 /--A general version of the slash action of the space of modular forms.-/
-class slash_action (β G α γ : Type*) [group G] [has_zero α ]
-[has_one α] [has_smul γ α] [has_add α] :=
+class slash_action (β G α γ : Type*) [group G] [has_zero α]
+  [has_one α] [has_smul γ α] [has_add α] :=
 (map : β → G → α → α)
 (mul_zero : ∀ (k : β) (g : G), map k g 0 = 0)
 (one_mul : ∀ (k : β) (a : α) , map k 1 a = a)
@@ -40,8 +40,8 @@ def monoid_hom_slash_action {β G H α γ : Type*} [group G] [has_zero α]
   (h : H →* G) : slash_action β H α γ :=
 { map := λ k g , slash_action.map γ k (h g),
   mul_zero := λ k g, slash_action.mul_zero k (h g),
-  one_mul := by {intros k a, simp only [map_one], apply slash_action.one_mul},
-  right_action := by {simp only [map_mul], intros k g gg a, apply slash_action.right_action},
+  one_mul := λ k a, by simp only [map_one, slash_action.one_mul],
+  right_action := λ k g gg a, by simp only [map_mul, slash_action.right_action],
   smul_action := λ _ _, slash_action.smul_action _ _,
   add_action := λ _ g _ _, slash_action.add_action _ (h g) _ _,}
 
@@ -86,10 +86,7 @@ begin
 end
 
 lemma slash_one (k : ℤ) (f : ℍ → ℂ) : (f ∣[k] 1) = f :=
-begin
- ext1,
- simp [slash],
-end
+funext $ by simp [slash]
 
 lemma smul_slash (k : ℤ) (A : GL(2, ℝ)⁺) (f : ℍ → ℂ) (c : ℂ) : (c • f) ∣[k] A = c • (f ∣[k] A) :=
 begin
@@ -105,7 +102,7 @@ funext $ by simp [slash]
 
 instance : slash_action ℤ GL(2, ℝ)⁺ (ℍ → ℂ) ℂ :=
 { map := slash,
-  mul_zero := by {intros k g, funext, simp only [slash, pi.zero_apply, zero_mul]},
+  mul_zero := λ k g, funext $ λ _, by simp only [slash, pi.zero_apply, zero_mul],
   one_mul := slash_one,
   right_action := slash_right_action,
   smul_action := smul_slash,

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -25,18 +25,18 @@ local notation `GL(` n `, ` R `)`⁺ := matrix.GL_pos (fin n) R
 local notation `SL(` n `, ` R `)` := matrix.special_linear_group (fin n) R
 
 /--A general version of the slash action of the space of modular forms.-/
-class slash_action (β G α γ : Type*) [group G] [has_zero α]
-[has_one α] [has_smul γ α] [has_add α] :=
-(map : β → G → α → α)
+class slash_action (β G α γ : Type*) [group G] [has_zero α ]
+[has_one α ] [has_smul γ α ] [has_add α ] :=
+(map : β → G → α → α )
 (mul_zero : ∀ (k : β) (g : G), map k g 0 = 0)
 (one_mul : ∀ (k : β) (a : α) , map k 1 a = a)
-(right_action : ∀ (k : β) (g h : G) (a : α), map k h (map k g a) = map k (g * h) a)
+(right_action : ∀ (k : β) (g h : G) (a : α), map k h (map k g a) = map k (g * h) a )
 (smul_action : ∀ (k : β) (g : G) (a : α) (z : γ), map k g (z • a) = z • (map k g a))
 (add_action : ∀ (k : β) (g : G) (a b : α), map k g (a + b) = map k g a + map k g b)
 
 /--Slash_action induced by a monoid homomorphism.-/
 def monoid_hom_slash_action {β G H α γ : Type*} [group G] [has_zero α]
-  [has_one α] [has_smul γ α] [has_add α] [group H] [slash_action β G α γ]
+  [has_one α] [has_smul γ α ] [has_add α ] [group H] [slash_action β G α γ]
   (h : H →* G) : slash_action β H α γ :=
 { map := λ k g , slash_action.map γ k (h g) ,
   mul_zero := by {intros k g, apply slash_action.mul_zero k (h g), },
@@ -146,15 +146,17 @@ end
 /-- A function `f : ℍ → ℂ` is weakly modular, of weight `k ∈ ℤ` and level `Γ`, if for every matrix .
  `γ ∈ Γ` we have `f(γ • z)= (c*z+d)^k f(z)` where `γ= ![![a, b], ![c, d]]`, and it acts on `ℍ`
   via Möbius transformations. -/
-lemma slash_action_eq'_iff (k : ℤ) (Γ : subgroup SL(2, ℤ)) (f : ℍ → ℂ) (γ : Γ) :
-  ∀ z : ℍ, f ∣[k, γ] z = f z ↔ f (γ • z) = ((↑ₘγ 1 0 : ℝ) * z +(↑ₘγ 1 1 : ℝ))^k * f z :=
+lemma slash_action_eq'_iff (k : ℤ) (Γ : subgroup SL(2, ℤ)) (f : ℍ → ℂ) (γ : Γ)  (z : ℍ) :
+  f ∣[k, γ] z = f z ↔ f (γ • z) = ((↑ₘγ 1 0 : ℂ) * z +(↑ₘγ 1 1 : ℂ))^k * f z :=
 begin
-  intro z,
   simp only [subgroup_slash, modular_form.slash],
   convert inv_mul_eq_iff_eq_mul₀ _ using 2,
   { rw mul_comm,
-    simp [-matrix.special_linear_group.coe_matrix_coe] },
-  { exact zpow_ne_zero _ (denom_ne_zero _ _) },
+    simp only [denom, coe_coe, matrix.special_linear_group.coe_GL_pos_coe_GL_coe_matrix, zpow_neg,
+      matrix.special_linear_group.det_coe, of_real_one, one_zpow, mul_one, subgroup_to_sl_moeb,
+      sl_moeb],
+  refl,},
+  {convert zpow_ne_zero k (denom_ne_zero γ z)},
 end
 
 lemma mul_slash (k1 k2 : ℤ) (A : GL(2, ℝ)⁺) (f g : ℍ → ℂ) :

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -38,7 +38,7 @@ class slash_action (β G α γ : Type*) [group G] [has_zero α]
 def monoid_hom_slash_action {β G H α γ : Type*} [group G] [has_zero α]
   [has_one α] [has_smul γ α] [has_add α] [group H] [slash_action β G α γ]
   (h : H →* G) : slash_action β H α γ :=
-{ map := λ k g , slash_action.map γ k (h g),
+{ map := λ k g, slash_action.map γ k (h g),
   mul_zero := λ k g, slash_action.mul_zero k (h g),
   one_mul := λ k a, by simp only [map_one, slash_action.one_mul],
   right_action := λ k g gg a, by simp only [map_mul, slash_action.right_action],
@@ -136,9 +136,9 @@ begin
   simp,
 end
 
-/-- A function `f : ℍ → ℂ` is weakly modular, of weight `k ∈ ℤ` and level `Γ`, if for every matrix .
- `γ ∈ Γ` we have `f(γ • z)= (c*z+d)^k f(z)` where `γ= ![![a, b], ![c, d]]`, and it acts on `ℍ`
-  via Möbius transformations. -/
+/-- A function `f : ℍ → ℂ` is `slash_invariant`, of weight `k ∈ ℤ` and level `Γ`,
+  if for every matrix `γ ∈ Γ` we have `f(γ • z)= (c*z+d)^k f(z)` where `γ= ![![a, b], ![c, d]]`,
+  and it acts on `ℍ` via Möbius transformations. -/
 lemma slash_action_eq'_iff (k : ℤ) (Γ : subgroup SL(2, ℤ)) (f : ℍ → ℂ) (γ : Γ)  (z : ℍ) :
   f ∣[k, γ] z = f z ↔ f (γ • z) = ((↑ₘγ 1 0 : ℂ) * z +(↑ₘγ 1 1 : ℂ))^k * f z :=
 begin

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -101,10 +101,7 @@ begin
 end
 
 lemma neg_slash (k : ℤ) (A : GL(2, ℝ)⁺) (f : ℍ → ℂ) : (-f) ∣[k] A = - (f ∣[k] A) :=
-begin
-  ext1,
-  simp [slash],
-end
+funext $ by simp [slash]
 
 instance : slash_action ℤ GL(2, ℝ)⁺ (ℍ → ℂ) ℂ :=
 { map := slash,
@@ -133,13 +130,12 @@ local notation f `∣[`:73 k:0, A `]` :72 := slash_action.map ℂ k A f
 /-- The constant function 1 is invariant under any subgroup of `SL(2, ℤ)`. -/
 lemma is_invariant_one (A : SL(2, ℤ)) : (1 : ℍ → ℂ) ∣[(0 : ℤ), A] = (1 : ℍ → ℂ) :=
 begin
-  rw [SL_slash],
   have : (((↑ₘ(A : GL(2,ℝ)⁺)).det) : ℝ) = 1,
   { simp only [coe_coe,
       matrix.special_linear_group.coe_GL_pos_coe_GL_coe_matrix,
       matrix.special_linear_group.det_coe], },
   funext,
-  rw [slash, zero_sub, this],
+  rw [SL_slash, slash, zero_sub, this],
   simp,
 end
 

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -151,8 +151,8 @@ begin
     simp only [denom, coe_coe, matrix.special_linear_group.coe_GL_pos_coe_GL_coe_matrix, zpow_neg,
       matrix.special_linear_group.det_coe, of_real_one, one_zpow, mul_one, subgroup_to_sl_moeb,
       sl_moeb],
-  refl,},
-  {convert zpow_ne_zero k (denom_ne_zero γ z)},
+    refl, },
+  { convert zpow_ne_zero k (denom_ne_zero γ z) },
 end
 
 lemma mul_slash (k1 k2 : ℤ) (A : GL(2, ℝ)⁺) (f g : ℍ → ℂ) :

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -25,18 +25,18 @@ local notation `GL(` n `, ` R `)`⁺ := matrix.GL_pos (fin n) R
 local notation `SL(` n `, ` R `)` := matrix.special_linear_group (fin n) R
 
 /--A general version of the slash action of the space of modular forms.-/
-class slash_action (β G α γ : Type*) [group G] [has_zero α ]
-[has_one α ] [has_smul γ α ] [has_add α ] :=
-(map : β → G → α → α )
+class slash_action (β G α γ : Type*) [group G] [has_zero α]
+[has_one α] [has_smul γ α] [has_add α] :=
+(map : β → G → α → α)
 (mul_zero : ∀ (k : β) (g : G), map k g 0 = 0)
 (one_mul : ∀ (k : β) (a : α) , map k 1 a = a)
-(right_action : ∀ (k : β) (g h : G) (a : α), map k h (map k g a) = map k (g * h) a )
+(right_action : ∀ (k : β) (g h : G) (a : α), map k h (map k g a) = map k (g * h) a)
 (smul_action : ∀ (k : β) (g : G) (a : α) (z : γ), map k g (z • a) = z • (map k g a))
 (add_action : ∀ (k : β) (g : G) (a b : α), map k g (a + b) = map k g a + map k g b)
 
 /--Slash_action induced by a monoid homomorphism.-/
 def monoid_hom_slash_action {β G H α γ : Type*} [group G] [has_zero α]
-  [has_one α] [has_smul γ α ] [has_add α ] [group H] [slash_action β G α γ]
+  [has_one α] [has_smul γ α] [has_add α] [group H] [slash_action β G α γ]
   (h : H →* G) : slash_action β H α γ :=
 { map := λ k g , slash_action.map γ k (h g) ,
   mul_zero := by {intros k g, apply slash_action.mul_zero k (h g), },

--- a/src/number_theory/modular_forms/slash_invariant_forms.lean
+++ b/src/number_theory/modular_forms/slash_invariant_forms.lean
@@ -45,7 +45,7 @@ structure slash_invariant_form :=
 /--`slash_invariant_form_class F Γ k` asserts `F` is a type of bundled functions that are invariant
 under the `slash_action`. -/
 class slash_invariant_form_class extends fun_like F ℍ (λ _, ℂ) :=
-(slash_action_eq : ∀ (f : F) (γ : Γ),  (f : ℍ → ℂ) ∣[k, γ] = f)
+(slash_action_eq : ∀ (f : F) (γ : Γ), (f : ℍ → ℂ) ∣[k, γ] = f)
 
 attribute [nolint dangerous_instance] slash_invariant_form_class.to_fun_like
 
@@ -88,10 +88,9 @@ instance slash_invariant_form_class.coe_to_fun [slash_invariant_form_class F Γ 
 @[simp] lemma slash_action_eqn [slash_invariant_form_class F Γ k] (f : F) (γ : Γ) :
    slash_action.map ℂ k γ ⇑f = ⇑f := slash_invariant_form_class.slash_action_eq f γ
 
-lemma slash_action_eqn' (k : ℤ) (Γ : subgroup SL(2, ℤ)) [slash_invariant_form_class F Γ k] (f : F) :
-∀ γ : Γ, ∀ z : ℍ, f (γ • z) = ((↑ₘγ 1 0 : ℝ) * z +(↑ₘγ 1 1 : ℝ))^k * f z :=
+lemma slash_action_eqn' (k : ℤ) (Γ : subgroup SL(2, ℤ)) [slash_invariant_form_class F Γ k] (f : F)
+  (γ : Γ) (z : ℍ) : f (γ • z) = ((↑ₘγ 1 0 : ℂ) * z +(↑ₘγ 1 1 : ℂ))^k * f z :=
 begin
-  intros γ z,
   rw ←modular_form.slash_action_eq'_iff,
   simp,
 end
@@ -100,11 +99,15 @@ instance [slash_invariant_form_class F Γ k] : has_coe_t F (slash_invariant_form
 ⟨λ f, { to_fun := f, slash_action_eq' := slash_action_eqn f }⟩
 
 @[simp] lemma slash_invariant_form_class.coe_coe [slash_invariant_form_class F Γ k] (f : F) :
-  ((f : (slash_invariant_form Γ k)) : ℍ → ℂ) = f := rfl
+  ((f : slash_invariant_form Γ k) : ℍ → ℂ) = f := rfl
 
 instance has_add : has_add (slash_invariant_form Γ k) :=
-⟨λ f g , ⟨ f + g, by {intro γ, convert slash_action.add_action k γ (f : ℍ → ℂ) g,
-   exact ((f.slash_action_eq') γ).symm, exact ((g.slash_action_eq') γ).symm} ⟩⟩
+⟨λ f g, ⟨ f + g, begin
+  intro γ,
+  convert slash_action.add_action k γ (f : ℍ → ℂ) g,
+  exact (f.slash_action_eq' γ).symm,
+  exact (g.slash_action_eq' γ).symm
+  end⟩⟩
 
 @[simp] lemma coe_add (f g : slash_invariant_form Γ k) : ⇑(f + g) = f + g := rfl
 @[simp] lemma add_apply (f g : slash_invariant_form Γ k) (z : ℍ) : (f + g) z = f z + g z := rfl
@@ -128,11 +131,12 @@ end
 
 instance has_nsmul : has_smul ℕ (slash_invariant_form Γ k) :=
 ⟨ λ c f, {to_fun := c • f,
-    slash_action_eq' := by {intro γ,
+    slash_action_eq' := begin
+      intro γ,
       rw nsmul_coe,
       convert slash_action.smul_action k γ ⇑f (c : ℂ),
-      exact ((f.slash_action_eq') γ).symm},}⟩
-
+      exact (f.slash_action_eq' γ).symm,
+    end}⟩
 @[simp] lemma coe_nsmul (f : slash_invariant_form Γ k) (n : ℕ) : ⇑(n • f) = n • f := rfl
 
 @[simp] lemma nsmul_apply (f : slash_invariant_form Γ k) (n : ℕ) (z : ℍ) :
@@ -140,10 +144,12 @@ instance has_nsmul : has_smul ℕ (slash_invariant_form Γ k) :=
 
 instance has_zsmul : has_smul ℤ (slash_invariant_form Γ k) :=
 ⟨ λ c f, {to_fun := c • f,
-    slash_action_eq' := by {intro γ,
+    slash_action_eq' := begin
+      intro γ,
       rw zsmul_coe,
       convert slash_action.smul_action k γ ⇑f (c : ℂ),
-      exact ((f.slash_action_eq') γ).symm},}⟩
+      exact (f.slash_action_eq' γ).symm
+    end}⟩
 
 @[simp] lemma coe_zsmul (f : slash_invariant_form Γ k) (n : ℤ) : ⇑(n • f) = n • f := rfl
 
@@ -153,18 +159,17 @@ instance has_zsmul : has_smul ℤ (slash_invariant_form Γ k) :=
 instance has_csmul : has_smul ℂ (slash_invariant_form Γ k) :=
 ⟨ λ c f, {to_fun := c • f,
     slash_action_eq' := by {intro γ, convert slash_action.smul_action k γ ⇑f c,
-    exact ((f.slash_action_eq') γ).symm}}⟩
+    exact (f.slash_action_eq' γ).symm}}⟩
 
 @[simp] lemma coe_csmul (f : slash_invariant_form Γ k) (n : ℂ) : ⇑(n • f) = n • f := rfl
 @[simp] lemma csmul_apply (f : slash_invariant_form Γ k) (n : ℂ) (z : ℍ) :
   (n • f) z = n • (f z) := rfl
 
 instance has_neg : has_neg (slash_invariant_form Γ k) :=
-⟨λ f, ⟨ -f,
-  begin intro g,
+⟨λ f, ⟨ -f, begin
+  intro g,
   have := ((f.slash_action_eq') g),
-  rw modular_form.subgroup_slash at *,
-  rw modular_form.neg_slash,
+  rw [modular_form.subgroup_slash, modular_form.neg_slash] at *,
   simp only [neg_inj],
   convert this
   end⟩ ⟩
@@ -174,13 +179,14 @@ instance has_neg : has_neg (slash_invariant_form Γ k) :=
 
 instance has_sub : has_sub (slash_invariant_form Γ k) :=
 ⟨λ f g, ⟨f - g, by { intro γ,
-  have : (f : ℍ → ℂ) - g = f + (-g), by {funext, simp, ring,},
+  have : (f : ℍ → ℂ) - g = f + (-g), by {funext, simp only [pi.sub_apply, pi.add_apply,
+    pi.neg_apply], ring,},
   rw [this, slash_action.add_action k γ],
   simp only [modular_form.subgroup_slash, add_right_inj, slash_invariant_form.slash_action_eqn,
     coe_coe],
   rw modular_form.neg_slash,
   simp only [neg_inj],
-  convert ((g.slash_action_eq') γ)} ⟩⟩
+  convert (g.slash_action_eq' γ)} ⟩⟩
 
 @[simp] lemma coe_sub (f g : slash_invariant_form Γ k) : ⇑(f - g) = f - g := rfl
 @[simp] lemma sub_apply (f g : slash_invariant_form Γ k) (z : ℍ) : (f - g) z = f z - g z := rfl
@@ -201,8 +207,8 @@ instance : module ℂ (slash_invariant_form Γ k) :=
 coe_hom_injective.module ℂ (coe_hom) (λ _ _, rfl)
 
 instance : has_one (slash_invariant_form Γ 0) :=
-{one := {to_fun := 1, slash_action_eq' := by {intro A,
-  convert modular_form.is_invariant_one A}}}
+{one := { to_fun := 1,
+  slash_action_eq' := by {intro A, convert modular_form.is_invariant_one A}}}
 
 instance : inhabited (slash_invariant_form Γ k) := ⟨0⟩
 

--- a/src/number_theory/modular_forms/slash_invariant_forms.lean
+++ b/src/number_theory/modular_forms/slash_invariant_forms.lean
@@ -129,32 +129,7 @@ begin
  congr,
 end
 
-instance has_nsmul : has_smul ℕ (slash_invariant_form Γ k) :=
-⟨ λ c f, {to_fun := c • f,
-    slash_action_eq' := begin
-      intro γ,
-      rw nsmul_coe,
-      convert slash_action.smul_action k γ ⇑f (c : ℂ),
-      exact (f.slash_action_eq' γ).symm,
-    end}⟩
-@[simp] lemma coe_nsmul (f : slash_invariant_form Γ k) (n : ℕ) : ⇑(n • f) = n • f := rfl
 
-@[simp] lemma nsmul_apply (f : slash_invariant_form Γ k) (n : ℕ) (z : ℍ) :
-   (n • f) z = n • (f z) := rfl
-
-instance has_zsmul : has_smul ℤ (slash_invariant_form Γ k) :=
-⟨ λ c f, {to_fun := c • f,
-    slash_action_eq' := begin
-      intro γ,
-      rw zsmul_coe,
-      convert slash_action.smul_action k γ ⇑f (c : ℂ),
-      exact (f.slash_action_eq' γ).symm
-    end}⟩
-
-@[simp] lemma coe_zsmul (f : slash_invariant_form Γ k) (n : ℤ) : ⇑(n • f) = n • f := rfl
-
-@[simp] lemma zsmul_apply (f : slash_invariant_form Γ k) (n : ℤ) (z : ℍ) :
-   (n • f) z = n • (f z) := rfl
 
 instance has_csmul : has_smul ℂ (slash_invariant_form Γ k) :=
 ⟨ λ c f, {to_fun := c • f,
@@ -164,6 +139,20 @@ instance has_csmul : has_smul ℂ (slash_invariant_form Γ k) :=
 @[simp] lemma coe_csmul (f : slash_invariant_form Γ k) (n : ℂ) : ⇑(n • f) = n • f := rfl
 @[simp] lemma csmul_apply (f : slash_invariant_form Γ k) (n : ℂ) (z : ℍ) :
   (n • f) z = n • (f z) := rfl
+
+instance has_nsmul : has_smul ℕ (slash_invariant_form Γ k) :=
+⟨ λ c f, ((c : ℂ) • f).copy (c • f) (nsmul_eq_smul_cast _ _ _)⟩
+
+@[simp] lemma coe_nsmul (f : slash_invariant_form Γ k) (n : ℕ) : ⇑(n • f) = n • f := rfl
+@[simp] lemma nsmul_apply (f : slash_invariant_form Γ k) (n : ℕ) (z : ℍ) :
+   (n • f) z = n • (f z) := rfl
+
+instance has_zsmul : has_smul ℤ (slash_invariant_form Γ k) :=
+⟨ λ c f, ((c : ℂ) • f).copy (c • f) (zsmul_eq_smul_cast _ _ _)⟩
+
+@[simp] lemma coe_zsmul (f : slash_invariant_form Γ k) (n : ℤ) : ⇑(n • f) = n • f := rfl
+@[simp] lemma zsmul_apply (f : slash_invariant_form Γ k) (n : ℤ) (z : ℍ) :
+   (n • f) z = n • (f z) := rfl
 
 instance has_neg : has_neg (slash_invariant_form Γ k) :=
 ⟨λ f, ⟨ -f, begin
@@ -177,16 +166,7 @@ instance has_neg : has_neg (slash_invariant_form Γ k) :=
 @[simp] lemma coe_neg (f : slash_invariant_form Γ k) : ⇑(-f) = -f := rfl
 @[simp] lemma neg_apply (f : slash_invariant_form Γ k) (z : ℍ) : (-f) z = - (f z) := rfl
 
-instance has_sub : has_sub (slash_invariant_form Γ k) :=
-⟨λ f g, ⟨f - g, by { intro γ,
-  have : (f : ℍ → ℂ) - g = f + (-g), by {funext, simp only [pi.sub_apply, pi.add_apply,
-    pi.neg_apply], ring,},
-  rw [this, slash_action.add_action k γ],
-  simp only [modular_form.subgroup_slash, add_right_inj, slash_invariant_form.slash_action_eqn,
-    coe_coe],
-  rw modular_form.neg_slash,
-  simp only [neg_inj],
-  convert (g.slash_action_eq' γ)} ⟩⟩
+instance has_sub : has_sub (slash_invariant_form Γ k) := ⟨ λ f g, f + -g ⟩
 
 @[simp] lemma coe_sub (f g : slash_invariant_form Γ k) : ⇑(f - g) = f - g := rfl
 @[simp] lemma sub_apply (f g : slash_invariant_form Γ k) (z : ℍ) : (f - g) z = f z - g z := rfl
@@ -196,7 +176,7 @@ fun_like.coe_injective.add_comm_group _ rfl (coe_add) (coe_neg) (coe_sub) (coe_n
 
 lemma coe_zero : ⇑(0 : slash_invariant_form Γ k) = (0 : ℍ → ℂ) := rfl
 
-/--Additive coercieon from `slash_invariant_form` to `ℍ → ℂ`.-/
+/--Additive coercion from `slash_invariant_form` to `ℍ → ℂ`.-/
 def coe_hom : (slash_invariant_form Γ k) →+ (ℍ → ℂ) :=
 { to_fun := λ f, f, map_zero' := slash_invariant_form.coe_zero, map_add' := λ _ _, rfl }
 

--- a/src/number_theory/modular_forms/slash_invariant_forms.lean
+++ b/src/number_theory/modular_forms/slash_invariant_forms.lean
@@ -10,7 +10,7 @@ import number_theory.modular_forms.slash_actions
 /-!
 # Slash invariant forms
 
-This file defines funtions that are invariant under a `slash_action` which forms the basis for
+This file defines functions that are invariant under a `slash_action` which forms the basis for
 defining `modular_form` and `cusp_form`. We prove several instances for such spaces, in particular
 that they form a module.
 -/

--- a/src/number_theory/modular_forms/slash_invariant_forms.lean
+++ b/src/number_theory/modular_forms/slash_invariant_forms.lean
@@ -3,9 +3,7 @@ Copyright (c) 2022 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
-import analysis.complex.upper_half_plane.basic
 import number_theory.modular_forms.slash_actions
-
 
 /-!
 # Slash invariant forms
@@ -63,7 +61,7 @@ instance : has_coe_to_fun (slash_invariant_form Γ k) (λ _, ℍ → ℂ) := fun
 @[simp] lemma slash_invariant_form_to_fun_eq_coe {f : slash_invariant_form Γ k} :
   f.to_fun = (f : ℍ → ℂ) := rfl
 
-@[ext] theorem slash_invaraint_form_ext {f g : slash_invariant_form Γ k} (h : ∀ x, f x = g x) :
+@[ext] theorem slash_invariant_form_ext {f g : slash_invariant_form Γ k} (h : ∀ x, f x = g x) :
   f = g := fun_like.ext f g h
 
 /-- Copy of a `slash_invariant_form` with a new `to_fun` equal to the old one.
@@ -113,6 +111,8 @@ instance has_zero : has_zero (slash_invariant_form Γ k) :=
 ⟨ { to_fun := 0,
     slash_action_eq' := slash_action.mul_zero _} ⟩
 
+@[simp] lemma coe_zero : ⇑(0 : slash_invariant_form Γ k) = (0 : ℍ → ℂ) := rfl
+
 lemma nsmul_coe [slash_invariant_form_class F Γ k] (f : F) (c : ℕ) :
   c • (f : ℍ → ℂ) = (c : ℂ) • f :=
 begin
@@ -140,13 +140,13 @@ instance has_nsmul : has_smul ℕ (slash_invariant_form Γ k) :=
 ⟨ λ c f, ((c : ℂ) • f).copy (c • f) (nsmul_eq_smul_cast _ _ _)⟩
 
 @[simp] lemma nsmul_apply (f : slash_invariant_form Γ k) (n : ℕ) (z : ℍ) :
-   (n • f) z = n • (f z) := rfl
+  (n • f) z = n • (f z) := rfl
 
 instance has_zsmul : has_smul ℤ (slash_invariant_form Γ k) :=
 ⟨ λ c f, ((c : ℂ) • f).copy (c • f) (zsmul_eq_smul_cast _ _ _)⟩
 
 @[simp] lemma zsmul_apply (f : slash_invariant_form Γ k) (n : ℤ) (z : ℍ) :
-   (n • f) z = n • (f z) := rfl
+  (n • f) z = n • (f z) := rfl
 
 instance has_neg : has_neg (slash_invariant_form Γ k) :=
 ⟨ λ f,
@@ -165,8 +165,6 @@ instance has_sub : has_sub (slash_invariant_form Γ k) := ⟨ λ f g, f + -g ⟩
 instance : add_comm_group (slash_invariant_form Γ k) :=
 fun_like.coe_injective.add_comm_group _ rfl coe_add coe_neg coe_sub
   (λ f n, nsmul_eq_smul_cast _ n f) (λ f n, zsmul_eq_smul_cast _ n f)
-
-lemma coe_zero : ⇑(0 : slash_invariant_form Γ k) = (0 : ℍ → ℂ) := rfl
 
 /--Additive coercion from `slash_invariant_form` to `ℍ → ℂ`.-/
 def coe_hom : slash_invariant_form Γ k →+ (ℍ → ℂ) :=

--- a/src/number_theory/modular_forms/slash_invariant_forms.lean
+++ b/src/number_theory/modular_forms/slash_invariant_forms.lean
@@ -113,20 +113,6 @@ instance has_zero : has_zero (slash_invariant_form Γ k) :=
 
 @[simp] lemma coe_zero : ⇑(0 : slash_invariant_form Γ k) = (0 : ℍ → ℂ) := rfl
 
-lemma nsmul_coe [slash_invariant_form_class F Γ k] (f : F) (c : ℕ) :
-  c • (f : ℍ → ℂ) = (c : ℂ) • f :=
-begin
- simp only [nsmul_eq_mul],
- congr,
-end
-
-lemma zsmul_coe [slash_invariant_form_class F Γ k] (f : F) (c : ℤ) :
-  c • (f : ℍ → ℂ) = (c : ℂ) • f :=
-begin
- simp only [zsmul_eq_mul],
- congr,
-end
-
 instance has_csmul : has_smul ℂ (slash_invariant_form Γ k) :=
 ⟨ λ c f, {to_fun := c • f,
     slash_action_eq' := by {intro γ, convert slash_action.smul_action k γ ⇑f c,
@@ -139,12 +125,14 @@ instance has_csmul : has_smul ℂ (slash_invariant_form Γ k) :=
 instance has_nsmul : has_smul ℕ (slash_invariant_form Γ k) :=
 ⟨ λ c f, ((c : ℂ) • f).copy (c • f) (nsmul_eq_smul_cast _ _ _)⟩
 
+@[simp] lemma coe_nsmul (f : slash_invariant_form Γ k) (n : ℕ) : ⇑(n • f) = n • f := rfl
 @[simp] lemma nsmul_apply (f : slash_invariant_form Γ k) (n : ℕ) (z : ℍ) :
   (n • f) z = n • (f z) := rfl
 
 instance has_zsmul : has_smul ℤ (slash_invariant_form Γ k) :=
 ⟨ λ c f, ((c : ℂ) • f).copy (c • f) (zsmul_eq_smul_cast _ _ _)⟩
 
+@[simp] lemma coe_zsmul (f : slash_invariant_form Γ k) (n : ℤ) : ⇑(n • f) = n • f := rfl
 @[simp] lemma zsmul_apply (f : slash_invariant_form Γ k) (n : ℤ) (z : ℍ) :
   (n • f) z = n • (f z) := rfl
 
@@ -163,8 +151,7 @@ instance has_sub : has_sub (slash_invariant_form Γ k) := ⟨ λ f g, f + -g ⟩
 @[simp] lemma sub_apply (f g : slash_invariant_form Γ k) (z : ℍ) : (f - g) z = f z - g z := rfl
 
 instance : add_comm_group (slash_invariant_form Γ k) :=
-fun_like.coe_injective.add_comm_group _ rfl coe_add coe_neg coe_sub
-  (λ f n, nsmul_eq_smul_cast _ n f) (λ f n, zsmul_eq_smul_cast _ n f)
+fun_like.coe_injective.add_comm_group _ rfl coe_add coe_neg coe_sub coe_nsmul coe_zsmul
 
 /--Additive coercion from `slash_invariant_form` to `ℍ → ℂ`.-/
 def coe_hom : slash_invariant_form Γ k →+ (ℍ → ℂ) :=

--- a/src/number_theory/modular_forms/slash_invariant_forms.lean
+++ b/src/number_theory/modular_forms/slash_invariant_forms.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2022 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+import analysis.complex.upper_half_plane.basic
+import number_theory.modular_forms.slash_actions
+
+
+/-!
+# Slash invariant forms
+
+This file defines funtions that are invariant under a `slash_action` which forms the basis for
+defining `modular_form` and `cusp_form`. We prove several instances for such spaces, in particular
+that they form a module.
+-/
+
+open complex upper_half_plane
+
+open_locale upper_half_plane
+
+noncomputable theory
+
+local prefix `↑ₘ`:1024 := @coe _ (matrix (fin 2) (fin 2) _) _
+
+local notation `GL(` n `, ` R `)`⁺ := matrix.GL_pos (fin n) R
+
+local notation `SL(` n `, ` R `)` := matrix.special_linear_group (fin n) R
+
+section slash_invariant_forms
+
+set_option old_structure_cmd true
+
+open modular_form
+
+variables (F : Type*) (Γ : out_param $ subgroup SL(2, ℤ)) (k : out_param ℤ)
+
+localized "notation f `∣[`:73 k:0, A `]` :72 := slash_action.map ℂ k A f" in slash_invariant_forms
+
+/--Functions `ℍ → ℂ` that are invariant under the `slash_action`. -/
+structure slash_invariant_form :=
+(to_fun : ℍ → ℂ)
+(slash_action_eq' : ∀ γ : Γ, to_fun ∣[k, γ] = to_fun)
+
+/--`slash_invariant_form_class F Γ k` asserts `F` is a type of bundled functions that are invariant
+under the `slash_action`. -/
+class slash_invariant_form_class extends fun_like F ℍ (λ _, ℂ) :=
+(slash_action_eq : ∀ (f : F) (γ : Γ),  (f : ℍ → ℂ) ∣[k, γ] = f)
+
+attribute [nolint dangerous_instance] slash_invariant_form_class.to_fun_like
+
+@[priority 100]
+instance slash_invariant_form_class.slash_invariant_form :
+   slash_invariant_form_class (slash_invariant_form Γ k) Γ k :=
+{ coe := (slash_invariant_form.to_fun),
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  slash_action_eq := slash_invariant_form.slash_action_eq' }
+
+variables {F Γ k}
+
+instance : has_coe_to_fun (slash_invariant_form Γ k) (λ _, ℍ → ℂ) := fun_like.has_coe_to_fun
+
+@[simp] lemma slash_invariant_form_to_fun_eq_coe {f : slash_invariant_form Γ k} :
+  f.to_fun = (f : ℍ → ℂ) := rfl
+
+@[ext] theorem slash_invaraint_form_ext {f g : slash_invariant_form Γ k} (h : ∀ x, f x = g x) :
+  f = g := fun_like.ext f g h
+
+/-- Copy of a `slash_invariant_form` with a new `to_fun` equal to the old one.
+Useful to fix definitional equalities. -/
+protected def slash_invariant_form.copy (f : slash_invariant_form Γ k) (f' : ℍ → ℂ) (h : f' = ⇑f) :
+  slash_invariant_form Γ k :=
+{ to_fun := f',
+  slash_action_eq' := h.symm ▸ f.slash_action_eq',}
+
+end slash_invariant_forms
+
+namespace slash_invariant_form
+
+open slash_invariant_form
+
+variables {F : Type*} {Γ : out_param $ subgroup SL(2, ℤ)} {k : out_param ℤ}
+
+@[priority 100, nolint dangerous_instance]
+instance slash_invariant_form_class.coe_to_fun [slash_invariant_form_class F Γ k] :
+  has_coe_to_fun F (λ _, ℍ → ℂ) := fun_like.has_coe_to_fun
+
+@[simp] lemma slash_action_eqn [slash_invariant_form_class F Γ k] (f : F) (γ : Γ) :
+   slash_action.map ℂ k γ ⇑f = ⇑f := slash_invariant_form_class.slash_action_eq f γ
+
+lemma slash_action_eqn' (k : ℤ) (Γ : subgroup SL(2, ℤ)) [slash_invariant_form_class F Γ k] (f : F) :
+∀ γ : Γ, ∀ z : ℍ, f (γ • z) = ((↑ₘγ 1 0 : ℝ) * z +(↑ₘγ 1 1 : ℝ))^k * f z :=
+begin
+  intros γ z,
+  rw ←modular_form.slash_action_eq'_iff,
+  simp,
+end
+
+instance [slash_invariant_form_class F Γ k] : has_coe_t F (slash_invariant_form Γ k) :=
+⟨λ f, { to_fun := f, slash_action_eq' := slash_action_eqn f }⟩
+
+@[simp] lemma slash_invariant_form_class.coe_coe [slash_invariant_form_class F Γ k] (f : F) :
+  ((f : (slash_invariant_form Γ k)) : ℍ → ℂ) = f := rfl
+
+instance has_add : has_add (slash_invariant_form Γ k) :=
+⟨λ f g , ⟨ f + g, by {intro γ, convert slash_action.add_action k γ (f : ℍ → ℂ) g,
+   exact ((f.slash_action_eq') γ).symm, exact ((g.slash_action_eq') γ).symm} ⟩⟩
+
+@[simp] lemma coe_add (f g : slash_invariant_form Γ k) : ⇑(f + g) = f + g := rfl
+@[simp] lemma add_apply (f g : slash_invariant_form Γ k) (z : ℍ) : (f + g) z = f z + g z := rfl
+
+instance has_zero : has_zero (slash_invariant_form Γ k) :=
+{zero := ⟨ 0 , slash_action.mul_zero _⟩}
+
+lemma nsmul_coe [slash_invariant_form_class F Γ k] (f : F) (c : ℕ) :
+  c • (f : ℍ → ℂ) = (c : ℂ) • f :=
+begin
+ simp only [nsmul_eq_mul],
+ congr,
+end
+
+lemma zsmul_coe [slash_invariant_form_class F Γ k] (f : F) (c : ℤ) :
+  c • (f : ℍ → ℂ) = (c : ℂ) • f :=
+begin
+ simp only [zsmul_eq_mul],
+ congr,
+end
+
+instance has_nsmul : has_smul ℕ (slash_invariant_form Γ k) :=
+⟨ λ c f, {to_fun := c • f,
+    slash_action_eq' := by {intro γ,
+      rw nsmul_coe,
+      convert slash_action.smul_action k γ ⇑f (c : ℂ),
+      exact ((f.slash_action_eq') γ).symm},}⟩
+
+@[simp] lemma coe_nsmul (f : slash_invariant_form Γ k) (n : ℕ) : ⇑(n • f) = n • f := rfl
+
+@[simp] lemma nsmul_apply (f : slash_invariant_form Γ k) (n : ℕ) (z : ℍ) :
+   (n • f) z = n • (f z) := rfl
+
+instance has_zsmul : has_smul ℤ (slash_invariant_form Γ k) :=
+⟨ λ c f, {to_fun := c • f,
+    slash_action_eq' := by {intro γ,
+      rw zsmul_coe,
+      convert slash_action.smul_action k γ ⇑f (c : ℂ),
+      exact ((f.slash_action_eq') γ).symm},}⟩
+
+@[simp] lemma coe_zsmul (f : slash_invariant_form Γ k) (n : ℤ) : ⇑(n • f) = n • f := rfl
+
+@[simp] lemma zsmul_apply (f : slash_invariant_form Γ k) (n : ℤ) (z : ℍ) :
+   (n • f) z = n • (f z) := rfl
+
+instance has_csmul : has_smul ℂ (slash_invariant_form Γ k) :=
+⟨ λ c f, {to_fun := c • f,
+    slash_action_eq' := by {intro γ, convert slash_action.smul_action k γ ⇑f c,
+    exact ((f.slash_action_eq') γ).symm}}⟩
+
+@[simp] lemma coe_csmul (f : slash_invariant_form Γ k) (n : ℂ) : ⇑(n • f) = n • f := rfl
+@[simp] lemma csmul_apply (f : slash_invariant_form Γ k) (n : ℂ) (z : ℍ) :
+  (n • f) z = n • (f z) := rfl
+
+instance has_neg : has_neg (slash_invariant_form Γ k) :=
+⟨λ f, ⟨ -f,
+  begin intro g,
+  have := ((f.slash_action_eq') g),
+  rw modular_form.subgroup_slash at *,
+  rw modular_form.neg_slash,
+  simp only [neg_inj],
+  convert this
+  end⟩ ⟩
+
+@[simp] lemma coe_neg (f : slash_invariant_form Γ k) : ⇑(-f) = -f := rfl
+@[simp] lemma neg_apply (f : slash_invariant_form Γ k) (z : ℍ) : (-f) z = - (f z) := rfl
+
+instance has_sub : has_sub (slash_invariant_form Γ k) :=
+⟨λ f g, ⟨f - g, by { intro γ,
+  have : (f : ℍ → ℂ) - g = f + (-g), by {funext, simp, ring,},
+  rw [this, slash_action.add_action k γ],
+  simp only [modular_form.subgroup_slash, add_right_inj, slash_invariant_form.slash_action_eqn,
+    coe_coe],
+  rw modular_form.neg_slash,
+  simp only [neg_inj],
+  convert ((g.slash_action_eq') γ)} ⟩⟩
+
+@[simp] lemma coe_sub (f g : slash_invariant_form Γ k) : ⇑(f - g) = f - g := rfl
+@[simp] lemma sub_apply (f g : slash_invariant_form Γ k) (z : ℍ) : (f - g) z = f z - g z := rfl
+
+instance : add_comm_group (slash_invariant_form Γ k) :=
+fun_like.coe_injective.add_comm_group _ rfl (coe_add) (coe_neg) (coe_sub) (coe_nsmul) (coe_zsmul)
+
+lemma coe_zero : ⇑(0 : slash_invariant_form Γ k) = (0 : ℍ → ℂ) := rfl
+
+/--Additive coercieon from `slash_invariant_form` to `ℍ → ℂ`.-/
+def coe_hom : (slash_invariant_form Γ k) →+ (ℍ → ℂ) :=
+{ to_fun := λ f, f, map_zero' := slash_invariant_form.coe_zero, map_add' := λ _ _, rfl }
+
+lemma coe_hom_injective : function.injective (@coe_hom Γ k) :=
+fun_like.coe_injective
+
+instance : module ℂ (slash_invariant_form Γ k) :=
+coe_hom_injective.module ℂ (coe_hom) (λ _ _, rfl)
+
+instance : has_one (slash_invariant_form Γ 0) :=
+{one := {to_fun := 1, slash_action_eq' := by {intro A,
+  convert modular_form.is_invariant_one A}}}
+
+instance : inhabited (slash_invariant_form Γ k) := ⟨0⟩
+
+end slash_invariant_form

--- a/src/number_theory/modular_forms/slash_invariant_forms.lean
+++ b/src/number_theory/modular_forms/slash_invariant_forms.lean
@@ -52,7 +52,7 @@ attribute [nolint dangerous_instance] slash_invariant_form_class.to_fun_like
 @[priority 100]
 instance slash_invariant_form_class.slash_invariant_form :
    slash_invariant_form_class (slash_invariant_form Γ k) Γ k :=
-{ coe := (slash_invariant_form.to_fun),
+{ coe := slash_invariant_form.to_fun,
   coe_injective' := λ f g h, by cases f; cases g; congr',
   slash_action_eq := slash_invariant_form.slash_action_eq' }
 
@@ -110,7 +110,8 @@ instance has_add : has_add (slash_invariant_form Γ k) :=
 @[simp] lemma add_apply (f g : slash_invariant_form Γ k) (z : ℍ) : (f + g) z = f z + g z := rfl
 
 instance has_zero : has_zero (slash_invariant_form Γ k) :=
-{zero := ⟨ 0 , slash_action.mul_zero _⟩}
+⟨ { to_fun := 0,
+    slash_action_eq' := slash_action.mul_zero _} ⟩
 
 lemma nsmul_coe [slash_invariant_form_class F Γ k] (f : F) (c : ℕ) :
   c • (f : ℍ → ℂ) = (c : ℂ) • f :=
@@ -138,14 +139,12 @@ instance has_csmul : has_smul ℂ (slash_invariant_form Γ k) :=
 instance has_nsmul : has_smul ℕ (slash_invariant_form Γ k) :=
 ⟨ λ c f, ((c : ℂ) • f).copy (c • f) (nsmul_eq_smul_cast _ _ _)⟩
 
-@[simp] lemma coe_nsmul (f : slash_invariant_form Γ k) (n : ℕ) : ⇑(n • f) = n • f := rfl
 @[simp] lemma nsmul_apply (f : slash_invariant_form Γ k) (n : ℕ) (z : ℍ) :
    (n • f) z = n • (f z) := rfl
 
 instance has_zsmul : has_smul ℤ (slash_invariant_form Γ k) :=
 ⟨ λ c f, ((c : ℂ) • f).copy (c • f) (zsmul_eq_smul_cast _ _ _)⟩
 
-@[simp] lemma coe_zsmul (f : slash_invariant_form Γ k) (n : ℤ) : ⇑(n • f) = n • f := rfl
 @[simp] lemma zsmul_apply (f : slash_invariant_form Γ k) (n : ℤ) (z : ℍ) :
    (n • f) z = n • (f z) := rfl
 
@@ -164,19 +163,22 @@ instance has_sub : has_sub (slash_invariant_form Γ k) := ⟨ λ f g, f + -g ⟩
 @[simp] lemma sub_apply (f g : slash_invariant_form Γ k) (z : ℍ) : (f - g) z = f z - g z := rfl
 
 instance : add_comm_group (slash_invariant_form Γ k) :=
-fun_like.coe_injective.add_comm_group _ rfl (coe_add) (coe_neg) (coe_sub) (coe_nsmul) (coe_zsmul)
+fun_like.coe_injective.add_comm_group _ rfl coe_add coe_neg coe_sub
+  (λ f n, nsmul_eq_smul_cast _ n f) (λ f n, zsmul_eq_smul_cast _ n f)
 
 lemma coe_zero : ⇑(0 : slash_invariant_form Γ k) = (0 : ℍ → ℂ) := rfl
 
 /--Additive coercion from `slash_invariant_form` to `ℍ → ℂ`.-/
-def coe_hom : (slash_invariant_form Γ k) →+ (ℍ → ℂ) :=
-{ to_fun := λ f, f, map_zero' := slash_invariant_form.coe_zero, map_add' := λ _ _, rfl }
+def coe_hom : slash_invariant_form Γ k →+ (ℍ → ℂ) :=
+{ to_fun := λ f, f,
+  map_zero' := rfl,
+  map_add' := λ _ _, rfl }
 
 lemma coe_hom_injective : function.injective (@coe_hom Γ k) :=
 fun_like.coe_injective
 
 instance : module ℂ (slash_invariant_form Γ k) :=
-coe_hom_injective.module ℂ (coe_hom) (λ _ _, rfl)
+coe_hom_injective.module ℂ coe_hom (λ _ _, rfl)
 
 instance : has_one (slash_invariant_form Γ 0) :=
 ⟨ { to_fun := 1,

--- a/src/number_theory/modular_forms/slash_invariant_forms.lean
+++ b/src/number_theory/modular_forms/slash_invariant_forms.lean
@@ -102,12 +102,9 @@ instance [slash_invariant_form_class F Γ k] : has_coe_t F (slash_invariant_form
   ((f : slash_invariant_form Γ k) : ℍ → ℂ) = f := rfl
 
 instance has_add : has_add (slash_invariant_form Γ k) :=
-⟨λ f g, ⟨ f + g, begin
-  intro γ,
-  convert slash_action.add_action k γ (f : ℍ → ℂ) g,
-  exact (f.slash_action_eq' γ).symm,
-  exact (g.slash_action_eq' γ).symm
-  end⟩⟩
+⟨ λ f g,
+  { to_fun := f + g,
+    slash_action_eq' := λ γ, by convert slash_action.add_action k γ (f : ℍ → ℂ) g; simp } ⟩
 
 @[simp] lemma coe_add (f g : slash_invariant_form Γ k) : ⇑(f + g) = f + g := rfl
 @[simp] lemma add_apply (f g : slash_invariant_form Γ k) (z : ℍ) : (f + g) z = f z + g z := rfl
@@ -128,8 +125,6 @@ begin
  simp only [zsmul_eq_mul],
  congr,
 end
-
-
 
 instance has_csmul : has_smul ℂ (slash_invariant_form Γ k) :=
 ⟨ λ c f, {to_fun := c • f,
@@ -155,13 +150,10 @@ instance has_zsmul : has_smul ℤ (slash_invariant_form Γ k) :=
    (n • f) z = n • (f z) := rfl
 
 instance has_neg : has_neg (slash_invariant_form Γ k) :=
-⟨λ f, ⟨ -f, begin
-  intro g,
-  have := ((f.slash_action_eq') g),
-  rw [modular_form.subgroup_slash, modular_form.neg_slash] at *,
-  simp only [neg_inj],
-  convert this
-  end⟩ ⟩
+⟨ λ f,
+  { to_fun := -f,
+    slash_action_eq' := λ γ, by simpa [modular_form.subgroup_slash,
+      modular_form.neg_slash] using f.slash_action_eq' γ } ⟩
 
 @[simp] lemma coe_neg (f : slash_invariant_form Γ k) : ⇑(-f) = -f := rfl
 @[simp] lemma neg_apply (f : slash_invariant_form Γ k) (z : ℍ) : (-f) z = - (f z) := rfl
@@ -187,8 +179,8 @@ instance : module ℂ (slash_invariant_form Γ k) :=
 coe_hom_injective.module ℂ (coe_hom) (λ _ _, rfl)
 
 instance : has_one (slash_invariant_form Γ 0) :=
-{one := { to_fun := 1,
-  slash_action_eq' := by {intro A, convert modular_form.is_invariant_one A}}}
+⟨ { to_fun := 1,
+    slash_action_eq' := λ A, modular_form.is_invariant_one A } ⟩
 
 instance : inhabited (slash_invariant_form Γ k) := ⟨0⟩
 


### PR DESCRIPTION
We define a new class of functions called `slash_invariant_forms` which will form the basis of the definition for modular forms.
This is split from #13250 to make the PR smaller. 



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
