### PR TITLE
[Merged by Bors] - refactor(algebra/algebra/{pi,prod}): extract into new files

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -36,8 +36,6 @@ See the implementation notes for remarks about non-associative and non-unital al
 * `algebra.of_id R A : R →ₐ[R] A`: the canonical map from `R` to `A`, as n `alg_hom`.
 * Instances of `algebra` in this file:
   * `algebra.id`
-  * `pi.algebra`
-  * `prod.algebra`
   * `algebra_nat`
   * `algebra_int`
   * `algebra_rat`
@@ -418,22 +416,6 @@ lemma _root_.ulift.algebra_map_eq (r : R) :
   (algebra_map R (ulift A) r).down = algebra_map R A r := rfl
 
 end ulift
-
-section prod
-variables (R A B)
-
-instance _root_.prod.algebra : algebra R (A × B) :=
-{ commutes' := by { rintro r ⟨a, b⟩, dsimp, rw [commutes r a, commutes r b] },
-  smul_def' := by { rintro r ⟨a, b⟩, dsimp, rw [smul_def r a, smul_def r b] },
-  .. prod.module,
-  .. ring_hom.prod (algebra_map R A) (algebra_map R B) }
-
-variables {R A B}
-
-@[simp] lemma algebra_map_prod_apply (r : R) :
-  algebra_map R (A × B) r = (algebra_map R A r, algebra_map R B r) := rfl
-
-end prod
 
 /-- Algebra over a subsemiring. This builds upon `subsemiring.module`. -/
 instance of_subsemiring (S : subsemiring R) : algebra S A :=
@@ -850,47 +832,6 @@ lemma map_list_prod (s : list A) :
 @[simp] lemma one_apply (x : A) : (1 : A →ₐ[R] A) x = x := rfl
 
 @[simp] lemma mul_apply (φ ψ : A →ₐ[R] A) (x : A) : (φ * ψ) x = φ (ψ x) := rfl
-
-section prod
-
-variables (R A B)
-
-/-- First projection as `alg_hom`. -/
-def fst : A × B →ₐ[R] A :=
-{ commutes' := λ r, rfl, .. ring_hom.fst A B}
-
-/-- Second projection as `alg_hom`. -/
-def snd : A × B →ₐ[R] B :=
-{ commutes' := λ r, rfl, .. ring_hom.snd A B}
-
-variables {R A B}
-
-/-- The `pi.prod` of two morphisms is a morphism. -/
-@[simps] def prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) : (A →ₐ[R] B × C) :=
-{ commutes' := λ r, by simp only [to_ring_hom_eq_coe, ring_hom.to_fun_eq_coe, ring_hom.prod_apply,
-    coe_to_ring_hom, commutes, algebra.algebra_map_prod_apply],
-  .. (f.to_ring_hom.prod g.to_ring_hom) }
-
-lemma coe_prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) : ⇑(f.prod g) = pi.prod f g := rfl
-
-@[simp] theorem fst_prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) :
-  (fst R B C).comp (prod f g) = f := by ext; refl
-
-@[simp] theorem snd_prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) :
-  (snd R B C).comp (prod f g) = g := by ext; refl
-
-@[simp] theorem prod_fst_snd : prod (fst R A B) (snd R A B) = 1 :=
-fun_like.coe_injective pi.prod_fst_snd
-
-/-- Taking the product of two maps with the same domain is equivalent to taking the product of
-their codomains. -/
-@[simps] def prod_equiv : ((A →ₐ[R] B) × (A →ₐ[R] C)) ≃ (A →ₐ[R] B × C) :=
-{ to_fun := λ f, f.1.prod f.2,
-  inv_fun := λ f, ((fst _ _ _).comp f, (snd _ _ _).comp f),
-  left_inv := λ f, by ext; refl,
-  right_inv := λ f, by ext; refl }
-
-end prod
 
 lemma algebra_map_eq_apply (f : A →ₐ[R] B) {y : R} {x : A} (h : algebra_map R A y = x) :
   algebra_map R B y = f x :=
@@ -1638,109 +1579,6 @@ end field
 
 end no_zero_smul_divisors
 
-/-!
-The R-algebra structure on `Π i : I, A i` when each `A i` is an R-algebra.
-
-We couldn't set this up back in `algebra.pi_instances` because this file imports it.
--/
-namespace pi
-
-variable {I : Type u}     -- The indexing type
-variable {R : Type*}      -- The scalar type
-variable {f : I → Type v} -- The family of types already equipped with instances
-variables (x y : Π i, f i) (i : I)
-variables (I f)
-
-instance algebra {r : comm_semiring R}
-  [s : ∀ i, semiring (f i)] [∀ i, algebra R (f i)] :
-  algebra R (Π i : I, f i) :=
-{ commutes' := λ a f, begin ext, simp [algebra.commutes], end,
-  smul_def' := λ a f, begin ext, simp [algebra.smul_def], end,
-  ..(pi.ring_hom (λ i, algebra_map R (f i)) : R →+* Π i : I, f i) }
-
-lemma algebra_map_def {r : comm_semiring R}
-  [s : ∀ i, semiring (f i)] [∀ i, algebra R (f i)] (a : R) :
-  algebra_map R (Π i, f i) a = (λ i, algebra_map R (f i) a) := rfl
-
-@[simp] lemma algebra_map_apply {r : comm_semiring R}
-  [s : ∀ i, semiring (f i)] [∀ i, algebra R (f i)] (a : R) (i : I) :
-  algebra_map R (Π i, f i) a i = algebra_map R (f i) a := rfl
-
--- One could also build a `Π i, R i`-algebra structure on `Π i, A i`,
--- when each `A i` is an `R i`-algebra, although I'm not sure that it's useful.
-
-variables {I} (R) (f)
-
-/-- `function.eval` as an `alg_hom`. The name matches `pi.eval_ring_hom`, `pi.eval_monoid_hom`,
-etc. -/
-@[simps]
-def eval_alg_hom {r : comm_semiring R} [Π i, semiring (f i)] [Π i, algebra R (f i)] (i : I) :
-  (Π i, f i) →ₐ[R] f i :=
-{ to_fun := λ f, f i, commutes' := λ r, rfl, .. pi.eval_ring_hom f i}
-
-variables (A B : Type*) [comm_semiring R] [semiring B] [algebra R B]
-
-/-- `function.const` as an `alg_hom`. The name matches `pi.const_ring_hom`, `pi.const_monoid_hom`,
-etc. -/
-@[simps]
-def const_alg_hom : B →ₐ[R] (A → B) :=
-{ to_fun := function.const _,
-  commutes' := λ r, rfl,
-  .. pi.const_ring_hom A B}
-
-/-- When `R` is commutative and permits an `algebra_map`, `pi.const_ring_hom` is equal to that
-map. -/
-@[simp] lemma const_ring_hom_eq_algebra_map : const_ring_hom A R = algebra_map R (A → R) :=
-rfl
-
-@[simp] lemma const_alg_hom_eq_algebra_of_id : const_alg_hom R A R = algebra.of_id R (A → R) :=
-rfl
-
-end pi
-
-/-- A special case of `pi.algebra` for non-dependent types. Lean struggles to elaborate
-definitions elsewhere in the library without this, -/
-instance function.algebra {R : Type*} (I : Type*)  (A : Type*) [comm_semiring R]
-  [semiring A] [algebra R A] : algebra R (I → A) :=
-pi.algebra _ _
-
-namespace alg_equiv
-
-/-- A family of algebra equivalences `Π j, (A₁ j ≃ₐ A₂ j)` generates a
-multiplicative equivalence between `Π j, A₁ j` and `Π j, A₂ j`.
-
-This is the `alg_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
-`alg_equiv.arrow_congr`.
--/
-@[simps apply]
-def Pi_congr_right {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
-  [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]
-  (e : Π i, A₁ i ≃ₐ[R] A₂ i) : (Π i, A₁ i) ≃ₐ[R] Π i, A₂ i :=
-{ to_fun := λ x j, e j (x j),
-  inv_fun := λ x j, (e j).symm (x j),
-  commutes' := λ r, by { ext i, simp },
-  .. @ring_equiv.Pi_congr_right ι A₁ A₂ _ _ (λ i, (e i).to_ring_equiv) }
-
-@[simp]
-lemma Pi_congr_right_refl {R ι : Type*} {A : ι → Type*} [comm_semiring R]
-  [Π i, semiring (A i)] [Π i, algebra R (A i)] :
-  Pi_congr_right (λ i, (alg_equiv.refl : A i ≃ₐ[R] A i)) = alg_equiv.refl := rfl
-
-@[simp]
-lemma Pi_congr_right_symm {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
-  [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]
-  (e : Π i, A₁ i ≃ₐ[R] A₂ i) : (Pi_congr_right e).symm = (Pi_congr_right $ λ i, (e i).symm) := rfl
-
-@[simp]
-lemma Pi_congr_right_trans {R ι : Type*} {A₁ A₂ A₃ : ι → Type*} [comm_semiring R]
-  [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, semiring (A₃ i)]
-  [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)] [Π i, algebra R (A₃ i)]
-  (e₁ : Π i, A₁ i ≃ₐ[R] A₂ i) (e₂ : Π i, A₂ i ≃ₐ[R] A₃ i) :
-  (Pi_congr_right e₁).trans (Pi_congr_right e₂) = (Pi_congr_right $ λ i, (e₁ i).trans (e₂ i)) :=
-rfl
-
-end alg_equiv
-
 section is_scalar_tower
 
 variables {R : Type*} [comm_semiring R]
@@ -1850,22 +1688,6 @@ begin
 end
 
 end submodule
-
-namespace alg_hom
-
-variables {R : Type u} {A : Type v} {B : Type w} {I : Type*}
-
-variables [comm_semiring R] [semiring A] [semiring B]
-variables [algebra R A] [algebra R B]
-
-/-- `R`-algebra homomorphism between the function spaces `I → A` and `I → B`, induced by an
-`R`-algebra homomorphism `f` between `A` and `B`. -/
-@[simps] protected def comp_left (f : A →ₐ[R] B) (I : Type*) : (I → A) →ₐ[R] (I → B) :=
-{ to_fun := λ h, f ∘ h,
-  commutes' := λ c, by { ext, exact f.commutes' c },
-  .. f.to_ring_hom.comp_left I }
-
-end alg_hom
 
 example {R A} [comm_semiring R] [semiring A]
   [module R A] [smul_comm_class R A A] [is_scalar_tower R A A] : algebra R A :=

--- a/src/algebra/algebra/pi.lean
+++ b/src/algebra/algebra/pi.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau, Yury Kudryashov
+-/
+import algebra.algebra.basic
+
+/-!
+# The R-algebra structure on families of R-algebras
+
+The R-algebra structure on `Π i : I, A i` when each `A i` is an R-algebra.
+
+## Main defintions
+
+* `pi.algebra`
+* `pi.eval_alg_hom`
+* `pi.const_alg_hom`
+-/
+universes u v w
+
+namespace pi
+
+variable {I : Type u}     -- The indexing type
+variable {R : Type*}      -- The scalar type
+variable {f : I → Type v} -- The family of types already equipped with instances
+variables (x y : Π i, f i) (i : I)
+variables (I f)
+
+instance algebra {r : comm_semiring R}
+  [s : ∀ i, semiring (f i)] [∀ i, algebra R (f i)] :
+  algebra R (Π i : I, f i) :=
+{ commutes' := λ a f, begin ext, simp [algebra.commutes], end,
+  smul_def' := λ a f, begin ext, simp [algebra.smul_def], end,
+  ..(pi.ring_hom (λ i, algebra_map R (f i)) : R →+* Π i : I, f i) }
+
+lemma algebra_map_def {r : comm_semiring R}
+  [s : ∀ i, semiring (f i)] [∀ i, algebra R (f i)] (a : R) :
+  algebra_map R (Π i, f i) a = (λ i, algebra_map R (f i) a) := rfl
+
+@[simp] lemma algebra_map_apply {r : comm_semiring R}
+  [s : ∀ i, semiring (f i)] [∀ i, algebra R (f i)] (a : R) (i : I) :
+  algebra_map R (Π i, f i) a i = algebra_map R (f i) a := rfl
+
+-- One could also build a `Π i, R i`-algebra structure on `Π i, A i`,
+-- when each `A i` is an `R i`-algebra, although I'm not sure that it's useful.
+
+variables {I} (R) (f)
+
+/-- `function.eval` as an `alg_hom`. The name matches `pi.eval_ring_hom`, `pi.eval_monoid_hom`,
+etc. -/
+@[simps]
+def eval_alg_hom {r : comm_semiring R} [Π i, semiring (f i)] [Π i, algebra R (f i)] (i : I) :
+  (Π i, f i) →ₐ[R] f i :=
+{ to_fun := λ f, f i, commutes' := λ r, rfl, .. pi.eval_ring_hom f i}
+
+variables (A B : Type*) [comm_semiring R] [semiring B] [algebra R B]
+
+/-- `function.const` as an `alg_hom`. The name matches `pi.const_ring_hom`, `pi.const_monoid_hom`,
+etc. -/
+@[simps]
+def const_alg_hom : B →ₐ[R] (A → B) :=
+{ to_fun := function.const _,
+  commutes' := λ r, rfl,
+  .. pi.const_ring_hom A B}
+
+/-- When `R` is commutative and permits an `algebra_map`, `pi.const_ring_hom` is equal to that
+map. -/
+@[simp] lemma const_ring_hom_eq_algebra_map : const_ring_hom A R = algebra_map R (A → R) :=
+rfl
+
+@[simp] lemma const_alg_hom_eq_algebra_of_id : const_alg_hom R A R = algebra.of_id R (A → R) :=
+rfl
+
+end pi
+
+/-- A special case of `pi.algebra` for non-dependent types. Lean struggles to elaborate
+definitions elsewhere in the library without this, -/
+instance function.algebra {R : Type*} (I : Type*)  (A : Type*) [comm_semiring R]
+  [semiring A] [algebra R A] : algebra R (I → A) :=
+pi.algebra _ _
+
+namespace alg_hom
+
+variables {R : Type u} {A : Type v} {B : Type w} {I : Type*}
+
+variables [comm_semiring R] [semiring A] [semiring B]
+variables [algebra R A] [algebra R B]
+
+/-- `R`-algebra homomorphism between the function spaces `I → A` and `I → B`, induced by an
+`R`-algebra homomorphism `f` between `A` and `B`. -/
+@[simps] protected def comp_left (f : A →ₐ[R] B) (I : Type*) : (I → A) →ₐ[R] (I → B) :=
+{ to_fun := λ h, f ∘ h,
+  commutes' := λ c, by { ext, exact f.commutes' c },
+  .. f.to_ring_hom.comp_left I }
+
+end alg_hom
+
+namespace alg_equiv
+
+/-- A family of algebra equivalences `Π j, (A₁ j ≃ₐ A₂ j)` generates a
+multiplicative equivalence between `Π j, A₁ j` and `Π j, A₂ j`.
+
+This is the `alg_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
+`alg_equiv.arrow_congr`.
+-/
+@[simps apply]
+def Pi_congr_right {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
+  [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]
+  (e : Π i, A₁ i ≃ₐ[R] A₂ i) : (Π i, A₁ i) ≃ₐ[R] Π i, A₂ i :=
+{ to_fun := λ x j, e j (x j),
+  inv_fun := λ x j, (e j).symm (x j),
+  commutes' := λ r, by { ext i, simp },
+  .. @ring_equiv.Pi_congr_right ι A₁ A₂ _ _ (λ i, (e i).to_ring_equiv) }
+
+@[simp]
+lemma Pi_congr_right_refl {R ι : Type*} {A : ι → Type*} [comm_semiring R]
+  [Π i, semiring (A i)] [Π i, algebra R (A i)] :
+  Pi_congr_right (λ i, (alg_equiv.refl : A i ≃ₐ[R] A i)) = alg_equiv.refl := rfl
+
+@[simp]
+lemma Pi_congr_right_symm {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
+  [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]
+  (e : Π i, A₁ i ≃ₐ[R] A₂ i) : (Pi_congr_right e).symm = (Pi_congr_right $ λ i, (e i).symm) := rfl
+
+@[simp]
+lemma Pi_congr_right_trans {R ι : Type*} {A₁ A₂ A₃ : ι → Type*} [comm_semiring R]
+  [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, semiring (A₃ i)]
+  [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)] [Π i, algebra R (A₃ i)]
+  (e₁ : Π i, A₁ i ≃ₐ[R] A₂ i) (e₂ : Π i, A₂ i ≃ₐ[R] A₃ i) :
+  (Pi_congr_right e₁).trans (Pi_congr_right e₂) = (Pi_congr_right $ λ i, (e₁ i).trans (e₂ i)) :=
+rfl
+
+end alg_equiv

--- a/src/algebra/algebra/prod.lean
+++ b/src/algebra/algebra/prod.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau, Yury Kudryashov
+-/
+import algebra.algebra.basic
+
+/-!
+# The R-algebra structure on products of R-algebras
+
+The R-algebra structure on `Π i : I, A i` when each `A i` is an R-algebra.
+
+## Main defintions
+
+* `pi.algebra`
+* `pi.eval_alg_hom`
+* `pi.const_alg_hom`
+-/
+
+variables {R A B C : Type*}
+variables [comm_semiring R]
+variables [semiring A] [algebra R A] [semiring B] [algebra R B] [semiring C] [algebra R C]
+
+namespace prod
+variables (R A B)
+
+open algebra
+
+instance algebra : algebra R (A × B) :=
+{ commutes' := by { rintro r ⟨a, b⟩, dsimp, rw [commutes r a, commutes r b] },
+  smul_def' := by { rintro r ⟨a, b⟩, dsimp, rw [algebra.smul_def r a, algebra.smul_def r b] },
+  .. prod.module,
+  .. ring_hom.prod (algebra_map R A) (algebra_map R B) }
+
+variables {R A B}
+
+@[simp] lemma algebra_map_apply (r : R) :
+  algebra_map R (A × B) r = (algebra_map R A r, algebra_map R B r) := rfl
+
+end prod
+
+namespace alg_hom
+variables (R A B)
+
+/-- First projection as `alg_hom`. -/
+def fst : A × B →ₐ[R] A :=
+{ commutes' := λ r, rfl, .. ring_hom.fst A B}
+
+/-- Second projection as `alg_hom`. -/
+def snd : A × B →ₐ[R] B :=
+{ commutes' := λ r, rfl, .. ring_hom.snd A B}
+
+variables {R A B}
+
+/-- The `pi.prod` of two morphisms is a morphism. -/
+@[simps] def prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) : (A →ₐ[R] B × C) :=
+{ commutes' := λ r, by simp only [to_ring_hom_eq_coe, ring_hom.to_fun_eq_coe, ring_hom.prod_apply,
+    coe_to_ring_hom, commutes, prod.algebra_map_apply],
+  .. (f.to_ring_hom.prod g.to_ring_hom) }
+
+lemma coe_prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) : ⇑(f.prod g) = pi.prod f g := rfl
+
+@[simp] theorem fst_prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) :
+  (fst R B C).comp (prod f g) = f := by ext; refl
+
+@[simp] theorem snd_prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) :
+  (snd R B C).comp (prod f g) = g := by ext; refl
+
+@[simp] theorem prod_fst_snd : prod (fst R A B) (snd R A B) = 1 :=
+fun_like.coe_injective pi.prod_fst_snd
+
+/-- Taking the product of two maps with the same domain is equivalent to taking the product of
+their codomains. -/
+@[simps] def prod_equiv : ((A →ₐ[R] B) × (A →ₐ[R] C)) ≃ (A →ₐ[R] B × C) :=
+{ to_fun := λ f, f.1.prod f.2,
+  inv_fun := λ f, ((fst _ _ _).comp f, (snd _ _ _).comp f),
+  left_inv := λ f, by ext; refl,
+  right_inv := λ f, by ext; refl }
+
+end alg_hom

--- a/src/algebra/star/star_alg_hom.lean
+++ b/src/algebra/star/star_alg_hom.lean
@@ -6,6 +6,7 @@ Authors: Jireh Loreaux
 
 import algebra.hom.non_unital_alg
 import algebra.star.prod
+import algebra.algebra.prod
 
 /-!
 # Morphisms of star algebras

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
 -/
+import algebra.algebra.pi
 import algebra.algebra.restrict_scalars
 import analysis.normed.field.basic
 import data.real.sqrt

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu-Ming Zhang
 -/
 
-import algebra.algebra.basic
+import algebra.algebra.pi
 import algebra.big_operators.pi
 import algebra.big_operators.ring
 import algebra.big_operators.ring_equiv

--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 -/
+import algebra.algebra.pi
 import ring_theory.adjoin.basic
 import data.polynomial.eval
 

--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov, Eric W
 -/
 import linear_algebra.span
 import order.partial_sups
-import algebra.algebra.basic
+import algebra.algebra.prod
 
 /-! ### Products of modules
 

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -8,6 +8,7 @@ import topology.continuous_function.ordered
 import topology.algebra.uniform_group
 import topology.uniform_space.compact_convergence
 import topology.algebra.star
+import algebra.algebra.pi
 import algebra.algebra.subalgebra.basic
 import tactic.field_simp
 import algebra.star.star_alg_hom

--- a/src/topology/locally_constant/algebra.lean
+++ b/src/topology/locally_constant/algebra.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import algebra.algebra.basic
+import algebra.algebra.pi
 import topology.locally_constant.basic
 
 /-!


### PR DESCRIPTION
This matches `group/pi` and `ring/pi` etc.

The lemma `algebra.algebra_map_prod_apply` has been renamed to `prod.algebra_map_apply`.
Everything else has been moved without changes.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
