### PR TITLE
[Merged by Bors] - chore(data/multiset/nodup): remove dependency on `multiset.powerset`

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -12,6 +12,7 @@ import algebra.ring.opposite
 import data.finset.sum
 import data.fintype.basic
 import data.finset.sigma
+import data.multiset.powerset
 import data.set.pairwise
 
 /-!

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2493,4 +2493,5 @@ multiset.disjoint_to_finset
 
 end list
 
+-- Assert that we define `finset` without the material on `list.sublists`.
 assert_not_exists list.sublists_len

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2494,4 +2494,6 @@ multiset.disjoint_to_finset
 end list
 
 -- Assert that we define `finset` without the material on `list.sublists`.
+-- Note that we cannot use `list.sublists` itself as that is defined very early.
 assert_not_exists list.sublists_len
+assert_not_exists multiset.powerset

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2492,3 +2492,5 @@ lemma disjoint_to_finset_iff_disjoint : _root_.disjoint l.to_finset l'.to_finset
 multiset.disjoint_to_finset
 
 end list
+
+assert_not_exists list.sublists_len

--- a/src/data/finset/powerset.lean
+++ b/src/data/finset/powerset.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import data.finset.lattice
+import data.multiset.powerset
 
 /-!
 # The powerset of a finset

--- a/src/data/multiset/nodup.lean
+++ b/src/data/multiset/nodup.lean
@@ -3,8 +3,8 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import data.list.nodup
 import data.multiset.bind
-import data.multiset.powerset
 import data.multiset.range
 
 /-!
@@ -160,19 +160,6 @@ nodup_of_le $ inter_le_right _ _
 ⟨λ h, ⟨nodup_of_le (le_union_left _ _) h, nodup_of_le (le_union_right _ _) h⟩,
  λ ⟨h₁, h₂⟩, nodup_iff_count_le_one.2 $ λ a, by rw [count_union]; exact
    max_le (nodup_iff_count_le_one.1 h₁ a) (nodup_iff_count_le_one.1 h₂ a)⟩
-
-@[simp] theorem nodup_powerset {s : multiset α} : nodup (powerset s) ↔ nodup s :=
-⟨λ h, (nodup_of_le (map_single_le_powerset _) h).of_map _,
-  quotient.induction_on s $ λ l h,
-  by simp; refine (nodup_sublists'.2 h).map_on _ ; exact
-  λ x sx y sy e,
-    (h.sublist_ext (mem_sublists'.1 sx) (mem_sublists'.1 sy)).1
-      (quotient.exact e)⟩
-
-alias nodup_powerset ↔ nodup.of_powerset nodup.powerset
-
-protected lemma nodup.powerset_len {n : ℕ} (h : nodup s) : nodup (powerset_len n s) :=
-nodup_of_le (powerset_len_le_powerset _ _) (nodup_powerset.2 h)
 
 @[simp] lemma nodup_bind {s : multiset α} {t : α → multiset β} :
   nodup (bind s t) ↔ ((∀a∈s, nodup (t a)) ∧ (s.pairwise (λa b, disjoint (t a) (t b)))) :=

--- a/src/data/multiset/powerset.lean
+++ b/src/data/multiset/powerset.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import data.list.sublists
-import data.multiset.basic
-import data.multiset.range
-import data.multiset.bind
+import data.multiset.nodup
 
 /-!
 # The powerset of a multiset
@@ -269,5 +267,19 @@ begin
     coe_card],
   exact coe_eq_coe.mpr ((list.range_bind_sublists_len_perm S).map _),
 end
+
+@[simp] theorem nodup_powerset {s : multiset α} : nodup (powerset s) ↔ nodup s :=
+⟨λ h, (nodup_of_le (map_single_le_powerset _) h).of_map _,
+  quotient.induction_on s $ λ l h,
+  by simp; refine (nodup_sublists'.2 h).map_on _ ; exact
+  λ x sx y sy e,
+    (h.sublist_ext (mem_sublists'.1 sx) (mem_sublists'.1 sy)).1
+      (quotient.exact e)⟩
+
+alias nodup_powerset ↔ nodup.of_powerset nodup.powerset
+
+protected lemma nodup.powerset_len {n : ℕ} {s : multiset α} (h : nodup s) :
+  nodup (powerset_len n s) :=
+nodup_of_le (powerset_len_le_powerset _ _) (nodup_powerset.2 h)
 
 end multiset


### PR DESCRIPTION
This flips the import direction between `data.multiset.powerset` and `data.multiset.nodup`, such that the former now imports the latter, moving lemmas as necessary.

This matches how `data.list.sublists` (transitively) imports `data.list.nodup`.

More importantly, this means that `finset` (which needs `multiset.nodup`) can be defined without needing the material on `list.sublists` and `multiset.powerset`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
