### PR TITLE
[Merged by Bors] - chore(data/list/range): split & reduce imports

### DIFF
--- a/src/algebra/big_operators/fin.lean
+++ b/src/algebra/big_operators/fin.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov, Anne Baanen
 -/
 import data.fintype.big_operators
 import data.fintype.fin
+import data.list.fin_range
 import logic.equiv.fin
 
 /-!

--- a/src/algebra/graded_monoid.lean
+++ b/src/algebra/graded_monoid.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import algebra.group.inj_surj
+import algebra.group_power.basic
 import data.list.big_operators.basic
 import data.list.range
 import group_theory.group_action.defs

--- a/src/algebra/graded_monoid.lean
+++ b/src/algebra/graded_monoid.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import algebra.group.inj_surj
-import algebra.group_power.basic
 import data.list.big_operators.basic
-import data.list.range
+import data.list.fin_range
 import group_theory.group_action.defs
 import group_theory.submonoid.basic
 import data.set_like.basic

--- a/src/algebra/order/hom/ring.lean
+++ b/src/algebra/order/hom/ring.lean
@@ -7,6 +7,7 @@ import algebra.order.archimedean
 import algebra.order.hom.monoid
 import algebra.order.ring.defs
 import algebra.ring.equiv
+import tactic.by_contra
 import tactic.wlog
 
 /-!

--- a/src/data/fin/tuple/sort.lean
+++ b/src/data/fin/tuple/sort.lean
@@ -3,9 +3,8 @@ Copyright (c) 2021 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-
-import data.fin.basic
 import data.finset.sort
+import data.list.fin_range
 import data.prod.lex
 import group_theory.perm.basic
 

--- a/src/data/fin/vec_notation.lean
+++ b/src/data/fin/vec_notation.lean
@@ -3,7 +3,8 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
-import data.list.fin_range
+import data.fin.tuple.basic
+import data.list.range
 import group_theory.group_action.pi
 import meta.univs
 

--- a/src/data/fin/vec_notation.lean
+++ b/src/data/fin/vec_notation.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
-import data.list.range
+import data.list.fin_range
 import group_theory.group_action.pi
 import meta.univs
 

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -3,7 +3,9 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Minchao Wu, Mario Carneiro
 -/
+import data.int.order.basic
 import data.multiset.finset_ops
+import algebra.hom.embedding
 import tactic.apply
 import tactic.nth_rewrite
 import tactic.monotonicity

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -3,9 +3,7 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Minchao Wu, Mario Carneiro
 -/
-import data.int.order.basic
 import data.multiset.finset_ops
-import algebra.hom.embedding
 import tactic.apply
 import tactic.nth_rewrite
 import tactic.monotonicity

--- a/src/data/finset/image.lean
+++ b/src/data/finset/image.lean
@@ -3,6 +3,7 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Minchao Wu, Mario Carneiro
 -/
+import data.fin.basic
 import data.finset.basic
 
 /-! # Image and map operations on finite sets

--- a/src/data/finset/image.lean
+++ b/src/data/finset/image.lean
@@ -3,9 +3,7 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Minchao Wu, Mario Carneiro
 -/
-import algebra.hom.embedding
 import data.finset.basic
-import data.int.basic
 
 /-! # Image and map operations on finite sets
 
@@ -393,7 +391,7 @@ disjoint_iff_ne.2 $ λ a ha b hb, ne_of_apply_ne f $ h.forall_ne_finset
 
 lemma mem_range_iff_mem_finset_range_of_mod_eq' [decidable_eq α] {f : ℕ → α} {a : α} {n : ℕ}
   (hn : 0 < n) (h : ∀ i, f (i % n) = f i) :
-  a ∈ set.range f ↔ a ∈ (finset.range n).image f :=
+  a ∈ set.range f ↔ a ∈ (finset.range n).image (λi, f i) :=
 begin
   split,
   { rintros ⟨i, hi⟩,
@@ -407,18 +405,16 @@ end
 
 lemma mem_range_iff_mem_finset_range_of_mod_eq [decidable_eq α] {f : ℤ → α} {a : α} {n : ℕ}
   (hn : 0 < n) (h : ∀ i, f (i % n) = f i) :
-  a ∈ set.range f ↔ a ∈ (finset.range n).image (λ i, f i) :=
-begin
-  convert mem_range_iff_mem_finset_range_of_mod_eq' hn _ using 1,
-  swap, { exact λ i, h (i : ℤ), },
-  rw [eq_iff_iff], refine ⟨_, λ ⟨i, hi⟩, ⟨i, hi⟩⟩,
-  rintros ⟨(i | i), rfl⟩, { exact ⟨_, rfl⟩, },
-  refine ⟨n - 1 - i % n, _⟩, dsimp,
-  convert h (-[1+ i]),
-  rw [int.neg_succ_of_nat_mod _ (int.coe_nat_lt.mpr hn), ← int.coe_nat_mod,
-    int.coe_nat_sub (nat.le_pred_of_lt (nat.mod_lt _ hn)), int.coe_nat_sub (nat.one_le_of_lt hn)],
-  refl,
-end
+  a ∈ set.range f ↔ a ∈ (finset.range n).image (λi, f i) :=
+suffices (∃ i, f (i % n) = a) ↔ ∃ i, i < n ∧ f ↑i = a, by simpa [h],
+have hn' : 0 < (n : ℤ), from int.coe_nat_lt.mpr hn,
+iff.intro
+  (assume ⟨i, hi⟩,
+    have 0 ≤ i % ↑n, from int.mod_nonneg _ (ne_of_gt hn'),
+    ⟨int.to_nat (i % n),
+      by rw [←int.coe_nat_lt, int.to_nat_of_nonneg this]; exact ⟨int.mod_lt_of_pos i hn', hi⟩⟩)
+  (assume ⟨i, hi, ha⟩,
+    ⟨i, by rw [int.mod_eq_of_lt (int.coe_zero_le _) (int.coe_nat_lt_coe_nat_of_lt hi), ha]⟩)
 
 lemma range_add (a b : ℕ) : range (a + b) = range a ∪ (range b).map (add_left_embedding a) :=
 by { rw [←val_inj, union_val], exact multiset.range_add_eq_union a b }

--- a/src/data/finset/image.lean
+++ b/src/data/finset/image.lean
@@ -3,7 +3,9 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Minchao Wu, Mario Carneiro
 -/
+import algebra.hom.embedding
 import data.finset.basic
+import data.int.basic
 
 /-! # Image and map operations on finite sets
 
@@ -391,7 +393,7 @@ disjoint_iff_ne.2 $ λ a ha b hb, ne_of_apply_ne f $ h.forall_ne_finset
 
 lemma mem_range_iff_mem_finset_range_of_mod_eq' [decidable_eq α] {f : ℕ → α} {a : α} {n : ℕ}
   (hn : 0 < n) (h : ∀ i, f (i % n) = f i) :
-  a ∈ set.range f ↔ a ∈ (finset.range n).image (λi, f i) :=
+  a ∈ set.range f ↔ a ∈ (finset.range n).image f :=
 begin
   split,
   { rintros ⟨i, hi⟩,
@@ -405,16 +407,18 @@ end
 
 lemma mem_range_iff_mem_finset_range_of_mod_eq [decidable_eq α] {f : ℤ → α} {a : α} {n : ℕ}
   (hn : 0 < n) (h : ∀ i, f (i % n) = f i) :
-  a ∈ set.range f ↔ a ∈ (finset.range n).image (λi, f i) :=
-suffices (∃ i, f (i % n) = a) ↔ ∃ i, i < n ∧ f ↑i = a, by simpa [h],
-have hn' : 0 < (n : ℤ), from int.coe_nat_lt.mpr hn,
-iff.intro
-  (assume ⟨i, hi⟩,
-    have 0 ≤ i % ↑n, from int.mod_nonneg _ (ne_of_gt hn'),
-    ⟨int.to_nat (i % n),
-      by rw [←int.coe_nat_lt, int.to_nat_of_nonneg this]; exact ⟨int.mod_lt_of_pos i hn', hi⟩⟩)
-  (assume ⟨i, hi, ha⟩,
-    ⟨i, by rw [int.mod_eq_of_lt (int.coe_zero_le _) (int.coe_nat_lt_coe_nat_of_lt hi), ha]⟩)
+  a ∈ set.range f ↔ a ∈ (finset.range n).image (λ i, f i) :=
+begin
+  convert mem_range_iff_mem_finset_range_of_mod_eq' hn _ using 1,
+  swap, { exact λ i, h (i : ℤ), },
+  rw [eq_iff_iff], refine ⟨_, λ ⟨i, hi⟩, ⟨i, hi⟩⟩,
+  rintros ⟨(i | i), rfl⟩, { exact ⟨_, rfl⟩, },
+  refine ⟨n - 1 - i % n, _⟩, dsimp,
+  convert h (-[1+ i]),
+  rw [int.neg_succ_of_nat_mod _ (int.coe_nat_lt.mpr hn), ← int.coe_nat_mod,
+    int.coe_nat_sub (nat.le_pred_of_lt (nat.mod_lt _ hn)), int.coe_nat_sub (nat.one_le_of_lt hn)],
+  refl,
+end
 
 lemma range_add (a b : ℕ) : range (a + b) = range a ∪ (range b).map (add_left_embedding a) :=
 by { rw [←val_inj, union_val], exact multiset.range_add_eq_union a b }

--- a/src/data/list/fin_range.lean
+++ b/src/data/list/fin_range.lean
@@ -8,19 +8,12 @@ import data.list.nodup
 import data.list.range
 
 /-!
-# Ranges of naturals as lists
+# Lists of elements of `fin n`
 
-This file shows basic results about `list.iota`, `list.range`, `list.range'` (all defined in
-`data.list.defs`) and defines `list.fin_range`.
 `fin_range n` is the list of elements of `fin n`.
-`iota n = [n, n - 1, ..., 1]` and `range n = [0, ..., n - 1]` are basic list constructions used for
-tactics. `range' a b = [a, ..., a + b - 1]` is there to help prove properties about them.
-Actual maths should use `list.Ico` instead.
 -/
 
 universe u
-
-open nat
 
 namespace list
 variables {α : Type u}

--- a/src/data/list/fin_range.lean
+++ b/src/data/list/fin_range.lean
@@ -4,13 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kenny Lau, Scott Morrison
 -/
 import data.list.of_fn
-import data.list.nodup
-import data.list.range
+import data.list.perm
 
 /-!
 # Lists of elements of `fin n`
 
-`fin_range n` is the list of elements of `fin n`.
+This file defines `fin_range n`, which is the list of elements of `fin n`.
 -/
 
 universe u
@@ -87,6 +86,22 @@ begin
     rw fin.cons_injective_iff,
     simp_rw [of_fn_succ, fin.cons_succ, nodup_cons, fin.cons_zero, mem_of_fn] at h,
     exact h.imp_right ih }
+end
+
+lemma equiv.perm.map_fin_range_perm {n : ℕ} (σ : equiv.perm (fin n)) :
+  map σ (fin_range n) ~ fin_range n :=
+begin
+  rw [perm_ext ((nodup_fin_range n).map σ.injective) $ nodup_fin_range n],
+  simpa only [mem_map, mem_fin_range, true_and, iff_true] using σ.surjective
+end
+
+/-- The list obtained from a permutation of a tuple `f` is permutation equivalent to
+the list obtained from `f`. -/
+lemma equiv.perm.of_fn_comp_perm {n : ℕ} (σ : equiv.perm (fin n)) (f : fin n → α) :
+  of_fn (f ∘ σ) ~ of_fn f :=
+begin
+  rw [of_fn_eq_map, of_fn_eq_map, ←map_map],
+  exact σ.map_fin_range_perm.map f,
 end
 
 end list

--- a/src/data/list/fin_range.lean
+++ b/src/data/list/fin_range.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Kenny Lau, Scott Morrison
+-/
+import data.list.of_fn
+import data.list.nodup
+import data.list.range
+
+/-!
+# Ranges of naturals as lists
+
+This file shows basic results about `list.iota`, `list.range`, `list.range'` (all defined in
+`data.list.defs`) and defines `list.fin_range`.
+`fin_range n` is the list of elements of `fin n`.
+`iota n = [n, n - 1, ..., 1]` and `range n = [0, ..., n - 1]` are basic list constructions used for
+tactics. `range' a b = [a, ..., a + b - 1]` is there to help prove properties about them.
+Actual maths should use `list.Ico` instead.
+-/
+
+universe u
+
+open nat
+
+namespace list
+variables {α : Type u}
+
+/-- All elements of `fin n`, from `0` to `n-1`. The corresponding finset is `finset.univ`. -/
+def fin_range (n : ℕ) : list (fin n) :=
+(range n).pmap fin.mk (λ _, list.mem_range.1)
+
+@[simp] lemma fin_range_zero : fin_range 0 = [] := rfl
+
+@[simp] lemma mem_fin_range {n : ℕ} (a : fin n) : a ∈ fin_range n :=
+mem_pmap.2 ⟨a.1, mem_range.2 a.2, fin.eta _ _⟩
+
+lemma nodup_fin_range (n : ℕ) : (fin_range n).nodup :=
+(nodup_range _).pmap $ λ _ _ _ _, fin.veq_of_eq
+
+@[simp] lemma length_fin_range (n : ℕ) : (fin_range n).length = n :=
+by rw [fin_range, length_pmap, length_range]
+
+@[simp] lemma fin_range_eq_nil {n : ℕ} : fin_range n = [] ↔ n = 0 :=
+by rw [← length_eq_zero, length_fin_range]
+
+@[simp] lemma map_coe_fin_range (n : ℕ) : (fin_range n).map coe = list.range n :=
+begin
+  simp_rw [fin_range, map_pmap, fin.coe_mk, pmap_eq_map],
+  exact list.map_id _
+end
+
+lemma fin_range_succ_eq_map (n : ℕ) :
+  fin_range n.succ = 0 :: (fin_range n).map fin.succ :=
+begin
+  apply map_injective_iff.mpr fin.coe_injective,
+  rw [map_cons, map_coe_fin_range, range_succ_eq_map, fin.coe_zero, ←map_coe_fin_range, map_map,
+    map_map, function.comp, function.comp],
+  congr' 2 with x,
+  exact (fin.coe_succ _).symm,
+end
+
+@[simp] lemma nth_le_fin_range {n : ℕ} {i : ℕ} (h) :
+  (fin_range n).nth_le i h = ⟨i, length_fin_range n ▸ h⟩ :=
+by simp only [fin_range, nth_le_range, nth_le_pmap]
+
+@[simp] lemma map_nth_le (l : list α) :
+  (fin_range l.length).map (λ n, l.nth_le n n.2) = l :=
+ext_le (by rw [length_map, length_fin_range]) $ λ n _ h,
+by { rw ← nth_le_map_rev, congr, { rw nth_le_fin_range, refl }, { rw length_fin_range, exact h } }
+
+theorem of_fn_eq_pmap {α n} {f : fin n → α} :
+  of_fn f = pmap (λ i hi, f ⟨i, hi⟩) (range n) (λ _, mem_range.1) :=
+by rw [pmap_eq_map_attach]; from ext_le (by simp)
+  (λ i hi1 hi2, by { simp at hi1, simp [nth_le_of_fn f ⟨i, hi1⟩, -subtype.val_eq_coe] })
+
+theorem of_fn_id (n) : of_fn id = fin_range n := of_fn_eq_pmap
+
+theorem of_fn_eq_map {α n} {f : fin n → α} :
+  of_fn f = (fin_range n).map f :=
+by rw [← of_fn_id, map_of_fn, function.right_id]
+
+theorem nodup_of_fn_of_injective {α n} {f : fin n → α} (hf : function.injective f) :
+  nodup (of_fn f) :=
+by { rw of_fn_eq_pmap, exact (nodup_range n).pmap (λ _ _ _ _ H, fin.veq_of_eq $ hf H) }
+
+theorem nodup_of_fn {α n} {f : fin n → α} :
+  nodup (of_fn f) ↔ function.injective f :=
+begin
+  refine ⟨_, nodup_of_fn_of_injective⟩,
+  refine fin.cons_induction _ (λ n x₀ xs ih, _) f,
+  { intro h,
+    exact function.injective_of_subsingleton _ },
+  { intro h,
+    rw fin.cons_injective_iff,
+    simp_rw [of_fn_succ, fin.cons_succ, nodup_cons, fin.cons_zero, mem_of_fn] at h,
+    exact h.imp_right ih }
+end
+
+end list

--- a/src/data/list/fin_range.lean
+++ b/src/data/list/fin_range.lean
@@ -9,31 +9,13 @@ import data.list.perm
 /-!
 # Lists of elements of `fin n`
 
-This file defines `fin_range n`, which is the list of elements of `fin n`.
+This file develops some results on `fin_range n`.
 -/
 
 universe u
 
 namespace list
 variables {α : Type u}
-
-/-- All elements of `fin n`, from `0` to `n-1`. The corresponding finset is `finset.univ`. -/
-def fin_range (n : ℕ) : list (fin n) :=
-(range n).pmap fin.mk (λ _, list.mem_range.1)
-
-@[simp] lemma fin_range_zero : fin_range 0 = [] := rfl
-
-@[simp] lemma mem_fin_range {n : ℕ} (a : fin n) : a ∈ fin_range n :=
-mem_pmap.2 ⟨a.1, mem_range.2 a.2, fin.eta _ _⟩
-
-lemma nodup_fin_range (n : ℕ) : (fin_range n).nodup :=
-(nodup_range _).pmap $ λ _ _ _ _, fin.veq_of_eq
-
-@[simp] lemma length_fin_range (n : ℕ) : (fin_range n).length = n :=
-by rw [fin_range, length_pmap, length_range]
-
-@[simp] lemma fin_range_eq_nil {n : ℕ} : fin_range n = [] ↔ n = 0 :=
-by rw [← length_eq_zero, length_fin_range]
 
 @[simp] lemma map_coe_fin_range (n : ℕ) : (fin_range n).map coe = list.range n :=
 begin
@@ -88,6 +70,10 @@ begin
     exact h.imp_right ih }
 end
 
+end list
+
+open list
+
 lemma equiv.perm.map_fin_range_perm {n : ℕ} (σ : equiv.perm (fin n)) :
   map σ (fin_range n) ~ fin_range n :=
 begin
@@ -97,11 +83,9 @@ end
 
 /-- The list obtained from a permutation of a tuple `f` is permutation equivalent to
 the list obtained from `f`. -/
-lemma equiv.perm.of_fn_comp_perm {n : ℕ} (σ : equiv.perm (fin n)) (f : fin n → α) :
+lemma equiv.perm.of_fn_comp_perm {n : ℕ} {α : Type u} (σ : equiv.perm (fin n)) (f : fin n → α) :
   of_fn (f ∘ σ) ~ of_fn f :=
 begin
   rw [of_fn_eq_map, of_fn_eq_map, ←map_map],
   exact σ.map_fin_range_perm.map f,
 end
-
-end list

--- a/src/data/list/fin_range.lean
+++ b/src/data/list/fin_range.lean
@@ -33,10 +33,6 @@ begin
   exact (fin.coe_succ _).symm,
 end
 
-@[simp] lemma nth_le_fin_range {n : ℕ} {i : ℕ} (h) :
-  (fin_range n).nth_le i h = ⟨i, length_fin_range n ▸ h⟩ :=
-by simp only [fin_range, nth_le_range, nth_le_pmap]
-
 @[simp] lemma map_nth_le (l : list α) :
   (fin_range l.length).map (λ n, l.nth_le n n.2) = l :=
 ext_le (by rw [length_map, length_fin_range]) $ λ n _ h,

--- a/src/data/list/indexes.lean
+++ b/src/data/list/indexes.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Jannis Limperg. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
+import data.list.of_fn
 import data.list.range
 
 /-!

--- a/src/data/list/nat_antidiagonal.lean
+++ b/src/data/list/nat_antidiagonal.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
+import data.list.nodup
 import data.list.range
 
 /-!

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -1340,5 +1340,3 @@ end
 end permutations
 
 end list
-
-open list

--- a/src/data/list/perm.lean
+++ b/src/data/list/perm.lean
@@ -4,12 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import data.list.dedup
-import data.list.lattice
 import data.list.permutation
-import data.list.zip
 import data.list.range
 import data.nat.factorial.basic
-import logic.relation
 
 /-!
 # List Permutations
@@ -1345,19 +1342,3 @@ end permutations
 end list
 
 open list
-
-lemma equiv.perm.map_fin_range_perm {n : ℕ} (σ : equiv.perm (fin n)) :
-  map σ (fin_range n) ~ fin_range n :=
-begin
-  rw [perm_ext ((nodup_fin_range n).map σ.injective) $ nodup_fin_range n],
-  simpa only [mem_map, mem_fin_range, true_and, iff_true] using σ.surjective
-end
-
-/-- The list obtained from a permutation of a tuple `f` is permutation equivalent to
-the list obtained from `f`. -/
-lemma equiv.perm.of_fn_comp_perm {n : ℕ} {α : Type uu} (σ : equiv.perm (fin n)) (f : fin n → α) :
-  of_fn (f ∘ σ) ~ of_fn f :=
-begin
-  rw [of_fn_eq_map, of_fn_eq_map, ←map_map],
-  exact σ.map_fin_range_perm.map f,
-end

--- a/src/data/list/range.lean
+++ b/src/data/list/range.lean
@@ -10,7 +10,8 @@ import data.list.zip
 # Ranges of naturals as lists
 
 This file shows basic results about `list.iota`, `list.range`, `list.range'` (all defined in
-`data.list.defs`).
+`data.list.defs`) and defines `list.fin_range`.
+`fin_range n` is the list of elements of `fin n`.
 `iota n = [n, n - 1, ..., 1]` and `range n = [0, ..., n - 1]` are basic list constructions used for
 tactics. `range' a b = [a, ..., a + b - 1]` is there to help prove properties about them.
 Actual maths should use `list.Ico` instead.
@@ -198,6 +199,24 @@ theorem reverse_range' : ∀ s n : ℕ,
     reverse_singleton, map_cons, tsub_zero, cons_append,
     nil_append, eq_self_iff_true, true_and, map_map]
   using reverse_range' s n
+
+/-- All elements of `fin n`, from `0` to `n-1`. The corresponding finset is `finset.univ`. -/
+def fin_range (n : ℕ) : list (fin n) :=
+(range n).pmap fin.mk (λ _, list.mem_range.1)
+
+@[simp] lemma fin_range_zero : fin_range 0 = [] := rfl
+
+@[simp] lemma mem_fin_range {n : ℕ} (a : fin n) : a ∈ fin_range n :=
+mem_pmap.2 ⟨a.1, mem_range.2 a.2, by { cases a, refl, }⟩
+
+lemma nodup_fin_range (n : ℕ) : (fin_range n).nodup :=
+pairwise.pmap (nodup_range n) _ $ λ _ _ _ _, @fin.ne_of_vne _ ⟨_, _⟩ ⟨_, _⟩
+
+@[simp] lemma length_fin_range (n : ℕ) : (fin_range n).length = n :=
+by rw [fin_range, length_pmap, length_range]
+
+@[simp] lemma fin_range_eq_nil {n : ℕ} : fin_range n = [] ↔ n = 0 :=
+by rw [← length_eq_zero, length_fin_range]
 
 @[to_additive]
 theorem prod_range_succ {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :

--- a/src/data/list/range.lean
+++ b/src/data/list/range.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kenny Lau, Scott Morrison
 -/
 import data.list.chain
-import data.list.nodup
-import data.list.of_fn
 import data.list.zip
 
 /-!
@@ -187,7 +185,7 @@ theorem pairwise_gt_iota (n : ℕ) : pairwise (>) (iota n) :=
 by simp only [iota_eq_reverse_range', pairwise_reverse, pairwise_lt_range']
 
 theorem nodup_iota (n : ℕ) : nodup (iota n) :=
-by simp only [iota_eq_reverse_range', nodup_reverse, nodup_range']
+(pairwise_gt_iota n).imp (λ a b, ne_of_gt)
 
 theorem mem_iota {m n : ℕ} : m ∈ iota n ↔ 1 ≤ m ∧ m ≤ n :=
 by simp only [iota_eq_reverse_range', mem_reverse, mem_range', add_comm, lt_succ_iff]
@@ -201,40 +199,6 @@ theorem reverse_range' : ∀ s n : ℕ,
     reverse_singleton, map_cons, tsub_zero, cons_append,
     nil_append, eq_self_iff_true, true_and, map_map]
   using reverse_range' s n
-
-/-- All elements of `fin n`, from `0` to `n-1`. The corresponding finset is `finset.univ`. -/
-def fin_range (n : ℕ) : list (fin n) :=
-(range n).pmap fin.mk (λ _, list.mem_range.1)
-
-@[simp] lemma fin_range_zero : fin_range 0 = [] := rfl
-
-@[simp] lemma mem_fin_range {n : ℕ} (a : fin n) : a ∈ fin_range n :=
-mem_pmap.2 ⟨a.1, mem_range.2 a.2, fin.eta _ _⟩
-
-lemma nodup_fin_range (n : ℕ) : (fin_range n).nodup :=
-(nodup_range _).pmap $ λ _ _ _ _, fin.veq_of_eq
-
-@[simp] lemma length_fin_range (n : ℕ) : (fin_range n).length = n :=
-by rw [fin_range, length_pmap, length_range]
-
-@[simp] lemma fin_range_eq_nil {n : ℕ} : fin_range n = [] ↔ n = 0 :=
-by rw [← length_eq_zero, length_fin_range]
-
-@[simp] lemma map_coe_fin_range (n : ℕ) : (fin_range n).map coe = list.range n :=
-begin
-  simp_rw [fin_range, map_pmap, fin.coe_mk, pmap_eq_map],
-  exact list.map_id _
-end
-
-lemma fin_range_succ_eq_map (n : ℕ) :
-  fin_range n.succ = 0 :: (fin_range n).map fin.succ :=
-begin
-  apply map_injective_iff.mpr fin.coe_injective,
-  rw [map_cons, map_coe_fin_range, range_succ_eq_map, fin.coe_zero, ←map_coe_fin_range, map_map,
-    map_map, function.comp, function.comp],
-  congr' 2 with x,
-  exact (fin.coe_succ _).symm,
-end
 
 @[to_additive]
 theorem prod_range_succ {α : Type u} [monoid α] (f : ℕ → α) (n : ℕ) :
@@ -280,42 +244,5 @@ by simp only [enum_from_eq_zip_range', unzip_zip, length_range']
 @[simp] lemma nth_le_range {n} (i) (H : i < (range n).length) :
   nth_le (range n) i H = i :=
 option.some.inj $ by rw [← nth_le_nth _, nth_range (by simpa using H)]
-
-@[simp] lemma nth_le_fin_range {n : ℕ} {i : ℕ} (h) :
-  (fin_range n).nth_le i h = ⟨i, length_fin_range n ▸ h⟩ :=
-by simp only [fin_range, nth_le_range, nth_le_pmap]
-
-@[simp] lemma map_nth_le (l : list α) :
-  (fin_range l.length).map (λ n, l.nth_le n n.2) = l :=
-ext_le (by rw [length_map, length_fin_range]) $ λ n _ h,
-by { rw ← nth_le_map_rev, congr, { rw nth_le_fin_range, refl }, { rw length_fin_range, exact h } }
-
-theorem of_fn_eq_pmap {α n} {f : fin n → α} :
-  of_fn f = pmap (λ i hi, f ⟨i, hi⟩) (range n) (λ _, mem_range.1) :=
-by rw [pmap_eq_map_attach]; from ext_le (by simp)
-  (λ i hi1 hi2, by { simp at hi1, simp [nth_le_of_fn f ⟨i, hi1⟩, -subtype.val_eq_coe] })
-
-theorem of_fn_id (n) : of_fn id = fin_range n := of_fn_eq_pmap
-
-theorem of_fn_eq_map {α n} {f : fin n → α} :
-  of_fn f = (fin_range n).map f :=
-by rw [← of_fn_id, map_of_fn, function.right_id]
-
-theorem nodup_of_fn_of_injective {α n} {f : fin n → α} (hf : function.injective f) :
-  nodup (of_fn f) :=
-by { rw of_fn_eq_pmap, exact (nodup_range n).pmap (λ _ _ _ _ H, fin.veq_of_eq $ hf H) }
-
-theorem nodup_of_fn {α n} {f : fin n → α} :
-  nodup (of_fn f) ↔ function.injective f :=
-begin
-  refine ⟨_, nodup_of_fn_of_injective⟩,
-  refine fin.cons_induction _ (λ n x₀ xs ih, _) f,
-  { intro h,
-    exact function.injective_of_subsingleton _ },
-  { intro h,
-    rw fin.cons_injective_iff,
-    simp_rw [of_fn_succ, fin.cons_succ, nodup_cons, fin.cons_zero, mem_of_fn] at h,
-    exact h.imp_right ih }
-end
 
 end list

--- a/src/data/list/range.lean
+++ b/src/data/list/range.lean
@@ -263,4 +263,8 @@ by simp only [enum_from_eq_zip_range', unzip_zip, length_range']
   nth_le (range n) i H = i :=
 option.some.inj $ by rw [← nth_le_nth _, nth_range (by simpa using H)]
 
+@[simp] lemma nth_le_fin_range {n : ℕ} {i : ℕ} (h) :
+  (fin_range n).nth_le i h = ⟨i, length_fin_range n ▸ h⟩ :=
+by simp only [fin_range, nth_le_range, nth_le_pmap]
+
 end list

--- a/src/data/list/range.lean
+++ b/src/data/list/range.lean
@@ -10,7 +10,7 @@ import data.list.zip
 # Ranges of naturals as lists
 
 This file shows basic results about `list.iota`, `list.range`, `list.range'` (all defined in
-`data.list.defs`) and defines `list.fin_range`.
+`data.list.defs`).
 `iota n = [n, n - 1, ..., 1]` and `range n = [0, ..., n - 1]` are basic list constructions used for
 tactics. `range' a b = [a, ..., a + b - 1]` is there to help prove properties about them.
 Actual maths should use `list.Ico` instead.

--- a/src/data/list/range.lean
+++ b/src/data/list/range.lean
@@ -11,7 +11,6 @@ import data.list.zip
 
 This file shows basic results about `list.iota`, `list.range`, `list.range'` (all defined in
 `data.list.defs`) and defines `list.fin_range`.
-`fin_range n` is the list of elements of `fin n`.
 `iota n = [n, n - 1, ..., 1]` and `range n = [0, ..., n - 1]` are basic list constructions used for
 tactics. `range' a b = [a, ..., a + b - 1]` is there to help prove properties about them.
 Actual maths should use `list.Ico` instead.

--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -3,6 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
+import data.list.of_fn
 import data.list.perm
 
 /-!

--- a/src/data/matrix/dmatrix.lean
+++ b/src/data/matrix/dmatrix.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
+import algebra.group.pi
 import data.fintype.basic
 
 /-!

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -7,6 +7,7 @@ import linear_algebra.basic
 import algebra.algebra.basic
 import algebra.big_operators.order
 import algebra.big_operators.ring
+import data.list.fin_range
 import data.fintype.big_operators
 import data.fintype.sort
 


### PR DESCRIPTION
This PR splits most of the lemmas about `list.fin_range` into a new file.

`list.fin_range` is much less useful than `list.range`, but we need to import `data.list.of_fn` for `list.fin_range`, and then `data.list.of_fn` imports `data.fin.tuple.basic` and `data.fin.tuple.basic` imports many things.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
