### PR TITLE
[Merged by Bors] - chore(order/closure): improve theorem statement

### DIFF
--- a/src/order/closure.lean
+++ b/src/order/closure.lean
@@ -393,14 +393,14 @@ lemma closure_union_closure_subset (x y : α) :
 l.closure_sup_closure_le x y
 
 @[simp] lemma closure_union_closure_left (x y : α) :
-  (l ((l x) ∪ y) : set β) = l (x ∪ y) :=
-l.closure_sup_closure_left x y
+  l ((l x) ∪ y) = l (x ∪ y) :=
+set_like.coe_injective (l.closure_sup_closure_left x y)
 
 @[simp] lemma closure_union_closure_right (x y : α) :
   l (x ∪ (l y)) = l (x ∪ y) :=
 set_like.coe_injective (l.closure_sup_closure_right x y)
 
-@[simp] lemma closure_union_closure (x y : α) :
+lemma closure_union_closure (x y : α) :
   l ((l x) ∪ (l y)) = l (x ∪ y) :=
 set_like.coe_injective (l.closure_operator.closure_sup_closure x y)
 


### PR DESCRIPTION
---
This is a change I made to fix a linter error while porting the file to mathlib4 and I'm making it here so the libraries match

I removed the simp attribute from closure union closure because `simp` now proves it.

The mathlib4 PR is [mathlib4#1263](https://github.com/leanprover-community/mathlib4/pull/1263)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
