### PR TITLE
[Merged by Bors] - feat(measure_theory/measure/portmanteau): Add lemmas in preparation of implication from Borel condition.

### DIFF
--- a/src/measure_theory/measure/portmanteau.lean
+++ b/src/measure_theory/measure/portmanteau.lean
@@ -442,19 +442,6 @@ section borel_implies
 /-! ### Portmanteau implication: limit condition for Borel sets implies limsup for closed sets
 -/
 
-lemma _root_.metric.frontier_thickening_disjoint' {X : Type*} [pseudo_emetric_space X] (A : set X) :
-  pairwise (disjoint on (λ (r : ℝ), frontier (metric.thickening r A))) :=
-begin
-  -- Same proof as `frontier_thickening_disjoint`, just more relaxed typeclass assumption...
-  refine (pairwise_disjoint_on _).2 (λ r₁ r₂ hr, _),
-  cases le_total r₁ 0 with h₁ h₁,
-  { simp [metric.thickening_of_nonpos h₁] },
-  refine ((disjoint_singleton.2 $ λ h, hr.ne _).preimage _).mono
-    (metric.frontier_thickening_subset _) (metric.frontier_thickening_subset _),
-  apply_fun ennreal.to_real at h,
-  rwa [ennreal.to_real_of_real h₁, ennreal.to_real_of_real (h₁.trans hr.le)] at h
-end
-
 variables {Ω : Type*} [pseudo_emetric_space Ω] [measurable_space Ω] [opens_measurable_space Ω]
 
 lemma exists_null_frontier_thickening
@@ -463,7 +450,7 @@ lemma exists_null_frontier_thickening
 begin
   have mbles : ∀ (r : ℝ), measurable_set (frontier (metric.thickening r s)),
     from λ r, (is_closed_frontier).measurable_set,
-  have disjs := metric.frontier_thickening_disjoint' s,
+  have disjs := metric.frontier_thickening_disjoint s,
   have key := @measure.countable_meas_pos_of_disjoint_Union Ω _ _ μ _ _ mbles disjs,
   have vol_Ioo : volume (Ioo 0 r₀) = ennreal.of_real r₀,
   { simp only [real.volume_Ioo, tsub_zero, ennreal.of_real_to_real, ne.def, min_eq_top,

--- a/src/measure_theory/measure/portmanteau.lean
+++ b/src/measure_theory/measure/portmanteau.lean
@@ -488,29 +488,6 @@ begin
   { exact λ n, ⟨(obs n).some_spec.some.1, (obs n).some_spec.some_spec⟩, },
 end
 
-lemma _root_.measure_theory.measure.lintegral_indicator_one
-  {α : Type*} [measurable_space α] (μ : measure α) {s : set α} (s_mble : measurable_set s) :
-  ∫⁻ x, (s.indicator (λ _, (1 : ℝ≥0∞)) x) ∂μ = μ s :=
-by simp [lintegral_indicator _ s_mble]
-
-lemma tendsto_measure_of_tendsto_indicator {α ι : Type*} (L : filter ι) [is_countably_generated L]
-  [measurable_space α] (μ : measure α) [is_finite_measure μ] {A : set α} (A_mble : measurable_set A)
-  {As : ι → set α} (As_mble : ∀ i, measurable_set (As i))
-  (h_lim : ∀ᵐ x ∂μ, tendsto (λ i, (As i).indicator (λ _, (1 : ℝ≥0∞)) x)
-                            L (𝓝 (A.indicator (λ _, (1 : ℝ≥0∞)) x))) :
-  tendsto (λ i, μ (As i)) L (𝓝 (μ A)) :=
-begin
-  simp_rw [← μ.lintegral_indicator_one A_mble, ← μ.lintegral_indicator_one (As_mble _)],
-  refine tendsto_lintegral_filter_of_dominated_convergence (λ _, (1 : ℝ≥0∞))
-          (eventually_of_forall _) (eventually_of_forall _)  _ h_lim,
-  { exact λ n, measurable.indicator measurable_const (As_mble n), },
-  { intros n,
-    apply eventually_of_forall,
-    exact λ x, indicator_apply_le (λ _, le_refl _), },
-  { rw [lintegral_one],
-    exact (measure_lt_top μ univ).ne, },
-end
-
 end borel_implies
 
 end measure_theory --namespace

--- a/src/measure_theory/measure/portmanteau.lean
+++ b/src/measure_theory/measure/portmanteau.lean
@@ -440,6 +440,8 @@ end convergence_implies_limsup_closed_le --section
 
 section limit_borel_implies_limsup_closed_le
 /-! ### Portmanteau implication: limit condition for Borel sets implies limsup for closed sets
+
+TODO: The proof of the implication is not yet here. Add it.
 -/
 
 variables {Ω : Type*} [pseudo_emetric_space Ω] [measurable_space Ω] [opens_measurable_space Ω]
@@ -452,32 +454,10 @@ begin
     from λ r, (is_closed_frontier).measurable_set,
   have disjs := metric.frontier_thickening_disjoint s,
   have key := @measure.countable_meas_pos_of_disjoint_Union Ω _ _ μ _ _ mbles disjs,
-  have vol_Ioo : volume (Ioo a b) = ennreal.of_real (b - a),
-  { simp only [real.volume_Ioo, tsub_zero, ennreal.of_real_to_real, ne.def, min_eq_top,
-               ennreal.one_ne_top, false_and, not_false_iff], },
   have aux := @measure_diff_null ℝ _ volume (Ioo a b) _ (set.countable.measure_zero key volume),
   have len_pos : 0 < ennreal.of_real (b - a), by simp only [hab, ennreal.of_real_pos, sub_pos],
-  rw [← vol_Ioo, ← aux] at len_pos,
+  rw [← real.volume_Ioo, ← aux] at len_pos,
   rcases nonempty_of_measure_ne_zero len_pos.ne.symm with ⟨r, ⟨r_in_Ioo, hr⟩⟩,
-  refine ⟨r, r_in_Ioo, _⟩,
-  simpa only [mem_set_of_eq, not_lt, le_zero_iff] using hr,
-end
-
-lemma exists_null_frontier_thickening'
-  (μ : measure Ω) [sigma_finite μ] (s : set Ω) {r₀ : ℝ} (r₀_pos : 0 < r₀) :
-  ∃ r ∈ Ioo 0 r₀, μ (frontier (metric.thickening r s)) = 0 :=
-begin
-  have mbles : ∀ (r : ℝ), measurable_set (frontier (metric.thickening r s)),
-    from λ r, (is_closed_frontier).measurable_set,
-  have disjs := metric.frontier_thickening_disjoint s,
-  have key := @measure.countable_meas_pos_of_disjoint_Union Ω _ _ μ _ _ mbles disjs,
-  have vol_Ioo : volume (Ioo 0 r₀) = ennreal.of_real r₀,
-  { simp only [real.volume_Ioo, tsub_zero, ennreal.of_real_to_real, ne.def, min_eq_top,
-               ennreal.one_ne_top, false_and, not_false_iff], },
-  have aux := @measure_diff_null ℝ _ volume (Ioo 0 r₀) _ (set.countable.measure_zero key volume),
-  have r₀_pos' := ennreal.of_real_pos.mpr r₀_pos,
-  rw [← vol_Ioo, ← aux] at r₀_pos',
-  rcases nonempty_of_measure_ne_zero r₀_pos'.ne.symm with ⟨r, ⟨r_in_Ioo, hr⟩⟩,
   refine ⟨r, r_in_Ioo, _⟩,
   simpa only [mem_set_of_eq, not_lt, le_zero_iff] using hr,
 end

--- a/src/measure_theory/measure/portmanteau.lean
+++ b/src/measure_theory/measure/portmanteau.lean
@@ -438,13 +438,32 @@ end
 
 end convergence_implies_limsup_closed_le --section
 
-section borel_implies
+section limit_borel_implies_limsup_closed_le
 /-! ### Portmanteau implication: limit condition for Borel sets implies limsup for closed sets
 -/
 
 variables {Ω : Type*} [pseudo_emetric_space Ω] [measurable_space Ω] [opens_measurable_space Ω]
 
 lemma exists_null_frontier_thickening
+  (μ : measure Ω) [sigma_finite μ] (s : set Ω) {a b : ℝ} (hab : a < b) :
+  ∃ r ∈ Ioo a b, μ (frontier (metric.thickening r s)) = 0 :=
+begin
+  have mbles : ∀ (r : ℝ), measurable_set (frontier (metric.thickening r s)),
+    from λ r, (is_closed_frontier).measurable_set,
+  have disjs := metric.frontier_thickening_disjoint s,
+  have key := @measure.countable_meas_pos_of_disjoint_Union Ω _ _ μ _ _ mbles disjs,
+  have vol_Ioo : volume (Ioo a b) = ennreal.of_real (b - a),
+  { simp only [real.volume_Ioo, tsub_zero, ennreal.of_real_to_real, ne.def, min_eq_top,
+               ennreal.one_ne_top, false_and, not_false_iff], },
+  have aux := @measure_diff_null ℝ _ volume (Ioo a b) _ (set.countable.measure_zero key volume),
+  have len_pos : 0 < ennreal.of_real (b - a), by simp only [hab, ennreal.of_real_pos, sub_pos],
+  rw [← vol_Ioo, ← aux] at len_pos,
+  rcases nonempty_of_measure_ne_zero len_pos.ne.symm with ⟨r, ⟨r_in_Ioo, hr⟩⟩,
+  refine ⟨r, r_in_Ioo, _⟩,
+  simpa only [mem_set_of_eq, not_lt, le_zero_iff] using hr,
+end
+
+lemma exists_null_frontier_thickening'
   (μ : measure Ω) [sigma_finite μ] (s : set Ω) {r₀ : ℝ} (r₀_pos : 0 < r₀) :
   ∃ r ∈ Ioo 0 r₀, μ (frontier (metric.thickening r s)) = 0 :=
 begin
@@ -475,6 +494,6 @@ begin
   { exact λ n, ⟨(obs n).some_spec.some.1, (obs n).some_spec.some_spec⟩, },
 end
 
-end borel_implies
+end limit_borel_implies_limsup_closed_le --section
 
 end measure_theory --namespace

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -883,6 +883,23 @@ lemma mem_thickening_iff_exists_edist_lt {δ : ℝ} (E : set α) (x : α) :
   x ∈ thickening δ E ↔ ∃ z ∈ E, edist x z < ennreal.of_real δ :=
 inf_edist_lt_iff
 
+/-- The frontier of the (open) thickening of a set is contained in an `inf_edist` level set. -/
+lemma frontier_thickening_subset (E : set α) {δ : ℝ} :
+  frontier (thickening δ E) ⊆ {x : α | inf_edist x E = ennreal.of_real δ} :=
+frontier_lt_subset_eq continuous_inf_edist continuous_const
+
+lemma frontier_thickening_disjoint (A : set α) :
+  pairwise (disjoint on (λ (r : ℝ), frontier (thickening r A))) :=
+begin
+  refine (pairwise_disjoint_on _).2 (λ r₁ r₂ hr, _),
+  cases le_total r₁ 0 with h₁ h₁,
+  { simp [thickening_of_nonpos h₁] },
+  refine ((disjoint_singleton.2 $ λ h, hr.ne _).preimage _).mono
+    (frontier_thickening_subset _) (frontier_thickening_subset _),
+  apply_fun ennreal.to_real at h,
+  rwa [ennreal.to_real_of_real h₁, ennreal.to_real_of_real (h₁.trans hr.le)] at h
+end
+
 variables {X : Type u} [pseudo_metric_space X]
 
 /-- A point in a metric space belongs to the (open) `δ`-thickening of a subset `E` if and only if
@@ -920,23 +937,6 @@ begin
   rcases mem_thickening_iff.1 hy with ⟨z, zE, hz⟩,
   calc dist y x ≤ dist z x + dist y z : by { rw add_comm, exact dist_triangle _ _ _ }
   ... ≤ R + δ : add_le_add (hR zE) hz.le
-end
-
-/-- The frontier of the (open) thickening of a set is contained in an `inf_edist` level set. -/
-lemma frontier_thickening_subset (E : set α) {δ : ℝ} :
-  frontier (thickening δ E) ⊆ {x : α | inf_edist x E = ennreal.of_real δ} :=
-frontier_lt_subset_eq continuous_inf_edist continuous_const
-
-lemma frontier_thickening_disjoint (A : set X) :
-  pairwise (disjoint on (λ (r : ℝ), frontier (thickening r A))) :=
-begin
-  refine (pairwise_disjoint_on _).2 (λ r₁ r₂ hr, _),
-  cases le_total r₁ 0 with h₁ h₁,
-  { simp [thickening_of_nonpos h₁] },
-  refine ((disjoint_singleton.2 $ λ h, hr.ne _).preimage _).mono
-    (frontier_thickening_subset _) (frontier_thickening_subset _),
-  apply_fun ennreal.to_real at h,
-  rwa [ennreal.to_real_of_real h₁, ennreal.to_real_of_real (h₁.trans hr.le)] at h
 end
 
 end thickening --section


### PR DESCRIPTION
Add the essential lemmas about the existence of thickenings with null frontier that are needed to prove the portmanteau implication from Borel set condition to closed set condition.

---

Also generalize the lemma `frontier_thickening_disjoint` in `hausdorff_distance.lean` from assuming `[pseudo_metric_space _]` to `[pseudo_emetric_space _]`, and move this and another lemma together with others having the same assumptions.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
