### PR TITLE
[Merged by Bors] - feat(analysis/complex): integration and differentiation `ℝ → ℂ`

### DIFF
--- a/src/analysis/complex/real_deriv.lean
+++ b/src/analysis/complex/real_deriv.lean
@@ -51,8 +51,9 @@ begin
   simpa using (C.comp z (B.comp z A)).has_strict_deriv_at
 end
 
-/-- If a complex function is differentiable at a real point, then the induced real function is also
-differentiable at this point, with a derivative equal to the real part of the complex derivative. -/
+/-- If a complex function `e` is differentiable at a real point, then the function `ℝ → ℝ` given by
+the real part of `e` is also differentiable at this point, with a derivative equal to the real part
+of the complex derivative. -/
 theorem has_deriv_at.real_of_complex (h : has_deriv_at e e' z) :
   has_deriv_at (λx:ℝ, (e x).re) e'.re z :=
 begin
@@ -114,6 +115,19 @@ lemma has_deriv_within_at.complex_to_real_fderiv {f : ℂ → ℂ} {s : set ℂ}
   has_fderiv_within_at f (f' • (1 : ℂ →L[ℝ] ℂ)) s x :=
 by simpa only [complex.restrict_scalars_one_smul_right]
   using h.has_fderiv_within_at.restrict_scalars ℝ
+
+/-- If a complex function `e` is differentiable at a real point, then its restriction to `ℝ` is
+differentiable there as a function `ℝ → ℂ`, with the same derivative. -/
+lemma has_deriv_at.comp_of_real (hf : has_deriv_at e e' ↑z) : has_deriv_at (λ (y:ℝ), e ↑y) e' z :=
+by simpa only [of_real_clm_apply, of_real_one, mul_one]
+  using hf.comp z of_real_clm.has_deriv_at
+
+/-- If a function `f : ℝ → ℝ` is differentiable at a (real) point `x`, then it is also
+differentiable as a function `ℝ → ℂ`. -/
+lemma has_deriv_at.of_real_comp {f : ℝ → ℝ} {u : ℝ} (hf : has_deriv_at f u z) :
+has_deriv_at (λ (y:ℝ), ↑(f y) : ℝ → ℂ) u z :=
+by simpa only [of_real_clm_apply, of_real_one, real_smul, mul_one]
+  using of_real_clm.has_deriv_at.scomp z hf
 
 end real_deriv_of_complex
 

--- a/src/analysis/special_functions/gamma.lean
+++ b/src/analysis/special_functions/gamma.lean
@@ -25,7 +25,7 @@ Gamma
 -/
 
 noncomputable theory
-open filter interval_integral set real measure_theory asymptotics
+open filter set real measure_theory asymptotics
 open_locale topological_space
 
 lemma integral_exp_neg_Ioi : ∫ (x : ℝ) in Ioi 0, exp (-x) = 1 :=
@@ -67,7 +67,7 @@ begin
   { rw ←integrable_on_Icc_iff_integrable_on_Ioc,
     refine integrable_on.continuous_on_mul continuous_on_id.neg.exp _ is_compact_Icc,
     refine (interval_integrable_iff_integrable_Icc_of_le zero_le_one).mp _,
-    exact interval_integrable_rpow' (by linarith), },
+    exact interval_integral.interval_integrable_rpow' (by linarith), },
   { refine integrable_of_is_O_exp_neg one_half_pos _ (Gamma_integrand_is_o _ ).is_O,
     refine continuous_on_id.neg.exp.mul (continuous_on_id.rpow_const _),
     intros x hx,
@@ -208,7 +208,8 @@ begin
     (continuous_of_real_cpow_const hs),
   have der_ible := (Gamma_integrand_deriv_integrable_A hs hX).add
     (Gamma_integrand_deriv_integrable_B hs hX),
-  have int_eval := integral_eq_sub_of_has_deriv_at_of_le hX cont.continuous_on F_der_I der_ible,
+  have int_eval := interval_integral.integral_eq_sub_of_has_deriv_at_of_le
+    hX cont.continuous_on F_der_I der_ible,
   -- We are basically done here but manipulating the output into the right form is fiddly.
   apply_fun (λ x:ℂ, -x) at int_eval,
   rw [interval_integral.integral_add (Gamma_integrand_deriv_integrable_A hs hX)
@@ -220,7 +221,7 @@ begin
   have : (λ x, (-x).exp * (s * x ^ (s - 1)) : ℝ → ℂ) = (λ x, s * (-x).exp * x ^ (s - 1) : ℝ → ℂ),
   { ext1, ring,},
   rw this,
-  have t := @integral_const_mul (0:ℝ) X volume _ _ s (λ x:ℝ, (-x).exp * x ^ (s - 1)),
+  have t := @interval_integral.integral_const_mul 0 X volume _ _ s (λ x:ℝ, (-x).exp * x ^ (s - 1)),
   dsimp at t, rw [←t, of_real_zero, zero_cpow],
   { rw [mul_zero, add_zero], congr', ext1, ring },
   { contrapose! hs, rw [hs, zero_re] }

--- a/src/analysis/special_functions/gamma.lean
+++ b/src/analysis/special_functions/gamma.lean
@@ -67,7 +67,7 @@ begin
   { rw ←integrable_on_Icc_iff_integrable_on_Ioc,
     refine integrable_on.continuous_on_mul continuous_on_id.neg.exp _ is_compact_Icc,
     refine (interval_integrable_iff_integrable_Icc_of_le zero_le_one).mp _,
-    exact interval_integral.interval_integrable_rpow' (by linarith), },
+    exact interval_integrable_rpow' (by linarith), },
   { refine integrable_of_is_O_exp_neg one_half_pos _ (Gamma_integrand_is_o _ ).is_O,
     refine continuous_on_id.neg.exp.mul (continuous_on_id.rpow_const _),
     intros x hx,
@@ -206,8 +206,7 @@ begin
     (continuous_of_real_cpow_const hs),
   have der_ible := (Gamma_integrand_deriv_integrable_A hs hX).add
     (Gamma_integrand_deriv_integrable_B hs hX),
-  have int_eval := interval_integral.integral_eq_sub_of_has_deriv_at_of_le
-    hX cont.continuous_on F_der_I der_ible,
+  have int_eval := integral_eq_sub_of_has_deriv_at_of_le hX cont.continuous_on F_der_I der_ible,
   -- We are basically done here but manipulating the output into the right form is fiddly.
   apply_fun (λ x:ℂ, -x) at int_eval,
   rw [interval_integral.integral_add (Gamma_integrand_deriv_integrable_A hs hX)
@@ -218,7 +217,7 @@ begin
   have : (λ x, (-x).exp * (s * x ^ (s - 1)) : ℝ → ℂ) = (λ x, s * (-x).exp * x ^ (s - 1) : ℝ → ℂ),
   { ext1, ring,},
   rw this,
-  have t := @interval_integral.integral_const_mul 0 X volume _ _ s (λ x:ℝ, (-x).exp * x ^ (s - 1)),
+  have t := @integral_const_mul 0 X volume _ _ s (λ x:ℝ, (-x).exp * x ^ (s - 1)),
   dsimp at t, rw [←t, of_real_zero, zero_cpow],
   { rw [mul_zero, add_zero], congr', ext1, ring },
   { contrapose! hs, rw [hs, zero_re] }

--- a/src/analysis/special_functions/gamma.lean
+++ b/src/analysis/special_functions/gamma.lean
@@ -25,7 +25,7 @@ Gamma
 -/
 
 noncomputable theory
-open filter set real measure_theory asymptotics
+open filter interval_integral set real measure_theory asymptotics
 open_locale topological_space
 
 lemma integral_exp_neg_Ioi : ∫ (x : ℝ) in Ioi 0, exp (-x) = 1 :=
@@ -118,7 +118,7 @@ def Gamma_integral (s : ℂ) : ℂ := ∫ x in Ioi (0:ℝ), ↑(-x).exp * ↑x ^
 lemma Gamma_integral_of_real (s : ℝ) :
   Gamma_integral ↑s = ↑(s.Gamma_integral) :=
 begin
-  rw [real.Gamma_integral, ←integral_of_real],
+  rw [real.Gamma_integral, ←_root_.integral_of_real],
   refine set_integral_congr measurable_set_Ioi _,
   intros x hx, dsimp only,
   rw [of_real_mul, of_real_cpow (mem_Ioi.mp hx).le],
@@ -196,14 +196,12 @@ begin
   { intros x hx,
     have d1 : has_deriv_at (λ (y: ℝ), (-y).exp) (-(-x).exp) x,
     { simpa using (has_deriv_at_neg x).exp },
-    have d1b : has_deriv_at (λ y, ↑(-y).exp : ℝ → ℂ) (↑-(-x).exp) x,
-    { convert has_deriv_at.scomp x of_real_clm.has_deriv_at d1, simp, },
-    have d2: has_deriv_at (λ (y : ℝ), ↑y ^ s) (s * x ^ (s - 1)) x,
-    { have t := @has_deriv_at.cpow_const _ _ _ s (has_deriv_at_id ↑x),
-      simp only [id.def, of_real_re, of_real_im,
-        ne.def, eq_self_iff_true, not_true, or_false, mul_one] at t,
-      simpa using has_deriv_at.comp x (t hx.left) of_real_clm.has_deriv_at, },
-    simpa only [of_real_neg, neg_mul] using d1b.mul d2 },
+    have d2 : has_deriv_at (λ (y : ℝ), ↑y ^ s) (s * x ^ (s - 1)) x,
+    { have t := @has_deriv_at.cpow_const _ _ _ s (has_deriv_at_id ↑x) _,
+      simpa only [mul_one] using t.comp_of_real,
+      simpa only [id.def, of_real_re, of_real_im,
+        ne.def, eq_self_iff_true, not_true, or_false, mul_one] using hx.1, },
+    simpa only [of_real_neg, neg_mul] using d1.of_real_comp.mul d2 },
   have cont := (continuous_of_real.comp continuous_neg.exp).mul
     (continuous_of_real_cpow_const hs),
   have der_ible := (Gamma_integrand_deriv_integrable_A hs hX).add
@@ -215,8 +213,7 @@ begin
   rw [interval_integral.integral_add (Gamma_integrand_deriv_integrable_A hs hX)
     (Gamma_integrand_deriv_integrable_B hs hX), interval_integral.integral_neg, neg_add, neg_neg]
     at int_eval,
-  replace int_eval := eq_sub_of_add_eq int_eval,
-  rw [int_eval, sub_neg_eq_add, neg_sub, add_comm, add_sub],
+  rw [eq_sub_of_add_eq int_eval, sub_neg_eq_add, neg_sub, add_comm, add_sub],
   simp only [sub_left_inj, add_left_inj],
   have : (λ x, (-x).exp * (s * x ^ (s - 1)) : ℝ → ℂ) = (λ x, s * (-x).exp * x ^ (s - 1) : ℝ → ℂ),
   { ext1, ring,},

--- a/src/analysis/special_functions/integrals.lean
+++ b/src/analysis/special_functions/integrals.lean
@@ -242,12 +242,11 @@ end
 lemma integral_cpow {r : ℂ} (ha : 0 < a) (hb : 0 < b) (hr : r ≠ -1) :
   ∫ (x : ℝ) in a..b, (x : ℂ) ^ r = (b ^ (r + 1) - a ^ (r + 1)) / (r + 1) :=
 begin
-  suffices : ∀ x ∈ set.interval a b, has_deriv_at (λ x : ℝ, (x : ℂ) ^ (r + 1) / (r + 1)) (x ^ r) x,
-  { rw sub_div,
-    exact integral_eq_sub_of_has_deriv_at this (interval_integrable_cpow ha hb) },
+  rw sub_div,
+  suffices : ∀ x ∈ set.interval a b, has_deriv_at (λ z : ℂ, z ^ (r + 1) / (r + 1)) (x ^ r) x,
+  { exact integral_eq_sub_of_has_deriv_at
+      (λ x hx, (this x hx).comp_of_real) (interval_integrable_cpow ha hb) },
   intros x hx,
-  suffices : has_deriv_at (λ z : ℂ, z ^ (r + 1) / (r + 1)) (x ^ r) x,
-  { simpa using has_deriv_at.comp x this complex.of_real_clm.has_deriv_at },
   have hx' : 0 < (x : ℂ).re ∨ (x : ℂ).im ≠ 0,
   { left,
     norm_cast,
@@ -345,8 +344,7 @@ begin
   { intro x,
     conv { congr, skip, rw ←mul_div_cancel (complex.exp (c * x)) hc, },
     convert ((complex.has_deriv_at_exp _).comp x _).div_const c using 1,
-    simpa only [complex.of_real_clm_apply, complex.of_real_one, one_mul, mul_one, mul_comm] using
-      complex.of_real_clm.has_deriv_at.mul_const c },
+    simpa only [mul_one] using ((has_deriv_at_id (x:ℂ)).const_mul _).comp_of_real, },
   rw integral_deriv_eq_sub' _ (funext (λ x, (D x).deriv)) (λ x hx, (D x).differentiable_at),
   { ring_nf },
   { apply continuous.continuous_on, continuity,}

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -699,6 +699,15 @@ by simp only [interval_integral, measure.restrict_smul, integral_smul_measure, s
 
 end basic
 
+lemma integral_of_real {a b : ℝ} {μ : measure ℝ} {f : ℝ → ℝ} :
+  ∫ x in a..b, (f x : ℂ) ∂μ = ↑(∫ x in a..b, f x ∂μ) :=
+begin
+  simp_rw [interval_integral_eq_integral_interval_oc, integral_of_real],
+  split_ifs,
+  all_goals {simp only [is_R_or_C.of_real_smul, complex.of_real_neg, complex.of_real_one,
+    neg_mul, one_mul, algebra.id.smul_eq_mul]},
+end
+
 section continuous_linear_map
 
 variables {a b : ℝ} {μ : measure ℝ} {f : ℝ → E}

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -701,12 +701,7 @@ end basic
 
 lemma integral_of_real {a b : ℝ} {μ : measure ℝ} {f : ℝ → ℝ} :
   ∫ x in a..b, (f x : ℂ) ∂μ = ↑(∫ x in a..b, f x ∂μ) :=
-begin
-  simp_rw [interval_integral_eq_integral_interval_oc, integral_of_real],
-  split_ifs,
-  all_goals {simp only [is_R_or_C.of_real_smul, complex.of_real_neg, complex.of_real_one,
-    neg_mul, one_mul, algebra.id.smul_eq_mul]},
-end
+by simp only [interval_integral, integral_of_real, complex.of_real_sub]
 
 section continuous_linear_map
 


### PR DESCRIPTION
In Fourier theory it's often necessary to work with integrals and derivatives of functions `ℝ → ℂ`. This adds a couple of shortcuts for doing so, and uses them to slightly simplify some code already in the library. (Cherry-picked out of my Riemann zeta values project.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
