### PR TITLE
[Merged by Bors] - feat(measure_theory/integrals): integration by parts for algebra-valued functions

### DIFF
--- a/src/analysis/special_functions/integrals.lean
+++ b/src/analysis/special_functions/integrals.lean
@@ -409,7 +409,7 @@ lemma integral_sin_pow_aux :
     + (n + 1) * (∫ x in a..b, sin x ^ n) - (n + 1) * ∫ x in a..b, sin x ^ (n + 2) :=
 begin
   let C := sin a ^ (n + 1) * cos a - sin b ^ (n + 1) * cos b,
-  have h : ∀ α β γ : ℝ, α * (β * α * γ) = β * (α * α * γ) := λ α β γ, by ring,
+  have h : ∀ α β γ : ℝ, (β * α * γ) * α = β * (α * α * γ) := λ α β γ, by ring,
   have hu : ∀ x ∈ _, has_deriv_at (λ y, sin y ^ (n + 1)) ((n + 1 : ℕ) * cos x * sin x ^ n) x :=
     λ x hx, by simpa only [mul_right_comm] using (has_deriv_at_sin x).pow (n+1),
   have hv : ∀ x ∈ [a, b], has_deriv_at (-cos) (sin x) x :=
@@ -481,7 +481,7 @@ lemma integral_cos_pow_aux :
     + (n + 1) * (∫ x in a..b, cos x ^ n) - (n + 1) * ∫ x in a..b, cos x ^ (n + 2) :=
 begin
   let C := cos b ^ (n + 1) * sin b - cos a ^ (n + 1) * sin a,
-  have h : ∀ α β γ : ℝ, α * (β * α * γ) = β * (α * α * γ) := λ α β γ, by ring,
+  have h : ∀ α β γ : ℝ, (β * α * γ) * α = β * (α * α * γ) := λ α β γ, by ring,
   have hu : ∀ x ∈ _, has_deriv_at (λ y, cos y ^ (n + 1)) (-(n + 1 : ℕ) * sin x * cos x ^ n) x :=
     λ x hx, by simpa only [mul_right_comm, neg_mul, mul_neg]
       using (has_deriv_at_cos x).pow (n+1),

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -81,7 +81,7 @@ end
 section mul
 
 variables [opens_measurable_space X] [normed_ring R] [second_countable_topology_either X R]
-variables {A K : set X} {g g' : X → R}
+  {A K : set X} {g g' : X → R}
 
 lemma integrable_on.mul_continuous_on_of_subset
   (hg : integrable_on g A μ) (hg' : continuous_on g' K)

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -78,8 +78,9 @@ begin
     exact h this }
 end
 
-section real
-variables [opens_measurable_space X] {A K : set X} {g g' : X → ℝ}
+section mul
+variables [opens_measurable_space X] {R : Type*} {A K : set X} {g g' : X → R}
+[normed_ring R] [second_countable_topology R]
 
 lemma integrable_on.mul_continuous_on_of_subset
   (hg : integrable_on g A μ) (hg' : continuous_on g' K)
@@ -90,10 +91,11 @@ begin
   rw [integrable_on, ← mem_ℒp_one_iff_integrable] at hg ⊢,
   have : ∀ᵐ x ∂(μ.restrict A), ‖g x * g' x‖ ≤ C * ‖g x‖,
   { filter_upwards [ae_restrict_mem hA] with x hx,
-    rw [real.norm_eq_abs, abs_mul, mul_comm, real.norm_eq_abs],
-    apply mul_le_mul_of_nonneg_right (hC x (hAK hx)) (abs_nonneg _), },
-  exact mem_ℒp.of_le_mul hg (hg.ae_strongly_measurable.ae_measurable.mul
-    ((hg'.mono hAK).ae_measurable hA)).ae_strongly_measurable this,
+    refine (norm_mul_le _ _).trans _,
+    rw mul_comm,
+    apply mul_le_mul_of_nonneg_right (hC x (hAK hx)) (norm_nonneg _), },
+  exact mem_ℒp.of_le_mul hg (hg.ae_strongly_measurable.mul $
+    (hg'.mono hAK).ae_strongly_measurable hA) this,
 end
 
 lemma integrable_on.mul_continuous_on [t2_space X]
@@ -105,14 +107,22 @@ lemma integrable_on.continuous_on_mul_of_subset
   (hg : continuous_on g K) (hg' : integrable_on g' A μ)
   (hK : is_compact K) (hA : measurable_set A) (hAK : A ⊆ K) :
   integrable_on (λ x, g x * g' x) A μ :=
-by simpa [mul_comm] using hg'.mul_continuous_on_of_subset hg hA hK hAK
-
+begin
+  rcases is_compact.exists_bound_of_continuous_on hK hg with ⟨C, hC⟩,
+  rw [integrable_on, ← mem_ℒp_one_iff_integrable] at hg' ⊢,
+  have : ∀ᵐ x ∂(μ.restrict A), ‖g x * g' x‖ ≤ C * ‖g' x‖,
+  { filter_upwards [ae_restrict_mem hA] with x hx,
+    refine (norm_mul_le _ _).trans _,
+    apply mul_le_mul_of_nonneg_right (hC x (hAK hx)) (norm_nonneg _), },
+  exact mem_ℒp.of_le_mul hg' (((hg.mono hAK).ae_strongly_measurable hA).mul
+    hg'.ae_strongly_measurable) this,
+end
 lemma integrable_on.continuous_on_mul [t2_space X]
   (hg : continuous_on g K) (hg' : integrable_on g' K μ) (hK : is_compact K) :
   integrable_on (λ x, g x * g' x) K μ :=
 integrable_on.continuous_on_mul_of_subset hg hg' hK hK.measurable_set subset.rfl
 
-end real
+end mul
 
 end measure_theory
 open measure_theory

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -23,7 +23,7 @@ on compact sets.
 open measure_theory measure_theory.measure set function topological_space
 open_locale topological_space interval
 
-variables {X Y E : Type*} [measurable_space X] [topological_space X]
+variables {X Y E R : Type*} [measurable_space X] [topological_space X]
 variables [measurable_space Y] [topological_space Y]
 variables [normed_add_comm_group E] {f : X → E} {μ : measure X}
 
@@ -79,7 +79,8 @@ begin
 end
 
 section mul
-variables [opens_measurable_space X] {R : Type*} {A K : set X} {g g' : X → R}
+
+variables [opens_measurable_space X] {A K : set X} {g g' : X → R}
 [normed_ring R] [second_countable_topology R]
 
 lemma integrable_on.mul_continuous_on_of_subset
@@ -117,10 +118,11 @@ begin
   exact mem_ℒp.of_le_mul hg' (((hg.mono hAK).ae_strongly_measurable hA).mul
     hg'.ae_strongly_measurable) this,
 end
+
 lemma integrable_on.continuous_on_mul [t2_space X]
   (hg : continuous_on g K) (hg' : integrable_on g' K μ) (hK : is_compact K) :
   integrable_on (λ x, g x * g' x) K μ :=
-integrable_on.continuous_on_mul_of_subset hg hg' hK.measurable_set hK subset.rfl
+hg'.continuous_on_mul_of_subset hg hK.measurable_set hK subset.rfl
 
 end mul
 

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -80,8 +80,8 @@ end
 
 section mul
 
-variables [opens_measurable_space X] {A K : set X} {g g' : X → R}
-[normed_ring R] [second_countable_topology_either X R]
+variables [opens_measurable_space X] [normed_ring R] [second_countable_topology_either X R]
+variables {A K : set X} {g g' : X → R}
 
 lemma integrable_on.mul_continuous_on_of_subset
   (hg : integrable_on g A μ) (hg' : continuous_on g' K)

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -81,7 +81,7 @@ end
 section mul
 
 variables [opens_measurable_space X] {A K : set X} {g g' : X → R}
-[normed_ring R] [second_countable_topology R]
+[normed_ring R] [second_countable_topology_either X R]
 
 lemma integrable_on.mul_continuous_on_of_subset
   (hg : integrable_on g A μ) (hg' : continuous_on g' K)
@@ -106,7 +106,7 @@ hg.mul_continuous_on_of_subset hg' hK.measurable_set hK (subset.refl _)
 
 lemma integrable_on.continuous_on_mul_of_subset
   (hg : continuous_on g K) (hg' : integrable_on g' A μ)
-  (hA : measurable_set A) (hK : is_compact K) (hAK : A ⊆ K) :
+  (hK : is_compact K) (hA : measurable_set A) (hAK : A ⊆ K) :
   integrable_on (λ x, g x * g' x) A μ :=
 begin
   rcases is_compact.exists_bound_of_continuous_on hK hg with ⟨C, hC⟩,
@@ -122,7 +122,7 @@ end
 lemma integrable_on.continuous_on_mul [t2_space X]
   (hg : continuous_on g K) (hg' : integrable_on g' K μ) (hK : is_compact K) :
   integrable_on (λ x, g x * g' x) K μ :=
-hg'.continuous_on_mul_of_subset hg hK.measurable_set hK subset.rfl
+hg'.continuous_on_mul_of_subset hg hK hK.measurable_set subset.rfl
 
 end mul
 

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -105,7 +105,7 @@ hg.mul_continuous_on_of_subset hg' hK.measurable_set hK (subset.refl _)
 
 lemma integrable_on.continuous_on_mul_of_subset
   (hg : continuous_on g K) (hg' : integrable_on g' A μ)
-  (hK : is_compact K) (hA : measurable_set A) (hAK : A ⊆ K) :
+  (hA : measurable_set A) (hK : is_compact K) (hAK : A ⊆ K) :
   integrable_on (λ x, g x * g' x) A μ :=
 begin
   rcases is_compact.exists_bound_of_continuous_on hK hg with ⟨C, hC⟩,
@@ -120,7 +120,7 @@ end
 lemma integrable_on.continuous_on_mul [t2_space X]
   (hg : continuous_on g K) (hg' : integrable_on g' K μ) (hK : is_compact K) :
   integrable_on (λ x, g x * g' x) K μ :=
-integrable_on.continuous_on_mul_of_subset hg hg' hK hK.measurable_set subset.rfl
+integrable_on.continuous_on_mul_of_subset hg hg' hK.measurable_set hK subset.rfl
 
 end mul
 

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -383,7 +383,7 @@ lemma sum (s : finset ι) {f : ι → ℝ → E} (h : ∀ i ∈ s, interval_inte
   interval_integrable (∑ i in s, f i) μ a b :=
 ⟨integrable_finset_sum' s (λ i hi, (h i hi).1), integrable_finset_sum' s (λ i hi, (h i hi).2)⟩
 
-lemma mul_continuous_on {A : Type*} [normed_ring A] [second_countable_topology A] {f g : ℝ → A}
+lemma mul_continuous_on {A : Type*} [normed_ring A] {f g : ℝ → A}
   (hf : interval_integrable f μ a b) (hg : continuous_on g [a, b]) :
   interval_integrable (λ x, f x * g x) μ a b :=
 begin
@@ -391,7 +391,7 @@ begin
   exact hf.mul_continuous_on_of_subset hg measurable_set_Ioc is_compact_interval Ioc_subset_Icc_self
 end
 
-lemma continuous_on_mul {A : Type*} [normed_ring A] [second_countable_topology A] {f g : ℝ → A}
+lemma continuous_on_mul {A : Type*} [normed_ring A] {f g : ℝ → A}
   (hf : interval_integrable f μ a b) (hg : continuous_on g [a, b]) :
   interval_integrable (λ x, g x * f x) μ a b :=
 begin
@@ -399,11 +399,11 @@ begin
   exact hf.continuous_on_mul_of_subset hg measurable_set_Ioc is_compact_interval Ioc_subset_Icc_self
 end
 
-lemma const_mul {A : Type*} [normed_ring A] [second_countable_topology A] {f : ℝ → A}
+lemma const_mul {A : Type*} [normed_ring A] {f : ℝ → A}
   (hf : interval_integrable f μ a b) (c : A) : interval_integrable (λ x, c * f x) μ a b :=
 hf.continuous_on_mul continuous_on_const
 
-lemma mul_const {A : Type*} [normed_ring A] [second_countable_topology A] {f : ℝ → A}
+lemma mul_const {A : Type*} [normed_ring A] {f : ℝ → A}
   (hf : interval_integrable f μ a b) (c : A) : interval_integrable (λ x, f x * c) μ a b :=
 hf.mul_continuous_on continuous_on_const
 
@@ -2486,7 +2486,7 @@ end
 
 section parts
 
-variables [normed_ring A] [second_countable_topology A] [normed_algebra ℝ A] [complete_space A]
+variables [normed_ring A] [normed_algebra ℝ A] [complete_space A]
 
 theorem integral_deriv_mul_eq_sub {u v u' v' : ℝ → A}
   (hu : ∀ x ∈ interval a b, has_deriv_at u (u' x) x)

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -383,7 +383,7 @@ lemma sum (s : finset ι) {f : ι → ℝ → E} (h : ∀ i ∈ s, interval_inte
   interval_integrable (∑ i in s, f i) μ a b :=
 ⟨integrable_finset_sum' s (λ i hi, (h i hi).1), integrable_finset_sum' s (λ i hi, (h i hi).2)⟩
 
-lemma mul_continuous_on {A : Type*} [normed_ring A] {f g : ℝ → A}
+lemma mul_continuous_on [normed_ring A] {f g : ℝ → A}
   (hf : interval_integrable f μ a b) (hg : continuous_on g [a, b]) :
   interval_integrable (λ x, f x * g x) μ a b :=
 begin

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -364,7 +364,7 @@ h.2.ae_strongly_measurable
 
 end
 
-variables {f g : ℝ → E} {a b : ℝ} {μ : measure ℝ}
+variables [normed_ring A] {f g : ℝ → E} {a b : ℝ} {μ : measure ℝ}
 
 lemma smul [normed_field 𝕜] [normed_space 𝕜 E]
   {f : ℝ → E} {a b : ℝ} {μ : measure ℝ} (h : interval_integrable f μ a b) (r : 𝕜) :
@@ -383,7 +383,7 @@ lemma sum (s : finset ι) {f : ι → ℝ → E} (h : ∀ i ∈ s, interval_inte
   interval_integrable (∑ i in s, f i) μ a b :=
 ⟨integrable_finset_sum' s (λ i hi, (h i hi).1), integrable_finset_sum' s (λ i hi, (h i hi).2)⟩
 
-lemma mul_continuous_on [normed_ring A] {f g : ℝ → A}
+lemma mul_continuous_on {f g : ℝ → A}
   (hf : interval_integrable f μ a b) (hg : continuous_on g [a, b]) :
   interval_integrable (λ x, f x * g x) μ a b :=
 begin
@@ -391,7 +391,7 @@ begin
   exact hf.mul_continuous_on_of_subset hg measurable_set_Ioc is_compact_interval Ioc_subset_Icc_self
 end
 
-lemma continuous_on_mul {A : Type*} [normed_ring A] {f g : ℝ → A}
+lemma continuous_on_mul {f g : ℝ → A}
   (hf : interval_integrable f μ a b) (hg : continuous_on g [a, b]) :
   interval_integrable (λ x, g x * f x) μ a b :=
 begin
@@ -399,11 +399,11 @@ begin
   exact hf.continuous_on_mul_of_subset hg is_compact_interval measurable_set_Ioc Ioc_subset_Icc_self
 end
 
-lemma const_mul {A : Type*} [normed_ring A] {f : ℝ → A}
+lemma const_mul {f : ℝ → A}
   (hf : interval_integrable f μ a b) (c : A) : interval_integrable (λ x, c * f x) μ a b :=
 hf.continuous_on_mul continuous_on_const
 
-lemma mul_const {A : Type*} [normed_ring A] {f : ℝ → A}
+lemma mul_const {f : ℝ → A}
   (hf : interval_integrable f μ a b) (c : A) : interval_integrable (λ x, f x * c) μ a b :=
 hf.mul_continuous_on continuous_on_const
 

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -168,7 +168,7 @@ open measure_theory set classical filter function
 
 open_locale classical topological_space filter ennreal big_operators interval nnreal
 
-variables {ι 𝕜 E F : Type*} [normed_add_comm_group E]
+variables {ι 𝕜 E F A : Type*} [normed_add_comm_group E]
 
 /-!
 ### Integrability at an interval
@@ -2483,10 +2483,10 @@ end
 /-!
 ### Integration by parts
 -/
+
 section parts
 
-variables {A : Type*} [normed_ring A] [second_countable_topology A] [normed_algebra ℝ A]
-[complete_space A]
+variables [normed_ring A] [second_countable_topology A] [normed_algebra ℝ A] [complete_space A]
 
 theorem integral_deriv_mul_eq_sub {u v u' v' : ℝ → A}
   (hu : ∀ x ∈ interval a b, has_deriv_at u (u' x) x)
@@ -2511,6 +2511,7 @@ begin
 end
 
 end parts
+
 /-!
 ### Integration by substitution / Change of variables
 -/

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -396,7 +396,7 @@ lemma continuous_on_mul {A : Type*} [normed_ring A] {f g : ℝ → A}
   interval_integrable (λ x, g x * f x) μ a b :=
 begin
   rw interval_integrable_iff at hf ⊢,
-  exact hf.continuous_on_mul_of_subset hg measurable_set_Ioc is_compact_interval Ioc_subset_Icc_self
+  exact hf.continuous_on_mul_of_subset hg is_compact_interval measurable_set_Ioc Ioc_subset_Icc_self
 end
 
 lemma const_mul {A : Type*} [normed_ring A] {f : ℝ → A}


### PR DESCRIPTION
The code for integration by parts in the library presently assumes the functions are ℝ-valued. This generalises things to allow functions valued in a complete normed ℝ-algebra (not necessarily commutative); the motivating case is of course functions `ℝ → ℂ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
