### PR TITLE
[Merged by Bors] - chore(data/real/cau_seq): generalize to noncommutative settings

### DIFF
--- a/src/algebra/field/basic.lean
+++ b/src/algebra/field/basic.lean
@@ -115,6 +115,10 @@ lemma div_sub_one {a b : K} (h : b ≠ 0) : a / b - 1 = (a - b) / b := (div_sub_
 lemma sub_div (a b c : K) : (a - b) / c = a / c - b / c :=
 (div_sub_div_same _ _ _).symm
 
+/-- See `inv_sub_inv` for the more convenient version when `K` is commutative. -/
+lemma inv_sub_inv' {a b : K} (ha : a ≠ 0) (hb : b ≠ 0) : a⁻¹ - b⁻¹ = a⁻¹ * (b - a) * b⁻¹ :=
+by rw [mul_sub, sub_mul, mul_inv_cancel_right₀ hb, inv_mul_cancel ha, one_mul]
+
 lemma one_div_mul_sub_mul_one_div_eq_one_div_add_one_div (ha : a ≠ 0) (hb : b ≠ 0) :
           (1 / a) * (b - a) * (1 / b) = 1 / a - 1 / b :=
 by rw [(mul_sub_left_distrib (1 / a)), (one_div_mul_cancel ha), mul_sub_right_distrib,

--- a/src/data/real/cau_seq.lean
+++ b/src/data/real/cau_seq.lean
@@ -69,22 +69,20 @@ begin
 end
 
 theorem rat_inv_continuous_lemma
-  {β : Type*} [field β] (abv : β → α) [is_absolute_value abv]
+  {β : Type*} [division_ring β] (abv : β → α) [is_absolute_value abv]
   {ε K : α} (ε0 : 0 < ε) (K0 : 0 < K) :
   ∃ δ > 0, ∀ {a b : β}, K ≤ abv a → K ≤ abv b →
   abv (a - b) < δ → abv (a⁻¹ - b⁻¹) < ε :=
 begin
-  have KK := mul_pos K0 K0,
-  have εK := mul_pos ε0 KK,
-  refine ⟨_, εK, λ a b ha hb h, _⟩,
-  have a0 := lt_of_lt_of_le K0 ha,
-  have b0 := lt_of_lt_of_le K0 hb,
-  rw [inv_sub_inv ((abv_pos abv).1 a0) ((abv_pos abv).1 b0),
-      abv_div abv, abv_mul abv, mul_comm, abv_sub abv,
-      ← mul_div_cancel ε (ne_of_gt KK)],
-  exact div_lt_div h
-    (mul_le_mul hb ha (le_of_lt K0) (abv_nonneg abv _))
-    (le_of_lt $ mul_pos ε0 KK) KK
+  refine ⟨K * ε * K, mul_pos (mul_pos K0 ε0) K0, λ a b ha hb h, _⟩,
+  have a0 := K0.trans_le ha,
+  have b0 := K0.trans_le hb,
+  rw [inv_sub_inv' ((abv_pos abv).1 a0) ((abv_pos abv).1 b0), abv_mul abv, abv_mul abv,
+    abv_inv abv, abv_inv abv,  abv_sub abv],
+  refine lt_of_mul_lt_mul_left (lt_of_mul_lt_mul_right _ b0.le) a0.le,
+  rw [mul_assoc, inv_mul_cancel_right₀ b0.ne', ←mul_assoc, mul_inv_cancel a0.ne', one_mul],
+  refine h.trans_le _,
+  exact mul_le_mul (mul_le_mul ha le_rfl ε0.le a0.le) hb K0.le (mul_nonneg a0.le ε0.le),
 end
 end
 
@@ -406,6 +404,11 @@ have lim_zero (f - 0), from hf,
 have lim_zero (g*f), from mul_lim_zero_right _ $ by simpa,
 show lim_zero (g*f - 0), by simpa
 
+lemma mul_equiv_zero' (g : cau_seq _ abv) {f : cau_seq _ abv} (hf : f ≈ 0) : f * g ≈ 0 :=
+have lim_zero (f - 0), from hf,
+have lim_zero (f*g), from mul_lim_zero_left _ $ by simpa,
+show lim_zero (f*g - 0), by simpa
+
 lemma mul_not_equiv_zero {f g : cau_seq _ abv} (hf : ¬ f ≈ 0) (hg : ¬ g ≈ 0) : ¬ (f * g) ≈ 0 :=
 assume : lim_zero (f*g - 0),
 have hlz : lim_zero (f*g), by simpa,
@@ -431,20 +434,12 @@ end
 theorem const_equiv {x y : β} : const x ≈ const y ↔ x = y :=
 show lim_zero _ ↔ _, by rw [← const_sub, const_lim_zero, sub_eq_zero]
 
-end ring
-
-section comm_ring
-variables [comm_ring β] {abv : β → α} [is_absolute_value abv]
-
-lemma mul_equiv_zero' (g : cau_seq _ abv) {f : cau_seq _ abv} (hf : f ≈ 0) : f * g ≈ 0 :=
-by rw mul_comm; apply mul_equiv_zero _ hf
-
 lemma mul_equiv_mul {f1 f2 g1 g2 : cau_seq β abv} (hf : f1 ≈ f2) (hg : g1 ≈ g2) :
   f1 * g1 ≈ f2 * g2 :=
-by simpa only [mul_sub, mul_comm, sub_add_sub_cancel]
-  using add_lim_zero (mul_lim_zero_right g1 hf) (mul_lim_zero_right f2 hg)
+by simpa only [mul_sub, sub_mul, sub_add_sub_cancel]
+  using add_lim_zero (mul_lim_zero_left g1 hf) (mul_lim_zero_right f2 hg)
 
-end comm_ring
+end ring
 
 section is_domain
 variables [ring β] [is_domain β] (abv : β → α) [is_absolute_value abv]
@@ -463,8 +458,8 @@ absurd this one_ne_zero
 
 end is_domain
 
-section field
-variables [field β] {abv : β → α} [is_absolute_value abv]
+section division_ring
+variables [division_ring β] {abv : β → α} [is_absolute_value abv]
 
 theorem inv_aux {f : cau_seq β abv} (hf : ¬ lim_zero f) :
   ∀ ε > 0, ∃ i, ∀ j ≥ i, abv ((f j)⁻¹ - (f i)⁻¹) < ε | ε ε0 :=
@@ -486,10 +481,16 @@ theorem inv_mul_cancel {f : cau_seq β abv} (hf) : inv f hf * f ≈ 1 :=
   by simpa [(abv_pos abv).1 (lt_of_lt_of_le K0 (H _ ij)),
     abv_zero abv] using ε0⟩
 
+theorem mul_inv_cancel {f : cau_seq β abv} (hf) : f * inv f hf ≈ 1 :=
+λ ε ε0, let ⟨K, K0, i, H⟩ := abv_pos_of_not_lim_zero hf in
+⟨i, λ j ij,
+  by simpa [(abv_pos abv).1 (lt_of_lt_of_le K0 (H _ ij)),
+    abv_zero abv] using ε0⟩
+
 theorem const_inv {x : β} (hx : x ≠ 0) :
   const abv (x⁻¹) = inv (const abv x) (by rwa const_lim_zero) := rfl
 
-end field
+end division_ring
 
 section abs
 local notation `const` := const abs

--- a/src/data/real/cau_seq_completion.lean
+++ b/src/data/real/cau_seq_completion.lean
@@ -182,7 +182,7 @@ end
 theorem of_rat_inv (x : β) : of_rat (x⁻¹) = ((of_rat x)⁻¹ : Cauchy) :=
 congr_arg mk $ by split_ifs with h; [simp [const_lim_zero.1 h], refl]
 
-/-- The Cauchy completion forms a field. -/
+/-- The Cauchy completion forms a division ring. -/
 noncomputable instance : division_ring Cauchy :=
 { inv              := has_inv.inv,
   mul_inv_cancel   := λ x, cau_seq.completion.mul_inv_cancel,


### PR DESCRIPTION
The generalizations are all trivial algebra manipulations, just done in a slightly more careful order to avoid needing commutativity.

Many of the results about `cau_seq` were already stated without commutativity assumptions, this just propagates the weakening to downstream results.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
