### PR TITLE
[Merged by Bors] - chore(algebra/big_operators/multiset): split

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 
+import algebra.big_operators.multiset.lemmas
 import algebra.group.pi
 import algebra.group_power.lemmas
 import algebra.hom.equiv.basic

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -12,7 +12,6 @@ import algebra.ring.opposite
 import data.finset.sum
 import data.fintype.basic
 import data.finset.sigma
-import data.list.big_operators.lemmas
 import data.set.pairwise
 
 /-!

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -5,13 +5,14 @@ Authors: Johannes Hölzl
 -/
 
 import algebra.group.pi
+import algebra.group_power.lemmas
 import algebra.hom.equiv.basic
 import algebra.ring.opposite
-import data.set.pairwise
 import data.finset.sum
 import data.fintype.basic
 import data.finset.sigma
-import algebra.group_power.lemmas
+import data.list.big_operators.lemmas
+import data.set.pairwise
 
 /-!
 # Big operators

--- a/src/algebra/big_operators/multiset/basic.lean
+++ b/src/algebra/big_operators/multiset/basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import data.list.big_operators.lemmas
+import data.list.big_operators.basic
 import data.multiset.basic
 
 /-!
@@ -17,6 +17,12 @@ and sums indexed by finite sets.
 * `multiset.prod`: `s.prod f` is the product of `f i` over all `i ∈ s`. Not to be mistaken with
   the cartesian product `multiset.product`.
 * `multiset.sum`: `s.sum f` is the sum of `f i` over all `i ∈ s`.
+
+## Implementation notes
+
+Nov 2022: To speed the Lean 4 port, lemmas requiring extra algebra imports
+(`data.list.big_operators.lemmas` rather than `.basic`) have been moved to a separate file,
+`algebra.big_operators.multiset.lemmas`.  This split does not need to be permanent.
 -/
 
 variables {ι α β γ : Type*}
@@ -175,9 +181,6 @@ begin
   exact p_mul a s.prod (hpsa a (mem_cons_self a s)) (hs hs_empty hps),
 end
 
-lemma dvd_prod : a ∈ s → a ∣ s.prod :=
-quotient.induction_on s (λ l a h, by simpa using list.dvd_prod h) a
-
 lemma prod_dvd_prod_of_le (h : s ≤ t) : s.prod ∣ t.prod :=
 by { obtain ⟨z, rfl⟩ := exists_add_of_le h, simp only [prod_add, dvd_mul_right] }
 
@@ -246,18 +249,6 @@ end division_comm_monoid
 
 section non_unital_non_assoc_semiring
 variables [non_unital_non_assoc_semiring α] {a : α} {s : multiset ι} {f : ι → α}
-
-lemma _root_.commute.multiset_sum_right (s : multiset α) (a : α) (h : ∀ b ∈ s, commute a b) :
-  commute a s.sum :=
-begin
-  induction s using quotient.induction_on,
-  rw [quot_mk_to_coe, coe_sum],
-  exact commute.list_sum_right _ _ h,
-end
-
-lemma _root_.commute.multiset_sum_left (s : multiset α) (b : α) (h : ∀ a ∈ s, commute a b) :
-  commute s.sum b :=
-(commute.multiset_sum_right _ _ $ λ a ha, (h _ ha).symm).symm
 
 lemma sum_map_mul_left : sum (s.map (λ i, a * f i)) = a * sum (s.map f) :=
 multiset.induction_on s (by simp) (λ i s ih, by simp [ih, mul_add])
@@ -344,11 +335,6 @@ begin
   rw prod_cons,
   exact mul_nonneg (ih _ $ mem_cons_self _ _) (hs $ λ a ha, ih _ $ mem_cons_of_mem ha),
 end
-
-@[to_additive]
-lemma prod_eq_one_iff [canonically_ordered_monoid α] {m : multiset α} :
-  m.prod = 1 ↔ ∀ x ∈ m, x = (1 : α) :=
-quotient.induction_on m $ λ l, by simpa using list.prod_eq_one_iff l
 
 /-- Slightly more general version of `multiset.prod_eq_one_iff` for a non-ordered `monoid` -/
 @[to_additive "Slightly more general version of `multiset.sum_eq_zero_iff`

--- a/src/algebra/big_operators/multiset/lemmas.lean
+++ b/src/algebra/big_operators/multiset/lemmas.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2019 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes, Bhavik Mehta, Eric Wieser
+-/
+import data.list.big_operators.lemmas
+import algebra.big_operators.multiset.basic
+
+/-! # Lemmas about `multiset.sum` and `multiset.prod` requiring extra algebra imports -/
+
+variables {ι α β γ : Type*}
+
+namespace multiset
+
+lemma dvd_prod [comm_monoid α] {s : multiset α} {a : α}  : a ∈ s → a ∣ s.prod :=
+quotient.induction_on s (λ l a h, by simpa using list.dvd_prod h) a
+
+@[to_additive]
+lemma prod_eq_one_iff [canonically_ordered_monoid α] {m : multiset α} :
+  m.prod = 1 ↔ ∀ x ∈ m, x = (1 : α) :=
+quotient.induction_on m $ λ l, by simpa using list.prod_eq_one_iff l
+
+end multiset
+
+open multiset
+
+namespace commute
+variables [non_unital_non_assoc_semiring α] {a : α} {s : multiset ι} {f : ι → α}
+
+lemma multiset_sum_right (s : multiset α) (a : α) (h : ∀ b ∈ s, commute a b) :
+  commute a s.sum :=
+begin
+  induction s using quotient.induction_on,
+  rw [quot_mk_to_coe, coe_sum],
+  exact commute.list_sum_right _ _ h,
+end
+
+lemma multiset_sum_left (s : multiset α) (b : α) (h : ∀ a ∈ s, commute a b) :
+  commute s.sum b :=
+(commute.multiset_sum_right _ _ $ λ a ha, (h _ ha).symm).symm
+
+end commute

--- a/src/algebra/hom/freiman.lean
+++ b/src/algebra/hom/freiman.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import algebra.big_operators.multiset
+import algebra.big_operators.multiset.basic
 import data.fun_like.basic
 
 /-!

--- a/src/data/list/prime.lean
+++ b/src/data/list/prime.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Jens Wagemaker, Anne Baanen
 -/
 
 import algebra.associated
-import data.list.big_operators.basic
+import data.list.big_operators.lemmas
 import data.list.perm
 
 /-!

--- a/src/data/multiset/bind.lean
+++ b/src/data/multiset/bind.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import algebra.big_operators.multiset
+import algebra.big_operators.multiset.basic
 
 /-!
 # Bind operation for multisets


### PR DESCRIPTION
Split `algebra.big_operators.multiset` into `.basic` and `.lemmas`, with the former containing no algebra imports. This should make more of the `fintype` dependency tree portable sooner.

A follow-up on #17702 (for list).  See [the latest graph](https://tqft.net/mathlib4/2022-11-25/data.fintype.basic.pdf) for the motivation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
