### PR TITLE
[Merged by Bors] - feat(algebra/geom_sum): divisibility of sums and differences of powers

### DIFF
--- a/src/algebra/geom_sum.lean
+++ b/src/algebra/geom_sum.lean
@@ -172,6 +172,28 @@ theorem geom_sum₂_mul [comm_ring α] (x y : α) (n : ℕ) :
   (∑ i in range n, x ^ i * (y ^ (n - 1 - i))) * (x - y) = x ^ n - y ^ n :=
 (commute.all x y).geom_sum₂_mul n
 
+theorem sub_dvd_pow_sub_pow [comm_ring α] (x y : α) (n : ℕ) : x - y ∣ x^n - y^n :=
+  dvd.intro_left _ (geom_sum₂_mul x y n)
+
+theorem nat.sub_dvd_pow_sub_pow (x y n : ℕ) : x - y ∣ x^n - y^n :=
+begin
+  cases le_or_lt y x with h,
+  { have : y^n ≤ x^n := nat.pow_le_pow_of_le_left h _,
+    exact_mod_cast sub_dvd_pow_sub_pow (x : ℤ) ↑y n },
+  { have : x^n ≤ y^n := nat.pow_le_pow_of_le_left h.le _,
+    exact (nat.sub_eq_zero_of_le this).symm ▸ dvd_zero (x - y) }
+end
+
+theorem odd.add_dvd_pow_add_pow [comm_ring α] (x y : α) {n : ℕ} (h : odd n) : x + y ∣ x^n + y^n :=
+begin
+  have h₁ := geom_sum₂_mul x (-y) n,
+  rw [odd.neg_pow h y, sub_neg_eq_add, sub_neg_eq_add] at h₁,
+  exact dvd.intro_left _ h₁,
+end
+
+theorem nat.add_dvd_pow_add_pow_of_odd (x y : ℕ) {n : ℕ} (h : odd n) : x + y ∣ x^n + y^n :=
+by exact_mod_cast odd.add_dvd_pow_add_pow (x : ℤ) ↑y h
+
 theorem geom_sum_mul [ring α] (x : α) (n : ℕ) :
   (∑ i in range n, x ^ i) * (x - 1) = x ^ n - 1 :=
 begin

--- a/src/algebra/geom_sum.lean
+++ b/src/algebra/geom_sum.lean
@@ -175,7 +175,7 @@ theorem geom_sum₂_mul [comm_ring α] (x y : α) (n : ℕ) :
 theorem sub_dvd_pow_sub_pow [comm_ring α] (x y : α) (n : ℕ) : x - y ∣ x ^ n - y ^ n :=
   dvd.intro_left _ (geom_sum₂_mul x y n)
 
-theorem nat.sub_dvd_pow_sub_pow (x y n : ℕ) : x - y ∣ x ^ n - y ^ n :=
+theorem nat_sub_dvd_pow_sub_pow (x y n : ℕ) : x - y ∣ x ^ n - y ^ n :=
 begin
   cases le_or_lt y x with h,
   { have : y ^ n ≤ x ^ n := nat.pow_le_pow_of_le_left h _,
@@ -192,7 +192,7 @@ begin
   exact dvd.intro_left _ h₁,
 end
 
-theorem nat.add_dvd_pow_add_pow_of_odd (x y : ℕ) {n : ℕ} (h : odd n) : x + y ∣ x ^ n + y ^ n :=
+theorem odd.nat_add_dvd_pow_add_pow (x y : ℕ) {n : ℕ} (h : odd n) : x + y ∣ x ^ n + y ^ n :=
 by exact_mod_cast odd.add_dvd_pow_add_pow (x : ℤ) ↑y h
 
 theorem geom_sum_mul [ring α] (x : α) (n : ℕ) :

--- a/src/algebra/geom_sum.lean
+++ b/src/algebra/geom_sum.lean
@@ -184,8 +184,8 @@ begin
     exact (nat.sub_eq_zero_of_le this).symm ▸ dvd_zero (x - y) }
 end
 
-theorem odd.add_dvd_pow_add_pow [comm_ring α] (x y : α) {n : ℕ} (h : odd n) : x + y ∣ x ^ n + y ^ n
-:=
+theorem odd.add_dvd_pow_add_pow [comm_ring α] (x y : α) {n : ℕ} (h : odd n) :
+  x + y ∣ x ^ n + y ^ n :=
 begin
   have h₁ := geom_sum₂_mul x (-y) n,
   rw [odd.neg_pow h y, sub_neg_eq_add, sub_neg_eq_add] at h₁,

--- a/src/algebra/geom_sum.lean
+++ b/src/algebra/geom_sum.lean
@@ -172,26 +172,27 @@ theorem geom_sum₂_mul [comm_ring α] (x y : α) (n : ℕ) :
   (∑ i in range n, x ^ i * (y ^ (n - 1 - i))) * (x - y) = x ^ n - y ^ n :=
 (commute.all x y).geom_sum₂_mul n
 
-theorem sub_dvd_pow_sub_pow [comm_ring α] (x y : α) (n : ℕ) : x - y ∣ x^n - y^n :=
+theorem sub_dvd_pow_sub_pow [comm_ring α] (x y : α) (n : ℕ) : x - y ∣ x ^ n - y ^ n :=
   dvd.intro_left _ (geom_sum₂_mul x y n)
 
-theorem nat.sub_dvd_pow_sub_pow (x y n : ℕ) : x - y ∣ x^n - y^n :=
+theorem nat.sub_dvd_pow_sub_pow (x y n : ℕ) : x - y ∣ x ^ n - y ^ n :=
 begin
   cases le_or_lt y x with h,
-  { have : y^n ≤ x^n := nat.pow_le_pow_of_le_left h _,
+  { have : y ^ n ≤ x ^ n := nat.pow_le_pow_of_le_left h _,
     exact_mod_cast sub_dvd_pow_sub_pow (x : ℤ) ↑y n },
-  { have : x^n ≤ y^n := nat.pow_le_pow_of_le_left h.le _,
+  { have : x ^ n ≤ y ^ n := nat.pow_le_pow_of_le_left h.le _,
     exact (nat.sub_eq_zero_of_le this).symm ▸ dvd_zero (x - y) }
 end
 
-theorem odd.add_dvd_pow_add_pow [comm_ring α] (x y : α) {n : ℕ} (h : odd n) : x + y ∣ x^n + y^n :=
+theorem odd.add_dvd_pow_add_pow [comm_ring α] (x y : α) {n : ℕ} (h : odd n) : x + y ∣ x ^ n + y ^ n
+:=
 begin
   have h₁ := geom_sum₂_mul x (-y) n,
   rw [odd.neg_pow h y, sub_neg_eq_add, sub_neg_eq_add] at h₁,
   exact dvd.intro_left _ h₁,
 end
 
-theorem nat.add_dvd_pow_add_pow_of_odd (x y : ℕ) {n : ℕ} (h : odd n) : x + y ∣ x^n + y^n :=
+theorem nat.add_dvd_pow_add_pow_of_odd (x y : ℕ) {n : ℕ} (h : odd n) : x + y ∣ x ^ n + y ^ n :=
 by exact_mod_cast odd.add_dvd_pow_add_pow (x : ℤ) ↑y h
 
 theorem geom_sum_mul [ring α] (x : α) (n : ℕ) :


### PR DESCRIPTION
If `n : ℕ` and `x` and `y` belong to a `comm_ring`, then `x - y ∣ x ^ n - y ^ n`. If `n` is odd, then `x + y ∣ x ^ n + y ^ n`.
These results follow from `geom_sum₂_mul`. There are additional theorems for when `x` and `y` are natural numbers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This was discussed on Zulip [here](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/divisibilty.20of.20powers). The results follow mostly trivially from `geom_sum₂_mul`, but having them as separate theorems about divisibility helps with discoverability. I placed the code in `algebra/geom_sum` because that is where `geom_sum₂_mul` is defined but it can be moved if needed.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
