### PR TITLE
[Merged by Bors] - fix(scripts/add_port_comments): make message insertion less fragile

### DIFF
--- a/scripts/add_port_comments.py
+++ b/scripts/add_port_comments.py
@@ -1,4 +1,4 @@
-from mathlibtools.file_status import PortStatus
+from mathlibtools.file_status import PortStatus, FileStatus
 from pathlib import Path
 
 import re
@@ -19,53 +19,68 @@ def make_comment(fstatus):
     > https://github.com/leanprover-community/mathlib4/pull/{fstatus.mathlib4_pr}
     > Any changes to this file require a corresponding PR to mathlib4.""")
 
-def replace_range(src, pos, end_pos, new):
+def replace_range(src: str, pos: int, end_pos: int, new: str) -> str:
     return src[:pos] + new + src[end_pos:]
+
+def find_module_comment(s: str) -> Optional[re.Match]:
+    """ find a doc-comment, even if it contains nested comments """
+    start_marker = re.compile('/-!').search(s)
+    if not start_marker:
+        return None
+
+    depth = 1
+    ind = start_marker.end()
+    while depth > 0:
+        marker = re.compile(r'(/-)|(-/)').search(s, pos=ind)
+        if not marker:
+            raise ValueError('Could not find end of comment')
+        ind = marker.end()
+        if marker.group(1):
+            depth += 1
+        else:
+            depth -= 1
+
+    # Create a new match with sensible captures
+    m = re.compile('/-!(.*)-/', re.MULTILINE | re.DOTALL).fullmatch(s, start_marker.start(), marker.end())
+    assert m, s[start_marker.start():marker.end()]
+    return m
 
 
 class NoModuleDocstringError(ValueError): pass
 
-def add_port_status(fcontent, fstatus):
-    module_comment = re.search('/-!\s*(.*?)-/', fcontent, re.MULTILINE | re.DOTALL)
+def add_port_status(fcontent: str, fstatus: FileStatus) -> str:
+    module_comment = find_module_comment(fcontent)
     if not module_comment:
         raise NoModuleDocstringError()
 
     module_comment_start = module_comment.start(1)
     module_comment_end = module_comment.end(1)
+    module_comment = module_comment.group(1)
 
+    # remove any existing comment
     comment_re = re.compile(
-        r"^((?:> )?)THIS FILE IS SYNCHRONIZED WITH MATHLIB4\."
-        r"(?:\n\1[^\n]+)*\n*",
+        r"\n{,2}((?:> )?)THIS FILE IS SYNCHRONIZED WITH MATHLIB4\."
+        r"(?:\n\1[^\n]+)*",
         re.MULTILINE
     )
-    header_re = re.compile('^#[^\n]*\n?', re.MULTILINE)
+    module_comment = comment_re.sub('', module_comment)
 
-    existing_label = comment_re.search(fcontent, module_comment_start, module_comment_end)
-    existing_header = header_re.search(fcontent, module_comment_start, module_comment_end)
+    # find the header
+    header_re = re.compile('(#[^\n]*)', re.MULTILINE)
+    existing_header = header_re.search(module_comment)
+    if not existing_header:
+        raise ValueError(f"No header in {module_comment!r}")
 
-    if not existing_label:
-        rest = fcontent[existing_header.end():module_comment_end]
-        trailing_whitespace = "\n" if rest.strip() else ""
-        fcontent = replace_range(fcontent, existing_header.end(), existing_header.end(),
-            "\n" + make_comment(f_status) + trailing_whitespace)
-    else:
-        if existing_label.end() <= existing_header.start():
-            rest = fcontent[existing_header.end():module_comment_end]
-            trailing_whitespace = "\n" if rest.strip() else ""
-            fcontent = replace_range(fcontent, existing_header.end(), existing_header.end(),
-                "\n" + make_comment(f_status) + trailing_whitespace)
-            fcontent = replace_range(fcontent, existing_label.start(), existing_label.end(), "")
-        elif existing_header.end() <= existing_label.start():
-            rest = fcontent[existing_label.end():module_comment_end]
-            trailing_whitespace = "\n" if rest.strip() else ""
-            fcontent = replace_range(fcontent, existing_label.start(), existing_label.end(), "")
-            fcontent = replace_range(fcontent, existing_header.end(), existing_header.end(),
-                "\n" + make_comment(f_status) + trailing_whitespace)
-        else:
-            assert False
+    # insert a comment below the header
+    module_comment = replace_range(module_comment, existing_header.end(1), existing_header.end(1),
+        "\n\n" + make_comment(f_status))
+
+    # and insert the new module docstring
+    fcontent = replace_range(fcontent, module_comment_start, module_comment_end, module_comment)
+
     return fcontent
 
-def fname_for(import_path):
+def fname_for(import_path: str) -> Path:
     return src_path / Path(*import_path.split('.')).with_suffix('.lean')
 
 


### PR DESCRIPTION
This now doesn't make a mess of the whitespace.
Previously it would put the `-/` on the same line as the blockquote, which while valid leads to bad highlighting in vscode and github.

This also prevents mis-parsing caused by comments of the form `/-! /- -/ -/`



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
