### PR TITLE
chore(data/fin/vec_notation): make `matrix.vec_empty` reducible

### DIFF
--- a/src/data/fin/vec_notation.lean
+++ b/src/data/fin/vec_notation.lean
@@ -45,8 +45,8 @@ variables {α : Type u}
 section matrix_notation
 
 /-- `![]` is the vector with no entries. -/
-def vec_empty : fin 0 → α :=
-fin_zero_elim
+-- reducible since `elim0'` is already non-dependent
+@[reducible] def vec_empty : fin 0 → α := fin.elim0'
 
 /-- `vec_cons h t` prepends an entry `h` to a vector `t`.
 


### PR DESCRIPTION
The hope is that this simplifies some proofs downstream.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
