### PR TITLE
[Merged by Bors] - feat(algebra/module/big_operators): Product of sums

### DIFF
--- a/src/algebra/module/big_operators.lean
+++ b/src/algebra/module/big_operators.lean
@@ -28,7 +28,7 @@ lemma multiset.sum_smul_sum {s : multiset R} {t : multiset M} :
 begin
   induction s using multiset.induction with a s ih,
   { simp },
-  { simp [add_smul, ih, multiset.sum_map_smul] }
+  { simp [add_smul, ih, ←multiset.smul_sum] }
 end
 
 lemma finset.sum_smul {f : ι → R} {s : finset ι} {x : M} :

--- a/src/algebra/module/big_operators.lean
+++ b/src/algebra/module/big_operators.lean
@@ -1,11 +1,10 @@
 /-
-Copyright (c) 2015 Nathaniel Thomas. All rights reserved.
+Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
+Authors: Chris Hughes, Yury Kudryashov, Yaël Dillies
 -/
-
 import algebra.module.basic
-import algebra.big_operators.basic
+import group_theory.group_action.big_operators
 
 /-!
 # Finite sums over modules over a ring
@@ -13,20 +12,33 @@ import algebra.big_operators.basic
 
 open_locale big_operators
 
-universes u v
-variables {α R k S M M₂ M₃ ι : Type*}
+variables {α β R M ι : Type*}
+
 section add_comm_monoid
 variables [semiring R] [add_comm_monoid M] [module R M] (r s : R) (x y : M)
-variables {R M}
+
 lemma list.sum_smul {l : list R} {x : M} : l.sum • x = (l.map (λ r, r • x)).sum :=
 ((smul_add_hom R M).flip x).map_list_sum l
 
 lemma multiset.sum_smul {l : multiset R} {x : M} : l.sum • x = (l.map (λ r, r • x)).sum :=
 ((smul_add_hom R M).flip x).map_multiset_sum l
 
+lemma multiset.sum_smul_sum {s : multiset R} {t : multiset M} :
+  s.sum • t.sum = ((s ×ˢ t).map $ λ p : R × M, p.fst • p.snd).sum :=
+begin
+  induction s using multiset.induction with a s ih,
+  { simp },
+  { simp [add_smul, ih, multiset.sum_map_smul] }
+end
+
 lemma finset.sum_smul {f : ι → R} {s : finset ι} {x : M} :
   (∑ i in s, f i) • x = (∑ i in s, (f i) • x) :=
 ((smul_add_hom R M).flip x).map_sum f s
+
+lemma finset.sum_smul_sum {f : α → R} {g : β → M} {s : finset α} {t : finset β} :
+  (∑ i in s, f i) • (∑ i in t, g i) = ∑ p in s ×ˢ t, f p.fst • g p.snd :=
+by { rw [finset.sum_product, finset.sum_smul, finset.sum_congr rfl], intros, rw finset.smul_sum }
+
 end add_comm_monoid
 
 lemma finset.cast_card [comm_semiring R] (s : finset α) : (s.card : R) = ∑ a in s, 1 :=

--- a/src/data/multiset/bind.lean
+++ b/src/data/multiset/bind.lean
@@ -162,10 +162,9 @@ infixr (name := multiset.product) ` ×ˢ `:82 := multiset.product
 by { rw [product, list.product, ←coe_bind], simp }
 
 @[simp] lemma zero_product : @product α β 0 t = 0 := rfl
---TODO: Add `product_zero`
-
-@[simp] lemma cons_product : (a ::ₘ s) ×ˢ t = map (prod.mk a) t + s ×ˢ t :=
-by simp [product]
+@[simp] lemma cons_product : (a ::ₘ s) ×ˢ t = map (prod.mk a) t + s ×ˢ t := by simp [product]
+@[simp] lemma product_zero : s ×ˢ (0 : multiset β) = 0 := by simp [product]
+@[simp] lemma product_cons : s ×ˢ (b ::ₘ t) = s.map (λ a, (a, b)) + s ×ˢ t := by simp [product]
 
 @[simp] lemma product_singleton : ({a} : multiset α) ×ˢ ({b} : multiset β) = {(a, b)} :=
 by simp only [product, bind_singleton, map_singleton]

--- a/src/group_theory/group_action/big_operators.lean
+++ b/src/group_theory/group_action/big_operators.lean
@@ -47,6 +47,9 @@ lemma finset.smul_sum {r : α} {f : γ → β} {s : finset γ} :
   r • ∑ x in s, f x = ∑ x in s, r • f x :=
 (distrib_smul.to_add_monoid_hom β r).map_sum f s
 
+lemma multiset.sum_map_smul (a : α) (t : multiset β) : (t.map $ (•) a).sum = a • t.sum :=
+by induction t using multiset.induction; simp [*, smul_add]
+
 end
 
 section

--- a/src/group_theory/group_action/big_operators.lean
+++ b/src/group_theory/group_action/big_operators.lean
@@ -47,9 +47,6 @@ lemma finset.smul_sum {r : α} {f : γ → β} {s : finset γ} :
   r • ∑ x in s, f x = ∑ x in s, r • f x :=
 (distrib_smul.to_add_monoid_hom β r).map_sum f s
 
-lemma multiset.sum_map_smul (a : α) (t : multiset β) : (t.map $ (•) a).sum = a • t.sum :=
-by induction t using multiset.induction; simp [*, smul_add]
-
 end
 
 section


### PR DESCRIPTION
A few missing lemmas. `finset.sum_smul_sum` matches `finset.sum_mul_sum`.

Unrelatingly, fix the copyright after the split in #17764. I list as authors:
* Chris for #327
* Yury for #1910
* myself for this PR

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
