### PR TITLE
[Merged by Bors] - fix(analysis/normed_space/basic): add back computable module instance

### DIFF
--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -16,7 +16,6 @@ about these definitions.
 
 variables {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
 
-noncomputable theory
 open filter metric function set
 open_locale topological_space big_operators nnreal ennreal uniformity pointwise
 
@@ -47,6 +46,10 @@ instance normed_space.has_bounded_smul [normed_space α β] : has_bounded_smul �
     by simpa [dist_eq_norm, smul_sub] using normed_space.norm_smul_le x (y₁ - y₂),
   dist_pair_smul' := λ x₁ x₂ y,
     by simpa [dist_eq_norm, sub_smul] using normed_space.norm_smul_le (x₁ - x₂) y }
+
+-- Shortcut instance, as otherwise this will be found by `normed_space.to_module` and be
+-- noncomputable.
+instance : module ℝ ℝ := by apply_instance
 
 instance normed_field.to_normed_space : normed_space α α :=
 { norm_smul_le := λ a b, le_of_eq (norm_mul a b) }
@@ -185,7 +188,7 @@ In many cases the actual implementation is not important, so we don't mark the p
 See also `cont_diff_homeomorph_unit_ball` and `cont_diff_on_homeomorph_unit_ball_symm` for
 smoothness properties that hold when `E` is an inner-product space. -/
 @[simps { attrs := [] }]
-def homeomorph_unit_ball [normed_space ℝ E] :
+noncomputable def homeomorph_unit_ball [normed_space ℝ E] :
   E ≃ₜ ball (0 : E) 1 :=
 { to_fun := λ x, ⟨(1 + ‖x‖^2).sqrt⁻¹ • x, begin
     have : 0 < 1 + ‖x‖ ^ 2, by positivity,


### PR DESCRIPTION
This was added in #8164 but removed in #17804.

This also removes `noncomputable theory` since in fact only one result in the file needed it!



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
