### PR TITLE
[Merged by Bors] - chore(data/nat/basic): split out even_odd_rec

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -402,50 +402,6 @@ lemma decreasing_induction_succ_left {P : ℕ → Sort*} (h : ∀n, P (n+1) → 
 by { rw [subsingleton.elim mn (le_trans (le_succ m) smn), decreasing_induction_trans,
          decreasing_induction_succ'] }
 
-/-- Recursion principle on even and odd numbers: if we have `P 0`, and for all `i : ℕ` we can
-extend from `P i` to both `P (2 * i)` and `P (2 * i + 1)`, then we have `P n` for all `n : ℕ`.
-This is nothing more than a wrapper around `nat.binary_rec`, to avoid having to switch to
-dealing with `bit0` and `bit1`. -/
-@[elab_as_eliminator]
-def even_odd_rec {P : ℕ → Sort*} (h0 : P 0)
-  (h_even : ∀ n (ih : P n), P (2 * n))
-  (h_odd : ∀ n (ih : P n), P (2 * n + 1)) (n : ℕ) : P n :=
-begin
-  refine @binary_rec P h0 (λ b i hi, _) n,
-  cases b,
-  { simpa [bit, bit0_val i] using h_even i hi },
-  { simpa [bit, bit1_val i] using h_odd i hi },
-end
-
-@[simp] lemma even_odd_rec_zero (P : ℕ → Sort*) (h0 : P 0)
-  (h_even : ∀ i, P i → P (2 * i)) (h_odd : ∀ i, P i → P (2 * i + 1)) :
-  @even_odd_rec _ h0 h_even h_odd 0 = h0 := binary_rec_zero _ _
-
-@[simp] lemma even_odd_rec_even (n : ℕ) (P : ℕ → Sort*) (h0 : P 0)
-  (h_even : ∀ i, P i → P (2 * i)) (h_odd : ∀ i, P i → P (2 * i + 1))
-  (H : h_even 0 h0 = h0) :
-  @even_odd_rec _ h0 h_even h_odd (2 * n) = h_even n (even_odd_rec h0 h_even h_odd n) :=
-begin
-  convert binary_rec_eq _ ff n,
-  { exact (bit0_eq_two_mul _).symm },
-  { exact (bit0_eq_two_mul _).symm },
-  { apply heq_of_cast_eq, refl },
-  { exact H }
-end
-
-@[simp] lemma even_odd_rec_odd (n : ℕ) (P : ℕ → Sort*) (h0 : P 0)
-  (h_even : ∀ i, P i → P (2 * i)) (h_odd : ∀ i, P i → P (2 * i + 1))
-  (H : h_even 0 h0 = h0) :
-  @even_odd_rec _ h0 h_even h_odd (2 * n + 1) = h_odd n (even_odd_rec h0 h_even h_odd n) :=
-begin
-  convert binary_rec_eq _ tt n,
-  { exact (bit0_eq_two_mul _).symm },
-  { exact (bit0_eq_two_mul _).symm },
-  { apply heq_of_cast_eq, refl },
-  { exact H }
-end
-
-
 /-- Given `P : ℕ → ℕ → Sort*`, if for all `a b : ℕ` we can extend `P` from the rectangle
 strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ`.
 Note that for non-`Prop` output it is preferable to use the equation compiler directly if possible,

--- a/src/data/nat/even_odd_rec.lean
+++ b/src/data/nat/even_odd_rec.lean
@@ -6,7 +6,7 @@ Authors: Stuart Presnell
 
 import data.nat.basic
 
-/-! A recursion principle based on even and odd numbers. -/
+/-! # A recursion principle based on even and odd numbers. -/
 
 namespace nat
 

--- a/src/data/nat/even_odd_rec.lean
+++ b/src/data/nat/even_odd_rec.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2022 Stuart Presnell. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stuart Presnell
+-/
+
+import data.nat.basic
+
+/-! A recursion principle based on even and odd numbers. -/
+
+namespace nat
+
+/-- Recursion principle on even and odd numbers: if we have `P 0`, and for all `i : ℕ` we can
+extend from `P i` to both `P (2 * i)` and `P (2 * i + 1)`, then we have `P n` for all `n : ℕ`.
+This is nothing more than a wrapper around `nat.binary_rec`, to avoid having to switch to
+dealing with `bit0` and `bit1`. -/
+@[elab_as_eliminator]
+def even_odd_rec {P : ℕ → Sort*} (h0 : P 0)
+  (h_even : ∀ n (ih : P n), P (2 * n))
+  (h_odd : ∀ n (ih : P n), P (2 * n + 1)) (n : ℕ) : P n :=
+begin
+  refine @binary_rec P h0 (λ b i hi, _) n,
+  cases b,
+  { simpa [bit, bit0_val i] using h_even i hi },
+  { simpa [bit, bit1_val i] using h_odd i hi },
+end
+
+@[simp] lemma even_odd_rec_zero (P : ℕ → Sort*) (h0 : P 0)
+  (h_even : ∀ i, P i → P (2 * i)) (h_odd : ∀ i, P i → P (2 * i + 1)) :
+  @even_odd_rec _ h0 h_even h_odd 0 = h0 := binary_rec_zero _ _
+
+@[simp] lemma even_odd_rec_even (n : ℕ) (P : ℕ → Sort*) (h0 : P 0)
+  (h_even : ∀ i, P i → P (2 * i)) (h_odd : ∀ i, P i → P (2 * i + 1))
+  (H : h_even 0 h0 = h0) :
+  @even_odd_rec _ h0 h_even h_odd (2 * n) = h_even n (even_odd_rec h0 h_even h_odd n) :=
+begin
+  convert binary_rec_eq _ ff n,
+  { exact (bit0_eq_two_mul _).symm },
+  { exact (bit0_eq_two_mul _).symm },
+  { apply heq_of_cast_eq, refl },
+  { exact H }
+end
+
+@[simp] lemma even_odd_rec_odd (n : ℕ) (P : ℕ → Sort*) (h0 : P 0)
+  (h_even : ∀ i, P i → P (2 * i)) (h_odd : ∀ i, P i → P (2 * i + 1))
+  (H : h_even 0 h0 = h0) :
+  @even_odd_rec _ h0 h_even h_odd (2 * n + 1) = h_odd n (even_odd_rec h0 h_even h_odd n) :=
+begin
+  convert binary_rec_eq _ tt n,
+  { exact (bit0_eq_two_mul _).symm },
+  { exact (bit0_eq_two_mul _).symm },
+  { apply heq_of_cast_eq, refl },
+  { exact H }
+end
+
+end nat


### PR DESCRIPTION
`even_odd_rec` is annoying to port, because it is thoroughly tangled with `bit0` and `bit1`. It isn't used in mathlib, so I'm dumping it into its own file so we can get on with porting the critical `data.nat.basic` without delaying for this.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
