### PR TITLE
[Merged by Bors] - feat(dynamics/fixed_points/basic): `x` is fixed by `fⁿ` if it is fixed by `f`

### DIFF
--- a/src/dynamics/fixed_points/basic.lean
+++ b/src/dynamics/fixed_points/basic.lean
@@ -22,9 +22,11 @@ We also prove some simple lemmas about `is_fixed_pt` and `∘`, `iterate`, and `
 fixed point
 -/
 
+open equiv
+
 universes u v
 
-variables {α : Type u} {β : Type v} {f fa g : α → α} {x y : α} {fb : β → β} {m n k : ℕ} {e : α ≃ α}
+variables {α : Type u} {β : Type v} {f fa g : α → α} {x y : α} {fb : β → β} {m n k : ℕ} {e : perm α}
 
 namespace function
 
@@ -75,6 +77,18 @@ by convert hx
 lemma preimage_iterate {s : set α} (h : is_fixed_pt (set.preimage f) s) (n : ℕ) :
   is_fixed_pt (set.preimage (f^[n])) s :=
 by { rw set.preimage_iterate_eq, exact h.iterate n, }
+
+protected lemma symm (h : is_fixed_pt e x) : is_fixed_pt e.symm x :=
+h.to_left_inverse e.left_inverse_symm
+
+protected lemma inv (h : is_fixed_pt e x) : is_fixed_pt ⇑(e⁻¹) x := h.symm
+
+protected lemma pow (h : is_fixed_pt e x) (n : ℕ) : is_fixed_pt ⇑(e ^ n) x :=
+by { rw ←equiv.perm.iterate_eq_pow, exact h.iterate _ }
+
+protected lemma zpow (h : is_fixed_pt e x) : ∀ n : ℤ, is_fixed_pt ⇑(e ^ n) x
+| (int.of_nat n) := h.pow _
+| (int.neg_succ_of_nat n) := (h.pow $ n + 1).inv
 
 end is_fixed_pt
 
@@ -143,20 +157,3 @@ lemma commute.right_bij_on_fixed_pts_comp (h : commute f g) :
 by simpa only [h.comp_eq] using bij_on_fixed_pts_comp f g
 
 end function
-
-namespace equiv.is_fixed_pt
-
-protected lemma symm (h : function.is_fixed_pt e x) : function.is_fixed_pt e.symm x :=
-h.to_left_inverse e.left_inverse_symm
-
-protected lemma zpow (h : function.is_fixed_pt e x) (n : ℤ) : function.is_fixed_pt ⇑(e^n) x :=
-begin
-  cases n,
-  { rw [int.of_nat_eq_coe, zpow_coe_nat, ← equiv.perm.iterate_eq_pow],
-    exact h.iterate n, },
-  { change function.is_fixed_pt ⇑(e^(-(↑(n + 1) : ℤ))) x,
-    rw [zpow_neg, zpow_coe_nat, ← inv_pow, ← equiv.perm.iterate_eq_pow, equiv.perm.inv_def],
-    exact (equiv.is_fixed_pt.symm h).iterate (n + 1), },
-end
-
-end equiv.is_fixed_pt

--- a/src/dynamics/fixed_points/basic.lean
+++ b/src/dynamics/fixed_points/basic.lean
@@ -78,10 +78,10 @@ lemma preimage_iterate {s : set α} (h : is_fixed_pt (set.preimage f) s) (n : �
   is_fixed_pt (set.preimage (f^[n])) s :=
 by { rw set.preimage_iterate_eq, exact h.iterate n, }
 
-protected lemma perm_symm (h : is_fixed_pt e x) : is_fixed_pt e.symm x :=
+protected lemma equiv_symm (h : is_fixed_pt e x) : is_fixed_pt e.symm x :=
 h.to_left_inverse e.left_inverse_symm
 
-protected lemma perm_inv (h : is_fixed_pt e x) : is_fixed_pt ⇑(e⁻¹) x := h.perm_symm
+protected lemma perm_inv (h : is_fixed_pt e x) : is_fixed_pt ⇑(e⁻¹) x := h.equiv_symm
 
 protected lemma perm_pow (h : is_fixed_pt e x) (n : ℕ) : is_fixed_pt ⇑(e ^ n) x :=
 by { rw ←equiv.perm.iterate_eq_pow, exact h.iterate _ }

--- a/src/dynamics/fixed_points/basic.lean
+++ b/src/dynamics/fixed_points/basic.lean
@@ -78,17 +78,17 @@ lemma preimage_iterate {s : set α} (h : is_fixed_pt (set.preimage f) s) (n : �
   is_fixed_pt (set.preimage (f^[n])) s :=
 by { rw set.preimage_iterate_eq, exact h.iterate n, }
 
-protected lemma symm (h : is_fixed_pt e x) : is_fixed_pt e.symm x :=
+protected lemma perm_symm (h : is_fixed_pt e x) : is_fixed_pt e.symm x :=
 h.to_left_inverse e.left_inverse_symm
 
-protected lemma inv (h : is_fixed_pt e x) : is_fixed_pt ⇑(e⁻¹) x := h.symm
+protected lemma perm_inv (h : is_fixed_pt e x) : is_fixed_pt ⇑(e⁻¹) x := h.perm_symm
 
-protected lemma pow (h : is_fixed_pt e x) (n : ℕ) : is_fixed_pt ⇑(e ^ n) x :=
+protected lemma perm_pow (h : is_fixed_pt e x) (n : ℕ) : is_fixed_pt ⇑(e ^ n) x :=
 by { rw ←equiv.perm.iterate_eq_pow, exact h.iterate _ }
 
-protected lemma zpow (h : is_fixed_pt e x) : ∀ n : ℤ, is_fixed_pt ⇑(e ^ n) x
-| (int.of_nat n) := h.pow _
-| (int.neg_succ_of_nat n) := (h.pow $ n + 1).inv
+protected lemma perm_zpow (h : is_fixed_pt e x) : ∀ n : ℤ, is_fixed_pt ⇑(e ^ n) x
+| (int.of_nat n) := h.perm_pow _
+| (int.neg_succ_of_nat n) := (h.perm_pow $ n + 1).perm_inv
 
 end is_fixed_pt
 

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -449,7 +449,7 @@ begin
   obtain ⟨k, rfl⟩ := subgroup.mem_zpowers_iff.mp hx,
   rw [← mul_action.to_perm_apply, ← mul_action.to_perm_hom_apply,
     monoid_hom.map_zpow _ y k, mul_action.to_perm_hom_apply],
-  exact equiv.is_fixed_pt.zpow hs k,
+  exact hs.perm_zpow k,
 end
 
 lemma vadd_eq_self_of_mem_zmultiples {α G : Type*} [add_group G] [add_action G α] {x y : G}

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -449,7 +449,7 @@ begin
   obtain ⟨k, rfl⟩ := subgroup.mem_zpowers_iff.mp hx,
   rw [← mul_action.to_perm_apply, ← mul_action.to_perm_hom_apply,
     monoid_hom.map_zpow _ y k, mul_action.to_perm_hom_apply],
-  exact hs.perm_zpow k,
+  exact function.is_fixed_pt.perm_zpow hs k,
 end
 
 lemma vadd_eq_self_of_mem_zmultiples {α G : Type*} [add_group G] [add_action G α] {x y : G}

--- a/src/order/fixed_points.lean
+++ b/src/order/fixed_points.lean
@@ -187,7 +187,7 @@ lemma le_prev_fixed {x : α} (hx : f x ≤ x) {y : fixed_points f} (h : ↑y ≤
 (f.le_prev_fixed_iff hx).2 h
 
 lemma le_map_sup_fixed_points (x y : fixed_points f) : (x ⊔ y : α) ≤ f (x ⊔ y) :=
-calc (x ⊔ y : α) = f x ⊔ f y : congr_arg2 (⊔) x.2.symm y.2.symm
+calc (x ⊔ y : α) = f x ⊔ f y : congr_arg2 (⊔) x.2.eq.symm y.2.eq.symm
              ... ≤ f (x ⊔ y) : f.mono.le_map_sup x y
 
 lemma map_inf_fixed_points_le (x y : fixed_points f) : f (x ⊓ y) ≤ x ⊓ y :=

--- a/src/order/fixed_points.lean
+++ b/src/order/fixed_points.lean
@@ -187,7 +187,7 @@ lemma le_prev_fixed {x : α} (hx : f x ≤ x) {y : fixed_points f} (h : ↑y ≤
 (f.le_prev_fixed_iff hx).2 h
 
 lemma le_map_sup_fixed_points (x y : fixed_points f) : (x ⊔ y : α) ≤ f (x ⊔ y) :=
-calc (x ⊔ y : α) = f x ⊔ f y : congr_arg2 (⊔) x.2.eq.symm y.2.eq.symm
+calc (x ⊔ y : α) = f x ⊔ f y : congr_arg2 (⊔) x.2.symm y.2.symm
              ... ≤ f (x ⊔ y) : f.mono.le_map_sup x y
 
 lemma map_inf_fixed_points_le (x y : fixed_points f) : f (x ⊓ y) ≤ x ⊓ y :=


### PR DESCRIPTION
Rephrase `function.is_fixed_pt.iterate` and `equiv.is_fixed_pt.symm` in new lemmas that use the multiplicative structure on `perm α`.

Rename `equiv.is_fixed_pt.symm`/`equiv.is_fixed_pt.zpow` to `function.is_fixed_pt.equiv_symm`/`function.is_fixed_pt.perm_zpow` so that dot notation is possible.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
