### PR TITLE
[Merged by Bors] - chore(data/set/image): Turn lemma around

### DIFF
--- a/src/algebraic_geometry/ringed_space.lean
+++ b/src/algebraic_geometry/ringed_space.lean
@@ -174,7 +174,7 @@ end
 begin
   ext1,
   dsimp [RingedSpace.basic_open],
-  rw set.image_inter subtype.coe_injective,
+  rw ←set.image_inter subtype.coe_injective,
   congr,
   ext,
   simp_rw map_mul,

--- a/src/data/set/image.lean
+++ b/src/data/set/image.lean
@@ -296,7 +296,7 @@ theorem mem_image_iff_of_inverse {f : α → β} {g : β → α} {b : β} {s : s
 by rw image_eq_preimage_of_inverse h₁ h₂; refl
 
 theorem image_compl_subset {f : α → β} {s : set α} (H : injective f) : f '' sᶜ ⊆ (f '' s)ᶜ :=
-disjoint.subset_compl_left $ by simp [disjoint_iff_inf_le, image_inter H]
+disjoint.subset_compl_left $ by simp [disjoint_iff_inf_le, ←image_inter H]
 
 theorem subset_image_compl {f : α → β} {s : set α} (H : surjective f) : (f '' s)ᶜ ⊆ f '' sᶜ :=
 compl_subset_iff_union.2 $

--- a/src/data/set/image.lean
+++ b/src/data/set/image.lean
@@ -225,15 +225,15 @@ lemma image_inter_subset (f : α → β) (s t : set α) :
 subset_inter (image_subset _ $ inter_subset_left _ _) (image_subset _ $ inter_subset_right _ _)
 
 theorem image_inter_on {f : α → β} {s t : set α} (h : ∀x∈t, ∀y∈s, f x = f y → x = y) :
-  f '' s ∩ f '' t = f '' (s ∩ t) :=
-subset.antisymm
+  f '' (s ∩ t) = f '' s ∩ f '' t :=
+(image_inter_subset _ _ _).antisymm
   (assume b ⟨⟨a₁, ha₁, h₁⟩, ⟨a₂, ha₂, h₂⟩⟩,
     have a₂ = a₁, from h _ ha₂ _ ha₁ (by simp *),
     ⟨a₁, ⟨ha₁, this ▸ ha₂⟩, h₁⟩)
-  (image_inter_subset _ _ _)
+
 
 theorem image_inter {f : α → β} {s t : set α} (H : injective f) :
-  f '' s ∩ f '' t = f '' (s ∩ t) :=
+  f '' (s ∩ t) = f '' s ∩ f '' t :=
 image_inter_on (assume x _ y _ h, H h)
 
 theorem image_univ_of_surjective {ι : Type*} {f : ι → β} (H : surjective f) : f '' univ = univ :=

--- a/src/data/set/n_ary.lean
+++ b/src/data/set/n_ary.lean
@@ -100,10 +100,10 @@ begin
 end
 
 lemma image2_inter_left (hf : injective2 f) : image2 f (s ∩ s') t = image2 f s t ∩ image2 f s' t :=
-by simp_rw [←image_uncurry_prod, inter_prod, ←image_inter hf.uncurry]
+by simp_rw [←image_uncurry_prod, inter_prod, image_inter hf.uncurry]
 
 lemma image2_inter_right (hf : injective2 f) : image2 f s (t ∩ t') = image2 f s t ∩ image2 f s t' :=
-by simp_rw [←image_uncurry_prod, prod_inter, ←image_inter hf.uncurry]
+by simp_rw [←image_uncurry_prod, prod_inter, image_inter hf.uncurry]
 
 @[simp] lemma image2_empty_left : image2 f ∅ t = ∅ := ext $ by simp
 @[simp] lemma image2_empty_right : image2 f s ∅ = ∅ := ext $ by simp

--- a/src/data/set/pointwise/smul.lean
+++ b/src/data/set/pointwise/smul.lean
@@ -473,7 +473,7 @@ iff.symm $ (image_subset_iff).trans $ iff.symm $ iff_of_eq $ congr_arg _ $
   image_equiv_eq_preimage_symm _ $ mul_action.to_perm _
 
 @[to_additive] lemma smul_set_inter : a • (s ∩ t) = a • s ∩ a • t :=
-(image_inter $ mul_action.injective a).symm
+image_inter $ mul_action.injective a
 
 @[to_additive] lemma smul_set_sdiff : a • (s \ t) = a • s \ a • t :=
 image_diff (mul_action.injective a) _ _

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1089,8 +1089,7 @@ def comapₗ [measurable_space α] (f : α → β) : measure β →ₗ[ℝ≥0�
 if hf : injective f ∧ ∀ s, measurable_set s → measurable_set (f '' s) then
   lift_linear (outer_measure.comap f) $ λ μ s hs t,
   begin
-    simp only [coe_to_outer_measure, outer_measure.comap_apply, ← image_inter hf.1,
-      image_diff hf.1],
+    simp only [coe_to_outer_measure, outer_measure.comap_apply, image_inter hf.1, image_diff hf.1],
     apply le_to_outer_measure_caratheodory,
     exact hf.2 s hs
   end
@@ -1111,8 +1110,7 @@ def comap [measurable_space α] (f : α → β) (μ : measure β) : measure α :
 if hf : injective f ∧ ∀ s, measurable_set s → null_measurable_set (f '' s) μ then
   (outer_measure.comap f μ.to_outer_measure).to_measure $ λ s hs t,
   begin
-    simp only [coe_to_outer_measure, outer_measure.comap_apply, ← image_inter hf.1,
-      image_diff hf.1],
+    simp only [coe_to_outer_measure, outer_measure.comap_apply, image_inter hf.1, image_diff hf.1],
     exact (measure_inter_add_diff₀ _ (hf.2 s hs)).symm
   end
 else 0

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2080,7 +2080,7 @@ begin
   refine map_inf_le.antisymm _,
   rintro t ⟨s₁, hs₁, s₂, hs₂, ht : m ⁻¹' t = s₁ ∩ s₂⟩,
   refine mem_inf_of_inter (image_mem_map hs₁) (image_mem_map hs₂) _,
-  rw [image_inter h, image_subset_iff, ht]
+  rw [←image_inter h, image_subset_iff, ht]
 end
 
 lemma map_inf' {f g : filter α} {m : α → β} {t : set α} (htf : t ∈ f) (htg : t ∈ g)

--- a/src/order/upper_lower.lean
+++ b/src/order/upper_lower.lean
@@ -548,8 +548,7 @@ variables (f s t)
 
 @[simp, norm_cast] lemma coe_map : (map f s : set β) = f '' s := rfl
 
-@[simp] protected lemma map_sup : map f (s ⊔ t) = map f s ⊔ map f t :=
-ext $ (image_inter f.injective).symm
+@[simp] protected lemma map_sup : map f (s ⊔ t) = map f s ⊔ map f t := ext $ image_inter f.injective
 @[simp] protected lemma map_inf : map f (s ⊓ t) = map f s ⊓ map f t := ext $ image_union _ _ _
 @[simp] protected lemma map_top : map f ⊤ = ⊤ := ext $ image_empty _
 @[simp] protected lemma map_bot : map f ⊥ = ⊥ := ext $ image_univ_of_surjective f.surjective
@@ -594,8 +593,7 @@ variables (f s t)
 @[simp, norm_cast] lemma coe_map : (map f s : set β) = f '' s := rfl
 
 @[simp] protected lemma map_sup : map f (s ⊔ t) = map f s ⊔ map f t := ext $ image_union _ _ _
-@[simp] protected lemma map_inf : map f (s ⊓ t) = map f s ⊓ map f t :=
-ext $ (image_inter f.injective).symm
+@[simp] protected lemma map_inf : map f (s ⊓ t) = map f s ⊓ map f t := ext $ image_inter f.injective
 @[simp] protected lemma map_top : map f ⊤ = ⊤ := ext $ image_univ_of_surjective f.surjective
 @[simp] protected lemma map_bot : map f ⊥ = ⊥ := ext $ image_empty _
 @[simp] protected lemma map_Sup (S : set (lower_set α)) : map f (Sup S) = ⨆ s ∈ S, map f s :=

--- a/src/topology/gluing.lean
+++ b/src/topology/gluing.lean
@@ -220,8 +220,9 @@ end
 
 lemma preimage_range (i j : D.J) :
   𝖣 .ι j ⁻¹' (set.range (𝖣 .ι i)) = set.range (D.f j i) :=
-by rw [← preimage_image_eq (range (D.f j i)) (D.ι_injective j), ←image_univ, ←image_univ,
-  ←image_comp, ←coe_comp, image_univ, image_univ, image_inter, preimage_range_inter]
+by rw [← set.preimage_image_eq (set.range (D.f j i)) (D.ι_injective j), ← set.image_univ,
+      ← set.image_univ, ←set.image_comp, ←coe_comp, set.image_univ,set.image_univ,
+      ← image_inter, set.preimage_range_inter]
 
 lemma preimage_image_eq_image (i j : D.J) (U : set (𝖣 .U i)) :
   𝖣 .ι j ⁻¹' (𝖣 .ι i '' U) = D.f _ _ '' ((D.t j i ≫ D.f _ _) ⁻¹' U) :=

--- a/src/topology/gluing.lean
+++ b/src/topology/gluing.lean
@@ -220,9 +220,8 @@ end
 
 lemma preimage_range (i j : D.J) :
   𝖣 .ι j ⁻¹' (set.range (𝖣 .ι i)) = set.range (D.f j i) :=
-by rw [← set.preimage_image_eq (set.range (D.f j i)) (D.ι_injective j), ← set.image_univ,
-      ← set.image_univ, ←set.image_comp, ←coe_comp, set.image_univ,set.image_univ,
-      ← image_inter, set.preimage_range_inter]
+by rw [← preimage_image_eq (range (D.f j i)) (D.ι_injective j), ←image_univ, ←image_univ,
+  ←image_comp, ←coe_comp, image_univ, image_univ, image_inter, preimage_range_inter]
 
 lemma preimage_image_eq_image (i j : D.J) (U : set (𝖣 .U i)) :
   𝖣 .ι j ⁻¹' (𝖣 .ι i '' U) = D.f _ _ '' ((D.t j i ≫ D.f _ _) ⁻¹' U) :=

--- a/src/topology/quasi_separated.lean
+++ b/src/topology/quasi_separated.lean
@@ -83,7 +83,7 @@ lemma open_embedding.is_quasi_separated_iff (h : open_embedding f) {s : set α} 
 begin
   refine ⟨λ hs, hs.image_of_embedding h.to_embedding, _⟩,
   intros H U V hU hU' hU'' hV hV' hV'',
-  rw [h.to_embedding.is_compact_iff_is_compact_image, ← set.image_inter h.inj],
+  rw [h.to_embedding.is_compact_iff_is_compact_image, set.image_inter h.inj],
   exact H (f '' U) (f '' V)
     (set.image_subset _ hU) (h.is_open_map _ hU') (hU''.image h.continuous)
     (set.image_subset _ hV) (h.is_open_map _ hV') (hV''.image h.continuous)


### PR DESCRIPTION
Turn `set.image_inter` around to match all other distributivity lemmas (`set.image_union`, `set.image_Inter`, `set.image_Union`, `finset.image_inter`, `finset.image_union`, ...)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Match https://github.com/leanprover-community/mathlib4/pull/1045

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
