### PR TITLE
[Merged by Bors] - feat(data/real/basic): remove typeclass shortcircuit

### DIFF
--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -16,6 +16,10 @@ This choice is motivated by how easy it is to prove that `ℝ` is a commutative 
 lifting everything to `ℚ`.
 -/
 
+assert_not_exists finset
+assert_not_exists module
+assert_not_exists submonoid
+
 open_locale pointwise
 
 /-- The type `ℝ` of real numbers constructed as equivalence classes of Cauchy sequences of rational

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -3,12 +3,10 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Floris van Doorn
 -/
-import algebra.module.basic
 import algebra.bounds
 import algebra.order.archimedean
 import algebra.star.basic
 import data.real.cau_seq_completion
-import order.conditionally_complete_lattice.basic
 
 /-!
 # Real numbers from Cauchy sequences
@@ -148,7 +146,6 @@ instance : monoid ℝ             := by apply_instance
 instance : comm_semigroup ℝ     := by apply_instance
 instance : semigroup ℝ          := by apply_instance
 instance : has_sub ℝ            := by apply_instance
-instance : module ℝ ℝ           := by apply_instance
 instance : inhabited ℝ          := ⟨0⟩
 
 /-- The real numbers are a `*`-ring, with the trivial `*`-structure. -/


### PR DESCRIPTION
The only remaining use of `module` in `data/real/basic` and its prerequisites is to provide the typeclass shortcircuit
```lean
instance : module ℝ ℝ := by apply_instance
```
I propose deleting this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
