### PR TITLE
[Merged by Bors] - feat(analysis/convex/between): betweenness in a ring

### DIFF
--- a/src/analysis/convex/between.lean
+++ b/src/analysis/convex/between.lean
@@ -355,6 +355,37 @@ begin
   rw (line_map_injective R hxy).mem_set_image
 end
 
+omit V
+
+@[simp] lemma wbtw_mul_sub_add_iff [no_zero_divisors R] {x y r : R} :
+  wbtw R x (r * (y - x) + x) y ↔ x = y ∨ r ∈ set.Icc (0 : R) 1 :=
+wbtw_line_map_iff
+
+@[simp] lemma sbtw_mul_sub_add_iff [no_zero_divisors R] {x y r : R} :
+  sbtw R x (r * (y - x) + x) y ↔ x ≠ y ∧ r ∈ set.Ioo (0 : R) 1 :=
+sbtw_line_map_iff
+
+@[simp] lemma wbtw_zero_one_iff {x : R} : wbtw R 0 x 1 ↔ x ∈ set.Icc (0 : R) 1 :=
+begin
+  simp_rw [wbtw, affine_segment, set.mem_image, line_map_apply_ring],
+  simp
+end
+
+@[simp] lemma wbtw_one_zero_iff {x : R} : wbtw R 1 x 0 ↔ x ∈ set.Icc (0 : R) 1 :=
+by rw [wbtw_comm, wbtw_zero_one_iff]
+
+@[simp] lemma sbtw_zero_one_iff {x : R} : sbtw R 0 x 1 ↔ x ∈ set.Ioo (0 : R) 1 :=
+begin
+  rw [sbtw, wbtw_zero_one_iff, set.mem_Icc, set.mem_Ioo],
+  exact ⟨λ h, ⟨h.1.1.lt_of_ne (ne.symm h.2.1), h.1.2.lt_of_ne h.2.2⟩,
+         λ h, ⟨⟨h.1.le, h.2.le⟩, h.1.ne', h.2.ne⟩⟩
+end
+
+@[simp] lemma sbtw_one_zero_iff {x : R} : sbtw R 1 x 0 ↔ x ∈ set.Ioo (0 : R) 1 :=
+by rw [sbtw_comm, sbtw_zero_one_iff]
+
+include V
+
 lemma wbtw.trans_left {w x y z : P} (h₁ : wbtw R w y z) (h₂ : wbtw R w x y) : wbtw R w x z :=
 begin
   rcases h₁ with ⟨t₁, ht₁, rfl⟩,


### PR DESCRIPTION
Add some basic lemmas about betweenness in a ring as an affine space over itself.

---

There is certainly plenty of scope for more lemmas in this area, but the ones here are sufficient for what I want to do with them.  (That next step - relating betweenness and affine combinations - also depends on #17601, #17636, #17659 and #17660.)



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
