### PR TITLE
[Merged by Bors] - fix(scripts/add_port_comments): do not insert extra blank lines

### DIFF
--- a/scripts/add_port_comments.py
+++ b/scripts/add_port_comments.py
@@ -60,7 +60,7 @@ def add_port_status(fcontent: str, fstatus: FileStatus) -> str:
     # replace any markers that appear at the start of the docstring
     module_comment = re.compile(
         r"\A\n((?:> )?)THIS FILE IS SYNCHRONIZED WITH MATHLIB4\."
-        r"(?:\n\1[^\n]+)*",
+        r"(?:\n\1[^\n]+)*\n?",
         re.MULTILINE
     ).sub('', module_comment)
 


### PR DESCRIPTION
Since we insert the comment with a trailing newline, we should remove an extra newline when removing it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
