### PR TITLE
[Merged by Bors] - fix(tactic/assert_exists): use more unique names

### DIFF
--- a/src/tactic/assert_exists.lean
+++ b/src/tactic/assert_exists.lean
@@ -62,7 +62,7 @@ do
   ff ← succeeds (get_decl decl) |
   fail format!"Declaration {decl} is not allowed to exist in this file.",
   n ← tactic.mk_fresh_name,
-  let marker := (`assert_not_exists._checked).append n,
+  let marker := (`assert_not_exists._checked).append (decl.append n),
   add_decl
     (declaration.defn marker [] `(name) `(decl) default tt),
   pure ()
@@ -126,7 +126,8 @@ do
   match i with
   | none := do
       n ← tactic.mk_fresh_name,
-      let marker := (`assert_no_instance._checked).append n,
+      e_str ← to_string <$> pp e,
+      let marker := ((`assert_no_instance._checked).mk_string e_str).append n,
       et ← infer_type e,
       tt ← succeeds (get_decl marker) |
       add_decl


### PR DESCRIPTION
Previously we were relying on `tactic.mk_fresh_name` being globally unique, but this turned out to not be the case. Now we also combine the declaration name / instance string with the fresh name, to reduce the chance of conflicts.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
