### PR TITLE
[Merged by Bors] - fix(ci): do not fail when detecting ported files more than 40 commits old

### DIFF
--- a/.github/workflows/add_ported_warnings.yml
+++ b/.github/workflows/add_ported_warnings.yml
@@ -22,8 +22,8 @@ jobs:
       # TODO: is this really faster than just calling git from python?
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v34
+        uses: jitterbit/get-changed-files@v1
 
       - name: run the script
         run: |
-          python scripts/detect_ported_files.py ${{ steps.changed-files.outputs.all_changed_files }}
+          python scripts/detect_ported_files.py ${{ steps.changed-files.outputs.all }}


### PR DESCRIPTION
The previous action worked by using `git diff`, but this fails on shallow checkouts. This version hits the github API.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
