### PR TITLE
[Merged by Bors] - feat(logic/denumerable): Any two infinite countable types are equivalent

### DIFF
--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -338,6 +338,7 @@ lemma finite_iff_nonempty_fintype (α : Type*) :
 ⟨λ h, let ⟨k, ⟨e⟩⟩ := @finite.exists_equiv_fin α h in ⟨fintype.of_equiv _ e.symm⟩,
   λ ⟨_⟩, by exactI infer_instance⟩
 
+/-- See also `nonempty_encodable`, `nonempty_denumerable`. -/
 lemma nonempty_fintype (α : Type*) [finite α] : nonempty (fintype α) :=
 (finite_iff_nonempty_fintype α).mp ‹_›
 

--- a/src/logic/denumerable.lean
+++ b/src/logic/denumerable.lean
@@ -282,7 +282,7 @@ namespace denumerable
 open encodable
 
 /-- An infinite encodable type is denumerable. -/
-def of_encodable_of_infinite (α : Type*) [infinite α] [encodable α] : denumerable α :=
+def of_encodable_of_infinite (α : Type*) [encodable α] [infinite α] : denumerable α :=
 begin
   letI := @decidable_range_encode α _;
   letI : infinite (set.range (@encode α _)) :=
@@ -294,10 +294,10 @@ end
 end denumerable
 
 /-- See also `nonempty_encodable`, `nonempty_fintype`. -/
-lemma nonempty_denumerable (α : Type*) [infinite α] [countable α] : nonempty (denumerable α) :=
-(nonempty_encodable α).map $ @denumerable.of_encodable_of_infinite _ _
+lemma nonempty_denumerable (α : Type*) [countable α] [infinite α] : nonempty (denumerable α) :=
+(nonempty_encodable α).map $ λ h, by exactI denumerable.of_encodable_of_infinite _
 
-instance nonempty_equiv_of_countable [infinite α] [countable α] [infinite β] [countable β] :
+instance nonempty_equiv_of_countable [countable α] [infinite α] [countable β] [infinite β] :
   nonempty (α ≃ β) :=
 begin
   casesI nonempty_denumerable α,

--- a/src/logic/denumerable.lean
+++ b/src/logic/denumerable.lean
@@ -21,6 +21,8 @@ This property already has a name, namely `α ≃ ℕ`, but here we are intereste
 typeclass.
 -/
 
+variables {α β : Type*}
+
 /-- A denumerable type is (constructively) bijective with `ℕ`. Typeclass equivalent of `α ≃ ℕ`. -/
 class denumerable (α : Type*) extends encodable α :=
 (decode_inv : ∀ n, ∃ a ∈ decode n, encode a = n)
@@ -30,7 +32,7 @@ open nat
 namespace denumerable
 
 section
-variables {α : Type*} {β : Type*} [denumerable α] [denumerable β]
+variables [denumerable α] [denumerable β]
 open encodable
 
 theorem decode_is_some (α) [denumerable α] (n : ℕ) :
@@ -280,7 +282,7 @@ namespace denumerable
 open encodable
 
 /-- An infinite encodable type is denumerable. -/
-def of_encodable_of_infinite (α : Type*) [encodable α] [infinite α] : denumerable α :=
+def of_encodable_of_infinite (α : Type*) [infinite α] [encodable α] : denumerable α :=
 begin
   letI := @decidable_range_encode α _;
   letI : infinite (set.range (@encode α _)) :=
@@ -290,3 +292,15 @@ begin
 end
 
 end denumerable
+
+/-- See also `nonempty_encodable`, `nonempty_fintype`. -/
+lemma nonempty_denumerable (α : Type*) [infinite α] [countable α] : nonempty (denumerable α) :=
+(nonempty_encodable α).map $ @denumerable.of_encodable_of_infinite _ _
+
+instance nonempty_equiv_of_countable [infinite α] [countable α] [infinite β] [countable β] :
+  nonempty (α ≃ β) :=
+begin
+  casesI nonempty_denumerable α,
+  casesI nonempty_denumerable β,
+  exact ⟨(denumerable.eqv _).trans (denumerable.eqv _).symm⟩,
+end

--- a/src/logic/encodable/basic.lean
+++ b/src/logic/encodable/basic.lean
@@ -335,6 +335,7 @@ nonempty.some $ let ⟨f, hf⟩ := exists_injective_nat α in ⟨of_inj f hf⟩
 
 end encodable
 
+/-- See also `nonempty_fintype`, `nonempty_denumerable`. -/
 lemma nonempty_encodable (α : Type*) [countable α] : nonempty (encodable α) :=
 ⟨encodable.of_countable _⟩
 

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -1092,6 +1092,9 @@ by rw [← not_lt, lt_aleph_0_iff_finite, not_finite_iff_infinite]
 
 @[simp] lemma aleph_0_le_mk (α : Type u) [infinite α] : ℵ₀ ≤ #α := infinite_iff.1 ‹_›
 
+@[simp] lemma mk_eq_aleph_0 (α : Type*) [countable α] [infinite α] : #α = ℵ₀ :=
+mk_le_aleph_0.antisymm $ aleph_0_le_mk _
+
 lemma denumerable_iff {α : Type u} : nonempty (denumerable α) ↔ #α = ℵ₀ :=
 ⟨λ ⟨h⟩, mk_congr ((@denumerable.eqv α h).trans equiv.ulift.symm),
  λ h, by { cases quotient.exact h with f, exact ⟨denumerable.mk' $ f.trans equiv.ulift⟩ }⟩


### PR DESCRIPTION
If `α` and `β` are both infinite and countable, then `nonempty (α ≃ β)`. I prove it using the `denumerable` API, but I also provide a lemma to prove it from the `cardinal` one.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
