### PR TITLE
[Merged by Bors] - refactor(data/polynomial/ring_division): Generalize `irreducible_of_monic` to `no_zero_divisors`

### DIFF
--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -96,6 +96,12 @@ end
 @[simp] lemma mul_coeff_zero (p q : R[X]) : coeff (p * q) 0 = coeff p 0 * coeff q 0 :=
 by simp [coeff_mul]
 
+-- TODO: golf using `constant_coeff` once #17664 is merged
+lemma is_unit_C {x : R} : is_unit (C x) ↔ is_unit x :=
+⟨by { rintros ⟨⟨q, p, hqp, hpq⟩, rfl : q = C x⟩,
+  exact ⟨⟨(C x).coeff 0, p.coeff 0, by rw [←mul_coeff_zero, hqp, coeff_one_zero],
+    by rw [←mul_coeff_zero, hpq, coeff_one_zero]⟩, coeff_C_zero⟩ }, is_unit.map C⟩
+
 lemma coeff_mul_X_zero (p : R[X]) : coeff (p * X) 0 = 0 :=
 by simp
 

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -147,20 +147,6 @@ lemma is_unit_iff_degree_eq_zero : is_unit p ↔ degree p = 0 :=
       rw [← C_mul, _root_.mul_inv_cancel hc, C_1]
     end⟩⟩
 
-theorem irreducible_of_monic {p : R[X]} (hp1 : p.monic) (hp2 : p ≠ 1) :
-  irreducible p ↔ (∀ f g : R[X], f.monic → g.monic → f * g = p → f = 1 ∨ g = 1) :=
-⟨λ hp3 f g hf hg hfg, or.cases_on (hp3.is_unit_or_is_unit hfg.symm)
-  (assume huf : is_unit f, or.inl $ eq_one_of_is_unit_of_monic hf huf)
-  (assume hug : is_unit g, or.inr $ eq_one_of_is_unit_of_monic hg hug),
-λ hp3, ⟨mt (eq_one_of_is_unit_of_monic hp1) hp2, λ f g hp,
-have hf : f ≠ 0, from λ hf, by { rw [hp, hf, zero_mul] at hp1, exact not_monic_zero hp1 },
-have hg : g ≠ 0, from λ hg, by { rw [hp, hg, mul_zero] at hp1, exact not_monic_zero hp1 },
-or.imp (λ hf, is_unit_of_mul_eq_one _ _ hf) (λ hg, is_unit_of_mul_eq_one _ _ hg) $
-hp3 (f * C f.leading_coeff⁻¹) (g * C g.leading_coeff⁻¹)
-  (monic_mul_leading_coeff_inv hf) (monic_mul_leading_coeff_inv hg) $
-by rw [mul_assoc, mul_left_comm _ g, ← mul_assoc, ← C_mul, ← mul_inv, ← leading_coeff_mul,
-    ← hp, monic.def.1 hp1, inv_one, C_1, mul_one]⟩⟩
-
 /-- Division of polynomials. See `polynomial.div_by_monic` for more details.-/
 def div (p q : R[X]) :=
 C (leading_coeff q)⁻¹ * (p /ₘ (q * C (leading_coeff q)⁻¹))

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -213,6 +213,14 @@ end monic
   ((X + C r) ^ n).nat_degree = n :=
 by rw [(monic_X_add_C r).nat_degree_pow, nat_degree_X_add_C, mul_one]
 
+-- TODO: golf using `constant_coeff`
+lemma is_unit_C {x : R} : is_unit (C x) ↔ is_unit x :=
+⟨by { rintros ⟨⟨q, p, hqp, hpq⟩, rfl : q = C x⟩,
+  have h1 := mul_coeff_zero p (C x),
+  have h2 := mul_coeff_zero (C x) p,
+  simp only [hpq, hqp, coeff_one_zero, coeff_C_zero] at h1 h2,
+  exact ⟨⟨x, p.coeff 0, h2.symm, h1.symm⟩, rfl⟩ }, λ h, h.map C⟩
+
 end semiring
 
 section comm_semiring
@@ -232,18 +240,6 @@ end
 lemma monic_prod_of_monic (s : finset ι) (f : ι → R[X]) (hs : ∀ i ∈ s, monic (f i)) :
   monic (∏ i in s, f i) :=
 monic_multiset_prod_of_monic s.1 f hs
-
-lemma is_unit_C {x : R} : is_unit (C x) ↔ is_unit x :=
-begin
-  rw [is_unit_iff_dvd_one, is_unit_iff_dvd_one],
-  split,
-  { rintros ⟨g, hg⟩,
-    replace hg := congr_arg (eval 0) hg,
-    rw [eval_one, eval_mul, eval_C] at hg,
-    exact ⟨g.eval 0, hg⟩ },
-  { rintros ⟨y, hy⟩,
-    exact ⟨C y, by rw [← C_mul, ← hy, C_1]⟩ }
-end
 
 lemma eq_one_of_is_unit_of_monic (hm : monic p) (hpu : is_unit p) : p = 1 :=
 have degree p ≤ 0,

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -213,7 +213,7 @@ end monic
   ((X + C r) ^ n).nat_degree = n :=
 by rw [(monic_X_add_C r).nat_degree_pow, nat_degree_X_add_C, mul_one]
 
--- TODO: golf using `constant_coeff`
+-- TODO: golf using `constant_coeff` once #17664 is merged
 lemma is_unit_C {x : R} : is_unit (C x) ↔ is_unit x :=
 ⟨by { rintros ⟨⟨q, p, hqp, hpq⟩, rfl : q = C x⟩,
   have h1 := mul_coeff_zero p (C x),

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -213,14 +213,6 @@ end monic
   ((X + C r) ^ n).nat_degree = n :=
 by rw [(monic_X_add_C r).nat_degree_pow, nat_degree_X_add_C, mul_one]
 
--- TODO: golf using `constant_coeff` once #17664 is merged
-lemma is_unit_C {x : R} : is_unit (C x) ↔ is_unit x :=
-⟨by { rintros ⟨⟨q, p, hqp, hpq⟩, rfl : q = C x⟩,
-  have h1 := mul_coeff_zero p (C x),
-  have h2 := mul_coeff_zero (C x) p,
-  simp only [hpq, hqp, coeff_one_zero, coeff_C_zero] at h1 h2,
-  exact ⟨⟨x, p.coeff 0, h2.symm, h1.symm⟩, rfl⟩ }, λ h, h.map C⟩
-
 lemma monic.eq_one_of_is_unit (hm : monic p) (hpu : is_unit p) : p = 1 :=
 begin
   nontriviality R,

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -221,6 +221,15 @@ lemma is_unit_C {x : R} : is_unit (C x) ↔ is_unit x :=
   simp only [hpq, hqp, coeff_one_zero, coeff_C_zero] at h1 h2,
   exact ⟨⟨x, p.coeff 0, h2.symm, h1.symm⟩, rfl⟩ }, λ h, h.map C⟩
 
+lemma monic.eq_one_of_is_unit (hm : monic p) (hpu : is_unit p) : p = 1 :=
+begin
+  nontriviality R,
+  obtain ⟨q, h⟩ := hpu.exists_right_inv,
+  have := hm.nat_degree_mul' (right_ne_zero_of_mul_eq_one h),
+  rw [h, nat_degree_one, eq_comm, add_eq_zero_iff] at this,
+  exact hm.nat_degree_eq_zero_iff_eq_one.mp this.1,
+end
+
 end semiring
 
 section comm_semiring
@@ -240,25 +249,6 @@ end
 lemma monic_prod_of_monic (s : finset ι) (f : ι → R[X]) (hs : ∀ i ∈ s, monic (f i)) :
   monic (∏ i in s, f i) :=
 monic_multiset_prod_of_monic s.1 f hs
-
-lemma eq_one_of_is_unit_of_monic (hm : monic p) (hpu : is_unit p) : p = 1 :=
-have degree p ≤ 0,
-  from calc degree p ≤ degree (1 : R[X]) :
-    let ⟨u, hu⟩ := is_unit_iff_dvd_one.1 hpu in
-    if hu0 : u = 0
-    then begin
-        rw [hu0, mul_zero] at hu,
-        rw [← mul_one p, hu, mul_zero],
-        simp
-      end
-    else have p.leading_coeff * u.leading_coeff ≠ 0,
-        by rw [hm.leading_coeff, one_mul, ne.def, leading_coeff_eq_zero];
-          exact hu0,
-      by rw [hu, degree_mul' this];
-        exact le_add_of_nonneg_right (degree_nonneg_iff_ne_zero.2 hu0)
-  ... ≤ 0 : degree_one_le,
-by rw [eq_C_of_degree_le_zero this, ← nat_degree_eq_zero_iff_degree_le_zero.2 this,
-    ← leading_coeff, hm.leading_coeff, C_1]
 
 lemma monic.next_coeff_multiset_prod (t : multiset ι) (f : ι → R[X])
   (h : ∀ i ∈ t, monic (f i)) :
@@ -377,9 +367,7 @@ begin
   rcases eq_or_ne n 0 with rfl | hn,
   { simpa using h },
   apply hn,
-  rwa [← @nat_degree_X_pow_sub_C _ _ _ n (1 : R),
-      eq_one_of_is_unit_of_monic (monic_X_pow_sub_C (1 : R) hn),
-      nat_degree_one]
+  rw [←@nat_degree_one R, ←(monic_X_pow_sub_C _ hn).eq_one_of_is_unit h, nat_degree_X_pow_sub_C],
 end
 
 lemma monic.sub_of_left {p q : R[X]} (hp : monic p) (hpq : degree q < degree p) :

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -234,11 +234,10 @@ variables [comm_semiring R] [no_zero_divisors R] {p q : R[X]}
 lemma irreducible_of_monic (hp : p.monic) (hp1 : p ≠ 1) :
   irreducible p ↔ ∀ f g : R[X], f.monic → g.monic → f * g = p → f = 1 ∨ g = 1 :=
 begin
-  refine ⟨λ h f g hf hg hp, (h.2 f g hp.symm).elim
-    (or.inl ∘ hf.eq_one_of_is_unit) (or.inr ∘ hg.eq_one_of_is_unit),
-    λ h, ⟨hp1 ∘ hp.eq_one_of_is_unit, λ f g hfg, (h (g * C f.leading_coeff) (f * C g.leading_coeff) _ _ _).elim
-    (or.inr ∘ is_unit_of_mul_eq_one g (C f.leading_coeff))
-    (or.inl ∘ is_unit_of_mul_eq_one f (C g.leading_coeff))⟩⟩,
+  refine ⟨λ h f g hf hg hp, (h.2 f g hp.symm).elim (or.inl ∘ hf.eq_one_of_is_unit)
+    (or.inr ∘ hg.eq_one_of_is_unit), λ h, ⟨hp1 ∘ hp.eq_one_of_is_unit, λ f g hfg,
+      (h (g * C f.leading_coeff) (f * C g.leading_coeff) _ _ _).elim
+        (or.inr ∘ is_unit_of_mul_eq_one g _) (or.inl ∘ is_unit_of_mul_eq_one f _)⟩⟩,
   { rwa [monic, leading_coeff_mul, leading_coeff_C, ←leading_coeff_mul, mul_comm, ←hfg, ←monic] },
   { rwa [monic, leading_coeff_mul, leading_coeff_C, ←leading_coeff_mul, ←hfg, ←monic] },
   { rw [mul_mul_mul_comm, ←C_mul, ←leading_coeff_mul, ←hfg, hp.leading_coeff, C_1, mul_one,

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -186,10 +186,9 @@ le_antisymm (nat_degree_eq_zero_iff_degree_le_zero.mp (nat_degree_eq_zero_of_is_
   (zero_le_degree_iff.mpr h.ne_zero)
 
 theorem is_unit_iff : is_unit p ↔ ∃ r : R, is_unit r ∧ C r = p :=
-by nontriviality R; exact
 ⟨λ hp, ⟨p.coeff 0,
-  is_unit_C.1 $ eq_C_of_degree_eq_zero (degree_eq_zero_of_is_unit hp) ▸ hp,
-  (eq_C_of_degree_eq_zero (degree_eq_zero_of_is_unit hp)).symm⟩,
+  is_unit_C.1 $ eq_C_of_nat_degree_eq_zero (nat_degree_eq_zero_of_is_unit hp) ▸ hp,
+  (eq_C_of_nat_degree_eq_zero (nat_degree_eq_zero_of_is_unit hp)).symm⟩,
 λ ⟨r, hr, hrp⟩, hrp ▸ is_unit_C.2 hr⟩
 
 variables [char_zero R]

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -186,10 +186,8 @@ le_antisymm (nat_degree_eq_zero_iff_degree_le_zero.mp (nat_degree_eq_zero_of_is_
   (zero_le_degree_iff.mpr h.ne_zero)
 
 theorem is_unit_iff : is_unit p ↔ ∃ r : R, is_unit r ∧ C r = p :=
-⟨λ hp, ⟨p.coeff 0,
-  is_unit_C.1 $ eq_C_of_nat_degree_eq_zero (nat_degree_eq_zero_of_is_unit hp) ▸ hp,
-  (eq_C_of_nat_degree_eq_zero (nat_degree_eq_zero_of_is_unit hp)).symm⟩,
-λ ⟨r, hr, hrp⟩, hrp ▸ is_unit_C.2 hr⟩
+⟨λ hp, ⟨p.coeff 0, let h := eq_C_of_nat_degree_eq_zero (nat_degree_eq_zero_of_is_unit hp) in
+  ⟨is_unit_C.1 (h ▸ hp), h.symm⟩⟩, λ ⟨r, hr, hrp⟩, hrp ▸ is_unit_C.2 hr⟩
 
 variables [char_zero R]
 

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -172,16 +172,18 @@ begin
   rw [← nat_degree_mul hp₁ hq₂, ← nat_degree_mul hp₂ hq₁, h_eq]
 end
 
+lemma nat_degree_eq_zero_of_is_unit (h : is_unit p) : nat_degree p = 0 :=
+begin
+  nontriviality R,
+  obtain ⟨q, hq⟩ := h.exists_right_inv,
+  have := nat_degree_mul (left_ne_zero_of_mul_eq_one hq) (right_ne_zero_of_mul_eq_one hq),
+  rw [hq, nat_degree_one, eq_comm, add_eq_zero_iff] at this,
+  exact this.1,
+end
+
 lemma degree_eq_zero_of_is_unit [nontrivial R] (h : is_unit p) : degree p = 0 :=
-let ⟨q, hq⟩ := (h.dvd : p ∣ 1) in
-have hp0 : p ≠ 0, from λ hp0, by simpa [hp0] using hq,
-have hq0 : q ≠ 0, from λ hp0, by simpa [hp0] using hq,
-have nat_degree (1 : R[X]) = nat_degree (p * q),
-  from congr_arg _ hq,
-by rw [nat_degree_one, nat_degree_mul hp0 hq0, eq_comm,
-    _root_.add_eq_zero_iff, ← with_bot.coe_eq_coe,
-    ← degree_eq_nat_degree hp0] at this;
-  exact this.1
+le_antisymm (nat_degree_eq_zero_iff_degree_le_zero.mp (nat_degree_eq_zero_of_is_unit h))
+  (zero_le_degree_iff.mpr h.ne_zero)
 
 theorem is_unit_iff : is_unit p ↔ ∃ r : R, is_unit r ∧ C r = p :=
 by nontriviality R; exact

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -172,6 +172,30 @@ begin
   rw [← nat_degree_mul hp₁ hq₂, ← nat_degree_mul hp₂ hq₁, h_eq]
 end
 
+lemma degree_eq_zero_of_is_unit [nontrivial R] (h : is_unit p) : degree p = 0 :=
+let ⟨q, hq⟩ := (h.dvd : p ∣ 1) in
+have hp0 : p ≠ 0, from λ hp0, by simpa [hp0] using hq,
+have hq0 : q ≠ 0, from λ hp0, by simpa [hp0] using hq,
+have nat_degree (1 : R[X]) = nat_degree (p * q),
+  from congr_arg _ hq,
+by rw [nat_degree_one, nat_degree_mul hp0 hq0, eq_comm,
+    _root_.add_eq_zero_iff, ← with_bot.coe_eq_coe,
+    ← degree_eq_nat_degree hp0] at this;
+  exact this.1
+
+theorem is_unit_iff : is_unit p ↔ ∃ r : R, is_unit r ∧ C r = p :=
+by nontriviality R; exact
+⟨λ hp, ⟨p.coeff 0,
+  is_unit_C.1 $ eq_C_of_degree_eq_zero (degree_eq_zero_of_is_unit hp) ▸ hp,
+  (eq_C_of_degree_eq_zero (degree_eq_zero_of_is_unit hp)).symm⟩,
+λ ⟨r, hr, hrp⟩, hrp ▸ is_unit_C.2 hr⟩
+
+lemma monic.eq_one_of_is_unit (hp1 : p.monic) (hp2 : is_unit p) : p = 1 :=
+begin
+  obtain ⟨r, hr, rfl⟩ := is_unit_iff.mp hp2,
+  rw [(leading_coeff_C r).symm.trans hp1, C_1],
+end
+
 variables [char_zero R]
 
 @[simp] lemma degree_bit0_eq (p : R[X]) : degree (bit0 p) = degree p :=
@@ -206,6 +230,20 @@ end no_zero_divisors
 
 section no_zero_divisors
 variables [comm_semiring R] [no_zero_divisors R] {p q : R[X]}
+
+lemma irreducible_of_monic (hp : p.monic) (hp1 : p ≠ 1) :
+  irreducible p ↔ ∀ f g : R[X], f.monic → g.monic → f * g = p → f = 1 ∨ g = 1 :=
+begin
+  refine ⟨λ h f g hf hg hp, (h.2 f g hp.symm).elim
+    (or.inl ∘ hf.eq_one_of_is_unit) (or.inr ∘ hg.eq_one_of_is_unit),
+    λ h, ⟨hp1 ∘ hp.eq_one_of_is_unit, λ f g hfg, (h (g * C f.leading_coeff) (f * C g.leading_coeff) _ _ _).elim
+    (or.inr ∘ is_unit_of_mul_eq_one g (C f.leading_coeff))
+    (or.inl ∘ is_unit_of_mul_eq_one f (C g.leading_coeff))⟩⟩,
+  { rwa [monic, leading_coeff_mul, leading_coeff_C, ←leading_coeff_mul, mul_comm, ←hfg, ←monic] },
+  { rwa [monic, leading_coeff_mul, leading_coeff_C, ←leading_coeff_mul, ←hfg, ←monic] },
+  { rw [mul_mul_mul_comm, ←C_mul, ←leading_coeff_mul, ←hfg, hp.leading_coeff, C_1, mul_one,
+        mul_comm, ←hfg] },
+end
 
 lemma root_mul : is_root (p * q) a ↔ is_root p a ∨ is_root q a :=
 by simp_rw [is_root, eval_mul, mul_eq_zero]
@@ -260,17 +298,6 @@ variables [is_domain R] {p q : R[X]}
 section roots
 
 open multiset
-
-lemma degree_eq_zero_of_is_unit (h : is_unit p) : degree p = 0 :=
-let ⟨q, hq⟩ := is_unit_iff_dvd_one.1 h in
-have hp0 : p ≠ 0, from λ hp0, by simpa [hp0] using hq,
-have hq0 : q ≠ 0, from λ hp0, by simpa [hp0] using hq,
-have nat_degree (1 : R[X]) = nat_degree (p * q),
-  from congr_arg _ hq,
-by rw [nat_degree_one, nat_degree_mul hp0 hq0, eq_comm,
-    _root_.add_eq_zero_iff, ← with_bot.coe_eq_coe,
-    ← degree_eq_nat_degree hp0] at this;
-  exact this.1
 
 @[simp] lemma degree_coe_units (u : R[X]ˣ) :
   degree (u : R[X]) = 0 :=
@@ -736,12 +763,6 @@ lemma aeval_eq_zero_of_mem_root_set {p : T[X]} [comm_ring S] [is_domain S] [alge
 (mem_root_set_iff (ne_zero_of_mem_root_set hx) a).mp hx
 
 end roots
-
-theorem is_unit_iff {f : R[X]} : is_unit f ↔ ∃ r : R, is_unit r ∧ C r = f :=
-⟨λ hf, ⟨f.coeff 0,
-  is_unit_C.1 $ eq_C_of_degree_eq_zero (degree_eq_zero_of_is_unit hf) ▸ hf,
-  (eq_C_of_degree_eq_zero (degree_eq_zero_of_is_unit hf)).symm⟩,
-λ ⟨r, hr, hrf⟩, hrf ▸ is_unit_C.2 hr⟩
 
 lemma coeff_coe_units_zero_ne_zero (u : R[X]ˣ) :
   coeff (u : R[X]) 0 ≠ 0 :=

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -190,12 +190,6 @@ by nontriviality R; exact
   (eq_C_of_degree_eq_zero (degree_eq_zero_of_is_unit hp)).symm⟩,
 λ ⟨r, hr, hrp⟩, hrp ▸ is_unit_C.2 hr⟩
 
-lemma monic.eq_one_of_is_unit (hp1 : p.monic) (hp2 : is_unit p) : p = 1 :=
-begin
-  obtain ⟨r, hr, rfl⟩ := is_unit_iff.mp hp2,
-  rw [(leading_coeff_C r).symm.trans hp1, C_1],
-end
-
 variables [char_zero R]
 
 @[simp] lemma degree_bit0_eq (p : R[X]) : degree (bit0 p) = degree p :=

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -90,7 +90,7 @@ lemma not_is_unit [nontrivial B] : ¬ is_unit (minpoly A x) :=
 begin
   haveI : nontrivial A := (algebra_map A B).domain_nontrivial,
   by_cases hx : is_integral A x,
-  { exact mt (eq_one_of_is_unit_of_monic (monic hx)) (ne_one A x) },
+  { exact mt (monic hx).eq_one_of_is_unit (ne_one A x) },
   { rw [eq_zero hx], exact not_is_unit_zero }
 end
 


### PR DESCRIPTION
This PR generalizes `irreducible_of_monic` to `no_zero_divisors`, using some of the work from @alreadydone's PR #17664.

Co-Authored-By: Junyan Xu <junyanxumath@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
