### PR TITLE
[Merged by Bors] - feat(order/basic): Checking associativity in partial order

### DIFF
--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -383,14 +383,14 @@ variables [partial_order α]
 
 /-- To prove commutativity of a binary operation `○`, we only to check `a ○ b ≤ b ○ a` for all `a`,
 `b`. -/
-lemma comm_of_le {f : β → β → α} (comm : ∀ a b, f a b ≤ f b a) : ∀ a b, f a b = f b a :=
+lemma commutative_of_le {f : β → β → α} (comm : ∀ a b, f a b ≤ f b a) : ∀ a b, f a b = f b a :=
 λ a b, (comm _ _).antisymm $ comm _ _
 
 /-- To prove associativity of a commutative binary operation `○`, we only to check
 `(a ○ b) ○ c ≤ a ○ (b ○ c)` for all `a`, `b`, `c`. -/
-lemma assoc_of_comm_of_le {f : α → α → α} (comm : ∀ a b, f a b = f b a)
+lemma associative_of_commutative_of_le {f : α → α → α} (comm : commutative f)
   (assoc : ∀ a b c, f (f a b) c ≤ f a (f b c)) :
-  ∀ a b c, f (f a b) c = f a (f b c) :=
+  associative f :=
 λ a b c, le_antisymm (assoc _ _ _) $ by { rw [comm, comm b, comm _ c, comm a], exact assoc _ _ _ }
 
 end partial_order

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -378,6 +378,19 @@ lemma le_implies_le_of_le_of_le {a b c d : α} [preorder α] (hca : c ≤ a) (hb
   a ≤ b → c ≤ d :=
 λ hab, (hca.trans hab).trans hbd
 
+section partial_order
+variables [partial_order α]
+
+lemma comm_of_le {f : β → β → α} (comm : ∀ a b, f a b ≤ f b a) : ∀ a b, f a b = f b a :=
+λ a b, (comm _ _).antisymm $ comm _ _
+
+lemma assoc_of_comm_of_le {f : α → α → α} (comm : ∀ a b, f a b = f b a)
+  (assoc : ∀ a b c, f (f a b) c ≤ f a (f b c)) :
+  ∀ a b c, f (f a b) c = f a (f b c) :=
+λ a b c, le_antisymm (assoc _ _ _) $ by { rw [comm, comm b, comm _ c, comm a], exact assoc _ _ _ }
+
+end partial_order
+
 @[ext]
 lemma preorder.to_has_le_injective {α : Type*} :
   function.injective (@preorder.to_has_le α) :=

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -381,9 +381,13 @@ lemma le_implies_le_of_le_of_le {a b c d : α} [preorder α] (hca : c ≤ a) (hb
 section partial_order
 variables [partial_order α]
 
+/-- To prove commutativity of a binary operation `○`, we only to check `a ○ b ≤ b ○ a` for all `a`,
+`b`. -/
 lemma comm_of_le {f : β → β → α} (comm : ∀ a b, f a b ≤ f b a) : ∀ a b, f a b = f b a :=
 λ a b, (comm _ _).antisymm $ comm _ _
 
+/-- To prove associativity of a commutative binary operation `○`, we only to check
+`(a ○ b) ○ c ≤ a ○ (b ○ c)` for all `a`, `b`, `c`. -/
 lemma assoc_of_comm_of_le {f : α → α → α} (comm : ∀ a b, f a b = f b a)
   (assoc : ∀ a b c, f (f a b) c ≤ f a (f b c)) :
   ∀ a b c, f (f a b) c = f a (f b c) :=


### PR DESCRIPTION
Simpler conditions to check commutativity/associativity of a function valued in a partial order.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Match https://github.com/leanprover-community/mathlib4/pull/1030

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
