### PR TITLE
[Merged by Bors] - feat(group_theory/order_of_element): a condition on o(x) and o(y) that implies o(xy)=o(y)

### DIFF
--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -387,6 +387,14 @@ begin
   { rintro ⟨c, rfl⟩, rw factorization_mul hd (right_ne_zero_of_mul hn), simp },
 end
 
+lemma factorization_prime_le_iff_dvd {d n : ℕ} (hd : d ≠ 0) (hn : n ≠ 0) :
+  (∀ p : ℕ, p.prime → d.factorization p ≤ n.factorization p) ↔ d ∣ n :=
+begin
+  rw ← factorization_le_iff_dvd hd hn,
+  refine ⟨λ h p, (em p.prime).elim (h p) (λ hp, _), λ h p _, h p⟩,
+  simp_rw factorization_eq_zero_of_non_prime _ hp,
+end
+
 lemma pow_succ_factorization_not_dvd {n p : ℕ} (hn : n ≠ 0) (hp : p.prime) :
   ¬ p ^ (n.factorization p + 1) ∣ n :=
 begin
@@ -558,13 +566,11 @@ begin
   rcases eq_or_ne n 0 with rfl | hn, { simp },
   rcases eq_or_ne d 0 with rfl | hd,
   { simp only [zero_dvd_iff, hn, false_iff, not_forall],
-    refine ⟨2, n, prime_two, ⟨dvd_zero _, _⟩⟩,
-    apply mt (le_of_dvd hn.bot_lt) (not_le.mpr (lt_two_pow n)) },
+    exact ⟨2, n, prime_two, dvd_zero _, mt (le_of_dvd hn.bot_lt) (lt_two_pow n).not_le⟩ },
   refine ⟨λ h p k _ hpkd, dvd_trans hpkd h, _⟩,
-  rw [←factorization_le_iff_dvd hd hn, finsupp.le_def],
-  intros h p,
-  by_cases pp : prime p, swap, { simp [factorization_eq_zero_of_non_prime d pp] },
-  rw ←pp.pow_dvd_iff_le_factorization hn,
+  rw [←factorization_prime_le_iff_dvd hd hn],
+  intros h p pp,
+  simp_rw ←pp.pow_dvd_iff_le_factorization hn,
   exact h p _ pp (ord_proj_dvd _ _)
 end
 
@@ -595,6 +601,15 @@ begin
     have hea' := (factorization_le_iff_dvd he_pos ha_pos).mpr hea,
     have heb' := (factorization_le_iff_dvd he_pos hb_pos).mpr heb,
     simp [←factorization_le_iff_dvd he_pos hd_pos, h1, hea', heb'] },
+end
+
+lemma factorization_lcm {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
+  (a.lcm b).factorization = a.factorization ⊔ b.factorization :=
+begin
+  rw [← add_right_inj (a.gcd b).factorization,
+    ← factorization_mul (mt gcd_eq_zero_iff.1 $ λ h, ha h.1) (lcm_ne_zero ha hb),
+    gcd_mul_lcm, factorization_gcd ha hb, factorization_mul ha hb],
+  ext1, exact (min_add_max _ _).symm,
 end
 
 @[to_additive sum_factors_gcd_add_sum_factors_mul]

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -402,6 +402,14 @@ theorem exists_dvd_of_not_prime2 {n : ℕ} (n2 : 2 ≤ n) (np : ¬ prime n) :
 theorem exists_prime_and_dvd {n : ℕ} (hn : n ≠ 1) : ∃ p, prime p ∧ p ∣ n :=
 ⟨min_fac n, min_fac_prime hn, min_fac_dvd _⟩
 
+theorem dvd_of_forall_prime_mul_dvd {a b : ℕ}
+  (hdvd : ∀ p : ℕ, p.prime → p ∣ a → p * a ∣ b) : a ∣ b :=
+begin
+  obtain rfl | ha := eq_or_ne a 1, { apply one_dvd },
+  obtain ⟨p, hp⟩ := exists_prime_and_dvd ha,
+  exact trans (dvd_mul_left a p) (hdvd p hp.1 hp.2),
+end
+
 /-- Euclid's theorem on the **infinitude of primes**.
 Here given in the form: for every `n`, there exists a prime number `p ≥ n`. -/
 theorem exists_infinite_primes (n : ℕ) : ∃ p, n ≤ p ∧ prime p :=

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -315,7 +315,9 @@ order_of_pos_iff.mp $
 
 /-- If each prime factor of `order_of x` has higher multiplicity in `order_of y`, and `x` commutes
   with `y`, then the order of `x * y` is the same as the order of `y`. -/
-@[to_additive] lemma order_of_mul_eq_right_of_forall_prime_mul_dvd
+@[to_additive "If each prime factor of `add_order_of x` has higher multiplicity in `add_order_of y`,
+and `x` commutes with `y`, then the order of `x * y` is the same as the order of `y`."]
+lemma order_of_mul_eq_right_of_forall_prime_mul_dvd
   (hy : is_of_fin_order y)
   (hdvd : ∀ p : ℕ, p.prime → p ∣ order_of x → (p * order_of x) ∣ order_of y) :
   order_of (x * y) = order_of y :=


### PR DESCRIPTION
+ The main theorem is `order_of_mul_eq_right_of_forall_prime_mul_dvd`, which depends on `order_of_dvd_lcm_mul`, a variant of `order_of_mul_dvd_lcm`, and `dvd_of_forall_prime_mul_dvd`.

+ Also add lemmas `factorization_prime_le_iff_dvd` and `factorization_lcm` that were used in another approach towards the same theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
