### PR TITLE
fix(tactic/tauto) fix some bugs in symm_eq

### DIFF
--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -118,7 +118,6 @@ do (a',pa) ← root r a, -- pa : a = a'
    ((do unify a' b', -- rfl : a' = b'
         pbs ← mk_eq_symm pb, -- pbs : b' = b
         pab ← mk_eq_trans pa pbs, -- pab : a = b
-        add_edge r a b pab,
         return pab
    )) <|>
     do p ← match (a', b') with

--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -156,9 +156,10 @@ do (a',pa) ← root r a,       --  pa : a = a'
                 return p'
            | (`(%%a₀ → %%a₁), `(%%b₀ → %%b₁)) :=
              if ¬ a₁.has_var ∧ ¬ b₁.has_var then
-             do p₀ ← symm_eq a₀ b₀,
-                p₁ ← symm_eq a₁ b₁,
-                p' ← mk_app `congr_arg [`(implies),p₀,p₁],
+             do p₀ ← symm_eq a₀ b₀, -- p₀ : a₀ = b₀
+                p₁ ← symm_eq a₁ b₁, -- p₁ : a₁ = b₁
+                p₂ ← (mk_app `congr_arg [`(implies),p₀]), -- p₂ : (implies a₀) = (implies b₀)
+                p' ← (mk_app `congr [p₂, p₁]), -- p' : (a₀ → a₁) = (b₀ → b₁)
                 add_edge r a' b' p',
                 return p'
              else unify a' b' >> add_refl r a' *> mk_mapp `rfl [none,a]

--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -171,8 +171,8 @@ do (a',pa) ← root r a,       --  pa : a = a'
            end,
     -- p : a' = b'
     p' ← mk_eq_trans pa p, -- p' : a = b'
-    add_edge r a' b' p',
-    mk_eq_symm pb >>= mk_eq_trans p'
+    add_edge r a' b' p,
+    mk_eq_symm pb >>= mk_eq_trans p' -- : a = b
 
 meta def find_eq_type (r : tauto_state) : expr → list expr → tactic (expr × expr)
 | e []         := failed

--- a/test/tauto.lean
+++ b/test/tauto.lean
@@ -40,7 +40,6 @@ end tauto₂
 
 section tauto₃
 
-
 example (p : Prop) : p ∧ true ↔ p := by tauto
 example (p : Prop) : p ∨ false ↔ p := by tauto
 example (p q r : Prop) [decidable p] [decidable r] : p ∨ (q ∧ r) ↔ (p ∨ q) ∧ (r ∨ p ∨ r) := by tauto
@@ -108,3 +107,17 @@ example {x y : ℕ} (h : ¬x ≠ y) : x = y :=
 begin
   tauto!,
 end
+
+section module_symmetry₂
+
+variables (α : Type)
+variables (x y z w : α)
+
+-- This example is taken from pair_eq_pair_iff in data.set.basic.
+example : ((x = z ∨ x = w) ∧ (y = z ∨ y = w)) ∧
+           (z = x ∨ z = y) ∧ (w = x ∨ w = y) → x = z ∧ y = w ∨ x = w ∧ y = z :=
+begin
+  tauto!,
+end
+
+end module_symmetry₂

--- a/test/tauto.lean
+++ b/test/tauto.lean
@@ -120,4 +120,10 @@ begin
   tauto!,
 end
 
+-- This example exercises symm_eq on `implies`.
+example (h₁ : ¬((x = y) → (z = w))) (h₂ : ((x = y) → (w = z))) : false :=
+begin
+  tauto,
+end
+
 end module_symmetry₂


### PR DESCRIPTION
While working on porting `tauto` to mathlib4, I noticed some bugs in the existing implementation here.

## bug 1

`symm_eq a b` is supposed to return a proof of `a = b`. If `a` and `b` are not definitionally equal but do map to the same root in the union-find proof tree `r`, then the first branch of `symm_eq` incorrectly returns `rfl`.

I've added a test case that hits the problematic logic. In the existing version, the proof still gets closed because `solve_by_elim` handles the goals in a later stage of `tauto`. In the fixed version, the proof gets closed early, before `solve_by_elim` needs to act on it.

When I do `set_option profiler true` on this test case, the old version completes in 203ms, while the new one only takes 104ms.

## bug 2

In the `implies` arm of the main `symm_eq` match, a `mk_app` was failing to typecheck. I've fixed it, and added a test case that fails on master.

## bug 3

At the end `symm_eq`, we do 
```
    add_edge r a' b' p',
```
where `p' : a = b'`. We should instead do 
```
    add_edge r a' b' p,
```
because `p : a' = b'`, and it's no necessarily true that `b` and `b'` are definitionally equal.