### PR TITLE
[Merged by Bors] - feat(analysis/convolution): weaken topological assumptions

### DIFF
--- a/src/analysis/convolution.lean
+++ b/src/analysis/convolution.lean
@@ -163,13 +163,18 @@ variables (L)
 section group
 
 variables [add_group G]
-variables [has_measurable_add₂ G] [has_measurable_neg G]
 
-lemma measure_theory.ae_strongly_measurable.convolution_integrand' [sigma_finite ν]
+lemma measure_theory.ae_strongly_measurable.convolution_integrand'
+  [has_measurable_add₂ G] [has_measurable_neg G] [sigma_finite ν]
   (hf : ae_strongly_measurable f ν)
   (hg : ae_strongly_measurable g $ map (λ (p : G × G), p.1 - p.2) (μ.prod ν)) :
   ae_strongly_measurable (λ p : G × G, L (f p.2) (g (p.1 - p.2))) (μ.prod ν) :=
 L.ae_strongly_measurable_comp₂ hf.snd $ hg.comp_measurable measurable_sub
+
+
+section
+
+variables [has_measurable_add G] [has_measurable_neg G]
 
 lemma measure_theory.ae_strongly_measurable.convolution_integrand_snd'
   (hf : ae_strongly_measurable f μ) {x : G}
@@ -222,8 +227,10 @@ begin
   apply L.le_op_norm₂,
 end
 
+end
+
 section left
-variables [sigma_finite μ] [is_add_right_invariant μ]
+variables [has_measurable_add₂ G] [has_measurable_neg G] [sigma_finite μ] [is_add_right_invariant μ]
 
 lemma measure_theory.ae_strongly_measurable.convolution_integrand_snd
   (hf : ae_strongly_measurable f μ) (hg : ae_strongly_measurable g μ)
@@ -250,7 +257,8 @@ end left
 
 section right
 
-variables [sigma_finite μ] [is_add_right_invariant μ] [sigma_finite ν]
+variables [has_measurable_add₂ G] [has_measurable_neg G]
+[sigma_finite μ] [is_add_right_invariant μ] [sigma_finite ν]
 
 lemma measure_theory.ae_strongly_measurable.convolution_integrand
   (hf : ae_strongly_measurable f ν) (hg : ae_strongly_measurable g μ) :
@@ -338,7 +346,7 @@ variables [add_comm_group G]
 
 section measurable_group
 
-variables [has_measurable_add₂ G] [has_measurable_neg G] [is_add_left_invariant μ]
+variables [has_measurable_neg G] [is_add_left_invariant μ]
 
 /-- A sufficient condition to prove that `f ⋆[L, μ] g` exists.
 We assume that the integrand has compact support and `g` is bounded on this support (note that
@@ -347,7 +355,7 @@ integrable on the support of the integrand, and that both functions are strongly
 
 This is a variant of `bdd_above.convolution_exists_at'` in an abelian group with a left-invariant
 measure. This allows us to state the boundedness and measurability of `g` in a more natural way. -/
-lemma bdd_above.convolution_exists_at [sigma_finite μ] {x₀ : G}
+lemma bdd_above.convolution_exists_at [has_measurable_add₂ G] [sigma_finite μ] {x₀ : G}
   {s : set G} (hbg : bdd_above ((λ i, ‖g i‖) '' ((λ t, x₀ - t) ⁻¹' s)))
   (hs : measurable_set s) (h2s : support (λ t, L (f t) (g (x₀ - t))) ⊆ s)
   (hf : integrable_on f s μ) (hmg : ae_strongly_measurable g μ) :
@@ -362,7 +370,7 @@ begin
       (measurable_const.sub measurable_id').ae_measurable }
 end
 
-variables {L} [is_neg_invariant μ]
+variables {L} [has_measurable_add G] [is_neg_invariant μ]
 
 lemma convolution_exists_at_flip :
   convolution_exists_at g f x L.flip μ ↔ convolution_exists_at f g x L μ :=
@@ -379,7 +387,7 @@ convolution_exists_at_flip.symm
 
 end measurable_group
 
-variables [topological_space G] [topological_add_group G] [borel_space G] [has_measurable_add₂ G]
+variables [topological_space G] [topological_add_group G] [borel_space G]
  [is_add_left_invariant μ] [is_neg_invariant μ]
 
 lemma has_compact_support.convolution_exists_left
@@ -509,8 +517,7 @@ variables [borel_space G]
 
 /-- The convolution is continuous if one function is locally integrable and the other has compact
 support and is continuous. -/
-lemma has_compact_support.continuous_convolution_right
-  [first_countable_topology G] [has_measurable_add₂ G]
+lemma has_compact_support.continuous_convolution_right [first_countable_topology G]
   (hcg : has_compact_support g) (hf : locally_integrable f μ)
   (hg : continuous g) : continuous (f ⋆[L, μ] g) :=
 begin
@@ -616,15 +623,14 @@ variables [topological_space G]
 variables [topological_add_group G]
 variables [borel_space G]
 
-lemma has_compact_support.continuous_convolution_left
-  [first_countable_topology G] [has_measurable_add₂ G]
+lemma has_compact_support.continuous_convolution_left [first_countable_topology G]
   (hcf : has_compact_support f) (hf : continuous f) (hg : locally_integrable g μ) :
-    continuous (f ⋆[L, μ] g) :=
+  continuous (f ⋆[L, μ] g) :=
 by { rw [← convolution_flip], exact hcf.continuous_convolution_right L.flip hg hf }
 
 lemma bdd_above.continuous_convolution_left_of_integrable [second_countable_topology G]
   (hbf : bdd_above (range (λ x, ‖f x‖))) (hf : continuous f) (hg : integrable g μ) :
-    continuous (f ⋆[L, μ] g) :=
+  continuous (f ⋆[L, μ] g) :=
 by { rw [← convolution_flip], exact hbf.continuous_convolution_right_of_integrable L.flip hg hf }
 
 end comm_group
@@ -954,23 +960,18 @@ end
 
 end assoc
 
-variables [normed_add_comm_group G] [borel_space G] [normed_space 𝕜 G]
+variables [normed_add_comm_group G] [borel_space G]
 
 lemma convolution_precompR_apply {g : G → E'' →L[𝕜] E'}
   (hf : locally_integrable f μ) (hcg : has_compact_support g) (hg : continuous g)
   (x₀ : G) (x : E'') : (f ⋆[L.precompR E'', μ] g) x₀ x = (f ⋆[L, μ] (λ a, g a x)) x₀  :=
 begin
-  rcases hcg.eq_zero_or_finite_dimensional 𝕜 hg with rfl|fin_dim,
-  { simp only [convolution, pi.zero_apply, integral_const, smul_zero, zero_apply,
-      _root_.map_zero] },
-  resetI,
-  haveI : proper_space G, from finite_dimensional.proper_is_R_or_C 𝕜 G,
   have := hcg.convolution_exists_right (L.precompR E'' : _) hf hg x₀,
   simp_rw [convolution_def, continuous_linear_map.integral_apply this],
   refl,
 end
 
-variables [sigma_finite μ] [is_add_left_invariant μ]
+variables [normed_space 𝕜 G] [sigma_finite μ] [is_add_left_invariant μ]
 
 /-- Compute the total derivative of `f ⋆ g` if `g` is `C^1` with compact support and `f` is locally
 integrable. To write down the total derivative as a convolution, we use
@@ -1025,7 +1026,6 @@ begin
   rcases hcg.eq_zero_or_finite_dimensional 𝕜 hg.continuous with rfl|fin_dim,
   { simp only [convolution_zero], exact cont_diff_zero_fun, },
   resetI,
-  haveI : proper_space G, from finite_dimensional.proper_is_R_or_C 𝕜 G,
   induction n using enat.nat_induction with n ih ih generalizing g,
   { rw [cont_diff_zero] at hg ⊢,
     exact hcg.continuous_convolution_right L hf hg },

--- a/src/analysis/convolution.lean
+++ b/src/analysis/convolution.lean
@@ -508,14 +508,11 @@ begin
   have hK' : is_compact K' := hcg.neg.add is_compact_singleton,
   obtain ⟨U, U_open, K'U, hU⟩ : ∃ U, is_open U ∧ K' ⊆ U ∧ integrable_on f U μ,
     from hf.integrable_on_nhds_is_compact hK',
-  obtain ⟨V, V_mem, hV⟩ : ∃ (V : set G) (H : V ∈ 𝓝 (0 : G)), K' + V ⊆ U,
-    from compact_open_separated_add_right hK' U_open K'U,
   have : ∀ᶠ x in 𝓝 x₀, ∀ᵐ (t : G) ∂μ,
     ‖L (f t) (g (x - t))‖ ≤ U.indicator (λ t, ‖L‖ * ‖f t‖ * (⨆ i, ‖g i‖)) t,
-  { have : {x₀} + V ∈ 𝓝 x₀,
-    { apply add_mem_nhds
-
-    },
+  { obtain ⟨V, V_mem, hV⟩ : ∃ (V : set G) (H : V ∈ 𝓝 (0 : G)), K' + V ⊆ U,
+      from compact_open_separated_add_right hK' U_open K'U,
+    have : {x₀} + V ∈ 𝓝 x₀, from singleton_add_mem_nhds_of_nhds_zero x₀ V_mem,
     filter_upwards [this] with x hx,
     apply eventually_of_forall (λ t, _),
     apply hcg.convolution_integrand_bound_right_of_subset L hg hx,
@@ -528,8 +525,6 @@ begin
   { exact eventually_of_forall (λ t, (L.continuous₂.comp₂ continuous_const $
       hg.comp $ continuous_id.sub $ by apply continuous_const).continuous_at) }
 end
-
-#exit
 
 /-- The convolution is continuous if one function is integrable and the other is bounded and
 continuous. -/

--- a/src/analysis/convolution.lean
+++ b/src/analysis/convolution.lean
@@ -529,8 +529,8 @@ begin
     apply hcg.convolution_integrand_bound_right_of_subset L hg hx,
     rwa ← add_assoc },
   refine continuous_at_of_dominated _ this _ _,
-  { exact eventually_of_forall
-      (λ x, hf.ae_strongly_measurable.convolution_integrand_snd' L hg.ae_strongly_measurable) },
+  { apply eventually_of_forall (λ x, _),
+    exact (has_compact_support.convolution_exists_right L hcg hf hg x).ae_strongly_measurable },
   { rw [integrable_indicator_iff U_open.measurable_set],
     exact (hU.norm.const_mul _).mul_const _ },
   { exact eventually_of_forall (λ t, (L.continuous₂.comp₂ continuous_const $
@@ -539,7 +539,7 @@ end
 
 /-- The convolution is continuous if one function is integrable and the other is bounded and
 continuous. -/
-lemma bdd_above.continuous_convolution_right_of_integrable
+lemma bdd_above.continuous_convolution_right_of_integrable [second_countable_topology G]
   (hbg : bdd_above (range (λ x, ‖g x‖))) (hf : integrable f μ) (hg : continuous g) :
     continuous (f ⋆[L, μ] g) :=
 begin
@@ -557,14 +557,6 @@ begin
   { exact eventually_of_forall (λ t, (L.continuous₂.comp₂ continuous_const $
       hg.comp $ continuous_id.sub $ by apply continuous_const).continuous_at) }
 end
-
-/-- A version of `has_compact_support.continuous_convolution_right` that works if `G` is
-not locally compact but requires that `g` is integrable. -/
-lemma has_compact_support.continuous_convolution_right_of_integrable
-  (hcg : has_compact_support g) (hf : integrable f μ) (hg : continuous g) :
-    continuous (f ⋆[L, μ] g) :=
-(hg.norm.bdd_above_range_of_has_compact_support hcg.norm).continuous_convolution_right_of_integrable
-  L hf hg
 
 end group
 
@@ -623,24 +615,17 @@ end measurable
 variables [topological_space G]
 variables [topological_add_group G]
 variables [borel_space G]
-variables [second_countable_topology G]
 
 lemma has_compact_support.continuous_convolution_left
+  [first_countable_topology G] [has_measurable_add₂ G]
   (hcf : has_compact_support f) (hf : continuous f) (hg : locally_integrable g μ) :
     continuous (f ⋆[L, μ] g) :=
 by { rw [← convolution_flip], exact hcf.continuous_convolution_right L.flip hg hf }
 
-lemma bdd_above.continuous_convolution_left_of_integrable
+lemma bdd_above.continuous_convolution_left_of_integrable [second_countable_topology G]
   (hbf : bdd_above (range (λ x, ‖f x‖))) (hf : continuous f) (hg : integrable g μ) :
     continuous (f ⋆[L, μ] g) :=
 by { rw [← convolution_flip], exact hbf.continuous_convolution_right_of_integrable L.flip hg hf }
-
-/-- A version of `has_compact_support.continuous_convolution_left` that works if `G` is
-not locally compact but requires that `g` is integrable. -/
-lemma has_compact_support.continuous_convolution_left_of_integrable
-  (hcf : has_compact_support f) (hf : continuous f) (hg : integrable g μ) :
-    continuous (f ⋆[L, μ] g) :=
-by { rw [← convolution_flip], exact hcf.continuous_convolution_right_of_integrable L.flip hg hf }
 
 end comm_group
 
@@ -1101,5 +1086,3 @@ begin
 end
 
 end real
-
-#lint

--- a/src/analysis/convolution.lean
+++ b/src/analysis/convolution.lean
@@ -283,14 +283,14 @@ lemma measure_theory.integrable.ae_convolution_exists (hf : integrable f ν) (hg
 end right
 
 variables [topological_space G] [topological_add_group G] [borel_space G]
-  [second_countable_topology G] [sigma_compact_space G]
+  [second_countable_topology G]
 
 lemma has_compact_support.convolution_exists_at {x₀ : G}
   (h : has_compact_support (λ t, L (f t) (g (x₀ - t)))) (hf : locally_integrable f μ)
   (hg : continuous g) : convolution_exists_at f g x₀ L μ :=
 ((((homeomorph.neg G).trans $ homeomorph.add_right x₀).is_compact_preimage.mpr h).bdd_above_image
   hg.norm.continuous_on).convolution_exists_at' L is_closed_closure.measurable_set subset_closure
-  (hf h) hf.ae_strongly_measurable hg.ae_strongly_measurable
+  (hf.integrable_on_is_compact h) hf.ae_strongly_measurable hg.ae_strongly_measurable
 
 lemma has_compact_support.convolution_exists_right
   (hcg : has_compact_support g) (hf : locally_integrable f μ) (hg : continuous g) :
@@ -364,7 +364,6 @@ end measurable_group
 
 variables [topological_space G] [topological_add_group G] [borel_space G]
   [second_countable_topology G] [is_add_left_invariant μ] [is_neg_invariant μ]
-  [sigma_compact_space G]
 
 lemma has_compact_support.convolution_exists_left
   (hcf : has_compact_support f) (hf : continuous f) (hg : locally_integrable g μ) :
@@ -509,7 +508,7 @@ begin
   { exact eventually_of_forall
       (λ x, hf.ae_strongly_measurable.convolution_integrand_snd' L hg.ae_strongly_measurable) },
   { rw [integrable_indicator_iff hK'.measurable_set],
-    exact ((hf hK').norm.const_mul _).mul_const _ },
+    exact ((hf.integrable_on_is_compact hK').norm.const_mul _).mul_const _ },
   { exact eventually_of_forall (λ t, (L.continuous₂.comp₂ continuous_const $
       hg.comp $ continuous_id.sub $ by apply continuous_const).continuous_at) }
 end
@@ -998,7 +997,7 @@ begin
     exact (hcg.fderiv 𝕜).convolution_integrand_bound_right L'
       (hg.continuous_fderiv le_rfl) (ball_subset_closed_ball hx) },
   { rw [integrable_indicator_iff hK'.measurable_set],
-    exact ((hf hK').norm.const_mul _).mul_const _ },
+    exact ((hf.integrable_on_is_compact hK').norm.const_mul _).mul_const _ },
   { exact eventually_of_forall (λ t x hx, (L _).has_fderiv_at.comp x (h3 x t)) },
 end
 

--- a/src/analysis/convolution.lean
+++ b/src/analysis/convolution.lean
@@ -492,14 +492,20 @@ variables [borel_space G] [second_countable_topology G]
 
 /-- The convolution is continuous if one function is locally integrable and the other has compact
 support and is continuous. -/
-lemma has_compact_support.continuous_convolution_right [locally_compact_space G] [t2_space G]
+lemma has_compact_support.continuous_convolution_right [t2_space G]
   (hcg : has_compact_support g) (hf : locally_integrable f μ)
   (hg : continuous g) : continuous (f ⋆[L, μ] g) :=
 begin
   refine continuous_iff_continuous_at.mpr (λ x₀, _),
-  obtain ⟨K, hK, h2K⟩ := exists_compact_mem_nhds x₀,
-  let K' := - tsupport g + K,
-  have hK' : is_compact K' := hcg.neg.add hK,
+  apply continuous_at_of_dominated,
+  { exact eventually_of_forall
+      (λ x, hf.ae_strongly_measurable.convolution_integrand_snd' L hg.ae_strongly_measurable) },
+  let K' := - tsupport g + {x₀},
+  have hK' : is_compact K' := hcg.neg.add is_compact_singleton,
+  have : ∃ U, is_open U ∧ K' ⊆ U ∧ integrable_on f U μ,
+  {
+
+  },
   have : ∀ᶠ x in 𝓝 x₀, ∀ᵐ (t : G) ∂μ,
     ‖L (f t) (g (x - t))‖ ≤ K'.indicator (λ t, ‖L‖ * ‖f t‖ * (⨆ i, ‖g i‖)) t :=
   eventually_of_mem h2K (λ x hx, eventually_of_forall $
@@ -512,6 +518,8 @@ begin
   { exact eventually_of_forall (λ t, (L.continuous₂.comp₂ continuous_const $
       hg.comp $ continuous_id.sub $ by apply continuous_const).continuous_at) }
 end
+
+#exit
 
 /-- The convolution is continuous if one function is integrable and the other is bounded and
 continuous. -/

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -29,17 +29,14 @@ variables [normed_add_comm_group E] {f : X → E} {μ : measure X}
 
 namespace measure_theory
 
-/-- A function `f : X → E` is locally integrable if it is integrable on all compact sets.
-  See `measure_theory.locally_integrable_iff` for the justification of this name. -/
+/-- A function `f : X → E` is locally integrable if it is integrable on a neighborhood of every
+point. In particular, it is integrable on all compact sets,
+see `locally_integrable.integrable_on_is_compact`. -/
 def locally_integrable (f : X → E) (μ : measure X . volume_tac) : Prop :=
 ∀ (x : X), integrable_at_filter f (𝓝 x) μ
 
 lemma integrable.locally_integrable (hf : integrable f μ) : locally_integrable f μ :=
-begin
-  rw ← integrable_on_univ at hf,
-  assume x,
-  exact ⟨univ, is_open.mem_nhds is_open_univ (mem_univ _), hf⟩,
-end
+λ x, hf.integrable_at_filter _
 
 /-- If a function is locally integrable, then it is integrable on an open neighborhood of any
 compact set. -/

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -93,7 +93,7 @@ begin
   exact λ i, (hu i).ae_strongly_measurable,
 end
 
-lemma locally_integrable_const [hμ : is_locally_finite_measure μ] (c : E) :
+lemma locally_integrable_const [is_locally_finite_measure μ] (c : E) :
   locally_integrable (λ x, c) μ :=
 begin
   assume x,

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -9,9 +9,9 @@ import measure_theory.integral.integrable_on
 # Locally integrable functions
 
 A function is called *locally integrable* (`measure_theory.locally_integrable`) if it is integrable
-on every compact subset of its domain.
+on a neighborhood of every point.
 
-This file contains properties of locally integrable functions and of integrability results
+This file contains properties of locally integrable functions and integrability results
 on compact sets.
 
 ## Main statements
@@ -32,50 +32,84 @@ namespace measure_theory
 /-- A function `f : X → E` is locally integrable if it is integrable on all compact sets.
   See `measure_theory.locally_integrable_iff` for the justification of this name. -/
 def locally_integrable (f : X → E) (μ : measure X . volume_tac) : Prop :=
-∀ ⦃K⦄, is_compact K → integrable_on f K μ
+∀ (x : X), integrable_at_filter f (𝓝 x) μ
 
 lemma integrable.locally_integrable (hf : integrable f μ) : locally_integrable f μ :=
-λ K hK, hf.integrable_on
-
-lemma locally_integrable.ae_strongly_measurable [sigma_compact_space X]
-  (hf : locally_integrable f μ) :
-  ae_strongly_measurable f μ :=
 begin
-  rw [← @restrict_univ _ _ μ, ← Union_compact_covering, ae_strongly_measurable_Union_iff],
-  exact λ i, (hf $ is_compact_compact_covering X i).ae_strongly_measurable
+  rw ← integrable_on_univ at hf,
+  assume x,
+  exact ⟨univ, is_open.mem_nhds is_open_univ (mem_univ _), hf⟩,
 end
+
+lemma locally_integrable.integrable_on_is_compact {k : set X} (hf : locally_integrable f μ)
+  (hk : is_compact k) : integrable_on f k μ :=
+begin
+  refine is_compact.induction_on hk integrable_on_empty (λ s t hst h, h.mono_set hst)
+    (λ s t hs ht, integrable_on_union.mpr ⟨hs, ht⟩) (λ x hx, _),
+  obtain ⟨K, hK, h2K⟩ := hf x,
+  exact ⟨K, nhds_within_le_nhds hK, h2K⟩
+end
+
 
 lemma locally_integrable_iff [locally_compact_space X] :
-  locally_integrable f μ ↔ ∀ x : X, ∃ U ∈ 𝓝 x, integrable_on f U μ :=
+  locally_integrable f μ ↔ ∀ (k : set X), is_compact k → integrable_on f k μ :=
 begin
-  refine ⟨λ hf x, _, λ hf K hK, _⟩,
-  { obtain ⟨K, hK, h2K⟩ := exists_compact_mem_nhds x, exact ⟨K, h2K, hf hK⟩ },
-  { refine is_compact.induction_on hK integrable_on_empty (λ s t hst h, h.mono_set hst)
-      (λ s t hs ht, integrable_on_union.mpr ⟨hs, ht⟩) (λ x hx, _),
-    obtain ⟨K, hK, h2K⟩ := hf x,
-    exact ⟨K, nhds_within_le_nhds hK, h2K⟩ }
+  refine ⟨λ hf k hk, hf.integrable_on_is_compact hk, λ hf x, _⟩,
+  obtain ⟨K, hK, h2K⟩ := exists_compact_mem_nhds x,
+  exact ⟨K, h2K, hf K hK⟩,
 end
 
-lemma locally_integrable_const [is_locally_finite_measure μ] (c : E) :
+lemma locally_integrable.ae_strongly_measurable [second_countable_topology X]
+  (hf : locally_integrable f μ) : ae_strongly_measurable f μ :=
+begin
+  have : ∀ x, ∃ u, is_open u ∧ x ∈ u ∧ integrable_on f u μ,
+  { assume x,
+    rcases hf x with ⟨s, hs, h's⟩,
+    rcases mem_nhds_iff.1 hs with ⟨u, us, u_open, xu⟩,
+    exact ⟨u, u_open, xu, h's.mono_set us⟩ },
+  choose u u_open xu hu using this,
+  obtain ⟨T, T_count, hT⟩ : ∃ (T : set X), T.countable ∧ (⋃ (i : T), u i) = univ,
+  { have : (⋃ x, u x) = univ, from eq_univ_of_forall (λ x, mem_Union_of_mem x (xu x)),
+    rw ← this,
+    simp only [Union_coe_set, subtype.coe_mk],
+    exact is_open_Union_countable u u_open },
+  haveI : countable T, from countable_coe_iff.mpr T_count,
+  rw [← @restrict_univ _ _ μ, ← hT, ae_strongly_measurable_Union_iff],
+  exact λ i, (hu i).ae_strongly_measurable,
+end
+
+lemma locally_integrable_const [hμ : is_locally_finite_measure μ] (c : E) :
   locally_integrable (λ x, c) μ :=
-λ K hK, by simp only [integrable_on_const, hK.measure_lt_top, or_true]
+begin
+  assume x,
+  rcases μ.finite_at_nhds x with ⟨U, hU, h'U⟩,
+  refine ⟨U, hU, _⟩,
+  simp only [h'U, integrable_on_const, or_true],
+end
 
 lemma locally_integrable.indicator (hf : locally_integrable f μ)
   {s : set X} (hs : measurable_set s) : locally_integrable (s.indicator f) μ :=
-λ K hK, (hf hK).indicator hs
+begin
+  assume x,
+  rcases hf x with ⟨U, hU, h'U⟩,
+  exact ⟨U, hU, h'U.indicator hs⟩,
+end
 
 theorem locally_integrable_map_homeomorph [borel_space X] [borel_space Y]
   (e : X ≃ₜ Y) {f : Y → E} {μ : measure X} :
   locally_integrable f (measure.map e μ) ↔ locally_integrable (f ∘ e) μ :=
 begin
-  refine ⟨λ h k hk, _, λ h k hk, _⟩,
-  { have : is_compact (e.symm ⁻¹' k), from (homeomorph.is_compact_preimage _).2 hk,
-    convert (integrable_on_map_equiv e.to_measurable_equiv).1 (h this) using 1,
-    simp only [←preimage_comp, homeomorph.to_measurable_equiv_coe, homeomorph.symm_comp_self,
-      preimage_id_eq, id.def] },
-  { apply (integrable_on_map_equiv e.to_measurable_equiv).2,
-    have : is_compact (e ⁻¹' k), from (homeomorph.is_compact_preimage _).2 hk,
-    exact h this }
+  refine ⟨λ h x, _, λ h x, _⟩,
+  { rcases h (e x) with ⟨U, hU, h'U⟩,
+    refine ⟨e ⁻¹' U, e.continuous.continuous_at.preimage_mem_nhds hU, _⟩,
+    exact (integrable_on_map_equiv e.to_measurable_equiv).1 h'U },
+  { rcases h (e.symm x) with ⟨U, hU, h'U⟩,
+    refine ⟨e.symm ⁻¹' U, e.symm.continuous.continuous_at.preimage_mem_nhds hU, _⟩,
+    apply (integrable_on_map_equiv e.to_measurable_equiv).2,
+    simp only [homeomorph.to_measurable_equiv_coe],
+    convert h'U,
+    ext x,
+    simp only [mem_preimage, homeomorph.symm_apply_apply] }
 end
 
 section mul
@@ -138,8 +172,15 @@ is_compact.induction_on hK integrable_on_empty (λ s t hst ht, ht.mono_set hst)
 
 section borel
 
-variables [opens_measurable_space X] [metrizable_space X] [is_locally_finite_measure μ]
+variables [opens_measurable_space X]  [is_locally_finite_measure μ]
 variables {K : set X} {a b : X}
+
+/-- A continuous function `f` is locally integrable with respect to any locally finite measure. -/
+lemma continuous.locally_integrable [second_countable_topology_either X E]
+  (hf : continuous f) : locally_integrable f μ :=
+hf.integrable_at_nhds
+
+variables [metrizable_space X]
 
 /-- A function `f` continuous on a compact set `K` is integrable on this set with respect to any
 locally finite measure. -/
@@ -151,17 +192,13 @@ begin
   exact hf.integrable_at_nhds_within_of_is_separable hK.measurable_set hK.is_separable hx,
 end
 
-/-- A continuous function `f` is locally integrable with respect to any locally finite measure. -/
-lemma continuous.locally_integrable (hf : continuous f) : locally_integrable f μ :=
-λ s hs, hf.continuous_on.integrable_on_compact hs
-
 lemma continuous_on.integrable_on_Icc [preorder X] [compact_Icc_space X]
   (hf : continuous_on f (Icc a b)) : integrable_on f (Icc a b) μ :=
 hf.integrable_on_compact is_compact_Icc
 
 lemma continuous.integrable_on_Icc [preorder X] [compact_Icc_space X] (hf : continuous f) :
   integrable_on f (Icc a b) μ :=
-hf.locally_integrable is_compact_Icc
+hf.continuous_on.integrable_on_Icc
 
 lemma continuous.integrable_on_Ioc [preorder X] [compact_Icc_space X] (hf : continuous f) :
   integrable_on f (Ioc a b) μ :=
@@ -183,43 +220,74 @@ hf.integrable_on_Ioc
 lemma continuous.integrable_of_has_compact_support
   (hf : continuous f) (hcf : has_compact_support f) : integrable f μ :=
 (integrable_on_iff_integable_of_support_subset (subset_tsupport f) measurable_set_closure).mp $
-  hf.locally_integrable hcf
+  hf.continuous_on.integrable_on_compact hcf
 
 end borel
 
+open_locale ennreal
+
 section monotone
 
-variables [borel_space X] [metrizable_space X]
+variables [borel_space X]
   [conditionally_complete_linear_order X] [conditionally_complete_linear_order E]
   [order_topology X] [order_topology E] [second_countable_topology E]
-  [is_locally_finite_measure μ] {s : set X}
+  {s : set X}
 
-lemma monotone_on.integrable_on_compact (hs : is_compact s) (hmono : monotone_on f s) :
+lemma monotone_on.integrable_on_of_measure_ne_top
+  (hmono : monotone_on f s) {a b : X} (ha : is_least s a) (hb : is_greatest s b) (hs : μ s ≠ ∞)
+  (h's : measurable_set s) :
   integrable_on f s μ :=
 begin
   borelize E,
   obtain rfl | h := s.eq_empty_or_nonempty,
   { exact integrable_on_empty },
-  have hbelow : bdd_below (f '' s) :=
-    ⟨f (Inf s), λ x ⟨y, hy, hyx⟩, hyx ▸ hmono (hs.Inf_mem h) hy (cInf_le hs.bdd_below hy)⟩,
-  have habove : bdd_above (f '' s) :=
-    ⟨f (Sup s), λ x ⟨y, hy, hyx⟩, hyx ▸ hmono hy (hs.Sup_mem h) (le_cSup hs.bdd_above hy)⟩,
+  have hbelow : bdd_below (f '' s) := ⟨f a, λ x ⟨y, hy, hyx⟩, hyx ▸ hmono ha.1 hy (ha.2 hy)⟩,
+  have habove : bdd_above (f '' s) := ⟨f b, λ x ⟨y, hy, hyx⟩, hyx ▸ hmono hy hb.1 (hb.2 hy)⟩,
   have : metric.bounded (f '' s) := metric.bounded_of_bdd_above_of_bdd_below habove hbelow,
   rcases bounded_iff_forall_norm_le.mp this with ⟨C, hC⟩,
-  refine integrable.mono' (continuous_const.locally_integrable hs)
-    (ae_measurable_restrict_of_monotone_on hs.measurable_set hmono).ae_strongly_measurable
-    ((ae_restrict_iff' hs.measurable_set).mpr $ ae_of_all _ $
+  have A : integrable_on (λ x, C) s μ, by simp only [hs.lt_top, integrable_on_const, or_true],
+  refine integrable.mono' A
+    (ae_measurable_restrict_of_monotone_on h's hmono).ae_strongly_measurable
+    ((ae_restrict_iff' h's).mpr $ ae_of_all _ $
       λ y hy, hC (f y) (mem_image_of_mem f hy)),
 end
 
-lemma antitone_on.integrable_on_compact (hs : is_compact s) (hanti : antitone_on f s) :
+lemma monotone_on.integrable_on_is_compact [is_finite_measure_on_compacts μ]
+  (hs : is_compact s) (hmono : monotone_on f s) :
   integrable_on f s μ :=
-hanti.dual_right.integrable_on_compact hs
+begin
+  obtain rfl | h := s.eq_empty_or_nonempty,
+  { exact integrable_on_empty },
+  { exact hmono.integrable_on_of_measure_ne_top (hs.is_least_Inf h) (hs.is_greatest_Sup h)
+    hs.measure_lt_top.ne hs.measurable_set }
+end
 
-lemma monotone.locally_integrable (hmono : monotone f) : locally_integrable f μ :=
-λ s hs, (hmono.monotone_on _).integrable_on_compact hs
+lemma antitone_on.integrable_on_of_measure_ne_top
+  (hanti : antitone_on f s) {a b : X} (ha : is_least s a) (hb : is_greatest s b) (hs : μ s ≠ ∞)
+  (h's : measurable_set s) :
+  integrable_on f s μ :=
+hanti.dual_right.integrable_on_of_measure_ne_top ha hb  hs h's
 
-lemma antitone.locally_integrable (hanti : antitone f) : locally_integrable f μ :=
+lemma antione_on.integrable_on_is_compact [is_finite_measure_on_compacts μ]
+  (hs : is_compact s) (hanti : antitone_on f s) :
+  integrable_on f s μ :=
+hanti.dual_right.integrable_on_is_compact hs
+
+lemma monotone.locally_integrable [is_locally_finite_measure μ] (hmono : monotone f) :
+  locally_integrable f μ :=
+begin
+  assume x,
+  rcases μ.finite_at_nhds x with ⟨U, hU, h'U⟩,
+  obtain ⟨a, b, xab, hab, abU⟩ : ∃ (a b : X), x ∈ Icc a b ∧ Icc a b ∈ 𝓝 x ∧ Icc a b ⊆ U,
+    from exists_Icc_mem_subset_of_mem_nhds hU,
+  have ab : a ≤ b := xab.1.trans xab.2,
+  refine ⟨Icc a b, hab, _⟩,
+  exact (hmono.monotone_on _).integrable_on_of_measure_ne_top (is_least_Icc ab)
+    (is_greatest_Icc ab) ((measure_mono abU).trans_lt h'U).ne measurable_set_Icc,
+end
+
+lemma antitone.locally_integrable [is_locally_finite_measure μ] (hanti : antitone f) :
+  locally_integrable f μ :=
 hanti.dual_right.locally_integrable
 
 end monotone

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -41,15 +41,30 @@ begin
   exact ⟨univ, is_open.mem_nhds is_open_univ (mem_univ _), hf⟩,
 end
 
+/-- If a function is locally integrable, then it is integrable on an open neighborhood of any
+compact set. -/
+lemma locally_integrable.integrable_on_nhds_is_compact (hf : locally_integrable f μ) {k : set X}
+  (hk : is_compact k) : ∃ u, is_open u ∧ k ⊆ u ∧ integrable_on f u μ :=
+begin
+  refine is_compact.induction_on hk _ _ _ _,
+  { refine ⟨∅, is_open_empty, subset.rfl, integrable_on_empty⟩ },
+  { rintros s t hst ⟨u, u_open, tu, hu⟩,
+    exact ⟨u, u_open, hst.trans tu, hu⟩ },
+  { rintros s t ⟨u, u_open, su, hu⟩ ⟨v, v_open, tv, hv⟩,
+    exact ⟨u ∪ v, u_open.union v_open, union_subset_union su tv, hu.union hv⟩ },
+  { assume x hx,
+    rcases hf x with ⟨u, ux, hu⟩,
+    rcases mem_nhds_iff.1 ux with ⟨v, vu, v_open, xv⟩,
+    exact ⟨v, nhds_within_le_nhds (v_open.mem_nhds xv), v, v_open, subset.rfl, hu.mono_set vu⟩ }
+end
+
+/-- If a function is locally integrable, then it is integrable on any compact set. -/
 lemma locally_integrable.integrable_on_is_compact {k : set X} (hf : locally_integrable f μ)
   (hk : is_compact k) : integrable_on f k μ :=
 begin
-  refine is_compact.induction_on hk integrable_on_empty (λ s t hst h, h.mono_set hst)
-    (λ s t hs ht, integrable_on_union.mpr ⟨hs, ht⟩) (λ x hx, _),
-  obtain ⟨K, hK, h2K⟩ := hf x,
-  exact ⟨K, nhds_within_le_nhds hK, h2K⟩
+  rcases hf.integrable_on_nhds_is_compact hk with ⟨u, u_open, ku, hu⟩,
+  exact hu.mono_set ku
 end
-
 
 lemma locally_integrable_iff [locally_compact_space X] :
   locally_integrable f μ ↔ ∀ (k : set X), is_compact k → integrable_on f k μ :=

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -187,7 +187,7 @@ is_compact.induction_on hK integrable_on_empty (λ s t hst ht, ht.mono_set hst)
 
 section borel
 
-variables [opens_measurable_space X]  [is_locally_finite_measure μ]
+variables [opens_measurable_space X] [is_locally_finite_measure μ]
 variables {K : set X} {a b : X}
 
 /-- A continuous function `f` is locally integrable with respect to any locally finite measure. -/
@@ -234,7 +234,7 @@ hf.integrable_on_Ioc
 /-- A continuous function with compact support is integrable on the whole space. -/
 lemma continuous.integrable_of_has_compact_support
   (hf : continuous f) (hcf : has_compact_support f) : integrable f μ :=
-(integrable_on_iff_integable_of_support_subset (subset_tsupport f) measurable_set_closure).mp $
+(integrable_on_iff_integrable_of_support_subset (subset_tsupport f) measurable_set_closure).mp $
   hf.continuous_on.integrable_on_compact hcf
 
 end borel

--- a/src/measure_theory/integral/integrable_on.lean
+++ b/src/measure_theory/integral/integrable_on.lean
@@ -428,6 +428,16 @@ begin
     (μ.finite_at_nhds_within _ _),
 end
 
+lemma continuous.integrable_at_nhds
+  [topological_space α] [second_countable_topology_either α E]
+  [opens_measurable_space α] {μ : measure α} [is_locally_finite_measure μ]
+  {f : α → E} (hf : continuous f) (a : α) :
+  integrable_at_filter f (𝓝 a) μ :=
+begin
+  rw ← nhds_within_univ,
+  exact hf.continuous_on.integrable_at_nhds_within measurable_set.univ (mem_univ a),
+end
+
 /-- If a function is continuous on an open set `s`, then it is strongly measurable at the filter
 `𝓝 x` for all `x ∈ s` if either the source space or the target space is second-countable. -/
 lemma continuous_on.strongly_measurable_at_filter [topological_space α]

--- a/src/measure_theory/integral/integrable_on.lean
+++ b/src/measure_theory/integral/integrable_on.lean
@@ -231,7 +231,7 @@ begin
   simpa only [set.univ_inter, measurable_set.univ, measure.restrict_apply] using hμs,
 end
 
-lemma integrable_on_iff_integable_of_support_subset {f : α → E} {s : set α}
+lemma integrable_on_iff_integrable_of_support_subset {f : α → E} {s : set α}
   (h1s : support f ⊆ s) (h2s : measurable_set s) :
   integrable_on f s μ ↔ integrable f μ :=
 begin
@@ -403,6 +403,22 @@ begin
     ext x,
     simp },
   { exact is_separable_of_separable_space _ }
+end
+
+/-- A function which is continuous on a compact set `s` is almost everywhere strongly measurable
+with respect to `μ.restrict s`. -/
+lemma continuous_on.ae_strongly_measurable_of_is_compact
+  [topological_space α] [opens_measurable_space α] [topological_space β] [pseudo_metrizable_space β]
+  {f : α → β} {s : set α} {μ : measure α}
+  (hf : continuous_on f s) (hs : is_compact s) (h's : measurable_set s) :
+  ae_strongly_measurable f (μ.restrict s) :=
+begin
+  letI := pseudo_metrizable_space_pseudo_metric β,
+  borelize β,
+  rw ae_strongly_measurable_iff_ae_measurable_separable,
+  refine ⟨hf.ae_measurable h's, f '' s, _, _⟩,
+  { exact (hs.image_of_continuous_on hf).is_separable },
+  { exact mem_of_superset (self_mem_ae_restrict h's) (subset_preimage_image _ _) }
 end
 
 lemma continuous_on.integrable_at_nhds_within_of_is_separable

--- a/src/measure_theory/integral/integrable_on.lean
+++ b/src/measure_theory/integral/integrable_on.lean
@@ -267,6 +267,10 @@ def integrable_at_filter (f : α → E) (l : filter α) (μ : measure α . volum
 
 variables {l l' : filter α}
 
+lemma integrable.integrable_at_filter (h : integrable f μ) (l : filter α) :
+  integrable_at_filter f l μ :=
+⟨univ, filter.univ_mem, integrable_on_univ.2 h⟩
+
 protected lemma integrable_at_filter.eventually (h : integrable_at_filter f l μ) :
   ∀ᶠ s in l.small_sets, integrable_on f s μ :=
 iff.mpr (eventually_small_sets' $ λ s t hst ht, ht.mono_set hst) h

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -459,7 +459,7 @@ lemma monotone_on.interval_integrable {u : ℝ → E} {a b : ℝ} (hu : monotone
   interval_integrable u μ a b :=
 begin
   rw interval_integrable_iff,
-  exact (hu.integrable_on_compact is_compact_interval).mono_set Ioc_subset_Icc_self,
+  exact (hu.integrable_on_is_compact is_compact_interval).mono_set Ioc_subset_Icc_self,
 end
 
 lemma antitone_on.interval_integrable {u : ℝ → E} {a b : ℝ} (hu : antitone_on u (interval a b)) :

--- a/src/topology/algebra/group/basic.lean
+++ b/src/topology/algebra/group/basic.lean
@@ -955,6 +955,13 @@ by { rw ←bUnion_smul_set, exact is_open_bUnion (λ a _, ht.smul _) }
 @[to_additive] lemma subset_interior_smul_right : s • interior t ⊆ interior (s • t) :=
 interior_maximal (set.smul_subset_smul_left interior_subset) is_open_interior.smul_left
 
+@[to_additive] lemma smul_mem_nhds (a : α) {x : β} (ht : t ∈ 𝓝 x) :
+  a • t ∈ 𝓝 (a • x) :=
+begin
+  rcases mem_nhds_iff.1 ht with ⟨u, ut, u_open, hu⟩,
+  exact mem_nhds_iff.2 ⟨a • u, smul_set_mono ut, u_open.smul a, smul_mem_smul_set hu⟩,
+end
+
 variables [topological_space α]
 
 @[to_additive] lemma subset_interior_smul : interior s • interior t ⊆ interior (s • t) :=
@@ -973,6 +980,14 @@ subset_interior_smul_right
 @[to_additive] lemma subset_interior_mul : interior s * interior t ⊆ interior (s * t) :=
 subset_interior_smul
 
+@[to_additive] lemma singleton_mul_mem_nhds (a : α) {b : α} (h : s ∈ 𝓝 b) :
+  {a} * s ∈ 𝓝 (a * b) :=
+by { have := smul_mem_nhds a h, rwa ← singleton_smul at this }
+
+@[to_additive] lemma singleton_mul_mem_nhds_of_nhds_one (a : α) {b : α} (h : s ∈ 𝓝 (1 : α)) :
+  {a} * s ∈ 𝓝 a :=
+by simpa only [mul_one] using singleton_mul_mem_nhds a h
+
 end has_continuous_const_smul
 
 section has_continuous_const_smul_op
@@ -986,6 +1001,17 @@ interior_maximal (set.mul_subset_mul_right interior_subset) is_open_interior.mul
 
 @[to_additive] lemma subset_interior_mul' : interior s * interior t ⊆ interior (s * t) :=
 (set.mul_subset_mul_left interior_subset).trans subset_interior_mul_left
+
+@[to_additive] lemma mul_singleton_mem_nhds (a : α) {b : α} (h : s ∈ 𝓝 b) :
+  s * {a} ∈ 𝓝 (b * a) :=
+begin
+  simp only [←bUnion_op_smul_set, mem_singleton_iff, Union_Union_eq_left],
+  exact smul_mem_nhds _ h,
+end
+
+@[to_additive] lemma mul_singleton_mem_nhds_of_nhds_one (a : α) {b : α} (h : s ∈ 𝓝 (1 : α)) :
+  s * {a} ∈ 𝓝 a :=
+by simpa only [one_mul] using mul_singleton_mem_nhds a h
 
 end has_continuous_const_smul_op
 

--- a/src/topology/algebra/group/basic.lean
+++ b/src/topology/algebra/group/basic.lean
@@ -984,7 +984,7 @@ subset_interior_smul
   {a} * s ∈ 𝓝 (a * b) :=
 by { have := smul_mem_nhds a h, rwa ← singleton_smul at this }
 
-@[to_additive] lemma singleton_mul_mem_nhds_of_nhds_one (a : α) {b : α} (h : s ∈ 𝓝 (1 : α)) :
+@[to_additive] lemma singleton_mul_mem_nhds_of_nhds_one (a : α) (h : s ∈ 𝓝 (1 : α)) :
   {a} * s ∈ 𝓝 a :=
 by simpa only [mul_one] using singleton_mul_mem_nhds a h
 
@@ -1009,7 +1009,7 @@ begin
   exact smul_mem_nhds _ h,
 end
 
-@[to_additive] lemma mul_singleton_mem_nhds_of_nhds_one (a : α) {b : α} (h : s ∈ 𝓝 (1 : α)) :
+@[to_additive] lemma mul_singleton_mem_nhds_of_nhds_one (a : α) (h : s ∈ 𝓝 (1 : α)) :
   s * {a} ∈ 𝓝 a :=
 by simpa only [one_mul] using mul_singleton_mem_nhds a h
 

--- a/test/monotonicity.lean
+++ b/test/monotonicity.lean
@@ -442,9 +442,9 @@ end
 example : ∫ x in Icc 0 1, real.exp x ≤ ∫ x in Icc 0 1, real.exp (x+1) :=
 begin
   mono,
-  { exact real.continuous_exp.locally_integrable is_compact_Icc },
-  { exact (real.continuous_exp.comp $ continuous_add_right 1).locally_integrable
-      is_compact_Icc },
+  { exact real.continuous_exp.locally_integrable.integrable_on_is_compact is_compact_Icc },
+  { exact (real.continuous_exp.comp $ continuous_add_right 1)
+      .locally_integrable.integrable_on_is_compact is_compact_Icc },
   intro x,
   dsimp only,
   mono,


### PR DESCRIPTION
We redefine `locally_integrable`: currently, this means "integrable on every compact set", and we change it to "integrable on a neighborhood of any point", to bring it in line with `is_locally_finite_measure`.

This makes it possible to weaken a lot of assumptions in the file on convolutions, removing second countability or local compactness assumptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is related to #17626, but there is no direct dependence in one direction or the other. Whichever is merged first, I will adapt the other one.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
