### PR TITLE
[Merged by Bors] - feat(category_theory): is_zero.op and is_zero.unop

### DIFF
--- a/src/category_theory/limits/shapes/zero_objects.lean
+++ b/src/category_theory/limits/shapes/zero_objects.lean
@@ -162,6 +162,9 @@ end
 
 open_locale zero_object
 
+lemma has_zero_object_unop [has_zero_object Cᵒᵖ] : has_zero_object C :=
+⟨⟨opposite.unop 0, is_zero.unop (is_zero_zero Cᵒᵖ)⟩⟩
+
 variables {C}
 
 lemma is_zero.has_zero_object {X : C} (hX : is_zero X) : has_zero_object C := ⟨⟨X, hX⟩⟩

--- a/src/category_theory/limits/shapes/zero_objects.lean
+++ b/src/category_theory/limits/shapes/zero_objects.lean
@@ -99,6 +99,14 @@ begin
   { rw ← cancel_mono e.hom, apply hY.eq_of_tgt, },
 end
 
+lemma op (h : is_zero X) : is_zero (opposite.op X) :=
+⟨λ Y, ⟨⟨⟨(h.from (opposite.unop Y)).op⟩, λ f, quiver.hom.unop_inj (h.eq_of_tgt _ _)⟩⟩,
+  λ Y, ⟨⟨⟨(h.to (opposite.unop Y)).op⟩, λ f, quiver.hom.unop_inj (h.eq_of_src _ _)⟩⟩⟩
+
+lemma unop {X : Cᵒᵖ} (h : is_zero X) : is_zero (opposite.unop X) :=
+⟨λ Y, ⟨⟨⟨(h.from (opposite.op Y)).unop⟩, λ f, quiver.hom.op_inj (h.eq_of_tgt _ _)⟩⟩,
+  λ Y, ⟨⟨⟨(h.to (opposite.op Y)).unop⟩, λ f, quiver.hom.op_inj (h.eq_of_src _ _)⟩⟩⟩
+
 end is_zero
 
 end limits
@@ -147,6 +155,8 @@ localized "attribute [instance] category_theory.limits.has_zero_object.has_zero"
 
 lemma is_zero_zero : is_zero (0 : C) :=
 has_zero_object.zero.some_spec
+
+instance has_zero_object_op : has_zero_object Cᵒᵖ := ⟨⟨opposite.op 0, is_zero.op (is_zero_zero C)⟩⟩
 
 end
 


### PR DESCRIPTION
This PR shows that a zero object is also a zero object in the opposite category.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
