### PR TITLE
[Merged by Bors] - refactor(data/set/finite): add `finite_to_set` lemmas to simp set

### DIFF
--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -341,7 +341,7 @@ namespace finset
 
 /-- Gives a `set.finite` for the `finset` coerced to a `set`.
 This is a wrapper around `set.to_finite`. -/
-lemma finite_to_set (s : finset α) : (s : set α).finite := set.to_finite _
+@[simp] lemma finite_to_set (s : finset α) : (s : set α).finite := set.to_finite _
 
 @[simp] lemma finite_to_set_to_finset (s : finset α) : s.finite_to_set.to_finset = s :=
 by { ext, rw [set.finite.mem_to_finset, mem_coe] }
@@ -350,7 +350,7 @@ end finset
 
 namespace multiset
 
-lemma finite_to_set (s : multiset α) : {x | x ∈ s}.finite :=
+@[simp] lemma finite_to_set (s : multiset α) : {x | x ∈ s}.finite :=
 by { classical, simpa only [← multiset.mem_to_finset] using s.to_finset.finite_to_set }
 
 @[simp] lemma finite_to_set_to_finset [decidable_eq α] (s : multiset α) :
@@ -359,7 +359,7 @@ by { ext x, simp }
 
 end multiset
 
-lemma list.finite_to_set (l : list α) : {x | x ∈ l}.finite :=
+@[simp] lemma list.finite_to_set (l : list α) : {x | x ∈ l}.finite :=
 (show multiset α, from ⟦l⟧).finite_to_set
 
 /-! ### Finite instances


### PR DESCRIPTION
Making these be `simp` lemmas allows `simp` discharge such simple `set.finite` side-goals.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
