### PR TITLE
[Merged by Bors] - feat(topology/algebra/module/finite_dimension): `can_lift` instances

### DIFF
--- a/src/topology/algebra/module/finite_dimension.lean
+++ b/src/topology/algebra/module/finite_dimension.lean
@@ -347,7 +347,7 @@ begin
   { simp only [map_sub, map_add, ← comp_apply f g, hg, id_apply, sub_add_cancel] }
 end
 
-instance can_lift_continuous_linear_map : can_lift (E →ₗ[𝕜] F) (E →L[𝕜] F) coe ⊤ :=
+instance can_lift_continuous_linear_map : can_lift (E →ₗ[𝕜] F) (E →L[𝕜] F) coe (λ _, true) :=
 ⟨λ f _, ⟨f.to_continuous_linear_map, rfl⟩⟩
 
 end linear_map
@@ -387,7 +387,7 @@ by { ext x, refl }
 by { ext x, refl }
 
 instance can_lift_continuous_linear_equiv :
-  can_lift (E ≃ₗ[𝕜] F) (E ≃L[𝕜] F) continuous_linear_equiv.to_linear_equiv ⊤ :=
+  can_lift (E ≃ₗ[𝕜] F) (E ≃L[𝕜] F) continuous_linear_equiv.to_linear_equiv (λ _, true) :=
 ⟨λ f _, ⟨_, f.to_linear_equiv_to_continuous_linear_equiv⟩⟩
 
 end linear_equiv

--- a/src/topology/algebra/module/finite_dimension.lean
+++ b/src/topology/algebra/module/finite_dimension.lean
@@ -347,6 +347,9 @@ begin
   { simp only [map_sub, map_add, ← comp_apply f g, hg, id_apply, sub_add_cancel] }
 end
 
+instance can_lift_continuous_linear_map : can_lift (E →ₗ[𝕜] F) (E →L[𝕜] F) coe ⊤ :=
+⟨λ f _, ⟨f.to_continuous_linear_map, rfl⟩⟩
+
 end linear_map
 
 namespace linear_equiv
@@ -382,6 +385,10 @@ by { ext x, refl }
 @[simp] lemma to_linear_equiv_to_continuous_linear_equiv_symm (e : E ≃ₗ[𝕜] F) :
   e.to_continuous_linear_equiv.symm.to_linear_equiv = e.symm :=
 by { ext x, refl }
+
+instance can_lift_continuous_linear_equiv :
+  can_lift (E ≃ₗ[𝕜] F) (E ≃L[𝕜] F) continuous_linear_equiv.to_linear_equiv ⊤ :=
+⟨λ f _, ⟨_, f.to_linear_equiv_to_continuous_linear_equiv⟩⟩
 
 end linear_equiv
 


### PR DESCRIPTION
Those instances are quite practical to avoid using `linear_map.to_continuous_linear_map`/`linear_equiv.to_continuous_linear_equiv` explicitly in proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
