### PR TITLE
[Merged by Bors] - fix(scripts/port_status): fix `--ignore-matching-lines` arguments

### DIFF
--- a/scripts/port_status.py
+++ b/scripts/port_status.py
@@ -8,18 +8,20 @@ from urllib.request import urlopen
 from mathlibtools.lib import PortStatus, LeanProject, FileStatus
 from sys import argv
 from pathlib import Path
+import shlex
 
 import_re = re.compile(r"^import ([^ ]*)")
 synchronized_re = re.compile(r".*SYNCHRONIZED WITH MATHLIB4.*")
 hash_re = re.compile(r"[0-9a-f]*")
 
-# not using re.compile as this is passed to git
-comment_git_re = '^' + '|'.join(re.escape(line) for line in [
-    "> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.",
-    "> https://github.com/leanprover-community/mathlib4/pull/.*",
-    "> Any changes to this file require a corresponding PR to mathlib4.",
-    ""
-]) + '$'
+# Not using re.compile as this is passed to git which uses a different regex dialect:
+# https://www.sjoerdlangkemper.nl/2021/08/13/how-does-git-diff-ignore-matching-lines-work/
+comment_git_re = r'\`(' + r'|'.join([
+    re.escape("> THIS FILE IS SYNCHRONIZED WITH MATHLIB4."),
+    re.escape("> https://github.com/leanprover-community/mathlib4/pull/") + r"[0-9]*",
+    re.escape("> Any changes to this file require a corresponding PR to mathlib4."),
+    r"",
+]) + r")" + "\n"
 
 proj = LeanProject.from_path(Path(__file__).parent.parent)
 
@@ -69,12 +71,12 @@ touched = dict()
 for node in graph.nodes:
     if data[node].mathlib3_hash:
         verified[node] = data[node].mathlib3_hash
-        git_command = ['git', 'diff', '--name-only',
+        git_command = ['git', 'diff', '--quiet',
             f'--ignore-matching-lines={comment_git_re}',
-            data[node].mathlib3_hash + "..HEAD", "src" + os.sep + node.replace('.', os.sep) + ".lean"]
-        result = subprocess.run(git_command, stdout=subprocess.PIPE)
-        if result.stdout != b'':
-            del(git_command[2:4])
+            data[node].mathlib3_hash + "..HEAD", "--", "src" + os.sep + node.replace('.', os.sep) + ".lean"]
+        result = subprocess.run(git_command)
+        if result.returncode == 1:
+            git_command.remove('--quiet')
             touched[node] = git_command
     elif data[node].ported:
         print("Bad status for " + node)
@@ -120,4 +122,4 @@ if len(touched) > 0:
     print()
     print('# The following files have been modified since the commit at which they were verified.')
     for v in touched.values():
-        print(' '.join(v))
+        print(' '.join(shlex.quote(vi) for vi in v))


### PR DESCRIPTION
It turns out that in `--name-only` mode these arguments are ignored. It also turns out that the regex that was in this Python script did not work.

Thankfully these errors conspired together, meaning that ultimately #17788 was mostly a no-op (except on old versions of git, where it stopped working entirely)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
