### PR TITLE
[Merged by Bors] - feat(number_theory/diophantine_approximation): add new file proving Dirichlet's approximation theorem

### DIFF
--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -52,7 +52,10 @@ Diophantine approximation, Dirichlet's approximation theorem
 namespace dioph_approx
 
 /-!
-### Preliminaries
+### Dirichlet's approximation theorem
+
+We show that for any real number `ξ` and positive natural `n`, there is a fraction `q`
+such that `q.denom ≤ n` and `|ξ - q| < 1/(n*q.denom)`.
 -/
 
 section pigeonhole

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -233,24 +233,26 @@ We show that an irrational real number `ξ` has infinitely many "good rational a
 i.e., fractions `x/y` in lowest terms such that `|ξ - x/y| < 1/y^2`.
 -/
 
-/-- Given any rational approximation `x/y` to the irrational real number `ξ`, there is
-a good rational approximation `X/Y` such that `|ξ - X/Y| < |ξ - x/y|`. -/
-lemma ex_better_approx {ξ : ℝ} (hξ : irrational ξ) (x y : ℤ) :
-  ∃ X Y : ℤ, (X, Y) ∈ rat_approx ξ ∧ |ξ - X / Y| < |ξ - x / y| :=
+/-- Given any rational approximation `q` to the irrational real number `ξ`, there is
+a good rational approximation `q'` such that `|ξ - q'| < |ξ - q|`. -/
+lemma ex_better_approx {ξ : ℝ} (hξ : irrational ξ) (q : ℚ) :
+  ∃ q' : ℚ, |ξ - q'| < 1 / q'.denom ^ 2 ∧ |ξ - q'| < |ξ - q| :=
 begin
-  have h := abs_pos.mpr (sub_ne_zero.mpr $ (irrational_iff_ne_rational ξ).mp hξ x y),
-  obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - x / y|),
+  have h : 0 < |ξ - q|,
+  { refine abs_pos.mpr (sub_ne_zero.mpr _),
+    simp only [irrational, set.mem_range, not_exists, ← ne.def] at hξ,
+    exact (hξ q).symm, },
+  obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - q|),
   have m_pos : 0 < (m : ℝ) := (one_div_pos.mpr h).trans hm,
-  obtain ⟨X, Y, hcp, hbd, Y_pos, Y_le_m⟩ := ex_approx ξ (nat.cast_pos.mp m_pos),
-  have Y_pos_ℝ : (0 : ℝ) < Y := int.cast_pos.mpr Y_pos,
-  refine ⟨X, Y, ⟨Y_pos, hcp,
-                 lt_of_lt_of_le hbd (one_div_le_one_div_of_le (sq_pos_of_pos Y_pos_ℝ) _)⟩,
-                 (lt_of_lt_of_le hbd _).trans ((one_div_lt h m_pos).mp hm)⟩,
-  { rw [pow_two, mul_le_mul_right Y_pos_ℝ],
-    exact_mod_cast Y_le_m, },
-  { rw [mul_comm, ← div_div],
-    refine div_le_div_of_le m_pos.le ((div_le_one Y_pos_ℝ).mpr _),
-    exact_mod_cast (int.cast_le.mpr Y_pos : (_ : ℝ) ≤ Y), }
+  obtain ⟨q', hbd, hden⟩ := ex_approx ξ (nat.cast_pos.mp m_pos),
+  have den_pos : (0 : ℝ) < q'.denom := nat.cast_pos.mpr q'.pos,
+  have md_pos := mul_pos m_pos den_pos,
+  refine ⟨q', lt_of_lt_of_le hbd _, hbd.trans _⟩,
+  { rw [sq, one_div_le_one_div md_pos (mul_pos den_pos den_pos), mul_le_mul_right den_pos],
+    exact_mod_cast hden, },
+  { rw [one_div_lt md_pos h],
+    refine lt_of_lt_of_le hm ((le_mul_iff_one_le_right m_pos).mpr _),
+    exact_mod_cast (q'.pos : 1 ≤ q'.denom), }
 end
 
 /-- If `ξ` is an irrational real number, then there are infinitely many good

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -144,7 +144,7 @@ open set
 
 /-- Given any rational approximation `q` to the irrational real number `ξ`, there is
 a good rational approximation `q'` such that `|ξ - q'| < |ξ - q|`. -/
-lemma ex_better_approx {ξ : ℝ} (hξ : irrational ξ) (q : ℚ) :
+lemma ex_better_approx_of_irrational {ξ : ℝ} (hξ : irrational ξ) (q : ℚ) :
   ∃ q' : ℚ, |ξ - q'| < 1 / q'.denom ^ 2 ∧ |ξ - q'| < |ξ - q| :=
 begin
   have h : 0 < |ξ - q|,
@@ -173,7 +173,7 @@ begin
   refine or.resolve_left (set.finite_or_infinite _) (λ h, _),
   obtain ⟨q, _, hq⟩ := exists_min_image {q : ℚ | |ξ - q| < 1 / q.denom ^ 2} (λ q, |ξ - q|) h
                                         ⟨⌊ξ⌋, by simp [abs_of_nonneg, int.fract_lt_one]⟩,
-  obtain ⟨q', hmem, hbetter⟩ := ex_better_approx hξ q,
+  obtain ⟨q', hmem, hbetter⟩ := ex_better_approx_of_irrational hξ q,
   exact lt_irrefl _ (lt_of_le_of_lt (hq q' hmem) hbetter),
 end
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -72,14 +72,14 @@ open finset int
 
 /-- *Dirichlet's approximation theorem:*
 For any real number `ξ` and positive natural `n`, there are integers `j` and `k`,
-with `0 < k ≤ n` and `|ξ*k - j| ≤ 1/(n+1)`. -/
+with `0 < k ≤ n` and `|k*ξ - j| ≤ 1/(n+1)`. -/
 lemma exists_int_int_abs_mul_sub_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
-  ∃ j k : ℤ, 0 < k ∧ k ≤ n ∧ |ξ * k - j| ≤ 1 / (n + 1) :=
+  ∃ j k : ℤ, 0 < k ∧ k ≤ n ∧ |↑k * ξ - j| ≤ 1 / (n + 1) :=
 begin
   let f : ℤ → ℤ := λ m, ⌊fract (ξ * m) * (n + 1)⌋,
   have hn : 0 < (n : ℝ) + 1 := by exact_mod_cast nat.succ_pos _,
   have hfu := λ m : ℤ, mul_lt_of_lt_one_left hn $ fract_lt_one (ξ * ↑m),
-  conv in (|_| ≤ _) { rw [le_div_iff hn, ← abs_of_pos hn, ← abs_mul], },
+  conv in (|_| ≤ _) { rw [mul_comm, le_div_iff hn, ← abs_of_pos hn, ← abs_mul], },
   let D := Icc (0 : ℤ) n,
   by_cases H : ∃ m ∈ D, f m = n,
   { obtain ⟨m, hm, hf⟩ := H,
@@ -123,7 +123,6 @@ lemma exists_int_abs_mul_sub_round_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
   ∃ k : ℤ, 0 < k ∧ k ≤ n ∧ |↑k * ξ - round (↑k * ξ)| ≤ 1 / (n + 1) :=
 begin
   obtain ⟨j, k, hk₀, hk₁, h⟩ := exists_int_int_abs_mul_sub_le ξ n_pos,
-  rw [mul_comm] at h,
   exact ⟨k, hk₀, hk₁, (round_le (↑k * ξ) j).trans h⟩,
 end
 
@@ -141,7 +140,7 @@ begin
   rw [← div_div, le_div_iff (nat.cast_pos.mpr $ rat.pos _ : (0 : ℝ) < _)],
   refine (mul_le_mul_of_nonneg_left (int.cast_le.mpr hden : _ ≤ (k : ℝ)) (abs_nonneg _)).trans _,
   rwa [← abs_of_pos hk₀', rat.cast_div, rat.cast_coe_int, rat.cast_coe_int,
-       ← abs_mul, sub_mul, div_mul_cancel _ hk₀'.ne'],
+       ← abs_mul, sub_mul, div_mul_cancel _ hk₀'.ne', mul_comm],
 end
 
 end real

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -56,8 +56,6 @@ We use the namespace `dioph_approx`.
 Diophantine approximation, Dirichlet's approximation theorem
 -/
 
-namespace dioph_approx
-
 /-!
 ### Dirichlet's approximation theorem
 
@@ -65,7 +63,7 @@ We show that for any real number `ξ` and positive natural `n`, there is a fract
 such that `q.denom ≤ n` and `|ξ - q| ≤ 1/((n+1)*q.denom)`.
 -/
 
-section pigeonhole
+namespace real
 
 open finset int
 
@@ -145,7 +143,9 @@ begin
        ← abs_mul, sub_mul, div_mul_cancel _ hk₀'.ne'],
 end
 
-end pigeonhole
+end real
+
+namespace dioph_approx
 
 section rat_approx
 
@@ -274,7 +274,7 @@ begin
     exact (hξ q).symm, },
   obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - q|),
   have m_pos : 0 < (m : ℝ) := (one_div_pos.mpr h).trans hm,
-  obtain ⟨q', hbd, hden⟩ := exists_rat_abs_sub_le_and_denom_le ξ (nat.cast_pos.mp m_pos),
+  obtain ⟨q', hbd, hden⟩ := real.exists_rat_abs_sub_le_and_denom_le ξ (nat.cast_pos.mp m_pos),
   have den_pos : (0 : ℝ) < q'.denom := nat.cast_pos.mpr q'.pos,
   have md_pos := mul_pos (add_pos m_pos zero_lt_one) den_pos,
   refine ⟨q', lt_of_le_of_lt hbd _, lt_of_le_of_lt hbd _⟩,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -14,17 +14,7 @@ This file gives proofs of various versions of **Dirichlet's approximation theore
 and its important consequence that when `ξ` is an irrational real number, then there are
 infinitely many rationals `x/y` (in lowest terms) such that `|ξ - x/y| < 1/y^2`.
 
-We also show the converse, i.e., that for rational `ξ` there are only finitely many
-such rational approximations.
-
-The proof (of the interesting direction) is based on the pigeonhole principle.
-
-## Main definitions
-
-We define the set `dioph_approx.rat_approx ξ` for a real number `ξ` to be the set
-of pairs `(x, y)` of coprime integers with `y` positive such that `|ξ - x/y| < 1/y^2`.
-This set is in natural bijection with `{q : ℚ | |ξ - q| < 1/q.denom^2}`
-(see `dioph_approx.rat_approx_equiv`).
+The proof is based on the pigeonhole principle.
 
 ## Main statements
 
@@ -38,17 +28,10 @@ The main results are
   satisfying `|ξ - q| ≤ 1/((n+1)*q.denom)` and `q.denom ≤ n`,
 * `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`,
   `{q : ℚ | |ξ - q| < 1/q.denom^2}` is infinite,
-* `dioph_approx.rat_approx_finite`, which states that `{q : ℚ | |a/b - q| < 1/q.denom^2}`
-  is finite for integers `a` and `b`,
-* `dioph_approx.rat_approx_infinite_iff_irrational`, which combines the two previous
-  statements to give an iff statement, and
-* `dioph_approx.rat_approx_infinite_iff_irrational'`, which is a version
-   in terms of `dioph_approx.rat_approx ξ`.
 
 ## Implementation notes
 
-We use the namespace `real` for the various statements of Diriechlet's approximation
-theorem and the namespace `dioph_approx` for the remaining definitions and results.
+We use the namespace `real` for the results.
 
 ## References
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -305,8 +305,8 @@ end
 
 /-- If `ξ = a/b` is rational, then it has only finitely many good rational approximations. -/
 lemma rat_approx_finite (a b : ℤ) : {q : ℚ | |(a / b : ℝ) - q| < 1 / q.denom ^ 2}.finite :=
-set.finite_coe_iff.mp $ (equiv.finite_iff $ bij_on.equiv _ $ rat_approx_equiv (a / b)).mp $
-  set.finite_coe_iff.mpr (rat_approx_finite' a b)
+set.not_infinite.mp $ (mt rat_approx_infinite_iff.mpr) $ set.not_infinite.mpr $
+  rat_approx_finite' a b
 
 /-- The set of good rational approximations to a real number `ξ` is infinite if and only if
 `ξ` is irrational. -/

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -126,10 +126,11 @@ end pigeonhole
 section rat_approx
 
 /-!
-### Infinitely many good approximations to irrational numbers
+### Equivalence between `rat_approx ξ` and approximating fractions
 
-We show that an irrational real number `ξ` has infinitely many "good rational approximations",
-i.e., fractions `x/y` in lowest terms such that `|ξ - x/y| < 1/y^2`.
+We define `dioph_approx.rat_approx ξ` and show that it is bijective to the
+set of fractions `q` such that `|ξ - q| < 1/q.denom^2`. We also prove some
+more properties.
 -/
 
 open set

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -72,7 +72,7 @@ open finset int
 /-- *Dirichlet's approximation theorem:*
 For any real number `ξ` and positive natural `n`, there are integers `j` and `k`,
 with `0 < k ≤ n` and `|ξ*k - j| ≤ 1/(n+1)`. -/
-lemma dirichlet_approx (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
+lemma exists_int_int_abs_mul_sub_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
   ∃ j k : ℤ, 0 < k ∧ k ≤ n ∧ |ξ * k - j| ≤ 1 / (n + 1) :=
 begin
   let f : ℤ → ℤ := λ m, ⌊fract (ξ * m) * (n + 1)⌋,
@@ -123,7 +123,7 @@ with `0 < k ≤ n` such that `|k*ξ - round(k*ξ)| ≤ 1/(n+1)`.
 lemma exists_int_abs_mul_sub_round_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
   ∃ k : ℤ, 0 < k ∧ k ≤ n ∧ |↑k * ξ - round (↑k * ξ)| ≤ 1 / (n + 1) :=
 begin
-  obtain ⟨j, k, hk₀, hk₁, h⟩ := dirichlet_approx ξ n_pos,
+  obtain ⟨j, k, hk₀, hk₁, h⟩ := exists_int_int_abs_mul_sub_le ξ n_pos,
   rw [mul_comm] at h,
   exact ⟨k, hk₀, hk₁, (round_le (↑k * ξ) j).trans h⟩,
 end
@@ -131,10 +131,10 @@ end
 /-- *Dirichlet's approximation theorem:*
 For any real number `ξ` and positive natural `n`, there is a fraction `q`
 such that `q.denom ≤ n` and `|ξ - q| ≤ 1/((n+1)*q.denom)`. -/
-lemma dirichlet_approx' (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
+lemma exists_rat_abs_sub_le_and_denom_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
   ∃ q : ℚ, |ξ - q| ≤ 1 / ((n + 1) * q.denom) ∧ q.denom ≤ n :=
 begin
-  obtain ⟨j, k, hk₀, hk₁, h⟩ := dirichlet_approx ξ n_pos,
+  obtain ⟨j, k, hk₀, hk₁, h⟩ := exists_int_int_abs_mul_sub_le ξ n_pos,
   have hk₀' : (0 : ℝ) < k := int.cast_pos.mpr hk₀,
   have hden : ((j / k : ℚ).denom : ℤ) ≤ k,
   { convert le_of_dvd hk₀ (rat.denom_dvd j k), exact rat.coe_int_div_eq_mk, },
@@ -274,7 +274,7 @@ begin
     exact (hξ q).symm, },
   obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - q|),
   have m_pos : 0 < (m : ℝ) := (one_div_pos.mpr h).trans hm,
-  obtain ⟨q', hbd, hden⟩ := dirichlet_approx' ξ (nat.cast_pos.mp m_pos),
+  obtain ⟨q', hbd, hden⟩ := exists_rat_abs_sub_le_and_denom_le ξ (nat.cast_pos.mp m_pos),
   have den_pos : (0 : ℝ) < q'.denom := nat.cast_pos.mpr q'.pos,
   have md_pos := mul_pos (add_pos m_pos zero_lt_one) den_pos,
   refine ⟨q', lt_of_le_of_lt hbd _, lt_of_le_of_lt hbd _⟩,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -172,8 +172,8 @@ begin
   have hpos' : (0 : ℝ) < y := int.cast_pos.mpr hpos,
   rw [← mul_lt_mul_right hpos'] at hbd,
   nth_rewrite 1 ← abs_of_pos hpos' at hbd,
-  rw [← abs_mul, sub_mul, sq, ← div_div, div_mul_cancel _ hpos'.ne.symm,
-      div_mul_cancel _ hpos'.ne.symm] at hbd,
+  rw [← abs_mul, sub_mul, sq, ← div_div, div_mul_cancel _ hpos'.ne', div_mul_cancel _ hpos'.ne']
+    at hbd,
   have H : (1 : ℝ) / y ≤ 1,
   { refine (one_div_le zero_lt_one hpos').mp _,
     simp only [div_self one_ne_zero],

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -285,10 +285,10 @@ lemma denom_bounded_of_rat_approx_rational (a b x y : ℤ) (hb : b ≠ 0)
 begin
   obtain ⟨h₁, h₂, h₃⟩ := hxy,
   refine ⟨h₁, _⟩,
-  have hy₀ : (y : ℝ) ≠ 0 := int.cast_ne_zero.mpr h₁.ne.symm,
+  have hy₀ : (y : ℝ) ≠ 0 := int.cast_ne_zero.mpr h₁.ne',
   have hy : 0 < (y ^ 2 : ℝ) := (sq_pos_iff _).mpr hy₀,
   have hb₀ : (b : ℝ) ≠ 0 := int.cast_ne_zero.mpr hb,
-  rw [← mul_lt_mul_right (abs_pos.mpr hy.ne.symm), ← mul_lt_mul_right (abs_pos.mpr hb₀),
+  rw [← mul_lt_mul_right (abs_pos.mpr hy.ne'), ← mul_lt_mul_right (abs_pos.mpr hb₀),
       ← abs_mul, ← abs_mul] at h₃,
   field_simp at h₃, -- why doesn't it cancel `↑b * ↑y`?
   rw [sq, ← mul_assoc, ← div_div, mul_div_cancel _ hb₀, mul_div_cancel _ hy₀, abs_mul,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -83,10 +83,8 @@ begin
   let D := Icc (0 : ℤ) n,
   by_cases H : ∃ m ∈ D, f m = n,
   { obtain ⟨m, hm, hf⟩ := H,
-    have hf' : (n : ℝ) ≤ fract (ξ * ↑m) * (↑n + 1),
-    { have : (f m : ℝ) ≤ fract (ξ * ↑m) * (↑n + 1) := floor_le (fract (ξ * ↑m) * (↑n + 1)),
-      rw hf at this,
-      exact_mod_cast this, },
+    have hf' : (n : ℝ) ≤ fract (ξ * m) * (n + 1) :=
+      (hf ▸ floor_le (fract (ξ * m) * (n + 1)) : ((n : ℤ) : ℝ) ≤ fract (ξ * m) * (n + 1)),
     have hm₀ : 0 < m,
     { have hf₀ : f 0 = 0,
       { simp only [floor_eq_zero_iff, algebra_map.coe_zero, mul_zero, fract_zero, zero_mul,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -42,16 +42,16 @@ We use the namespace `real` for the results.
 Diophantine approximation, Dirichlet's approximation theorem
 -/
 
+namespace real
+
+section dirichlet
+
 /-!
 ### Dirichlet's approximation theorem
 
 We show that for any real number `ξ` and positive natural `n`, there is a fraction `q`
 such that `q.denom ≤ n` and `|ξ - q| ≤ 1/((n+1)*q.denom)`.
 -/
-
-namespace real
-
-section dirichlet
 
 open finset int
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -32,8 +32,8 @@ The main results are
 * `real.exists_int_int_abs_mul_sub_le`, which is a version of Dirichlet's approximation
   theorem and states that for all real `ξ` and natural `0 < n`, there are integers
   `j` and `k` with `0 < k ≤ n` and `|k*ξ - j| ≤ 1/(n+1)`,
-* `real.exists_int_abs_mul_sub_round_le`, which is a variant of this replacing `j`
-  by `round(k*ξ)`,
+* `real.exists_nat_abs_mul_sub_round_le`, which is a variant of this replacing `j`
+  by `round(k*ξ)` and using a natural number `k`,
 * A further variant `real.exists_rat_abs_sub_le_and_denom_le` in terms of rationals `q`
   satisfying `|ξ - q| ≤ 1/((n+1)*q.denom)` and `q.denom ≤ n`,
 * `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`,
@@ -115,14 +115,16 @@ begin
 end
 
 /-- *Dirichlet's approximation theorem:*
-For any real number `ξ` and positive natural `n`, there is an integer `k`,
+For any real number `ξ` and positive natural `n`, there is a natural number `k`,
 with `0 < k ≤ n` such that `|k*ξ - round(k*ξ)| ≤ 1/(n+1)`.
 -/
-lemma exists_int_abs_mul_sub_round_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
-  ∃ k : ℤ, 0 < k ∧ k ≤ n ∧ |↑k * ξ - round (↑k * ξ)| ≤ 1 / (n + 1) :=
+lemma exists_nat_abs_mul_sub_round_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
+  ∃ k : ℕ, 0 < k ∧ k ≤ n ∧ |↑k * ξ - round (↑k * ξ)| ≤ 1 / (n + 1) :=
 begin
   obtain ⟨j, k, hk₀, hk₁, h⟩ := exists_int_int_abs_mul_sub_le ξ n_pos,
-  exact ⟨k, hk₀, hk₁, (round_le (↑k * ξ) j).trans h⟩,
+  have hk := to_nat_of_nonneg hk₀.le,
+  rw [← hk] at hk₀ hk₁ h,
+  exact ⟨k.to_nat, coe_nat_pos.mp hk₀, nat.cast_le.mp hk₁, (round_le (↑k.to_nat * ξ) j).trans h⟩,
 end
 
 /-- *Dirichlet's approximation theorem:*

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -31,12 +31,12 @@ This set is in natural bijection with `{q : ℚ | |ξ - q| < 1/q.denom^2}`
 The main results are
 * `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`,
   `{q : ℚ | |ξ - q| < 1/q.denom^2}` is infinite,
-* `dioph_approx.rat_approx_finite`, which states that `dioph_approx.rat_approx (a/b)`
+* `dioph_approx.rat_approx_finite`, which states that `{q : ℚ | |a/b - q| < 1/q.denom^2}`
   is finite for integers `a` and `b`,
-* `dioph_approx.rat_approx_infinite_iff_irrational'`, which combines the two previous
-  statements to give an iff statement in terms of `dioph_approx.rat_approx ξ`, and
-* `dioph_approx.rat_approx_infinite_iff_irrational`, which is a version
-  using `{q : ℚ | |ξ - q| < 1/q.denom^2}`.
+* `dioph_approx.rat_approx_infinite_iff_irrational`, which combines the two previous
+  statements to give an iff statement, and
+* `dioph_approx.rat_approx_infinite_iff_irrational'`, which is a version
+   in terms of `dioph_approx.rat_approx ξ`.
 
 ## Implementation notes
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -144,9 +144,6 @@ begin
        ← abs_mul, sub_mul, div_mul_cancel _ hk₀'.ne', mul_comm],
 end
 
-end real
-
-namespace dioph_approx
 
 section rat_approx
 
@@ -199,7 +196,6 @@ begin
   exact lt_irrefl _ (lt_of_le_of_lt (hq q' hmem) hbetter),
 end
 
-
 end rat_approx
 
-end dioph_approx
+end real

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -218,6 +218,34 @@ begin
   exact λ y _, (rat_approx_to_denom_finite_fibers ξ y),
 end
 
+/-- The map sending `(x, y)` to `x/y` gives a bijection between `rat_approx ξ` and
+the set `{q : ℚ | |ξ - q| < 1/q.denom^2}`. -/
+lemma rat_approx_equiv (ξ : ℝ) :
+  bij_on (λ xy : ℤ × ℤ, (xy.1 : ℚ) / xy.2) (rat_approx ξ) {q : ℚ | |ξ - q| < 1 / q.denom ^ 2} :=
+begin
+  have hcp : ∀ {a b : ℤ}, a.gcd b = 1 → a.nat_abs.coprime b.nat_abs :=
+    λ a b h, @int.gcd_eq_nat_abs a b ▸ h,
+  refine ⟨_, _, λ q hq, _⟩,
+  { simp only [maps_to, mem_set_of_eq, rat.cast_div, rat.cast_coe_int, prod.forall],
+    rintros x y ⟨h₁, h₂, h₃⟩,
+    rwa [(by norm_cast : ((x / y : ℚ).denom : ℝ) = ((x / y : ℚ).denom : ℤ)),
+         rat.denom_div_eq_of_coprime h₁ (hcp h₂)], },
+  { simp only [inj_on, prod.forall, prod.mk.inj_iff],
+    rintros x y ⟨hxy₁, hxy₂, hxy₃⟩ u v ⟨huv₁, huv₂, huv₃⟩ h,
+    have hx := rat.num_div_eq_of_coprime hxy₁ (hcp hxy₂),
+    have hy := rat.denom_div_eq_of_coprime hxy₁ (hcp hxy₂),
+    rw h at hx hy,
+    exact ⟨hx.symm.trans $ rat.num_div_eq_of_coprime huv₁ (hcp huv₂),
+           hy.symm.trans $ rat.denom_div_eq_of_coprime huv₁ (hcp huv₂)⟩, },
+  { simp only [mem_image, prod.exists],
+    refine ⟨q.num, q.denom,
+            ⟨by exact_mod_cast q.pos, by {rw [int.gcd_eq_nat_abs], exact q.cop}, _⟩,
+            by simp only [int.cast_coe_nat, rat.num_div_denom]⟩,
+    rwa [(by norm_cast : ((q.denom : ℤ) : ℝ) = q.denom),
+         (by norm_cast : (q.num : ℝ) / q.denom = (q.num / q.denom : ℚ)),
+         rat.num_div_denom q], },
+end
+
 /-- If `ξ` is an irrational real number, then there are infinitely many good
 rational approximations to `ξ`. -/
 lemma rat_approx_infinite {ξ : ℝ} (h : irrational ξ) : (rat_approx ξ).infinite :=
@@ -285,34 +313,6 @@ lemma rat_approx_infinite_iff_irrational' {ξ : ℝ} : (rat_approx ξ).infinite 
 /-!
 ### Equivalence between `rat_approx ξ` and approximating fractions
 -/
-
-/-- The map sending `(x, y)` to `x/y` gives a bijection between `rat_approx ξ` and
-the set `{q : ℚ | |ξ - q| < 1/q.denom^2}`. -/
-lemma rat_approx_equiv (ξ : ℝ) :
-  bij_on (λ xy : ℤ × ℤ, (xy.1 : ℚ) / xy.2) (rat_approx ξ) {q : ℚ | |ξ - q| < 1 / q.denom ^ 2} :=
-begin
-  have hcp : ∀ {a b : ℤ}, a.gcd b = 1 → a.nat_abs.coprime b.nat_abs :=
-    λ a b h, @int.gcd_eq_nat_abs a b ▸ h,
-  refine ⟨_, _, λ q hq, _⟩,
-  { simp only [maps_to, mem_set_of_eq, rat.cast_div, rat.cast_coe_int, prod.forall],
-    rintros x y ⟨h₁, h₂, h₃⟩,
-    rwa [(by norm_cast : ((x / y : ℚ).denom : ℝ) = ((x / y : ℚ).denom : ℤ)),
-         rat.denom_div_eq_of_coprime h₁ (hcp h₂)], },
-  { simp only [inj_on, prod.forall, prod.mk.inj_iff],
-    rintros x y ⟨hxy₁, hxy₂, hxy₃⟩ u v ⟨huv₁, huv₂, huv₃⟩ h,
-    have hx := rat.num_div_eq_of_coprime hxy₁ (hcp hxy₂),
-    have hy := rat.denom_div_eq_of_coprime hxy₁ (hcp hxy₂),
-    rw h at hx hy,
-    exact ⟨hx.symm.trans $ rat.num_div_eq_of_coprime huv₁ (hcp huv₂),
-           hy.symm.trans $ rat.denom_div_eq_of_coprime huv₁ (hcp huv₂)⟩, },
-  { simp only [mem_image, prod.exists],
-    refine ⟨q.num, q.denom,
-            ⟨by exact_mod_cast q.pos, by {rw [int.gcd_eq_nat_abs], exact q.cop}, _⟩,
-            by simp only [int.cast_coe_nat, rat.num_div_denom]⟩,
-    rwa [(by norm_cast : ((q.denom : ℤ) : ℝ) = q.denom),
-         (by norm_cast : (q.num : ℝ) / q.denom = (q.num / q.denom : ℚ)),
-         rat.num_div_denom q], },
-end
 
 /-- The set of good rational approximations to a real number `ξ` is infinite if and only if
 `ξ` is irrational. -/

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -1,0 +1,343 @@
+/-
+Copyright (c) 2022 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Geißer, Michael Stoll
+-/
+import tactic
+import data.real.irrational
+import combinatorics.pigeonhole
+
+/-!
+# Diophantine Approximation
+
+This file gives proofs of various versions of **Dirichlet's approximation theorem**,
+the statement that when `ξ` is an irrational real number, then there are infinitely
+many rationals `x/y` (in lowest terms) such that `|ξ - x/y| < 1/y^2`.
+
+We also show the converse, i.e., that for rational `ξ` there are only finitely many
+such rational approximations.
+
+The proof (of the interesting direction) is based on the pigeonhole principle.
+
+## Main definitions
+
+We define the set `dioph_approx.rat_approx ξ` for a real number `ξ` to be the set
+of pairs `(x, y)` of coprime integers with `y` positive such that `|ξ - x/y| < 1/y^2`.
+
+## Main statements
+
+The main results are
+* `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`,
+  `dioph_approx.rat_approx ξ` is infinite,
+* `dioph_approx.rat_approx_finite`, which states that `dioph_approx.rat_approx (a/b)`
+  is finite for integers `a` and `b`,
+* `dioph_approx.rat_approx_infinite_iff_irrational'`, which combines the two previous
+  statements to give an iff statement, and
+* `dioph_approx.rat_approx_infinite_iff_irrational`, which is an alternative version
+  using `{q : ℚ | |ξ - q| < 1/q.denom^2}` instead of `dioph_approx.rat_approx ξ`.
+
+## Implementation notes
+
+We use the namespace `dioph_approx`.
+
+## References
+
+<https://en.wikipedia.org/wiki/Dirichlet%27s_approximation_theorem>
+
+## Tags
+
+Diophantine approximation, Dirichlet's approximation theorem
+-/
+
+namespace dioph_approx
+
+/-!
+### Preliminaries
+-/
+
+section pigeonhole
+
+open finset int
+
+/-- Use the pigeonhole principle to show that two distinct multiples `m*ξ` with `0 ≤ m ≤ n`
+have fractional parts that differ by less than `1/n`. -/
+lemma ex_approx_aux (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
+  ∃ (j k : ℤ), 0 ≤ k ∧ j ≤ n ∧ k < j ∧ |fract (ξ * j) - fract (ξ * k)| < 1 / n :=
+begin
+  have n_pos_ℝ : 0 < (n : ℝ) := nat.cast_pos.mpr n_pos,
+  let f : ℤ → ℤ := λ m, ⌊fract (ξ * m) * n⌋,
+  let D := Icc 0 (n : ℤ),
+  have too_many : (Ico 0 (n : ℤ)).card < D.card,
+  { rw [card_Icc, card_Ico],
+    exact lt_add_one n, },
+  have well_defined : ∀ m : ℤ, m ∈ D → f m ∈ Ico 0 (n : ℤ) :=
+  λ x _, mem_Ico.mpr
+         ⟨floor_nonneg.mpr (mul_nonneg (fract_nonneg (ξ * x)) (nat.cast_nonneg n)),
+          floor_lt.mpr (mul_lt_of_lt_one_left n_pos_ℝ (fract_lt_one (ξ * x)))⟩,
+  -- applpy the pigeonhole principle to `f`
+  obtain ⟨x, x_mem, y, y_mem, x_neq_y, f_x_eq_f_y⟩ :=
+    exists_ne_map_eq_of_card_lt_of_maps_to too_many well_defined,
+  -- show the claim assuming `x < y`; then use symmetry
+  have H : ∀ (x' y' : ℤ) (hx : x' ∈ D) (hy : y' ∈ D) (h : x' < y') (hf : f y' = f x'),
+              ∃ (j k : ℤ), 0 ≤ k ∧ j ≤ n ∧ k < j ∧ |fract (ξ * j) - fract (ξ * k)| < 1 / n,
+  { refine λ x' y' hx hy h hf, ⟨y', x', (mem_Icc.mp hx).1, (mem_Icc.mp hy).2, h, _⟩,
+    have q := abs_sub_lt_one_of_floor_eq_floor hf,
+    rw [← sub_mul, abs_mul, nat.abs_cast] at q,
+    exact (lt_div_iff n_pos_ℝ).mpr q, },
+  by_cases h : x < y,
+  { exact H x y x_mem y_mem h f_x_eq_f_y.symm, },
+  { exact H y x y_mem x_mem (lt_iff_le_and_ne.mpr ⟨le_of_not_lt h, x_neq_y.symm⟩) f_x_eq_f_y, },
+end
+
+/-- For any real number `ξ` and positive natural `n`, there is a fraction `x/y`
+such that `0 < y ≤ n` and `|ξ - x/y| < 1/(n*y)`. -/
+lemma ex_approx' (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
+  ∃ x y : ℤ, |ξ - x / y| < 1 / (n * y) ∧ 0 < y ∧ y ≤ n :=
+begin
+  obtain ⟨j, k, hk, hj, hjk, bound⟩ := ex_approx_aux ξ n_pos,
+  refine ⟨⌊ξ * j⌋ - ⌊ξ * k⌋, j - k, _, sub_pos_of_lt hjk,
+          sub_left_le_of_le_add (le_add_of_nonneg_of_le hk hj)⟩,
+  push_cast,
+  have y_pos : 0 < (j - k : ℝ) := sub_pos.mpr (int.cast_lt.mpr hjk),
+  have yi_pos := one_div_pos.mpr y_pos,
+  replace bound := (mul_lt_mul_right yi_pos).mpr bound,
+  simp only [fract] at bound,
+  rwa [one_div_mul_one_div, ← abs_eq_self.mpr $ le_of_lt yi_pos, ← abs_mul, ← div_eq_mul_one_div,
+       ← sub_add, sub_right_comm, ← mul_sub, sub_add, sub_div, mul_div_cancel _  $ ne_of_gt y_pos]
+       at bound,
+end
+
+end pigeonhole
+
+/-- If `x` and `y` satisfying `|ξ - x/y| < 1/(n*y)` have a common
+divisor `d`, then we also have `|ξ - (x/d)/(y/d)| < 1/(n*y/d)`. -/
+lemma reduce_approx {ξ : ℝ} {x y x' y' : ℤ} {d n : ℕ} (hd : 0 < d) (hx : x = d * x')
+  (hy : y = d * y') (y_pos : 0 < y) (hn : y ≤ n) (h : |ξ - x / y| < 1 / (n * y)) :
+  |ξ - x' / y'| < 1 / (n * y') ∧ 0 < y' ∧ y' ≤ n :=
+begin
+  have d_pos_ℝ : (0 : ℝ) < d := nat.cast_pos.mpr hd,
+  rw [hx, hy] at h,
+  push_cast at h,
+  rw [mul_div_mul_left _ _ d_pos_ℝ.ne.symm] at h,
+  have hy' : 0 < y' := pos_of_mul_pos_right (lt_of_lt_of_eq y_pos hy) (nat.cast_nonneg d),
+  refine ⟨lt_of_lt_of_le h _, hy', le_trans _ hn⟩,
+  { rw [mul_left_comm, ← div_div],
+    exact div_le_div_of_le (mul_nonneg (nat.cast_nonneg n) $ le_of_lt $ int.cast_pos.mpr hy')
+                           ((div_le_one d_pos_ℝ).mpr $ nat.one_le_cast.mpr hd), },
+  { exact hy.symm ▸ le_mul_of_one_le_left (le_of_lt hy') (nat.one_le_cast.mpr hd), }
+end
+
+/-- For any real number `ξ` and positive natural `n`, there is a fraction `x/y`
+in lowest terms such that `0 < y ≤ n` and `|ξ - x/y| < 1/(n*y)`.-/
+lemma ex_approx (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
+  ∃ x y : ℤ, x.gcd y = 1 ∧ |ξ - x / y| < 1 / (n * y) ∧ 0 < y ∧ y ≤ n :=
+begin
+  obtain ⟨x, y, bound, y_pos, hy⟩ := ex_approx' ξ n_pos,
+  obtain ⟨x₁, hx₁⟩ := int.gcd_dvd_left x y,
+  obtain ⟨y₁, hy₁⟩ := int.gcd_dvd_right x y,
+  have hd : 0 < x.gcd y := int.gcd_pos_of_non_zero_right _ (ne_of_gt y_pos),
+  refine ⟨x₁, y₁, mul_left_cancel₀ (ne_of_gt hd) _, reduce_approx hd hx₁ hy₁ y_pos hy bound⟩,
+  rw [← int.nat_abs_of_nat (x.gcd y), ← int.gcd_mul_left, ← hx₁, ← hy₁,
+      int.nat_abs_of_nat, mul_one],
+end
+
+section rat_approx
+
+/-!
+### Infinitely many good approximations to irrational numbers
+
+We show that an irrational real number `ξ` has infinitely many "good rational approximations",
+i.e., fractions `x/y` in lowest terms such that `|ξ - x/y| < 1/y^2`.
+-/
+
+open set
+
+/-- We define the set `rat_approx ξ` of good rational approximations to `ξ`
+as a set of pairs `(x, y)` of integers (corresponding to the fraction `x/y`). -/
+def rat_approx (ξ : ℝ) : set (ℤ × ℤ) :=
+  {xy : ℤ × ℤ | 0 < xy.2 ∧ int.gcd xy.1 xy.2 = 1 ∧ |ξ - xy.1 / xy.2| < 1 / xy.2 ^ 2}
+
+/-- There is always at least one good rational approximation. -/
+lemma rat_approx_nonempty (ξ : ℝ) : (rat_approx ξ).nonempty :=
+⟨(⌊ξ⌋, 1), by simp [rat_approx, abs_of_nonneg (int.fract_nonneg ξ), int.fract_lt_one]⟩
+
+/-- Given any rational approximation `x/y` to the irrational real number `ξ`, there is
+a good rational approximation `X/Y` such that `|ξ - X/Y| < |ξ - x/y|`. -/
+lemma ex_better_approx {ξ : ℝ} (hξ : irrational ξ) (x y : ℤ) :
+  ∃ X Y : ℤ, (X, Y) ∈ rat_approx ξ ∧ |ξ - X / Y| < |ξ - x / y| :=
+begin
+  have h := abs_pos.mpr (sub_ne_zero.mpr $ (irrational_iff_ne_rational ξ).mp hξ x y),
+  obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - x / y|),
+  have m_pos : 0 < (m : ℝ) := (one_div_pos.mpr h).trans hm,
+  obtain ⟨X, Y, hcp, hbd, Y_pos, Y_le_m⟩ := ex_approx ξ (nat.cast_pos.mp m_pos),
+  have Y_pos_ℝ : (0 : ℝ) < Y := int.cast_pos.mpr Y_pos,
+  refine ⟨X, Y, ⟨Y_pos, hcp,
+                 lt_of_lt_of_le hbd (one_div_le_one_div_of_le (sq_pos_of_pos Y_pos_ℝ) _)⟩,
+                 (lt_of_lt_of_le hbd _).trans ((one_div_lt h m_pos).mp hm)⟩,
+  { rw [pow_two, mul_le_mul_right Y_pos_ℝ],
+    exact_mod_cast Y_le_m, },
+  { rw [mul_comm, ← div_div],
+    refine div_le_div_of_le m_pos.le ((div_le_one Y_pos_ℝ).mpr _),
+    exact_mod_cast (int.cast_le.mpr Y_pos : (_ : ℝ) ≤ Y), }
+end
+
+/-- If `x/y` is a good approximation to `ξ`, then `x` is bounded in terms of `y` (and `ξ`). -/
+lemma rat_approx_num_bound {ξ : ℝ} {x y : ℤ} (h : (x, y) ∈ rat_approx ξ) :
+  ⌈ξ * y⌉ - 1 ≤ x ∧ x ≤ ⌊ξ * y⌋ + 1 :=
+begin
+  obtain ⟨hpos, _, hbd⟩ := h,
+  have hpos' : (0 : ℝ) < y := int.cast_pos.mpr hpos,
+  rw [← mul_lt_mul_right hpos'] at hbd,
+  nth_rewrite 1 ← abs_of_pos hpos' at hbd,
+  rw [← abs_mul, sub_mul, sq, ← div_div, div_mul_cancel _ hpos'.ne.symm,
+      div_mul_cancel _ hpos'.ne.symm] at hbd,
+  have H : (1 : ℝ) / y ≤ 1,
+  { refine (one_div_le zero_lt_one hpos').mp _,
+    simp only [div_self one_ne_zero],
+    exact_mod_cast hpos, },
+  obtain ⟨hbd₁, hbd₂⟩ := abs_sub_lt_iff.mp (lt_of_lt_of_le hbd H),
+  rw [sub_lt_iff_lt_add, add_comm] at hbd₁ hbd₂,
+  rw [← sub_lt_iff_lt_add] at hbd₂,
+  norm_cast at hbd₁ hbd₂,
+  exact ⟨sub_le_iff_le_add.mpr (int.ceil_le.mpr hbd₁.le),
+         sub_le_iff_le_add.mp (int.le_floor.mpr hbd₂.le)⟩,
+end
+
+/-- There are only finitely many good approximations to `ξ` with given denominator. -/
+lemma rat_approx_to_denom_finite_fibers (ξ : ℝ) (y : ℤ) :
+  (prod.snd ⁻¹' {y} ∩ rat_approx ξ).finite :=
+begin
+  cases le_or_gt y 0 with hy hy,
+  { have : (prod.snd ⁻¹' {y} ∩ rat_approx ξ) = ∅,
+    { ext xy,
+      simp only [mem_inter_iff, mem_preimage, mem_singleton_iff, mem_empty_iff_false,
+                 iff_false, not_and],
+      rintros h₁ ⟨ypos, _⟩,
+      exact lt_irrefl (0 : ℤ) (lt_of_lt_of_le (h₁ ▸ ypos : 0 < y) hy), },
+    exact this.symm ▸ finite_empty, },
+  { refine finite.subset (finite.prod (finite_Icc (⌈ξ * y⌉ - 1) (⌊ξ * y⌋ + 1))
+             (finite_singleton y)) (λ xy hxy, _),
+    simp only [prod_singleton, mem_image, mem_Icc],
+    simp only [mem_inter_iff, mem_preimage, mem_singleton_iff] at hxy,
+    exact ⟨xy.1, rat_approx_num_bound $ hxy.1 ▸ hxy.2, hxy.1 ▸ prod.mk.eta⟩, }
+end
+
+/-- The set of good rational approximations is infinite if and only if the set of
+denominators of good rational approximations is infinite. -/
+lemma rat_approx_infinite_iff_to_denom_infinite (ξ : ℝ) :
+  (rat_approx ξ).infinite ↔ (prod.snd '' rat_approx ξ).infinite :=
+begin
+  have H : rat_approx ξ ⊆ ⋃ y ∈ (prod.snd '' rat_approx ξ), prod.snd ⁻¹' {y} ∩ rat_approx ξ,
+  { intros xy hxy,
+    simp_rw [mem_Union, mem_inter_iff, mem_preimage],
+    exact ⟨xy.2, mem_image_of_mem _ hxy, mem_singleton _, hxy⟩, },
+  refine ⟨mt (λ h, finite.subset (finite.bUnion h _) H), infinite_of_infinite_image prod.snd⟩,
+  exact λ y _, (rat_approx_to_denom_finite_fibers ξ y),
+end
+
+/-- If `ξ` is an irrational real number, then there are infinitely many good
+rational approximations to `ξ`. -/
+lemma rat_approx_infinite {ξ : ℝ} (h : irrational ξ) : (rat_approx ξ).infinite :=
+begin
+  refine or.resolve_left (set.finite_or_infinite (rat_approx ξ)) (λ hfin, _),
+  obtain ⟨xy, _, hxy⟩ :=
+    exists_min_image (rat_approx ξ) (λ xy, |ξ - xy.1 / xy.2|) hfin (rat_approx_nonempty ξ),
+  obtain ⟨x', y', hmem, hbetter⟩ := ex_better_approx h xy.1 xy.2,
+  exact lt_irrefl _ (lt_of_le_of_lt (hxy (x', y') hmem) hbetter),
+end
+
+/-!
+### Finitely many good approximations to rational numbers
+
+We now show that a rational number `ξ` has only finitely many good rational
+approximations.
+-/
+
+/-- If `x/y` is a good approximation to `a/b`, then `y ≤ b`. -/
+lemma denom_bounded_of_rat_approx_rational (a b x y : ℤ) (hb : b ≠ 0)
+  (hxy : (x, y) ∈ rat_approx (a / b)) :
+  0 < y ∧ y ≤ |b| :=
+begin
+  obtain ⟨h₁, h₂, h₃⟩ := hxy,
+  refine ⟨h₁, _⟩,
+  have hy₀ : (y : ℝ) ≠ 0 := int.cast_ne_zero.mpr h₁.ne.symm,
+  have hy : 0 < (y ^ 2 : ℝ) := (sq_pos_iff _).mpr hy₀,
+  have hb₀ : (b : ℝ) ≠ 0 := int.cast_ne_zero.mpr hb,
+  rw [← mul_lt_mul_right (abs_pos.mpr hy.ne.symm), ← mul_lt_mul_right (abs_pos.mpr hb₀),
+      ← abs_mul, ← abs_mul] at h₃,
+  field_simp at h₃, -- why doesn't it cancel `↑b * ↑y`?
+  rw [sq, ← mul_assoc, ← div_div, mul_div_cancel _ hb₀, mul_div_cancel _ hy₀, abs_mul,
+      abs_of_pos (int.cast_pos.mpr h₁ : 0 < (y : ℝ)), mul_comm ↑b] at h₃,
+  norm_cast at h₃,
+  cases eq_or_ne (a * y - x * b) 0 with H H,
+  { exact int.le_of_dvd (abs_pos.mpr hb) ((dvd_abs y b).mpr (int.dvd_of_dvd_mul_right_of_gcd_one
+          (dvd_of_mul_left_eq a (eq_of_sub_eq_zero H)) (int.gcd_comm x y ▸ h₂))), },
+  { exact ((le_mul_iff_one_le_left h₁).mpr (abs_pos.mpr H)).trans h₃.le, }
+end
+
+/-- If `ξ = a/b` is rational, then it has only finitely many good rational approximations. -/
+lemma rat_approx_finite (a b : ℤ) : (rat_approx (a / b)).finite :=
+begin
+  -- first prove it assuming `b ≠ 0`, then deal with `b = 0` by reducing to `0/1`.
+  have H : ∀ a b : ℤ, b ≠ 0 → (rat_approx (a / b)).finite,
+  { refine λ a b hb, not_infinite.mp $
+             mt (rat_approx_infinite_iff_to_denom_infinite (a / b)).mp (not_infinite.mpr _),
+    have h : ∀ y : ℤ, y ∈ prod.snd '' rat_approx (a / b) → 0 < y ∧ y ≤ |b|,
+    { intros y hy,
+      obtain ⟨xy, hxy⟩ := (mem_image prod.snd (rat_approx (a / b)) y).mp hy,
+      exact hxy.2 ▸ denom_bounded_of_rat_approx_rational a b xy.1 xy.2 hb hxy.1, },
+    refine finite.subset (finite_Ioc _ _) h, },
+  refine or.elim (eq_or_ne b 0) (λ hb, _) (H a b),
+  convert H 0 1 one_ne_zero using 2,
+  rw [hb, algebra_map.coe_zero, zero_div, div_zero],
+end
+
+/-- The set of good approximations to a real number `ξ` is infinite if and only if
+`ξ` is irrational. -/
+lemma rat_approx_infinite_iff_irrational' {ξ : ℝ} : (rat_approx ξ).infinite ↔ irrational ξ :=
+⟨λ h, (irrational_iff_ne_rational ξ).mpr
+        (λ a b H, not_infinite.mpr (rat_approx_finite a b) (H ▸ h)),
+ rat_approx_infinite⟩
+
+/-!
+### Equivalence between `rat_approx ξ` and approximating fractions
+-/
+
+/-- The map sending `(x, y)` to `x/y` gives a bijection between `rat_approx ξ` and
+the set `{q : ℚ | |ξ - q| < 1/q.denom^2}`. -/
+lemma rat_approx_equiv (ξ : ℝ) :
+  bij_on (λ xy : ℤ × ℤ, (xy.1 : ℚ) / xy.2) (rat_approx ξ) {q : ℚ | |ξ - q| < 1 / q.denom ^ 2} :=
+begin
+  have hcp : ∀ {a b : ℤ}, a.gcd b = 1 → a.nat_abs.coprime b.nat_abs :=
+    λ a b h, @int.gcd_eq_nat_abs a b ▸ h,
+  refine ⟨_, _, λ q hq, _⟩,
+  { simp only [maps_to, mem_set_of_eq, rat.cast_div, rat.cast_coe_int, prod.forall],
+    rintros x y ⟨h₁, h₂, h₃⟩,
+    rwa [(by norm_cast : ((x / y : ℚ).denom : ℝ) = ((x / y : ℚ).denom : ℤ)),
+         rat.denom_div_eq_of_coprime h₁ (hcp h₂)], },
+  { simp only [inj_on, prod.forall, prod.mk.inj_iff],
+    rintros x y ⟨hxy₁, hxy₂, hxy₃⟩ u v ⟨huv₁, huv₂, huv₃⟩ h,
+    have hx := rat.num_div_eq_of_coprime hxy₁ (hcp hxy₂),
+    have hy := rat.denom_div_eq_of_coprime hxy₁ (hcp hxy₂),
+    rw h at hx hy,
+    exact ⟨hx.symm.trans $ rat.num_div_eq_of_coprime huv₁ (hcp huv₂),
+           hy.symm.trans $ rat.denom_div_eq_of_coprime huv₁ (hcp huv₂)⟩, },
+  { simp only [mem_image, prod.exists],
+    refine ⟨q.num, q.denom,
+            ⟨by exact_mod_cast q.pos, by {rw [int.gcd_eq_nat_abs], exact q.cop}, _⟩,
+            by simp only [int.cast_coe_nat, rat.num_div_denom]⟩,
+    rwa [(by norm_cast : ((q.denom : ℤ) : ℝ) = q.denom),
+         (by norm_cast : (q.num : ℝ) / q.denom = (q.num / q.denom : ℚ)),
+         rat.num_div_denom q], },
+end
+
+/-- The set of good rational approximations to a real number `ξ` is infinite if and only if
+`ξ` is irrational. -/
+lemma rat_approx_infinite_iff_irrational {ξ : ℝ} :
+  {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite ↔ irrational ξ :=
+infinite_coe_iff.symm.trans $ (equiv.infinite_iff $ bij_on.equiv _ $
+  rat_approx_equiv ξ).symm.trans $ infinite_coe_iff.trans rat_approx_infinite_iff_irrational'
+
+end rat_approx
+
+end dioph_approx

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -165,10 +165,6 @@ begin
     exact_mod_cast (q'.pos : 1 ≤ q'.denom), }
 end
 
-/-- There is always at least one good rational approximation. -/
-lemma rat_approx_nonempty (ξ : ℝ) : {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.nonempty :=
-⟨⌊ξ⌋, by simp [abs_of_nonneg, int.fract_lt_one]⟩
-
 /-- If `ξ` is an irrational real number, then there are infinitely many good
 rational approximations to `ξ`. -/
 lemma rat_approx_infinite {ξ : ℝ} (hξ : irrational ξ) :
@@ -176,7 +172,8 @@ lemma rat_approx_infinite {ξ : ℝ} (hξ : irrational ξ) :
 begin
   refine or.resolve_left (set.finite_or_infinite _) (λ h, _),
   obtain ⟨q, _, hq⟩ :=
-    exists_min_image {q : ℚ | |ξ - q| < 1 / q.denom ^ 2} (λ q, |ξ - q|) h (rat_approx_nonempty ξ),
+    exists_min_image {q : ℚ | |ξ - q| < 1 / q.denom ^ 2} (λ q, |ξ - q|) h
+                     ⟨⌊ξ⌋, by simp [abs_of_nonneg, int.fract_lt_one]⟩,
   obtain ⟨q', hmem, hbetter⟩ := ex_better_approx hξ q,
   exact lt_irrefl _ (lt_of_le_of_lt (hq q' hmem) hbetter),
 end

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -254,6 +254,9 @@ begin
     refine lt_of_lt_of_le hm ((le_mul_iff_one_le_right m_pos).mpr _),
     exact_mod_cast (q'.pos : 1 ≤ q'.denom), }
 end
+/-- There is always at least one good rational approximation. -/
+lemma rat_approx_nonempty (ξ : ℝ) : {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.nonempty :=
+⟨⌊ξ⌋, by simp [abs_of_nonneg, int.fract_lt_one]⟩
 
 /-- If `ξ` is an irrational real number, then there are infinitely many good
 rational approximations to `ξ`. -/

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -199,11 +199,6 @@ begin
   exact lt_irrefl _ (lt_of_le_of_lt (hq q' hmem) hbetter),
 end
 
-/-- If `ξ` is an irrational real number, then there are infinitely many good
-rational approximations to `ξ`. -/
-lemma rat_approx_infinite' {ξ : ℝ} (hξ : irrational ξ) : (rat_approx ξ).infinite :=
-rat_approx_infinite_iff.mpr (rat_approx_infinite hξ)
-
 /-!
 ### Finitely many good approximations to rational numbers
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Geißer, Michael Stoll
 -/
-import tactic
+import tactic.basic
 import data.real.irrational
 import combinatorics.pigeonhole
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -29,10 +29,12 @@ This set is in natural bijection with `{q : ℚ | |ξ - q| < 1/q.denom^2}`
 ## Main statements
 
 The main results are
-* `dioph_approx.dirichlet_approx`, which is a version of Dirichlet's approximation
+* `real.exists_int_int_abs_mul_sub_le`, which is a version of Dirichlet's approximation
   theorem and states that for all real `ξ` and natural `0 < n`, there are integers
   `j` and `k` with `0 < k ≤ n` and `|ξ*k - j| ≤ 1/(n+1)`,
-* A variant `dioph_approx.dirichlet_approx'` of this in terms of rationals `q`
+* `real.exists_int_abs_mul_sub_round_le`, which is a variant of this in terms of `k*ξ`
+   and replacing `j` by `round(k*ξ)`,
+* A further variant `exists_rat_abs_sub_le_and_denom_le` in terms of rationals `q`
   satisfying `|ξ - q| ≤ 1/((n+1)*q.denom)` and `q.denom ≤ n`,
 * `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`,
   `{q : ℚ | |ξ - q| < 1/q.denom^2}` is infinite,
@@ -45,7 +47,8 @@ The main results are
 
 ## Implementation notes
 
-We use the namespace `dioph_approx`.
+We use the namespace `real` for the various statements of Diriechlet's approximation
+theorem and the namespace `dioph_approx` for the remaining definitions and results.
 
 ## References
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -77,8 +77,8 @@ begin
       exact_mod_cast hf₀.symm.trans (h.symm ▸ hf : f 0 = n), },
     refine ⟨⌊ξ * m⌋ + 1, m, hm₀, (mem_Icc.mp hm).2, _⟩,
     rw [cast_add, ← sub_sub, sub_mul, cast_one, one_mul, abs_le],
-    refine ⟨le_sub_iff_add_le.mpr _, sub_le_iff_le_add.mpr $ le_of_lt $
-             (hfu m).trans $ lt_one_add _⟩,
+    refine ⟨le_sub_iff_add_le.mpr _,
+            sub_le_iff_le_add.mpr $ le_of_lt $ (hfu m).trans $ lt_one_add _⟩,
     simpa only [neg_add_cancel_comm_assoc] using hf', },
   { simp_rw [not_exists] at H,
     have hD : (Ico (0 : ℤ) n).card < D.card,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -171,9 +171,8 @@ lemma rat_approx_infinite {ξ : ℝ} (hξ : irrational ξ) :
   {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite :=
 begin
   refine or.resolve_left (set.finite_or_infinite _) (λ h, _),
-  obtain ⟨q, _, hq⟩ :=
-    exists_min_image {q : ℚ | |ξ - q| < 1 / q.denom ^ 2} (λ q, |ξ - q|) h
-                     ⟨⌊ξ⌋, by simp [abs_of_nonneg, int.fract_lt_one]⟩,
+  obtain ⟨q, _, hq⟩ := exists_min_image {q : ℚ | |ξ - q| < 1 / q.denom ^ 2} (λ q, |ξ - q|) h
+                                        ⟨⌊ξ⌋, by simp [abs_of_nonneg, int.fract_lt_one]⟩,
   obtain ⟨q', hmem, hbetter⟩ := ex_better_approx hξ q,
   exact lt_irrefl _ (lt_of_le_of_lt (hq q' hmem) hbetter),
 end

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -95,8 +95,8 @@ begin
 end
 
 /-- *Dirichlet's approximation theorem:*
-For any real number `ξ` and positive natural `n`, there is a fraction `x/y`
-such that `0 < y ≤ n` and `|ξ - x/y| < 1/(n*y)`. -/
+For any real number `ξ` and positive natural `n`, there is a fraction `q`
+such that `q.denom ≤ n` and `|ξ - q| < 1/(n*q.denom)`. -/
 lemma ex_approx' (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
   ∃ x y : ℤ, |ξ - x / y| < 1 / (n * y) ∧ 0 < y ∧ y ≤ n :=
 begin

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -336,17 +336,6 @@ lemma rat_approx_infinite_iff_irrational' {ξ : ℝ} : (rat_approx ξ).infinite 
 infinite_coe_iff.symm.trans $ iff.trans (iff.trans (equiv.infinite_iff $ bij_on.equiv _ $
   rat_approx_equiv _) infinite_coe_iff) rat_approx_infinite_iff_irrational
 
-/-!
-### Equivalence between `rat_approx ξ` and approximating fractions
--/
-
-/-- The set of good rational approximations to a real number `ξ` is infinite if and only if
-`ξ` is irrational. -/
-lemma rat_approx_infinite_iff_irrational {ξ : ℝ} :
-  {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite ↔ irrational ξ :=
-infinite_coe_iff.symm.trans $ (equiv.infinite_iff $ bij_on.equiv _ $
-  rat_approx_equiv ξ).symm.trans $ infinite_coe_iff.trans rat_approx_infinite_iff_irrational'
-
 end rat_approx
 
 end dioph_approx

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -333,9 +333,8 @@ lemma rat_approx_infinite_iff_irrational {ξ : ℝ} :
 /-- The set of good rational approximations to a real number `ξ` is infinite if and only if
 `ξ` is irrational. -/
 lemma rat_approx_infinite_iff_irrational' {ξ : ℝ} : (rat_approx ξ).infinite ↔ irrational ξ :=
-⟨λ h, (irrational_iff_ne_rational ξ).mpr
-        (λ a b H, not_infinite.mpr (rat_approx_finite a b) (H ▸ h)),
- rat_approx_infinite⟩
+infinite_coe_iff.symm.trans $ iff.trans (iff.trans (equiv.infinite_iff $ bij_on.equiv _ $
+  rat_approx_equiv _) infinite_coe_iff) rat_approx_infinite_iff_irrational
 
 /-!
 ### Equivalence between `rat_approx ξ` and approximating fractions

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -30,13 +30,13 @@ This set is in natural bijection with `{q : ℚ | |ξ - q| < 1/q.denom^2}`
 
 The main results are
 * `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`,
-  `dioph_approx.rat_approx ξ` is infinite,
+  `{q : ℚ | |ξ - q| < 1/q.denom^2}` is infinite,
 * `dioph_approx.rat_approx_finite`, which states that `dioph_approx.rat_approx (a/b)`
   is finite for integers `a` and `b`,
 * `dioph_approx.rat_approx_infinite_iff_irrational'`, which combines the two previous
-  statements to give an iff statement, and
-* `dioph_approx.rat_approx_infinite_iff_irrational`, which is an alternative version
-  using `{q : ℚ | |ξ - q| < 1/q.denom^2}` instead of `dioph_approx.rat_approx ξ`.
+  statements to give an iff statement in terms of `dioph_approx.rat_approx ξ`, and
+* `dioph_approx.rat_approx_infinite_iff_irrational`, which is a version
+  using `{q : ℚ | |ξ - q| < 1/q.denom^2}`.
 
 ## Implementation notes
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -317,6 +317,11 @@ begin
   rw [hb, algebra_map.coe_zero, zero_div, div_zero],
 end
 
+/-- If `ξ = a/b` is rational, then it has only finitely many good rational approximations. -/
+lemma rat_approx_finite (a b : ℤ) : {q : ℚ | |(a / b : ℝ) - q| < 1 / q.denom ^ 2}.finite :=
+set.finite_coe_iff.mp $ (equiv.finite_iff $ bij_on.equiv _ $ rat_approx_equiv (a / b)).mp $
+  set.finite_coe_iff.mpr (rat_approx_finite' a b)
+
 /-- The set of good approximations to a real number `ξ` is infinite if and only if
 `ξ` is irrational. -/
 lemma rat_approx_infinite_iff_irrational' {ξ : ℝ} : (rat_approx ξ).infinite ↔ irrational ξ :=

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -77,7 +77,7 @@ begin
   have hwd : ∀ m : ℤ, m ∈ Icc (0 : ℤ) n → f m ∈ Ico (0 : ℤ) n :=
     λ x hx, mem_Ico.mpr ⟨floor_nonneg.mpr (mul_nonneg (fract_nonneg (ξ * x)) hn.le),
             floor_lt.mpr (by exact_mod_cast (mul_lt_of_lt_one_left hn $ fract_lt_one (ξ * x)))⟩,
-  have : ∃ (x : ℤ) (H : x ∈ Icc (0 : ℤ) n) (y : ℤ) (H : y ∈ Icc (0 : ℤ) n), x < y ∧ f x = f y,
+  have : ∃ (x : ℤ) (hx : x ∈ Icc (0 : ℤ) n) (y : ℤ) (hy : y ∈ Icc (0 : ℤ) n), x < y ∧ f x = f y,
   { obtain ⟨x, hx, y, hy, x_ne_y, hxy⟩ := exists_ne_map_eq_of_card_lt_of_maps_to hD hwd,
     rcases lt_trichotomy x y with h | h | h,
     exacts [⟨x, hx, y, hy, h, hxy⟩, false.elim (x_ne_y h), ⟨y, hy, x, hx, h, hxy.symm⟩], },
@@ -205,6 +205,12 @@ begin
          (by norm_cast : (q.num : ℝ) / q.denom = (q.num / q.denom : ℚ)),
          rat.num_div_denom q], },
 end
+
+/-- `rat_approx ξ` is infinite if and only if `{q : ℚ | |ξ - q| < 1/q.denom^2}` is infinite. -/
+lemma rat_approx_infinite_iff (ξ : ℝ) :
+  (rat_approx ξ).infinite ↔ {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite :=
+infinite_coe_iff.symm.trans $ (equiv.infinite_iff $ bij_on.equiv _ $ rat_approx_equiv ξ).trans
+  infinite_coe_iff
 
 /-!
 ### Infinitely many good approximations to irrational numbers

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -226,7 +226,7 @@ lemma ex_better_approx {ξ : ℝ} (hξ : irrational ξ) (q : ℚ) :
 begin
   have h : 0 < |ξ - q|,
   { refine abs_pos.mpr (sub_ne_zero.mpr _),
-    simp only [irrational, set.mem_range, not_exists, ← ne.def] at hξ,
+    simp only [irrational, mem_range, not_exists, ← ne.def] at hξ,
     exact (hξ q).symm, },
   obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - q|),
   have m_pos : 0 < (m : ℝ) := (one_div_pos.mpr h).trans hm,
@@ -305,8 +305,7 @@ end
 
 /-- If `ξ = a/b` is rational, then it has only finitely many good rational approximations. -/
 lemma rat_approx_finite (a b : ℤ) : {q : ℚ | |(a / b : ℝ) - q| < 1 / q.denom ^ 2}.finite :=
-set.not_infinite.mp $ (mt rat_approx_infinite_iff.mpr) $ set.not_infinite.mpr $
-  rat_approx_finite' a b
+not_infinite.mp $ (mt rat_approx_infinite_iff.mpr) $ not_infinite.mpr $ rat_approx_finite' a b
 
 /-- The set of good rational approximations to a real number `ξ` is infinite if and only if
 `ξ` is irrational. -/

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -322,6 +322,14 @@ lemma rat_approx_finite (a b : ℤ) : {q : ℚ | |(a / b : ℝ) - q| < 1 / q.den
 set.finite_coe_iff.mp $ (equiv.finite_iff $ bij_on.equiv _ $ rat_approx_equiv (a / b)).mp $
   set.finite_coe_iff.mpr (rat_approx_finite' a b)
 
+/-- The set of good rational approximations to a real number `ξ` is infinite if and only if
+`ξ` is irrational. -/
+lemma rat_approx_infinite_iff_irrational {ξ : ℝ} :
+  {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite ↔ irrational ξ :=
+⟨λ h, (irrational_iff_ne_rational ξ).mpr
+        (λ a b H, not_infinite.mpr (rat_approx_finite a b) (H ▸ h)),
+ rat_approx_infinite⟩
+
 /-- The set of good approximations to a real number `ξ` is infinite if and only if
 `ξ` is irrational. -/
 lemma rat_approx_infinite_iff_irrational' {ξ : ℝ} : (rat_approx ξ).infinite ↔ irrational ξ :=

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -246,6 +246,13 @@ begin
          rat.num_div_denom q], },
 end
 
+/-!
+### Infinitely many good approximations to irrational numbers
+
+We show that an irrational real number `ξ` has infinitely many "good rational approximations",
+i.e., fractions `x/y` in lowest terms such that `|ξ - x/y| < 1/y^2`.
+-/
+
 /-- If `ξ` is an irrational real number, then there are infinitely many good
 rational approximations to `ξ`. -/
 lemma rat_approx_infinite {ξ : ℝ} (h : irrational ξ) : (rat_approx ξ).infinite :=

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -301,7 +301,7 @@ begin
 end
 
 /-- If `ξ = a/b` is rational, then it has only finitely many good rational approximations. -/
-lemma rat_approx_finite (a b : ℤ) : (rat_approx (a / b)).finite :=
+lemma rat_approx_finite' (a b : ℤ) : (rat_approx (a / b)).finite :=
 begin
   -- first prove it assuming `b ≠ 0`, then deal with `b = 0` by reducing to `0/1`.
   have H : ∀ a b : ℤ, b ≠ 0 → (rat_approx (a / b)).finite,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -18,15 +18,16 @@ The proof is based on the pigeonhole principle.
 
 ## Main statements
 
-The main results are
-* `real.exists_int_int_abs_mul_sub_le`, which is a version of Dirichlet's approximation
-  theorem and states that for all real `ξ` and natural `0 < n`, there are integers
-  `j` and `k` with `0 < k ≤ n` and `|k*ξ - j| ≤ 1/(n+1)`,
-* `real.exists_nat_abs_mul_sub_round_le`, which is a variant of this replacing `j`
-  by `round(k*ξ)` and using a natural number `k`,
-* A further variant `real.exists_rat_abs_sub_le_and_denom_le` in terms of rationals `q`
+The main results are three variants of Dirichlet's approximation theorem:
+* `real.exists_int_int_abs_mul_sub_le`, which states that for all real `ξ` and natural `0 < n`,
+  there are integers `j` and `k` with `0 < k ≤ n` and `|k*ξ - j| ≤ 1/(n+1)`,
+* `real.exists_nat_abs_mul_sub_round_le`, which replaces `j` by `round(k*ξ)` and uses
+  a natural number `k`,
+* `real.exists_rat_abs_sub_le_and_denom_le`, which says that there is a rational number `q`
   satisfying `|ξ - q| ≤ 1/((n+1)*q.denom)` and `q.denom ≤ n`,
-* `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`,
+
+and
+* `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`, the set
   `{q : ℚ | |ξ - q| < 1/q.denom^2}` is infinite,
 
 ## Implementation notes

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -152,7 +152,7 @@ begin
     simp only [irrational, mem_range, not_exists, ← ne.def] at hξ,
     exact (hξ q).symm, },
   obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - q|),
-  have m_pos : 0 < (m : ℝ) := (one_div_pos.mpr h).trans hm,
+  have m_pos : (0 : ℝ) < m := (one_div_pos.mpr h).trans hm,
   obtain ⟨q', hbd, hden⟩ := real.exists_rat_abs_sub_le_and_denom_le ξ (nat.cast_pos.mp m_pos),
   have den_pos : (0 : ℝ) < q'.denom := nat.cast_pos.mpr q'.pos,
   have md_pos := mul_pos (add_pos m_pos zero_lt_one) den_pos,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -257,14 +257,15 @@ begin
     exact (hξ q).symm, },
   obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - q|),
   have m_pos : 0 < (m : ℝ) := (one_div_pos.mpr h).trans hm,
-  obtain ⟨q', hbd, hden⟩ := ex_approx ξ (nat.cast_pos.mp m_pos),
+  obtain ⟨q', hbd, hden⟩ := dirichlet_approx' ξ (nat.cast_pos.mp m_pos),
   have den_pos : (0 : ℝ) < q'.denom := nat.cast_pos.mpr q'.pos,
-  have md_pos := mul_pos m_pos den_pos,
-  refine ⟨q', lt_of_lt_of_le hbd _, hbd.trans _⟩,
-  { rw [sq, one_div_le_one_div md_pos (mul_pos den_pos den_pos), mul_le_mul_right den_pos],
-    exact_mod_cast hden, },
+  have md_pos := mul_pos (add_pos m_pos zero_lt_one) den_pos,
+  refine ⟨q', lt_of_le_of_lt hbd _, lt_of_le_of_lt hbd _⟩,
+  { rw [sq, one_div_lt_one_div md_pos (mul_pos den_pos den_pos), mul_lt_mul_right den_pos],
+    exact lt_add_of_le_of_pos (nat.cast_le.mpr hden) zero_lt_one, },
   { rw [one_div_lt md_pos h],
-    refine lt_of_lt_of_le hm ((le_mul_iff_one_le_right m_pos).mpr _),
+    refine hm.trans (lt_of_lt_of_le (lt_add_one _) $
+                      (le_mul_iff_one_le_right $ add_pos m_pos zero_lt_one).mpr _),
     exact_mod_cast (q'.pos : 1 ≤ q'.denom), }
 end
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -153,7 +153,7 @@ begin
     exact (hξ q).symm, },
   obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - q|),
   have m_pos : (0 : ℝ) < m := (one_div_pos.mpr h).trans hm,
-  obtain ⟨q', hbd, hden⟩ := real.exists_rat_abs_sub_le_and_denom_le ξ (nat.cast_pos.mp m_pos),
+  obtain ⟨q', hbd, hden⟩ := exists_rat_abs_sub_le_and_denom_le ξ (nat.cast_pos.mp m_pos),
   have den_pos : (0 : ℝ) < q'.denom := nat.cast_pos.mpr q'.pos,
   have md_pos := mul_pos (add_pos m_pos zero_lt_one) den_pos,
   refine ⟨q', lt_of_le_of_lt hbd _, lt_of_le_of_lt hbd _⟩,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -58,7 +58,9 @@ open finset int
 
 /-- *Dirichlet's approximation theorem:*
 For any real number `ξ` and positive natural `n`, there are integers `j` and `k`,
-with `0 < k ≤ n` and `|k*ξ - j| ≤ 1/(n+1)`. -/
+with `0 < k ≤ n` and `|k*ξ - j| ≤ 1/(n+1)`.
+
+See also `real.exists_nat_abs_mul_sub_round_le`. -/
 lemma exists_int_int_abs_mul_sub_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
   ∃ j k : ℤ, 0 < k ∧ k ≤ n ∧ |↑k * ξ - j| ≤ 1 / (n + 1) :=
 begin
@@ -145,7 +147,7 @@ open set
 
 /-- Given any rational approximation `q` to the irrational real number `ξ`, there is
 a good rational approximation `q'` such that `|ξ - q'| < |ξ - q|`. -/
-lemma ex_better_approx_of_irrational {ξ : ℝ} (hξ : irrational ξ) (q : ℚ) :
+lemma exists_rat_abs_sub_lt_and_lt_of_irrational {ξ : ℝ} (hξ : irrational ξ) (q : ℚ) :
   ∃ q' : ℚ, |ξ - q'| < 1 / q'.denom ^ 2 ∧ |ξ - q'| < |ξ - q| :=
 begin
   have h := abs_pos.mpr (sub_ne_zero.mpr $ irrational.ne_rat hξ q),
@@ -164,13 +166,13 @@ end
 
 /-- If `ξ` is an irrational real number, then there are infinitely many good
 rational approximations to `ξ`. -/
-lemma rat_approx_infinite_of_irrational {ξ : ℝ} (hξ : irrational ξ) :
+lemma infinite_rat_abs_sub_lt_one_div_denom_sq_of_irrational {ξ : ℝ} (hξ : irrational ξ) :
   {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite :=
 begin
   refine or.resolve_left (set.finite_or_infinite _) (λ h, _),
   obtain ⟨q, _, hq⟩ := exists_min_image {q : ℚ | |ξ - q| < 1 / q.denom ^ 2} (λ q, |ξ - q|) h
                                         ⟨⌊ξ⌋, by simp [abs_of_nonneg, int.fract_lt_one]⟩,
-  obtain ⟨q', hmem, hbetter⟩ := ex_better_approx_of_irrational hξ q,
+  obtain ⟨q', hmem, hbetter⟩ := exists_rat_abs_sub_lt_and_lt_of_irrational hξ q,
   exact lt_irrefl _ (lt_of_le_of_lt (hq q' hmem) hbetter),
 end
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -34,7 +34,7 @@ The main results are
   `j` and `k` with `0 < k ≤ n` and `|k*ξ - j| ≤ 1/(n+1)`,
 * `real.exists_int_abs_mul_sub_round_le`, which is a variant of this replacing `j`
   by `round(k*ξ)`,
-* A further variant `exists_rat_abs_sub_le_and_denom_le` in terms of rationals `q`
+* A further variant `real.exists_rat_abs_sub_le_and_denom_le` in terms of rationals `q`
   satisfying `|ξ - q| ≤ 1/((n+1)*q.denom)` and `q.denom ≤ n`,
 * `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`,
   `{q : ℚ | |ξ - q| < 1/q.denom^2}` is infinite,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -154,9 +154,9 @@ begin
   have den_pos : (0 : ℝ) < q'.denom := nat.cast_pos.mpr q'.pos,
   have md_pos := mul_pos (add_pos m_pos zero_lt_one) den_pos,
   refine ⟨q', lt_of_le_of_lt hbd _,
-          lt_of_le_of_lt hbd $ (one_div_lt md_pos h).mpr $ hm.trans
-            (lt_of_lt_of_le (lt_add_one _) $ (le_mul_iff_one_le_right $
-            add_pos m_pos zero_lt_one).mpr $ by exact_mod_cast (q'.pos : 1 ≤ q'.denom))⟩,
+          lt_of_le_of_lt hbd $ (one_div_lt md_pos h).mpr $ hm.trans $
+            lt_of_lt_of_le (lt_add_one _) $ (le_mul_iff_one_le_right $
+            add_pos m_pos zero_lt_one).mpr $ by exact_mod_cast (q'.pos : 1 ≤ q'.denom)⟩,
   rw [sq, one_div_lt_one_div md_pos (mul_pos den_pos den_pos), mul_lt_mul_right den_pos],
   exact lt_add_of_le_of_pos (nat.cast_le.mpr hden) zero_lt_one,
 end

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -207,7 +207,7 @@ begin
 end
 
 /-- `rat_approx ξ` is infinite if and only if `{q : ℚ | |ξ - q| < 1/q.denom^2}` is infinite. -/
-lemma rat_approx_infinite_iff (ξ : ℝ) :
+lemma rat_approx_infinite_iff {ξ : ℝ} :
   (rat_approx ξ).infinite ↔ {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite :=
 infinite_coe_iff.symm.trans $ (equiv.infinite_iff $ bij_on.equiv _ $ rat_approx_equiv ξ).trans
   infinite_coe_iff
@@ -319,8 +319,7 @@ lemma rat_approx_infinite_iff_irrational {ξ : ℝ} :
 /-- The set of good rational approximations to a real number `ξ` is infinite if and only if
 `ξ` is irrational. -/
 lemma rat_approx_infinite_iff_irrational' {ξ : ℝ} : (rat_approx ξ).infinite ↔ irrational ξ :=
-infinite_coe_iff.symm.trans $ iff.trans (iff.trans (equiv.infinite_iff $ bij_on.equiv _ $
-  rat_approx_equiv _) infinite_coe_iff) rat_approx_infinite_iff_irrational
+rat_approx_infinite_iff.trans rat_approx_infinite_iff_irrational
 
 end rat_approx
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -330,7 +330,7 @@ lemma rat_approx_infinite_iff_irrational {ξ : ℝ} :
         (λ a b H, not_infinite.mpr (rat_approx_finite a b) (H ▸ h)),
  rat_approx_infinite⟩
 
-/-- The set of good approximations to a real number `ξ` is infinite if and only if
+/-- The set of good rational approximations to a real number `ξ` is infinite if and only if
 `ξ` is irrational. -/
 lemma rat_approx_infinite_iff_irrational' {ξ : ℝ} : (rat_approx ξ).infinite ↔ irrational ξ :=
 ⟨λ h, (irrational_iff_ne_rational ξ).mpr

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -290,6 +290,11 @@ begin
   exact lt_irrefl _ (lt_of_le_of_lt (hq q' hmem) hbetter),
 end
 
+/-- If `ξ` is an irrational real number, then there are infinitely many good
+rational approximations to `ξ`. -/
+lemma rat_approx_infinite' {ξ : ℝ} (hξ : irrational ξ) : (rat_approx ξ).infinite :=
+rat_approx_infinite_iff.mpr (rat_approx_infinite hξ)
+
 /-!
 ### Finitely many good approximations to rational numbers
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -167,7 +167,7 @@ end
 
 /-- If `ξ` is an irrational real number, then there are infinitely many good
 rational approximations to `ξ`. -/
-lemma rat_approx_infinite {ξ : ℝ} (hξ : irrational ξ) :
+lemma rat_approx_infinite_of_irrational {ξ : ℝ} (hξ : irrational ξ) :
   {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite :=
 begin
   refine or.resolve_left (set.finite_or_infinite _) (λ h, _),

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -57,7 +57,7 @@ namespace dioph_approx
 ### Dirichlet's approximation theorem
 
 We show that for any real number `ξ` and positive natural `n`, there is a fraction `q`
-such that `q.denom ≤ n` and `|ξ - q| < 1/(n*q.denom)`.
+such that `q.denom ≤ n` and `|ξ - q| ≤ 1/((n+1)*q.denom)`.
 -/
 
 section pigeonhole

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -153,13 +153,12 @@ begin
   obtain ⟨q', hbd, hden⟩ := exists_rat_abs_sub_le_and_denom_le ξ (nat.cast_pos.mp m_pos),
   have den_pos : (0 : ℝ) < q'.denom := nat.cast_pos.mpr q'.pos,
   have md_pos := mul_pos (add_pos m_pos zero_lt_one) den_pos,
-  refine ⟨q', lt_of_le_of_lt hbd _, lt_of_le_of_lt hbd _⟩,
-  { rw [sq, one_div_lt_one_div md_pos (mul_pos den_pos den_pos), mul_lt_mul_right den_pos],
-    exact lt_add_of_le_of_pos (nat.cast_le.mpr hden) zero_lt_one, },
-  { rw [one_div_lt md_pos h],
-    refine hm.trans (lt_of_lt_of_le (lt_add_one _) $
-                      (le_mul_iff_one_le_right $ add_pos m_pos zero_lt_one).mpr _),
-    exact_mod_cast (q'.pos : 1 ≤ q'.denom), }
+  refine ⟨q', lt_of_le_of_lt hbd _,
+          lt_of_le_of_lt hbd $ (one_div_lt md_pos h).mpr $ hm.trans
+            (lt_of_lt_of_le (lt_add_one _) $ (le_mul_iff_one_le_right $
+            add_pos m_pos zero_lt_one).mpr $ by exact_mod_cast (q'.pos : 1 ≤ q'.denom))⟩,
+  rw [sq, one_div_lt_one_div md_pos (mul_pos den_pos den_pos), mul_lt_mul_right den_pos],
+  exact lt_add_of_le_of_pos (nat.cast_le.mpr hden) zero_lt_one,
 end
 
 /-- If `ξ` is an irrational real number, then there are infinitely many good

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -117,6 +117,18 @@ begin
 end
 
 /-- *Dirichlet's approximation theorem:*
+For any real number `ξ` and positive natural `n`, there is an integer `k`,
+with `0 < k ≤ n` such that `|k*ξ - round(k*ξ)| ≤ 1/(n+1)`.
+-/
+lemma exists_int_abs_mul_sub_round_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
+  ∃ k : ℤ, 0 < k ∧ k ≤ n ∧ |↑k * ξ - round (↑k * ξ)| ≤ 1 / (n + 1) :=
+begin
+  obtain ⟨j, k, hk₀, hk₁, h⟩ := dirichlet_approx ξ n_pos,
+  rw [mul_comm] at h,
+  exact ⟨k, hk₀, hk₁, (round_le (↑k * ξ) j).trans h⟩,
+end
+
+/-- *Dirichlet's approximation theorem:*
 For any real number `ξ` and positive natural `n`, there is a fraction `q`
 such that `q.denom ≤ n` and `|ξ - q| ≤ 1/((n+1)*q.denom)`. -/
 lemma dirichlet_approx' (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -261,13 +261,14 @@ lemma rat_approx_nonempty (ξ : ℝ) : {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.no
 
 /-- If `ξ` is an irrational real number, then there are infinitely many good
 rational approximations to `ξ`. -/
-lemma rat_approx_infinite {ξ : ℝ} (h : irrational ξ) : (rat_approx ξ).infinite :=
+lemma rat_approx_infinite {ξ : ℝ} (hξ : irrational ξ) :
+  {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite :=
 begin
-  refine or.resolve_left (set.finite_or_infinite (rat_approx ξ)) (λ hfin, _),
-  obtain ⟨xy, _, hxy⟩ :=
-    exists_min_image (rat_approx ξ) (λ xy, |ξ - xy.1 / xy.2|) hfin (rat_approx_nonempty ξ),
-  obtain ⟨x', y', hmem, hbetter⟩ := ex_better_approx h xy.1 xy.2,
-  exact lt_irrefl _ (lt_of_le_of_lt (hxy (x', y') hmem) hbetter),
+  refine or.resolve_left (set.finite_or_infinite _) (λ h, _),
+  obtain ⟨q, _, hq⟩ :=
+    exists_min_image {q : ℚ | |ξ - q| < 1 / q.denom ^ 2} (λ q, |ξ - q|) h (rat_approx_nonempty ξ),
+  obtain ⟨q', hmem, hbetter⟩ := ex_better_approx hξ q,
+  exact lt_irrefl _ (lt_of_le_of_lt (hq q' hmem) hbetter),
 end
 
 /-!

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -23,6 +23,8 @@ The proof (of the interesting direction) is based on the pigeonhole principle.
 
 We define the set `dioph_approx.rat_approx ξ` for a real number `ξ` to be the set
 of pairs `(x, y)` of coprime integers with `y` positive such that `|ξ - x/y| < 1/y^2`.
+This set is in natural bijection with `{q : ℚ | |ξ - q| < 1/q.denom^2}`
+(see `dioph_approx.rat_approx_equiv`).
 
 ## Main statements
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -94,7 +94,8 @@ begin
   { exact H y x y_mem x_mem (lt_iff_le_and_ne.mpr ⟨le_of_not_lt h, x_neq_y.symm⟩) f_x_eq_f_y, },
 end
 
-/-- For any real number `ξ` and positive natural `n`, there is a fraction `x/y`
+/-- *Dirichlet's approximation theorem:*
+For any real number `ξ` and positive natural `n`, there is a fraction `x/y`
 such that `0 < y ≤ n` and `|ξ - x/y| < 1/(n*y)`. -/
 lemma ex_approx' (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
   ∃ x y : ℤ, |ξ - x / y| < 1 / (n * y) ∧ 0 < y ∧ y ≤ n :=

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -83,8 +83,7 @@ begin
   let D := Icc (0 : ℤ) n,
   by_cases H : ∃ m ∈ D, f m = n,
   { obtain ⟨m, hm, hf⟩ := H,
-    have hf' : (n : ℝ) ≤ fract (ξ * m) * (n + 1) :=
-      (hf ▸ floor_le (fract (ξ * m) * (n + 1)) : ((n : ℤ) : ℝ) ≤ fract (ξ * m) * (n + 1)),
+    have hf' : ((n : ℤ) : ℝ) ≤ fract (ξ * m) * (n + 1) := hf ▸ floor_le (fract (ξ * m) * (n + 1)),
     have hm₀ : 0 < m,
     { have hf₀ : f 0 = 0,
       { simp only [floor_eq_zero_iff, algebra_map.coe_zero, mul_zero, fract_zero, zero_mul,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -144,26 +144,6 @@ def rat_approx (ξ : ℝ) : set (ℤ × ℤ) :=
 lemma rat_approx_nonempty' (ξ : ℝ) : (rat_approx ξ).nonempty :=
 ⟨(⌊ξ⌋, 1), by simp [rat_approx, abs_of_nonneg (int.fract_nonneg ξ), int.fract_lt_one]⟩
 
-/-- Given any rational approximation `x/y` to the irrational real number `ξ`, there is
-a good rational approximation `X/Y` such that `|ξ - X/Y| < |ξ - x/y|`. -/
-lemma ex_better_approx {ξ : ℝ} (hξ : irrational ξ) (x y : ℤ) :
-  ∃ X Y : ℤ, (X, Y) ∈ rat_approx ξ ∧ |ξ - X / Y| < |ξ - x / y| :=
-begin
-  have h := abs_pos.mpr (sub_ne_zero.mpr $ (irrational_iff_ne_rational ξ).mp hξ x y),
-  obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - x / y|),
-  have m_pos : 0 < (m : ℝ) := (one_div_pos.mpr h).trans hm,
-  obtain ⟨X, Y, hcp, hbd, Y_pos, Y_le_m⟩ := ex_approx ξ (nat.cast_pos.mp m_pos),
-  have Y_pos_ℝ : (0 : ℝ) < Y := int.cast_pos.mpr Y_pos,
-  refine ⟨X, Y, ⟨Y_pos, hcp,
-                 lt_of_lt_of_le hbd (one_div_le_one_div_of_le (sq_pos_of_pos Y_pos_ℝ) _)⟩,
-                 (lt_of_lt_of_le hbd _).trans ((one_div_lt h m_pos).mp hm)⟩,
-  { rw [pow_two, mul_le_mul_right Y_pos_ℝ],
-    exact_mod_cast Y_le_m, },
-  { rw [mul_comm, ← div_div],
-    refine div_le_div_of_le m_pos.le ((div_le_one Y_pos_ℝ).mpr _),
-    exact_mod_cast (int.cast_le.mpr Y_pos : (_ : ℝ) ≤ Y), }
-end
-
 /-- If `x/y` is a good approximation to `ξ`, then `x` is bounded in terms of `y` (and `ξ`). -/
 lemma rat_approx_num_bound {ξ : ℝ} {x y : ℤ} (h : (x, y) ∈ rat_approx ξ) :
   ⌈ξ * y⌉ - 1 ≤ x ∧ x ≤ ⌊ξ * y⌋ + 1 :=
@@ -252,6 +232,26 @@ end
 We show that an irrational real number `ξ` has infinitely many "good rational approximations",
 i.e., fractions `x/y` in lowest terms such that `|ξ - x/y| < 1/y^2`.
 -/
+
+/-- Given any rational approximation `x/y` to the irrational real number `ξ`, there is
+a good rational approximation `X/Y` such that `|ξ - X/Y| < |ξ - x/y|`. -/
+lemma ex_better_approx {ξ : ℝ} (hξ : irrational ξ) (x y : ℤ) :
+  ∃ X Y : ℤ, (X, Y) ∈ rat_approx ξ ∧ |ξ - X / Y| < |ξ - x / y| :=
+begin
+  have h := abs_pos.mpr (sub_ne_zero.mpr $ (irrational_iff_ne_rational ξ).mp hξ x y),
+  obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - x / y|),
+  have m_pos : 0 < (m : ℝ) := (one_div_pos.mpr h).trans hm,
+  obtain ⟨X, Y, hcp, hbd, Y_pos, Y_le_m⟩ := ex_approx ξ (nat.cast_pos.mp m_pos),
+  have Y_pos_ℝ : (0 : ℝ) < Y := int.cast_pos.mpr Y_pos,
+  refine ⟨X, Y, ⟨Y_pos, hcp,
+                 lt_of_lt_of_le hbd (one_div_le_one_div_of_le (sq_pos_of_pos Y_pos_ℝ) _)⟩,
+                 (lt_of_lt_of_le hbd _).trans ((one_div_lt h m_pos).mp hm)⟩,
+  { rw [pow_two, mul_le_mul_right Y_pos_ℝ],
+    exact_mod_cast Y_le_m, },
+  { rw [mul_comm, ← div_div],
+    refine div_le_div_of_le m_pos.le ((div_le_one Y_pos_ℝ).mpr _),
+    exact_mod_cast (int.cast_le.mpr Y_pos : (_ : ℝ) ≤ Y), }
+end
 
 /-- If `ξ` is an irrational real number, then there are infinitely many good
 rational approximations to `ξ`. -/

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -141,7 +141,7 @@ def rat_approx (ξ : ℝ) : set (ℤ × ℤ) :=
   {xy : ℤ × ℤ | 0 < xy.2 ∧ int.gcd xy.1 xy.2 = 1 ∧ |ξ - xy.1 / xy.2| < 1 / xy.2 ^ 2}
 
 /-- There is always at least one good rational approximation. -/
-lemma rat_approx_nonempty (ξ : ℝ) : (rat_approx ξ).nonempty :=
+lemma rat_approx_nonempty' (ξ : ℝ) : (rat_approx ξ).nonempty :=
 ⟨(⌊ξ⌋, 1), by simp [rat_approx, abs_of_nonneg (int.fract_nonneg ξ), int.fract_lt_one]⟩
 
 /-- Given any rational approximation `x/y` to the irrational real number `ξ`, there is

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -147,10 +147,7 @@ a good rational approximation `q'` such that `|ξ - q'| < |ξ - q|`. -/
 lemma ex_better_approx_of_irrational {ξ : ℝ} (hξ : irrational ξ) (q : ℚ) :
   ∃ q' : ℚ, |ξ - q'| < 1 / q'.denom ^ 2 ∧ |ξ - q'| < |ξ - q| :=
 begin
-  have h : 0 < |ξ - q|,
-  { refine abs_pos.mpr (sub_ne_zero.mpr _),
-    simp only [irrational, mem_range, not_exists, ← ne.def] at hξ,
-    exact (hξ q).symm, },
+  have h := abs_pos.mpr (sub_ne_zero.mpr $ irrational.ne_rat hξ q),
   obtain ⟨m, hm⟩ := exists_nat_gt (1 / |ξ - q|),
   have m_pos : (0 : ℝ) < m := (one_div_pos.mpr h).trans hm,
   obtain ⟨q', hbd, hden⟩ := exists_rat_abs_sub_le_and_denom_le ξ (nat.cast_pos.mp m_pos),

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -68,6 +68,8 @@ such that `q.denom ≤ n` and `|ξ - q| ≤ 1/((n+1)*q.denom)`.
 
 namespace real
 
+section dirichlet
+
 open finset int
 
 /-- *Dirichlet's approximation theorem:*
@@ -144,9 +146,9 @@ begin
        ← abs_mul, sub_mul, div_mul_cancel _ hk₀'.ne', mul_comm],
 end
 
+end dirichlet
 
 section rat_approx
-
 
 /-!
 ### Infinitely many good approximations to irrational numbers

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -254,6 +254,7 @@ begin
     refine lt_of_lt_of_le hm ((le_mul_iff_one_le_right m_pos).mpr _),
     exact_mod_cast (q'.pos : 1 ≤ q'.denom), }
 end
+
 /-- There is always at least one good rational approximation. -/
 lemma rat_approx_nonempty (ξ : ℝ) : {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.nonempty :=
 ⟨⌊ξ⌋, by simp [abs_of_nonneg, int.fract_lt_one]⟩

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -199,68 +199,6 @@ begin
   exact lt_irrefl _ (lt_of_le_of_lt (hq q' hmem) hbetter),
 end
 
-/-!
-### Finitely many good approximations to rational numbers
-
-We now show that a rational number `ξ` has only finitely many good rational
-approximations.
--/
-
-/-- If `x/y` is a good approximation to `a/b`, then `y ≤ b`. -/
-lemma denom_bounded_of_rat_approx_rational (a b x y : ℤ) (hb : b ≠ 0)
-  (hxy : (x, y) ∈ rat_approx (a / b)) :
-  0 < y ∧ y ≤ |b| :=
-begin
-  obtain ⟨h₁, h₂, h₃⟩ := hxy,
-  refine ⟨h₁, _⟩,
-  have hy₀ : (y : ℝ) ≠ 0 := int.cast_ne_zero.mpr h₁.ne',
-  have hy : 0 < (y ^ 2 : ℝ) := (sq_pos_iff _).mpr hy₀,
-  have hb₀ : (b : ℝ) ≠ 0 := int.cast_ne_zero.mpr hb,
-  rw [← mul_lt_mul_right (abs_pos.mpr hy.ne'), ← mul_lt_mul_right (abs_pos.mpr hb₀),
-      ← abs_mul, ← abs_mul] at h₃,
-  field_simp at h₃, -- why doesn't it cancel `↑b * ↑y`?
-  rw [sq, ← mul_assoc, ← div_div, mul_div_cancel _ hb₀, mul_div_cancel _ hy₀, abs_mul,
-      abs_of_pos (int.cast_pos.mpr h₁ : 0 < (y : ℝ)), mul_comm ↑b] at h₃,
-  norm_cast at h₃,
-  cases eq_or_ne (a * y - x * b) 0 with H H,
-  { exact int.le_of_dvd (abs_pos.mpr hb) ((dvd_abs y b).mpr (int.dvd_of_dvd_mul_right_of_gcd_one
-          (dvd_of_mul_left_eq a (eq_of_sub_eq_zero H)) (int.gcd_comm x y ▸ h₂))), },
-  { exact ((le_mul_iff_one_le_left h₁).mpr (abs_pos.mpr H)).trans h₃.le, }
-end
-
-/-- If `ξ = a/b` is rational, then it has only finitely many good rational approximations. -/
-lemma rat_approx_finite' (a b : ℤ) : (rat_approx (a / b)).finite :=
-begin
-  -- first prove it assuming `b ≠ 0`, then deal with `b = 0` by reducing to `0/1`.
-  have H : ∀ a b : ℤ, b ≠ 0 → (rat_approx (a / b)).finite,
-  { refine λ a b hb, not_infinite.mp $
-             mt (rat_approx_infinite_iff_to_denom_infinite (a / b)).mp (not_infinite.mpr _),
-    have h : ∀ y : ℤ, y ∈ prod.snd '' rat_approx (a / b) → 0 < y ∧ y ≤ |b|,
-    { intros y hy,
-      obtain ⟨xy, hxy⟩ := (mem_image prod.snd (rat_approx (a / b)) y).mp hy,
-      exact hxy.2 ▸ denom_bounded_of_rat_approx_rational a b xy.1 xy.2 hb hxy.1, },
-    refine finite.subset (finite_Ioc _ _) h, },
-  refine or.elim (eq_or_ne b 0) (λ hb, _) (H a b),
-  convert H 0 1 one_ne_zero using 2,
-  rw [hb, algebra_map.coe_zero, zero_div, div_zero],
-end
-
-/-- If `ξ = a/b` is rational, then it has only finitely many good rational approximations. -/
-lemma rat_approx_finite (a b : ℤ) : {q : ℚ | |(a / b : ℝ) - q| < 1 / q.denom ^ 2}.finite :=
-not_infinite.mp $ (mt rat_approx_infinite_iff.mpr) $ not_infinite.mpr $ rat_approx_finite' a b
-
-/-- The set of good rational approximations to a real number `ξ` is infinite if and only if
-`ξ` is irrational. -/
-lemma rat_approx_infinite_iff_irrational {ξ : ℝ} :
-  {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite ↔ irrational ξ :=
-⟨λ h, (irrational_iff_ne_rational ξ).mpr
-        (λ a b H, not_infinite.mpr (rat_approx_finite a b) (H ▸ h)),
- rat_approx_infinite⟩
-
-/-- The set of good rational approximations to a real number `ξ` is infinite if and only if
-`ξ` is irrational. -/
-lemma rat_approx_infinite_iff_irrational' {ξ : ℝ} : (rat_approx ξ).infinite ↔ irrational ξ :=
-rat_approx_infinite_iff.trans rat_approx_infinite_iff_irrational
 
 end rat_approx
 

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -31,9 +31,9 @@ This set is in natural bijection with `{q : ℚ | |ξ - q| < 1/q.denom^2}`
 The main results are
 * `real.exists_int_int_abs_mul_sub_le`, which is a version of Dirichlet's approximation
   theorem and states that for all real `ξ` and natural `0 < n`, there are integers
-  `j` and `k` with `0 < k ≤ n` and `|ξ*k - j| ≤ 1/(n+1)`,
-* `real.exists_int_abs_mul_sub_round_le`, which is a variant of this in terms of `k*ξ`
-   and replacing `j` by `round(k*ξ)`,
+  `j` and `k` with `0 < k ≤ n` and `|k*ξ - j| ≤ 1/(n+1)`,
+* `real.exists_int_abs_mul_sub_round_le`, which is a variant of this replacing `j`
+  by `round(k*ξ)`,
 * A further variant `exists_rat_abs_sub_le_and_denom_le` in terms of rationals `q`
   satisfying `|ξ - q| ≤ 1/((n+1)*q.denom)` and `q.denom ≤ n`,
 * `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`,

--- a/src/number_theory/diophantine_approximation.lean
+++ b/src/number_theory/diophantine_approximation.lean
@@ -10,9 +10,9 @@ import combinatorics.pigeonhole
 /-!
 # Diophantine Approximation
 
-This file gives proofs of various versions of **Dirichlet's approximation theorem**,
-the statement that when `ξ` is an irrational real number, then there are infinitely
-many rationals `x/y` (in lowest terms) such that `|ξ - x/y| < 1/y^2`.
+This file gives proofs of various versions of **Dirichlet's approximation theorem**
+and its important consequence that when `ξ` is an irrational real number, then there are
+infinitely many rationals `x/y` (in lowest terms) such that `|ξ - x/y| < 1/y^2`.
 
 We also show the converse, i.e., that for rational `ξ` there are only finitely many
 such rational approximations.
@@ -29,6 +29,11 @@ This set is in natural bijection with `{q : ℚ | |ξ - q| < 1/q.denom^2}`
 ## Main statements
 
 The main results are
+* `dioph_approx.dirichlet_approx`, which is a version of Dirichlet's approximation
+  theorem and states that for all real `ξ` and natural `0 < n`, there are integers
+  `j` and `k` with `0 < k ≤ n` and `|ξ*k - j| ≤ 1/(n+1)`,
+* A variant `dioph_approx.dirichlet_approx'` of this in terms of rationals `q`
+  satisfying `|ξ - q| ≤ 1/((n+1)*q.denom)` and `q.denom ≤ n`,
 * `dioph_approx.rat_approx_infinite`, which states that for irrational `ξ`,
   `{q : ℚ | |ξ - q| < 1/q.denom^2}` is infinite,
 * `dioph_approx.rat_approx_finite`, which states that `{q : ℚ | |a/b - q| < 1/q.denom^2}`


### PR DESCRIPTION
This PR adds a new file, `number_theory/diophantine_approximation.lean`, that contains proofs of various versions 
of **Dirichlet's approximation theorem**,
```lean
lemma real.exists_int_int_abs_mul_sub_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
  ∃ j k : ℤ, 0 < k ∧ k ≤ n ∧ |↑k * ξ - j| ≤ 1 / (n + 1)

lemma real.exists_nat_abs_mul_sub_round_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
  ∃ k : ℕ, 0 < k ∧ k ≤ n ∧ |↑k * ξ - round (↑k * ξ)| ≤ 1 / (n + 1)
```
and
```lean
lemma real.exists_rat_abs_sub_le_and_denom_le (ξ : ℝ) {n : ℕ} (n_pos : 0 < n) :
  ∃ q : ℚ, |ξ - q| ≤ 1 / ((n + 1) * q.denom) ∧ q.denom ≤ n
```

and also the following consequence:
```lean
lemma real.rat_approx_infinite_of_irrational {ξ : ℝ} (hξ : irrational ξ) :
  {q : ℚ | |ξ - q| < 1 / q.denom ^ 2}.infinite
```

The proof of `exists_int_int_abs_mul_sub_le` is the standard one based on the pigeonhole principle.

See also the [discussion on Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Diophantine.20approximation/near/318002909).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
