### PR TITLE
[Merged by Bors] - chore(algebra/order/group/defs): split file

### DIFF
--- a/counterexamples/linear_order_with_pos_mul_pos_eq_zero.lean
+++ b/counterexamples/linear_order_with_pos_mul_pos_eq_zero.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Damiano Testa, Kevin Buzzard
 -/
 import algebra.order.monoid.defs
-import algebra.order.monoid.with_zero
+import algebra.order.monoid.with_zero.defs
 
 /-!
 An example of a `linear_ordered_comm_monoid_with_zero` in which the product of two positive

--- a/src/algebra/category/Mon/adjunctions.lean
+++ b/src/algebra/category/Mon/adjunctions.lean
@@ -5,7 +5,7 @@ Authors: Julian Kuelshammer
 -/
 import algebra.category.Mon.basic
 import algebra.category.Semigroup.basic
-import algebra.group.with_one
+import algebra.group.with_one.basic
 import algebra.free_monoid.basic
 
 /-!

--- a/src/algebra/free.lean
+++ b/src/algebra/free.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 import algebra.hom.group
+import algebra.hom.equiv.basic
 import control.applicative
 import control.traversable.basic
 import logic.equiv.defs

--- a/src/algebra/group/default.lean
+++ b/src/algebra/group/default.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Michael Howes
 -/
 import algebra.group.conj
 import algebra.group.type_tags
-import algebra.group.with_one
+import algebra.group.with_one.basic
 import algebra.hom.units
 
 /-!

--- a/src/algebra/group/with_one/basic.lean
+++ b/src/algebra/group/with_one/basic.lean
@@ -7,15 +7,14 @@ import algebra.group.with_one.defs
 import algebra.hom.equiv.basic
 
 /-!
-# Adjoining a zero/one to semigroups and related algebraic structures
+# More operations on `with_one` and `with_zero`
 
-This file contains different results about adjoining an element to an algebraic structure which then
-behaves like a zero or a one. An example is adjoining a one to a semigroup to obtain a monoid. That
-this provides an example of an adjunction is proved in `algebra.category.Mon.adjunctions`.
+This file defines various bundled morphisms on `with_one` and `with_zero` that were not available in `algebra/group/with_one/defs`.
 
-Another result says that adjoining to a group an element `zero` gives a `group_with_zero`. For more
-information about these structures (which are not that standard in informal mathematics, see
-`algebra.group_with_zero.basic`)
+## Main definitions
+
+* `with_one.lift`, `with_zero.lift`
+* `with_one.map`, `with_zero.map`
 -/
 
 universes u v w

--- a/src/algebra/group/with_one/basic.lean
+++ b/src/algebra/group/with_one/basic.lean
@@ -9,7 +9,8 @@ import algebra.hom.equiv.basic
 /-!
 # More operations on `with_one` and `with_zero`
 
-This file defines various bundled morphisms on `with_one` and `with_zero` that were not available in `algebra/group/with_one/defs`.
+This file defines various bundled morphisms on `with_one` and `with_zero`
+that were not available in `algebra/group/with_one/defs`.
 
 ## Main definitions
 

--- a/src/algebra/group/with_one/basic.lean
+++ b/src/algebra/group/with_one/basic.lean
@@ -68,8 +68,6 @@ theorem lift_unique (f : with_one α →* β) : f = lift (f.to_mul_hom.comp coe_
 
 end lift
 
-attribute [irreducible] with_one
-
 section map
 
 variables [has_mul α] [has_mul β] [has_mul γ]

--- a/src/algebra/group/with_one/basic.lean
+++ b/src/algebra/group/with_one/basic.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Johan Commelin
+-/
+import algebra.group.with_one.defs
+import algebra.hom.equiv.basic
+
+/-!
+# Adjoining a zero/one to semigroups and related algebraic structures
+
+This file contains different results about adjoining an element to an algebraic structure which then
+behaves like a zero or a one. An example is adjoining a one to a semigroup to obtain a monoid. That
+this provides an example of an adjunction is proved in `algebra.category.Mon.adjunctions`.
+
+Another result says that adjoining to a group an element `zero` gives a `group_with_zero`. For more
+information about these structures (which are not that standard in informal mathematics, see
+`algebra.group_with_zero.basic`)
+-/
+
+universes u v w
+variables {α : Type u} {β : Type v} {γ : Type w}
+
+namespace with_one
+
+section
+-- workaround: we make `with_one`/`with_zero` irreducible for this definition, otherwise `simps`
+-- will unfold it in the statement of the lemma it generates.
+local attribute [irreducible] with_one with_zero
+/-- `coe` as a bundled morphism -/
+@[to_additive "`coe` as a bundled morphism", simps apply]
+def coe_mul_hom [has_mul α] : α →ₙ* (with_one α) :=
+{ to_fun := coe, map_mul' := λ x y, rfl }
+
+end
+
+section lift
+
+local attribute [semireducible] with_one with_zero
+
+variables [has_mul α] [mul_one_class β]
+
+/-- Lift a semigroup homomorphism `f` to a bundled monoid homorphism. -/
+@[to_additive "Lift an add_semigroup homomorphism `f` to a bundled add_monoid homorphism."]
+def lift : (α →ₙ* β) ≃ (with_one α →* β) :=
+{ to_fun := λ f,
+  { to_fun := λ x, option.cases_on x 1 f,
+    map_one' := rfl,
+    map_mul' := λ x y,
+      with_one.cases_on x (by { rw one_mul, exact (one_mul _).symm }) $ λ x,
+      with_one.cases_on y (by { rw mul_one, exact (mul_one _).symm }) $ λ y,
+      f.map_mul x y },
+  inv_fun := λ F, F.to_mul_hom.comp coe_mul_hom,
+  left_inv := λ f, mul_hom.ext $ λ x, rfl,
+  right_inv := λ F, monoid_hom.ext $ λ x, with_one.cases_on x F.map_one.symm $ λ x, rfl }
+
+variables (f : α →ₙ* β)
+
+@[simp, to_additive]
+lemma lift_coe (x : α) : lift f x = f x := rfl
+
+@[simp, to_additive]
+lemma lift_one : lift f 1 = 1 := rfl
+
+@[to_additive]
+theorem lift_unique (f : with_one α →* β) : f = lift (f.to_mul_hom.comp coe_mul_hom) :=
+(lift.apply_symm_apply f).symm
+
+end lift
+
+attribute [irreducible] with_one
+
+section map
+
+variables [has_mul α] [has_mul β] [has_mul γ]
+
+/-- Given a multiplicative map from `α → β` returns a monoid homomorphism
+  from `with_one α` to `with_one β` -/
+@[to_additive "Given an additive map from `α → β` returns an add_monoid homomorphism
+  from `with_zero α` to `with_zero β`"]
+def map (f : α →ₙ* β) : with_one α →* with_one β :=
+lift (coe_mul_hom.comp f)
+
+@[simp, to_additive] lemma map_coe (f : α →ₙ* β) (a : α) : map f (a : with_one α) = f a :=
+lift_coe _ _
+
+@[simp, to_additive]
+lemma map_id : map (mul_hom.id α) = monoid_hom.id (with_one α) :=
+by { ext, induction x using with_one.cases_on; refl }
+
+@[to_additive]
+lemma map_map (f : α →ₙ* β) (g : β →ₙ* γ) (x) :
+  map g (map f x) = map (g.comp f) x :=
+by { induction x using with_one.cases_on; refl }
+
+@[simp, to_additive]
+lemma map_comp (f : α →ₙ* β) (g : β →ₙ* γ) :
+  map (g.comp f) = (map g).comp (map f) :=
+monoid_hom.ext $ λ x, (map_map f g x).symm
+
+/-- A version of `equiv.option_congr` for `with_one`. -/
+@[to_additive "A version of `equiv.option_congr` for `with_zero`.", simps apply]
+def _root_.mul_equiv.with_one_congr (e : α ≃* β) : with_one α ≃* with_one β :=
+{ to_fun := map e.to_mul_hom,
+  inv_fun := map e.symm.to_mul_hom,
+  left_inv := λ x, (map_map _ _ _).trans $ by induction x using with_one.cases_on; { simp },
+  right_inv := λ x, (map_map _ _ _).trans $ by induction x using with_one.cases_on; { simp },
+  .. map e.to_mul_hom }
+
+@[simp]
+lemma _root_.mul_equiv.with_one_congr_refl : (mul_equiv.refl α).with_one_congr = mul_equiv.refl _ :=
+mul_equiv.to_monoid_hom_injective map_id
+
+@[simp]
+lemma _root_.mul_equiv.with_one_congr_symm (e : α ≃* β) :
+  e.with_one_congr.symm = e.symm.with_one_congr := rfl
+
+@[simp]
+lemma _root_.mul_equiv.with_one_congr_trans (e₁ : α ≃* β) (e₂ : β ≃* γ) :
+  e₁.with_one_congr.trans e₂.with_one_congr = (e₁.trans e₂).with_one_congr :=
+mul_equiv.to_monoid_hom_injective (map_comp _ _).symm
+
+end map
+
+end with_one

--- a/src/algebra/group/with_one/defs.lean
+++ b/src/algebra/group/with_one/defs.lean
@@ -132,6 +132,8 @@ instance [comm_semigroup α] : comm_monoid (with_one α) :=
 { mul_comm := (option.lift_or_get_comm _).1,
   ..with_one.monoid }
 
+attribute [irreducible] with_one
+
 @[simp, norm_cast, to_additive]
 lemma coe_mul [has_mul α] (a b : α) : ((a * b : α) : with_one α) = a * b := rfl
 

--- a/src/algebra/group/with_one/defs.lean
+++ b/src/algebra/group/with_one/defs.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johan Commelin
 -/
 import order.with_bot
-import algebra.hom.equiv.basic
-import algebra.group_with_zero.units.basic
 import algebra.ring.defs
 
 /-!
@@ -133,103 +131,6 @@ example [semigroup α] :
 instance [comm_semigroup α] : comm_monoid (with_one α) :=
 { mul_comm := (option.lift_or_get_comm _).1,
   ..with_one.monoid }
-
-section
--- workaround: we make `with_one`/`with_zero` irreducible for this definition, otherwise `simps`
--- will unfold it in the statement of the lemma it generates.
-local attribute [irreducible] with_one with_zero
-/-- `coe` as a bundled morphism -/
-@[to_additive "`coe` as a bundled morphism", simps apply]
-def coe_mul_hom [has_mul α] : α →ₙ* (with_one α) :=
-{ to_fun := coe, map_mul' := λ x y, rfl }
-
-end
-
-section lift
-
-variables [has_mul α] [mul_one_class β]
-
-/-- Lift a semigroup homomorphism `f` to a bundled monoid homorphism. -/
-@[to_additive "Lift an add_semigroup homomorphism `f` to a bundled add_monoid homorphism."]
-def lift : (α →ₙ* β) ≃ (with_one α →* β) :=
-{ to_fun := λ f,
-  { to_fun := λ x, option.cases_on x 1 f,
-    map_one' := rfl,
-    map_mul' := λ x y,
-      with_one.cases_on x (by { rw one_mul, exact (one_mul _).symm }) $ λ x,
-      with_one.cases_on y (by { rw mul_one, exact (mul_one _).symm }) $ λ y,
-      f.map_mul x y },
-  inv_fun := λ F, F.to_mul_hom.comp coe_mul_hom,
-  left_inv := λ f, mul_hom.ext $ λ x, rfl,
-  right_inv := λ F, monoid_hom.ext $ λ x, with_one.cases_on x F.map_one.symm $ λ x, rfl }
-
-variables (f : α →ₙ* β)
-
-@[simp, to_additive]
-lemma lift_coe (x : α) : lift f x = f x := rfl
-
-@[simp, to_additive]
-lemma lift_one : lift f 1 = 1 := rfl
-
-@[to_additive]
-theorem lift_unique (f : with_one α →* β) : f = lift (f.to_mul_hom.comp coe_mul_hom) :=
-(lift.apply_symm_apply f).symm
-
-end lift
-
-attribute [irreducible] with_one
-
-section map
-
-variables [has_mul α] [has_mul β] [has_mul γ]
-
-/-- Given a multiplicative map from `α → β` returns a monoid homomorphism
-  from `with_one α` to `with_one β` -/
-@[to_additive "Given an additive map from `α → β` returns an add_monoid homomorphism
-  from `with_zero α` to `with_zero β`"]
-def map (f : α →ₙ* β) : with_one α →* with_one β :=
-lift (coe_mul_hom.comp f)
-
-@[simp, to_additive] lemma map_coe (f : α →ₙ* β) (a : α) : map f (a : with_one α) = f a :=
-lift_coe _ _
-
-@[simp, to_additive]
-lemma map_id : map (mul_hom.id α) = monoid_hom.id (with_one α) :=
-by { ext, induction x using with_one.cases_on; refl }
-
-@[to_additive]
-lemma map_map (f : α →ₙ* β) (g : β →ₙ* γ) (x) :
-  map g (map f x) = map (g.comp f) x :=
-by { induction x using with_one.cases_on; refl }
-
-@[simp, to_additive]
-lemma map_comp (f : α →ₙ* β) (g : β →ₙ* γ) :
-  map (g.comp f) = (map g).comp (map f) :=
-monoid_hom.ext $ λ x, (map_map f g x).symm
-
-/-- A version of `equiv.option_congr` for `with_one`. -/
-@[to_additive "A version of `equiv.option_congr` for `with_zero`.", simps apply]
-def _root_.mul_equiv.with_one_congr (e : α ≃* β) : with_one α ≃* with_one β :=
-{ to_fun := map e.to_mul_hom,
-  inv_fun := map e.symm.to_mul_hom,
-  left_inv := λ x, (map_map _ _ _).trans $ by induction x using with_one.cases_on; { simp },
-  right_inv := λ x, (map_map _ _ _).trans $ by induction x using with_one.cases_on; { simp },
-  .. map e.to_mul_hom }
-
-@[simp]
-lemma _root_.mul_equiv.with_one_congr_refl : (mul_equiv.refl α).with_one_congr = mul_equiv.refl _ :=
-mul_equiv.to_monoid_hom_injective map_id
-
-@[simp]
-lemma _root_.mul_equiv.with_one_congr_symm (e : α ≃* β) :
-  e.with_one_congr.symm = e.symm.with_one_congr := rfl
-
-@[simp]
-lemma _root_.mul_equiv.with_one_congr_trans (e₁ : α ≃* β) (e₂ : β ≃* γ) :
-  e₁.with_one_congr.trans e₂.with_one_congr = (e₁.trans e₂).with_one_congr :=
-mul_equiv.to_monoid_hom_injective (map_comp _ _).symm
-
-end map
 
 @[simp, norm_cast, to_additive]
 lemma coe_mul [has_mul α] (a b : α) : ((a * b : α) : with_one α) = a * b := rfl
@@ -440,14 +341,6 @@ instance [semiring α] : semiring (with_zero α) :=
   ..with_zero.add_comm_monoid,
   ..with_zero.mul_zero_class,
   ..with_zero.monoid_with_zero }
-
-/-- Any group is isomorphic to the units of itself adjoined with `0`. -/
-def units_with_zero_equiv [group α] : (with_zero α)ˣ ≃* α :=
-{ to_fun    := λ a, unzero a.ne_zero,
-  inv_fun   := λ a, units.mk0 a coe_ne_zero,
-  left_inv  := λ _, units.ext $ by simpa only [coe_unzero],
-  right_inv := λ _, rfl,
-  map_mul'  := λ _ _, coe_inj.mp $ by simpa only [coe_unzero, coe_mul] }
 
 attribute [irreducible] with_zero
 

--- a/src/algebra/group/with_one/units.lean
+++ b/src/algebra/group/with_one/units.lean
@@ -6,7 +6,8 @@ Authors: Mario Carneiro, Johan Commelin
 import algebra.group.with_one.basic
 import algebra.group_with_zero.units.basic
 
-/-! A group is isomorphic to the units of itself adjoined with `0`.`
+/-!
+# Isomorphism between a group and the units of itself adjoined with `0`
 
 ## Notes
 This is here to keep `algebra.group_with_zero.units.basic` out of the import requirements of

--- a/src/algebra/group/with_one/units.lean
+++ b/src/algebra/group/with_one/units.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Johan Commelin
+-/
+import algebra.group.with_one.basic
+import algebra.group_with_zero.units.basic
+
+/-! A group is isomorphic to the units of itself adjoined with `0`.`
+
+## Notes
+This is here to keep `algebra.group_with_zero.units.basic` out of the import requirements of
+`algebra.order.field.defs`.
+-/
+
+namespace with_zero
+
+/-- Any group is isomorphic to the units of itself adjoined with `0`. -/
+def units_with_zero_equiv {α : Type*} [group α] : (with_zero α)ˣ ≃* α :=
+{ to_fun    := λ a, unzero a.ne_zero,
+  inv_fun   := λ a, units.mk0 a coe_ne_zero,
+  left_inv  := λ _, units.ext $ by simpa only [coe_unzero],
+  right_inv := λ _, rfl,
+  map_mul'  := λ _ _, coe_inj.mp $ by simpa only [coe_unzero, coe_mul] }
+
+end with_zero

--- a/src/algebra/order/field/defs.lean
+++ b/src/algebra/order/field/defs.lean
@@ -42,3 +42,6 @@ class linear_ordered_field (α : Type*) extends linear_ordered_comm_ring α, fie
 instance linear_ordered_field.to_linear_ordered_semifield [linear_ordered_field α] :
   linear_ordered_semifield α :=
 { ..linear_ordered_ring.to_linear_ordered_semiring, ..‹linear_ordered_field α› }
+
+-- Guard against import creep.
+assert_not_exists monoid_hom

--- a/src/algebra/order/group/abs.lean
+++ b/src/algebra/order/group/abs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import algebra.abs
-import algebra.order.group.defs
+import algebra.order.group.order_iso
 import order.min_max
 
 /-!

--- a/src/algebra/order/group/defs.lean
+++ b/src/algebra/order/group/defs.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import order.hom.basic
-import algebra.hom.equiv.units.basic
 import algebra.order.sub.defs
 import algebra.order.monoid.defs
 
@@ -232,29 +231,6 @@ by { rw [← mul_le_mul_iff_left a, ← mul_le_mul_iff_right b], simp }
 
 alias neg_le_neg_iff ↔ le_of_neg_le_neg _
 
-section
-
-variable (α)
-
-/-- `x ↦ x⁻¹` as an order-reversing equivalence. -/
-@[to_additive "`x ↦ -x` as an order-reversing equivalence.", simps]
-def order_iso.inv : α ≃o αᵒᵈ :=
-{ to_equiv := (equiv.inv α).trans order_dual.to_dual,
-  map_rel_iff' := λ a b, @inv_le_inv_iff α _ _ _ _ _ _ }
-
-end
-
-@[to_additive neg_le]
-lemma inv_le' : a⁻¹ ≤ b ↔ b⁻¹ ≤ a :=
-(order_iso.inv α).symm_apply_le
-
-alias inv_le' ↔ inv_le_of_inv_le' _
-attribute [to_additive neg_le_of_neg_le] inv_le_of_inv_le'
-
-@[to_additive le_neg]
-lemma le_inv' : a ≤ b⁻¹ ↔ b ≤ a⁻¹ :=
-(order_iso.inv α).le_symm_apply
-
 @[to_additive]
 lemma mul_inv_le_inv_mul_iff : a * b⁻¹ ≤ d⁻¹ * c ↔ d * a ≤ c * b :=
 by rw [← mul_le_mul_iff_left d, ← mul_le_mul_iff_right b, mul_inv_cancel_left, mul_assoc,
@@ -406,9 +382,6 @@ end has_lt
 
 end comm_group
 
-alias le_inv' ↔ le_inv_of_le_inv _
-attribute [to_additive] le_inv_of_le_inv
-
 alias left.inv_le_one_iff ↔ one_le_of_inv_le_one _
 attribute [to_additive] one_le_of_inv_le_one
 
@@ -520,30 +493,10 @@ instance add_group.to_has_ordered_sub {α : Type*} [add_group α] [has_le α]
   [covariant_class α α (swap (+)) (≤)] : has_ordered_sub α :=
 ⟨λ a b c, sub_le_iff_le_add⟩
 
-/-- `equiv.mul_right` as an `order_iso`. See also `order_embedding.mul_right`. -/
-@[to_additive "`equiv.add_right` as an `order_iso`. See also `order_embedding.add_right`.",
-  simps to_equiv apply {simp_rhs := tt}]
-def order_iso.mul_right (a : α) : α ≃o α :=
-{ map_rel_iff' := λ _ _, mul_le_mul_iff_right a, to_equiv := equiv.mul_right a }
-
-@[simp, to_additive] lemma order_iso.mul_right_symm (a : α) :
-  (order_iso.mul_right a).symm = order_iso.mul_right a⁻¹ :=
-by { ext x, refl }
-
 end right
 
 section left
 variables [covariant_class α α (*) (≤)]
-
-/-- `equiv.mul_left` as an `order_iso`. See also `order_embedding.mul_left`. -/
-@[to_additive "`equiv.add_left` as an `order_iso`. See also `order_embedding.add_left`.",
-  simps to_equiv apply  {simp_rhs := tt}]
-def order_iso.mul_left (a : α) : α ≃o α :=
-{ map_rel_iff' := λ _ _, mul_le_mul_iff_left a, to_equiv := equiv.mul_left a }
-
-@[simp, to_additive] lemma order_iso.mul_left_symm (a : α) :
-  (order_iso.mul_left a).symm = order_iso.mul_left a⁻¹ :=
-by { ext x, refl }
 
 variables [covariant_class α α (swap (*)) (≤)] {a b c : α}
 

--- a/src/algebra/order/group/order_iso.lean
+++ b/src/algebra/order/group/order_iso.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
+-/
+import algebra.order.group.defs
+import algebra.hom.equiv.units.basic
+
+/-!
+# Inverse and multiplication as order isomorphisms in ordered groups
+
+-/
+
+set_option old_structure_cmd true
+open function
+
+universe u
+variable {α : Type u}
+
+
+section group
+variables [group α]
+
+section typeclasses_left_right_le
+variables [has_le α] [covariant_class α α (*) (≤)] [covariant_class α α (swap (*)) (≤)]
+  {a b c d : α}
+
+section
+
+variable (α)
+
+/-- `x ↦ x⁻¹` as an order-reversing equivalence. -/
+@[to_additive "`x ↦ -x` as an order-reversing equivalence.", simps]
+def order_iso.inv : α ≃o αᵒᵈ :=
+{ to_equiv := (equiv.inv α).trans order_dual.to_dual,
+  map_rel_iff' := λ a b, @inv_le_inv_iff α _ _ _ _ _ _ }
+
+end
+
+@[to_additive neg_le]
+lemma inv_le' : a⁻¹ ≤ b ↔ b⁻¹ ≤ a :=
+(order_iso.inv α).symm_apply_le
+
+alias inv_le' ↔ inv_le_of_inv_le' _
+attribute [to_additive neg_le_of_neg_le] inv_le_of_inv_le'
+
+@[to_additive le_neg]
+lemma le_inv' : a ≤ b⁻¹ ↔ b ≤ a⁻¹ :=
+(order_iso.inv α).le_symm_apply
+
+end typeclasses_left_right_le
+
+end group
+
+alias le_inv' ↔ le_inv_of_le_inv _
+attribute [to_additive] le_inv_of_le_inv
+
+section group
+variables [group α] [has_le α]
+
+section right
+variables [covariant_class α α (swap (*)) (≤)] {a b c d : α}
+
+/-- `equiv.mul_right` as an `order_iso`. See also `order_embedding.mul_right`. -/
+@[to_additive "`equiv.add_right` as an `order_iso`. See also `order_embedding.add_right`.",
+  simps to_equiv apply {simp_rhs := tt}]
+def order_iso.mul_right (a : α) : α ≃o α :=
+{ map_rel_iff' := λ _ _, mul_le_mul_iff_right a, to_equiv := equiv.mul_right a }
+
+@[simp, to_additive] lemma order_iso.mul_right_symm (a : α) :
+  (order_iso.mul_right a).symm = order_iso.mul_right a⁻¹ :=
+by { ext x, refl }
+
+end right
+
+section left
+variables [covariant_class α α (*) (≤)]
+
+/-- `equiv.mul_left` as an `order_iso`. See also `order_embedding.mul_left`. -/
+@[to_additive "`equiv.add_left` as an `order_iso`. See also `order_embedding.add_left`.",
+  simps to_equiv apply  {simp_rhs := tt}]
+def order_iso.mul_left (a : α) : α ≃o α :=
+{ map_rel_iff' := λ _ _, mul_le_mul_iff_left a, to_equiv := equiv.mul_left a }
+
+@[simp, to_additive] lemma order_iso.mul_left_symm (a : α) :
+  (order_iso.mul_left a).symm = order_iso.mul_left a⁻¹ :=
+by { ext x, refl }
+
+end left
+
+end group

--- a/src/algebra/order/hom/monoid.lean
+++ b/src/algebra/order/hom/monoid.lean
@@ -3,9 +3,10 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import data.pi.algebra
 import algebra.hom.group
 import algebra.order.group.instances
-import algebra.order.monoid.with_zero
+import algebra.order.monoid.with_zero.defs
 import order.hom.basic
 
 /-!

--- a/src/algebra/order/monoid/with_top.lean
+++ b/src/algebra/order/monoid/with_top.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import algebra.hom.group
 import algebra.order.monoid.order_dual
-import algebra.order.monoid.with_zero
+import algebra.order.monoid.with_zero.basic
 import data.nat.cast.defs
 
 /-! # Adjoining top/bottom elements to ordered monoids. -/

--- a/src/algebra/order/monoid/with_zero/basic.lean
+++ b/src/algebra/order/monoid/with_zero/basic.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
+-/
+import algebra.order.monoid.with_zero.defs
+import algebra.group_with_zero.basic
+
+/-!
+# An instance orphaned from `algebra.order.monoid.with_zero.defs`
+
+We put this here to minimise imports: if you can move it back into
+`algebra.order.monoid.with_zero.defs` without increasing imports, please do.
+-/
+
+open function
+
+universe u
+variables {α : Type u}
+
+namespace with_zero
+
+instance contravariant_class_mul_lt {α : Type u} [has_mul α] [partial_order α]
+  [contravariant_class α α (*) (<)] :
+  contravariant_class (with_zero α) (with_zero α) (*) (<) :=
+begin
+  refine ⟨λ a b c h, _⟩,
+  have := ((zero_le _).trans_lt h).ne',
+  lift a to α using left_ne_zero_of_mul this,
+  lift c to α using right_ne_zero_of_mul this,
+  induction b using with_zero.rec_zero_coe,
+  exacts [zero_lt_coe _, coe_lt_coe.mpr (lt_of_mul_lt_mul_left' $ coe_lt_coe.mp h)]
+end
+
+end with_zero

--- a/src/algebra/order/monoid/with_zero/defs.lean
+++ b/src/algebra/order/monoid/with_zero/defs.lean
@@ -3,8 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
-import algebra.group.with_one
-import algebra.group_with_zero.basic
+import algebra.group.with_one.defs
 import algebra.order.monoid.canonical.defs
 
 /-!
@@ -103,18 +102,6 @@ begin
   rcases with_bot.coe_le_iff.1 hbc with ⟨c, rfl, hbc'⟩,
   rw [← coe_mul, ← coe_mul, coe_le_coe],
   exact mul_le_mul_left' hbc' a
-end
-
-instance contravariant_class_mul_lt {α : Type u} [has_mul α] [partial_order α]
-  [contravariant_class α α (*) (<)] :
-  contravariant_class (with_zero α) (with_zero α) (*) (<) :=
-begin
-  refine ⟨λ a b c h, _⟩,
-  have := ((zero_le _).trans_lt h).ne',
-  lift a to α using left_ne_zero_of_mul this,
-  lift c to α using right_ne_zero_of_mul this,
-  induction b using with_zero.rec_zero_coe,
-  exacts [zero_lt_coe _, coe_lt_coe.mpr (lt_of_mul_lt_mul_left' $ coe_lt_coe.mp h)]
 end
 
 @[simp] lemma le_max_iff [linear_order α] {a b c : α} :

--- a/src/algebra/order/ring/defs.lean
+++ b/src/algebra/order/ring/defs.lean
@@ -6,11 +6,14 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Yaël Dillies
 
 import algebra.order.group.defs
 import algebra.order.monoid.cancel.defs
-import algebra.order.monoid.with_zero
+import algebra.order.monoid.canonical.defs
+import algebra.order.monoid.with_zero.defs
 import algebra.order.ring.lemmas
 import algebra.ring.defs
 import order.min_max
 import tactic.nontriviality
+import data.pi.algebra
+import algebra.group.units
 
 /-!
 # Ordered rings and semirings
@@ -245,6 +248,9 @@ lemma antitone.mul_const (hf : antitone f) (ha : 0 ≤ a) : antitone (λ x, f x 
 
 lemma antitone.const_mul (hf : antitone f) (ha : 0 ≤ a) : antitone (λ x, a * f x) :=
 (monotone_mul_left_of_nonneg ha).comp_antitone hf
+
+-- FIXME remove
+example : has_mul (β → α) := pi.has_mul
 
 lemma monotone.mul (hf : monotone f) (hg : monotone g) (hf₀ : ∀ x, 0 ≤ f x) (hg₀ : ∀ x, 0 ≤ g x) :
   monotone (f * g) :=

--- a/src/algebra/order/ring/defs.lean
+++ b/src/algebra/order/ring/defs.lean
@@ -249,9 +249,6 @@ lemma antitone.mul_const (hf : antitone f) (ha : 0 ≤ a) : antitone (λ x, f x 
 lemma antitone.const_mul (hf : antitone f) (ha : 0 ≤ a) : antitone (λ x, a * f x) :=
 (monotone_mul_left_of_nonneg ha).comp_antitone hf
 
--- FIXME remove
-example : has_mul (β → α) := pi.has_mul
-
 lemma monotone.mul (hf : monotone f) (hg : monotone g) (hf₀ : ∀ x, 0 ≤ f x) (hg₀ : ∀ x, 0 ≤ g x) :
   monotone (f * g) :=
 λ b c h, mul_le_mul (hf h) (hg h) (hg₀ _) (hf₀ _)

--- a/src/algebra/order/ring/with_top.lean
+++ b/src/algebra/order/ring/with_top.lean
@@ -58,7 +58,7 @@ lemma mul_coe {b : α} (hb : b ≠ 0) : ∀{a : with_top α}, a * b = a.bind (λ
 | none     := show (if (⊤:with_top α) = 0 ∨ (b:with_top α) = 0 then 0 else ⊤ : with_top α) = ⊤,
     by simp [hb]
 | (some a) := show ↑a * ↑b = ↑(a * b), from coe_mul.symm
-
+attribute [simp] coe_ne_top
 @[simp] lemma mul_eq_top_iff {a b : with_top α} : a * b = ⊤ ↔ (a ≠ 0 ∧ b = ⊤) ∨ (a = ⊤ ∧ b ≠ 0) :=
 begin
   cases a; cases b; simp only [none_eq_top, some_eq_coe],

--- a/src/algebra/order/ring/with_top.lean
+++ b/src/algebra/order/ring/with_top.lean
@@ -58,7 +58,7 @@ lemma mul_coe {b : α} (hb : b ≠ 0) : ∀{a : with_top α}, a * b = a.bind (λ
 | none     := show (if (⊤:with_top α) = 0 ∨ (b:with_top α) = 0 then 0 else ⊤ : with_top α) = ⊤,
     by simp [hb]
 | (some a) := show ↑a * ↑b = ↑(a * b), from coe_mul.symm
-attribute [simp] coe_ne_top
+
 @[simp] lemma mul_eq_top_iff {a b : with_top α} : a * b = ⊤ ↔ (a ≠ 0 ∧ b = ⊤) ∨ (a = ⊤ ∧ b ≠ 0) :=
 begin
   cases a; cases b; simp only [none_eq_top, some_eq_coe],

--- a/src/algebra/order/with_zero.lean
+++ b/src/algebra/order/with_zero.lean
@@ -7,7 +7,7 @@ import algebra.hom.equiv.units.group_with_zero
 import algebra.group_with_zero.inj_surj
 import algebra.order.group.units
 import algebra.order.monoid.basic
-import algebra.order.monoid.with_zero
+import algebra.order.monoid.with_zero.defs
 import algebra.order.group.instances
 import algebra.order.monoid.type_tags
 


### PR DESCRIPTION
Splits:
* algebra/order/group/defs.lean
* algebra/group/with_one.lean
* algebra/order/monoid/with_zero.lean

This will get us unstuck on the mathlib4 port, moving some of the files (about algebraic morphisms and equivalences) that are currently waiting for fixes in Lean 4 off the critical path.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
