### PR TITLE
[Merged by Bors] - feat(algebra/hom/equiv/basic): Add `to_additive` to `Pi_congr_right` lemmas

### DIFF
--- a/src/algebra/hom/equiv/basic.lean
+++ b/src/algebra/hom/equiv/basic.lean
@@ -450,16 +450,16 @@ def Pi_congr_right {η : Type*}
   map_mul' := λ x y, funext $ λ j, (es j).map_mul (x j) (y j),
   .. equiv.Pi_congr_right (λ j, (es j).to_equiv) }
 
-@[simp]
+@[simp, to_additive]
 lemma Pi_congr_right_refl {η : Type*} {Ms : η → Type*} [Π j, has_mul (Ms j)] :
   Pi_congr_right (λ j, mul_equiv.refl (Ms j)) = mul_equiv.refl _ := rfl
 
-@[simp]
+@[simp, to_additive]
 lemma Pi_congr_right_symm {η : Type*}
   {Ms Ns : η → Type*} [Π j, has_mul (Ms j)] [Π j, has_mul (Ns j)]
   (es : ∀ j, Ms j ≃* Ns j) : (Pi_congr_right es).symm = (Pi_congr_right $ λ i, (es i).symm) := rfl
 
-@[simp]
+@[simp, to_additive]
 lemma Pi_congr_right_trans {η : Type*}
   {Ms Ns Ps : η → Type*} [Π j, has_mul (Ms j)] [Π j, has_mul (Ns j)]
   [Π j, has_mul (Ps j)]


### PR DESCRIPTION
Add `to_additive` attribute to three lemmas about `mul_equiv.Pi_congr_right`.
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
