### PR TITLE
[Merged by Bors] - fix(algebra/opposites): fix types in unop_div

### DIFF
--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -210,6 +210,6 @@ instance [has_involutive_inv α] : has_involutive_inv αᵃᵒᵖ :=
 instance [has_div α] : has_div αᵃᵒᵖ := { div := λ a b, op (unop a / unop b) }
 
 @[simp] lemma op_div [has_div α] (a b : α) : op (a / b) = op a / op b := rfl
-@[simp] lemma unop_div [has_div α] (a b : α) : unop (a / b) = unop a / unop b := rfl
+@[simp] lemma unop_div [has_div α] (a b : αᵃᵒᵖ) : unop (a / b) = unop a / unop b := rfl
 
 end add_opposite


### PR DESCRIPTION
This lemma only typechecked because of defeq abuse, which was presumably not intended. Remark: refactoring `mul_opposite` to be a structure in Lean 4 was what picked up on this error.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Corresponding mathlib4 PR is https://github.com/leanprover-community/mathlib4/pull/1036 . 
