### PR TITLE
[Merged by Bors] - refactor(measure_theory/group/fundamental_domain): Use `pairwise`

### DIFF
--- a/src/measure_theory/group/fundamental_domain.lean
+++ b/src/measure_theory/group/fundamental_domain.lean
@@ -70,6 +70,17 @@ lemma mk' (h_meas : null_measurable_set s μ) (h_exists : ∀ x : α, ∃! g : G
       exact hab (inv_injective $ (h_exists x).unique hxa hxb),
     end }
 
+/-- For `s` to be a fundamental domain, it's enough to check `ae_disjoint (g • s) s` for `g ≠ 1`. -/
+@[to_additive "For `s` to be a fundamental domain, it's enough to check `ae_disjoint (g +ᵥ s) s` for
+`g ≠ 0`."]
+lemma mk'' (h_meas : null_measurable_set s μ) (h_ae_covers : ∀ᵐ x ∂μ, ∃ g : G, g • x ∈ s)
+  (h_ae_disjoint : ∀ g ≠ (1 : G), ae_disjoint μ (g • s) s)
+  (h_qmp : ∀ (g : G), quasi_measure_preserving ((•) g : α → α) μ μ) :
+  is_fundamental_domain G s μ :=
+{ null_measurable_set := h_meas,
+  ae_covers := h_ae_covers,
+  ae_disjoint := pairwise_ae_disjoint_of_ae_disjoint_forall_ne_one h_ae_disjoint h_qmp }
+
 /-- If a measurable space has a finite measure `μ` and a countable group `G` acts
 quasi-measure-preservingly, then to show that a set `s` is a fundamental domain, it is sufficient
 to check that its translates `g • s` are (almost) disjoint and that the sum `∑' g, μ (g • s)` is
@@ -81,12 +92,14 @@ to check that its translates `g +ᵥ s` are (almost) disjoint and that the sum `
 sufficiently large."]
 lemma mk_of_measure_univ_le [is_finite_measure μ] [countable G]
   (h_meas : null_measurable_set s μ)
-  (h_ae_disjoint : pairwise $ λ a b : G, ae_disjoint μ (a • s) (b • s))
+  (h_ae_disjoint : ∀ g ≠ (1 : G), ae_disjoint μ (g • s) s)
   (h_qmp : ∀ (g : G), quasi_measure_preserving ((•) g : α → α) μ μ)
   (h_measure_univ_le : μ (univ : set α) ≤ ∑' (g : G), μ (g • s)) :
   is_fundamental_domain G s μ :=
+have ae_disjoint : pairwise (ae_disjoint μ on (λ (g : G), g • s)) :=
+  pairwise_ae_disjoint_of_ae_disjoint_forall_ne_one h_ae_disjoint h_qmp,
 { null_measurable_set := h_meas,
-  ae_disjoint := h_ae_disjoint,
+  ae_disjoint := ae_disjoint,
   ae_covers :=
   begin
     replace h_meas : ∀ (g : G), null_measurable_set (g • s) μ :=
@@ -95,7 +108,7 @@ lemma mk_of_measure_univ_le [is_finite_measure μ] [countable G]
     { rw ← Union_smul_eq_set_of_exists, exact null_measurable_set.Union h_meas, },
     rw [ae_iff_measure_eq h_meas', ← Union_smul_eq_set_of_exists],
     refine le_antisymm (measure_mono $ subset_univ _) _,
-    rw measure_Union₀ h_ae_disjoint h_meas,
+    rw measure_Union₀ ae_disjoint h_meas,
     exact h_measure_univ_le,
   end }
 


### PR DESCRIPTION
Replace `∀ g ≠ (1 : G), ae_disjoint μ (g • s) s` ("translates are disjoint to the original set") by the stronger and more symmetric `pairwise (ae_disjoint μ on λ g : G, g • s)` ("translates are disjoint"). In full generality, the latter condition is the one we mean, and indeed this change reduces typeclass assumptions for a few lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
