### PR TITLE
[Merged by Bors] - chore(field_theory/separable_degree): golf a proof using `wlog`

### DIFF
--- a/src/field_theory/separable_degree.lean
+++ b/src/field_theory/separable_degree.lean
@@ -100,25 +100,6 @@ begin
     exact ⟨g, hgs, n, hge⟩, }
 end
 
-/-- A helper lemma: if two expansions (along the positive characteristic) of two polynomials `g` and
-`g'` agree, and the one with the larger degree is separable, then their degrees are the same. -/
-lemma contraction_degree_eq_aux [hq : fact q.prime] [hF : char_p F q]
-  (g g' : F[X]) (m m' : ℕ)
-  (h_expand : expand F (q^m) g = expand F (q^m') g')
-  (h : m < m') (hg : g.separable):
-  g.nat_degree =  g'.nat_degree :=
-begin
-  obtain ⟨s, rfl⟩ := nat.exists_eq_add_of_lt h,
-  rw [add_assoc, pow_add, expand_mul] at h_expand,
-  let aux := expand_injective (pow_pos hq.1.pos m) h_expand,
-  rw aux at hg,
-  have := (is_unit_or_eq_zero_of_separable_expand q (s + 1) hq.out.pos hg).resolve_right
-    s.succ_ne_zero,
-  rw [aux, nat_degree_expand,
-    nat_degree_eq_of_degree_eq_some (degree_eq_zero_of_is_unit this),
-    zero_mul]
-end
-
 /-- If two expansions (along the positive characteristic) of two separable polynomials
 `g` and `g'` agree, then they have the same degree. -/
 theorem contraction_degree_eq_or_insep
@@ -128,17 +109,22 @@ theorem contraction_degree_eq_or_insep
   (hg : g.separable) (hg' : g'.separable) :
   g.nat_degree = g'.nat_degree :=
 begin
-  by_cases h : m = m',
+  wlog hm : m ≤ m' := le_total m m' using [m m' g g', m' m g' g],
+  rcases hm.eq_or_lt with rfl | h,
   { -- if `m = m'` then we show `g.nat_degree = g'.nat_degree` by unfolding the definitions
-    rw h at h_expand,
-    have expand_deg : ((expand F (q ^ m')) g).nat_degree =
-      (expand F (q ^ m') g').nat_degree, by rw h_expand,
-    rw [nat_degree_expand (q^m') g, nat_degree_expand (q^m') g'] at expand_deg,
-    apply nat.eq_of_mul_eq_mul_left (pow_pos hq.1.pos m'),
+    have expand_deg : ((expand F (q ^ m)) g).nat_degree =
+      (expand F (q ^ m) g').nat_degree, by rw h_expand,
+    rw [nat_degree_expand (q ^ m) g, nat_degree_expand (q ^ m) g'] at expand_deg,
+    apply mul_left_cancel₀ (pow_ne_zero m hq.1.ne_zero),
     rw [mul_comm] at expand_deg, rw expand_deg, rw [mul_comm] },
-  { cases ne.lt_or_lt h,
-    { exact contraction_degree_eq_aux q g g' m m' h_expand h_1 hg },
-    { exact (contraction_degree_eq_aux q g' g m' m h_expand.symm h_1 hg').symm, } }
+  { obtain ⟨s, rfl⟩ := nat.exists_eq_add_of_lt h,
+    rw [add_assoc, pow_add, expand_mul] at h_expand,
+    let aux := expand_injective (pow_pos hq.1.pos m) h_expand,
+    rw aux at hg,
+    have := (is_unit_or_eq_zero_of_separable_expand q (s + 1) hq.out.pos hg).resolve_right
+      s.succ_ne_zero,
+    rw [aux, nat_degree_expand, nat_degree_eq_of_degree_eq_some (degree_eq_zero_of_is_unit this),
+      zero_mul] }
 end
 
 /-- The separable degree equals the degree of any separable contraction, i.e., it is unique. -/

--- a/src/field_theory/separable_degree.lean
+++ b/src/field_theory/separable_degree.lean
@@ -100,8 +100,8 @@ begin
     exact ⟨g, hgs, n, hge⟩, }
 end
 
-/-- If two expansions (along the positive characteristic) of two separable polynomials
-`g` and `g'` agree, then they have the same degree. -/
+/-- If two expansions (along the positive characteristic) of two separable polynomials `g` and `g'`
+agree, then they have the same degree. -/
 theorem contraction_degree_eq_or_insep
   [hq : fact q.prime] [char_p F q]
   (g g' : F[X]) (m m' : ℕ)
@@ -110,21 +110,12 @@ theorem contraction_degree_eq_or_insep
   g.nat_degree = g'.nat_degree :=
 begin
   wlog hm : m ≤ m' := le_total m m' using [m m' g g', m' m g' g],
-  rcases hm.eq_or_lt with rfl | h,
-  { -- if `m = m'` then we show `g.nat_degree = g'.nat_degree` by unfolding the definitions
-    have expand_deg : ((expand F (q ^ m)) g).nat_degree =
-      (expand F (q ^ m) g').nat_degree, by rw h_expand,
-    rw [nat_degree_expand (q ^ m) g, nat_degree_expand (q ^ m) g'] at expand_deg,
-    apply mul_left_cancel₀ (pow_ne_zero m hq.1.ne_zero),
-    rw [mul_comm] at expand_deg, rw expand_deg, rw [mul_comm] },
-  { obtain ⟨s, rfl⟩ := nat.exists_eq_add_of_lt h,
-    rw [add_assoc, pow_add, expand_mul] at h_expand,
-    let aux := expand_injective (pow_pos hq.1.pos m) h_expand,
-    rw aux at hg,
-    have := (is_unit_or_eq_zero_of_separable_expand q (s + 1) hq.out.pos hg).resolve_right
-      s.succ_ne_zero,
-    rw [aux, nat_degree_expand, nat_degree_eq_of_degree_eq_some (degree_eq_zero_of_is_unit this),
-      zero_mul] }
+  obtain ⟨s, rfl⟩ := exists_add_of_le hm,
+  rw [pow_add, expand_mul, expand_inj (pow_pos hq.out.pos m)] at h_expand,
+  subst h_expand,
+  rcases is_unit_or_eq_zero_of_separable_expand q s hq.out.pos hg with h | rfl,
+  { rw [nat_degree_expand, nat_degree_eq_zero_of_is_unit h, zero_mul] },
+  { rw [nat_degree_expand, pow_zero, mul_one] },
 end
 
 /-- The separable degree equals the degree of any separable contraction, i.e., it is unique. -/

--- a/src/field_theory/separable_degree.lean
+++ b/src/field_theory/separable_degree.lean
@@ -103,7 +103,7 @@ end
 /-- If two expansions (along the positive characteristic) of two separable polynomials `g` and `g'`
 agree, then they have the same degree. -/
 theorem contraction_degree_eq_or_insep
-  [hq : fact q.prime] [char_p F q]
+  [hq : ne_zero q] [char_p F q]
   (g g' : F[X]) (m m' : ℕ)
   (h_expand : expand F (q^m) g = expand F (q^m') g')
   (hg : g.separable) (hg' : g'.separable) :
@@ -111,9 +111,9 @@ theorem contraction_degree_eq_or_insep
 begin
   wlog hm : m ≤ m' := le_total m m' using [m m' g g', m' m g' g],
   obtain ⟨s, rfl⟩ := exists_add_of_le hm,
-  rw [pow_add, expand_mul, expand_inj (pow_pos hq.out.pos m)] at h_expand,
+  rw [pow_add, expand_mul, expand_inj (pow_pos (ne_zero.pos q) m)] at h_expand,
   subst h_expand,
-  rcases is_unit_or_eq_zero_of_separable_expand q s hq.out.pos hg with h | rfl,
+  rcases is_unit_or_eq_zero_of_separable_expand q s (ne_zero.pos q) hg with h | rfl,
   { rw [nat_degree_expand, nat_degree_eq_zero_of_is_unit h, zero_mul] },
   { rw [nat_degree_expand, pow_zero, mul_one] },
 end


### PR DESCRIPTION
---

Is `_aux` lemma useful? If yes, then probably we should rename it instead of merging with the main lemma.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
