### PR TITLE
[Merged by Bors] - feat(analysis/convex/intrinsic): Intrinsic interior and frontier

### DIFF
--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -27,28 +27,6 @@ open_locale pointwise
 local attribute [instance, nolint fails_quickly] affine_subspace.to_normed_add_torsor
 local attribute [instance, nolint fails_quickly] affine_subspace.nonempty_map
 
-lemma affine_equiv.image_symm {R V₁ P₁ V₂ P₂ : Type*} [ring R]
-  [add_comm_group V₁] [add_comm_group V₂]
-  [module R V₁] [module R V₂]
-  [add_torsor V₁ P₁] [add_torsor V₂ P₂]
-  (f : P₁ ≃ᵃ[R] P₂) :
-set.image f.symm = set.preimage f :=
-funext f.symm.to_equiv.image_eq_preimage
-
-lemma affine_equiv.comap_span {R V₁ P₁ V₂ P₂ : Type*} [ring R]
-  [add_comm_group V₁] [add_comm_group V₂]
-  [module R V₁] [module R V₂]
-  [add_torsor V₁ P₁] [add_torsor V₂ P₂]
-  (f : P₁ ≃ᵃ[R] P₂) (A : set P₂) :
-affine_subspace.comap f.to_affine_map (affine_span R A) = affine_span R (f ⁻¹' A) :=
-begin
-  ext1,
-  simp only [affine_subspace.coe_comap, ←affine_equiv.image_symm],
-  simp only [←affine_equiv.coe_to_affine_map],
-  rw [←affine_subspace.map_span, affine_subspace.coe_map],
-  exact (f.to_equiv.symm.image_eq_preimage _).symm,
-end
-
 lemma affine_isometry_equiv.comap_span {𝕜 V₁ P₁ V₂ P₂ : Type*} [normed_field 𝕜]
   [normed_add_comm_group V₁] [normed_add_comm_group V₂]
   [pseudo_metric_space P₁] [pseudo_metric_space P₂] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -49,8 +49,6 @@ begin
   exact (f.to_equiv.symm.image_eq_preimage _).symm,
 end
 
-
--- IMPORTANT
 lemma affine_isometry_equiv.comap_span {𝕜 V₁ P₁ V₂ P₂ : Type} [normed_field 𝕜]
   [normed_add_comm_group V₁] [normed_add_comm_group V₂]
   [pseudo_metric_space P₁] [pseudo_metric_space P₂] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]
@@ -60,22 +58,13 @@ affine_subspace.comap f.to_affine_equiv.to_affine_map (affine_span 𝕜 A) =
   affine_span 𝕜 (f ⁻¹' A) :=
 f.to_affine_equiv.comap_span A
 
-
-lemma homeomorph.interior_nonempty_iff_image {α β : Type}
-  [topological_space α] [topological_space β] (φ : α ≃ₜ β) (A : set α) :
-(interior A).nonempty ↔ (interior (φ '' A)).nonempty :=
-begin
-  rw [←φ.image_interior, set.nonempty_image_iff],
-end
-
--- IMPORTANT -> make aux lemma
-lemma homeomorph.interior_nonempty_iff_preimage {α β : Type}
-  [topological_space α] [topological_space β] (φ : α ≃ₜ β) (A : set β) :
-(interior A).nonempty ↔ (interior (φ ⁻¹' A)).nonempty :=
-begin
-  rw [←φ.image_symm, φ.interior_nonempty_iff_image, ←set.image_comp, φ.self_comp_symm,
-    set.image_id],
-end
+noncomputable def inclusion_affine {V : Type} [normed_add_comm_group V] [normed_space ℝ V]
+  (E : affine_subspace ℝ V) [nonempty E] : E →ᵃ[ℝ] V :=
+{ to_fun := coe,
+  linear := E.direction.subtype,
+  map_vadd' := by
+    { simp only [affine_subspace.coe_vadd, submodule.coe_subtype, eq_self_iff_true,
+                 forall_const] } }
 
 -- ==============================
 -- BEGIN intrinsic_interior.lean
@@ -180,7 +169,8 @@ end
 example {𝕜 V V₂ P P₂: Type}
   [normed_field 𝕜] [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
   [normed_space 𝕜 V₂] [metric_space P] [pseudo_metric_space P₂] [normed_add_torsor V P]
-  [normed_add_torsor V₂ P₂] (A: set P) [nonempty A] : normed_add_torsor (affine_span 𝕜 A).direction (affine_span 𝕜 A) :=
+  [normed_add_torsor V₂ P₂] (A: set P) [nonempty A] :
+  normed_add_torsor (affine_span 𝕜 A).direction (affine_span 𝕜 A) :=
 affine_subspace.to_normed_add_torsor (affine_span 𝕜 A)
 
 /--
@@ -255,20 +245,12 @@ end
 closure A \ intrinsic_interior 𝕜 A = intrinsic_frontier 𝕜 A :=
 (intrinsic_closure_eq_closure 𝕜 A) ▸ intrinsic_closure_diff_intrinsic_interior A
 
--- @[simp] lemma intrinsic_interior_vadd {𝕜 V P : Type}
---   [normed_field 𝕜] [seminormed_add_comm_group V] [normed_space 𝕜 V]
---   [metric_space P] [normed_add_torsor V P] (x : V) (A : set P) :
--- intrinsic_interior 𝕜 (x +ᵥ A) = x +ᵥ intrinsic_interior 𝕜 A :=
--- (normed_add_torsor.vadd_affine_isometry 𝕜 P x).image_intrinsic_interior A
-
--- TODO
-noncomputable def inclusion_affine {V : Type} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
-  (E : affine_subspace ℝ V) [nonempty E] : E →ᵃ[ℝ] V :=
-{ to_fun := coe,
-  linear := E.direction.subtype,
-  map_vadd' := by
-    { simp only [affine_subspace.coe_vadd, submodule.coe_subtype, eq_self_iff_true,
-                 forall_const] } }
+lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux {α β : Type}
+  [topological_space α] [topological_space β] (φ : α ≃ₜ β) (A : set β) :
+(interior A).nonempty ↔ (interior (φ ⁻¹' A)).nonempty :=
+begin
+  rw [←φ.image_symm, ←φ.symm.image_interior, set.nonempty_image_iff],
+end
 
 lemma nonempty_intrinsic_interior_of_nonempty_of_convex
   {V : Type} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
@@ -279,7 +261,8 @@ begin
   rw [intrinsic_interior_def, set.nonempty_image_iff],
   obtain ⟨p, hp⟩ := Ane,
   let p' : affine_span ℝ A := ⟨p, subset_affine_span _ _ hp⟩,
-  rw [(affine_isometry_equiv.const_vsub ℝ p').symm.to_homeomorph.interior_nonempty_iff_preimage,
+  rw [nonempty_intrinsic_interior_of_nonempty_of_convex.aux
+    (affine_isometry_equiv.const_vsub ℝ p').symm.to_homeomorph,
     convex.interior_nonempty_iff_affine_span_eq_top],
   { rw [affine_isometry_equiv.coe_to_homeomorph,
       ←affine_isometry_equiv.comap_span (affine_isometry_equiv.const_vsub ℝ p').symm,

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -209,9 +209,9 @@ begin
   haveI : nonempty s := hs.to_subtype,
   let f := ((affine_span 𝕜 s).isometry_equiv_map φ).to_homeomorph,
   have : φ.to_affine_map ∘ coe ∘ f.symm = coe := funext isometry_equiv_map.apply_symm_apply,
-  rw [intrinsic_interior, intrinsic_interior, ←φ.coe_coe, ←map_span φ.to_affine_map s, ←this,
-    ←function.comp.assoc, image_comp, image_comp, f.symm.image_interior, f.image_symm,
-    ←preimage_comp, function.comp.assoc, f.symm_comp_self, affine_isometry.coe_coe,
+  rw [intrinsic_interior, intrinsic_interior, ←φ.coe_to_affine_map, ←map_span φ.to_affine_map s,
+    ←this, ←function.comp.assoc, image_comp, image_comp, f.symm.image_interior, f.image_symm,
+    ←preimage_comp, function.comp.assoc, f.symm_comp_self, affine_isometry.coe_to_affine_map,
     function.comp.right_id, preimage_comp, φ.injective.preimage_image],
 end
 
@@ -223,9 +223,9 @@ begin
   haveI : nonempty s := hs.to_subtype,
   let f := ((affine_span 𝕜 s).isometry_equiv_map φ).to_homeomorph,
   have : φ.to_affine_map ∘ coe ∘ f.symm = coe := funext isometry_equiv_map.apply_symm_apply,
-  rw [intrinsic_frontier, intrinsic_frontier, ←φ.coe_coe, ←map_span φ.to_affine_map s, ←this,
-    ←function.comp.assoc, image_comp, image_comp, f.symm.image_frontier, f.image_symm,
-    ←preimage_comp, function.comp.assoc, f.symm_comp_self, affine_isometry.coe_coe,
+  rw [intrinsic_frontier, intrinsic_frontier, ←φ.coe_to_affine_map, ←map_span φ.to_affine_map s,
+    ←this, ←function.comp.assoc, image_comp, image_comp, f.symm.image_frontier, f.image_symm,
+    ←preimage_comp, function.comp.assoc, f.symm_comp_self, affine_isometry.coe_to_affine_map,
     function.comp.right_id, preimage_comp, φ.injective.preimage_image],
 end
 
@@ -237,9 +237,9 @@ begin
   haveI : nonempty s := hs.to_subtype,
   let f := ((affine_span 𝕜 s).isometry_equiv_map φ).to_homeomorph,
   have : φ.to_affine_map ∘ coe ∘ f.symm = coe := funext isometry_equiv_map.apply_symm_apply,
-  rw [intrinsic_closure, intrinsic_closure, ←φ.coe_coe, ←map_span φ.to_affine_map s, ←this,
-    ←function.comp.assoc, image_comp, image_comp, f.symm.image_closure, f.image_symm,
-    ←preimage_comp, function.comp.assoc, f.symm_comp_self, affine_isometry.coe_coe,
+  rw [intrinsic_closure, intrinsic_closure, ←φ.coe_to_affine_map, ←map_span φ.to_affine_map s,
+    ←this, ←function.comp.assoc, image_comp, image_comp, f.symm.image_closure, f.image_symm,
+    ←preimage_comp, function.comp.assoc, f.symm_comp_self, affine_isometry.coe_to_affine_map,
     function.comp.right_id, preimage_comp, φ.injective.preimage_image],
 end
 

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Paul Reichert. All rights reserved.
+Copyright (c) 2023 Paul Reichert. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Reichert, Yaël Dillies
 -/
@@ -9,8 +9,8 @@ import analysis.normed_space.linear_isometry
 /-!
 # Intrinsic frontier and interior
 
-This file defines the intrinsic frontier and intrinsic interior of a set in
-a normed additive torsor, e.g. a real vector space or a nonempty affine subspace thereof.
+This file defines the intrinsic frontier and intrinsic interior of s set in
+s normed additive torsor, e.g. s real vector space or s nonempty affine subspace thereof.
 
 ## Definitions
 
@@ -25,98 +25,82 @@ The main results are:
 
 - `affine_isometry.image_intrinsic_interior`: The image of the intrinsic interior under an affine
   isometry is the relative interior of the image.
-- `nonempty_intrinsic_interior_of_nonempty_of_convex`: The intrinsic interior of a nonempty convex
+- `nonempty_intrinsic_interior_of_nonempty_of_convex`: The intrinsic interior of s nonempty convex
   set is nonempty.
 
 ## References
 
-See chapter 8 of [Barry Simon, *Convexity*][simon2011] or chapter 1 of
-[Rolf Schneider, *Convex Bodies: The Brunn-Minkowski theory*][schneider2013].
+* Chapter 8 of [Barry Simon, *Convexity*][simon2011]
+* Chapter 1 of [Rolf Schneider, *Convex Bodies: The Brunn-Minkowski theory*][schneider2013].
 -/
 
+open set
 open_locale pointwise
 
-section basic
-
-variables (R: Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V] [module R V]
-  [pseudo_metric_space P] [normed_add_torsor V P]
-
+section add_torsor
+variables (R : Type*) {V P : Type*} [ring R] [add_comm_group V] [module R V] [topological_space P]
+  [add_torsor V P] {s : set P} {x : P}
 include V
 
-/-- The intrinsic interior of a set is its interior considered as a set in its affine span. -/
-def intrinsic_interior (A : set P) : set P :=
-(coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A)
+/-- The intrinsic interior of s set is its interior considered as s set in its affine span. -/
+def intrinsic_interior (s : set P) : set P := coe '' interior (coe ⁻¹' s : set $ affine_span R s)
 
-/-- The intrinsic frontier of a set is its frontier considered as a set in its affine span. -/
-def intrinsic_frontier (A : set P) : set P :=
-(coe : affine_span R A → P) '' frontier ((coe : affine_span R A → P) ⁻¹' A)
+/-- The intrinsic frontier of s set is its frontier considered as s set in its affine span. -/
+def intrinsic_frontier (s : set P) : set P := coe '' frontier (coe ⁻¹' s : set $ affine_span R s)
 
-/-- The intrinsic closure of a set is its closure considered as a set in its affine span. -/
-def intrinsic_closure (A : set P) : set P :=
-(coe : affine_span R A → P) '' closure ((coe : affine_span R A → P) ⁻¹' A)
-
-lemma intrinsic_interior_def (A : set P) : intrinsic_interior R A =
-  (coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A) := rfl
-
-lemma intrinsic_frontier_def (A : set P) : intrinsic_frontier R A =
-  (coe : affine_span R A → P) '' frontier ((coe : affine_span R A → P) ⁻¹' A) := rfl
-
-lemma intrinsic_closure_def (A : set P) : intrinsic_closure R A =
-  (coe : affine_span R A → P) '' closure ((coe : affine_span R A → P) ⁻¹' A) := rfl
+/-- The intrinsic closure of s set is its closure considered as s set in its affine span. -/
+def intrinsic_closure (s : set P) : set P := coe '' closure (coe ⁻¹' s : set $ affine_span R s)
 
 variables {R}
 
-lemma intrinsic_interior_subset (A : set P) : intrinsic_interior R A ⊆ A :=
-set.image_subset_iff.mpr interior_subset
+@[simp] lemma mem_intrinsic_interior :
+  x ∈ intrinsic_interior R s ↔ ∃ y, y ∈ interior (coe ⁻¹' s : set $ affine_span R s) ∧ ↑y = x :=
+mem_image _ _ _
 
-lemma intrinsic_frontier_subset {A : set P} (hA : is_closed A) : intrinsic_frontier R A ⊆ A :=
-set.image_subset_iff.mpr (hA.preimage continuous_induced_dom).frontier_subset
+@[simp] lemma mem_intrinsic_frontier :
+  x ∈ intrinsic_frontier R s ↔ ∃ y, y ∈ frontier (coe ⁻¹' s : set $ affine_span R s) ∧ ↑y = x :=
+mem_image _ _ _
 
-@[simp]
-lemma intrinsic_interior_empty : intrinsic_interior R (∅ : set P) = ∅ :=
-set.subset_empty_iff.mp $ intrinsic_interior_subset _
+@[simp] lemma mem_intrinsic_closure :
+  x ∈ intrinsic_closure R s ↔ ∃ y, y ∈ closure (coe ⁻¹' s : set $ affine_span R s) ∧ ↑y = x :=
+mem_image _ _ _
 
-@[simp]
-lemma intrinsic_frontier_empty : intrinsic_frontier R (∅ : set P) = ∅ :=
-set.subset_empty_iff.mp $ intrinsic_frontier_subset is_closed_empty
+lemma intrinsic_interior_subset : intrinsic_interior R s ⊆ s := image_subset_iff.2 interior_subset
+
+lemma intrinsic_frontier_subset (hs : is_closed s) : intrinsic_frontier R s ⊆ s :=
+image_subset_iff.2 (hs.preimage continuous_induced_dom).frontier_subset
+
+@[simp] lemma intrinsic_interior_empty : intrinsic_interior R (∅ : set P) = ∅ :=
+subset_empty_iff.1 intrinsic_interior_subset
+
+@[simp] lemma intrinsic_frontier_empty : intrinsic_frontier R (∅ : set P) = ∅ :=
+subset_empty_iff.1 $ intrinsic_frontier_subset is_closed_empty
 
 lemma preimage_singleton_eq_univ (x : P) :
-  (coe : affine_span R ({x} : set P) → P) ⁻¹' {x} = set.univ :=
-begin
-  refine subset_antisymm (set.subset_univ _) _,
-  rintro ⟨y, hy⟩ -,
-  obtain rfl := (affine_subspace.mem_affine_span_singleton _ _ _ _).mp hy,
-  exact subtype.coe_mk _ _,
-end
+  (coe : affine_span R ({x} : set P) → P) ⁻¹' {x} = univ :=
+eq_univ_of_forall $ λ y, (affine_subspace.mem_affine_span_singleton _ _ _ _).1 y.2
+
+@[simp] lemma intrinsic_closure_diff_intrinsic_frontier (s : set P) :
+  intrinsic_closure R s \ intrinsic_frontier R s = intrinsic_interior R s :=
+(image_diff subtype.coe_injective _ _).symm.trans $
+  by rw [closure_diff_frontier, intrinsic_interior]
+
+@[simp] lemma intrinsic_closure_diff_intrinsic_interior (s : set P) :
+  intrinsic_closure R s \ intrinsic_interior R s = intrinsic_frontier R s :=
+(image_diff subtype.coe_injective _ _).symm
 
 @[simp] lemma intrinsic_interior_singleton (x : P) : intrinsic_interior R ({x} : set P) = {x} :=
-begin
-  rw [intrinsic_interior_def, interior_eq_iff_is_open.mpr], swap,
-  { convert is_open_univ,
-    exact preimage_singleton_eq_univ x },
-  { rw [set.eq_singleton_iff_unique_mem],
-    refine ⟨⟨⟨x, _⟩, subtype.coe_mk _ _, subtype.coe_mk _ _⟩, _⟩,
-    { exact (affine_subspace.mem_affine_span_singleton _ _ _ _).mpr rfl },
-    { rintro - ⟨⟨y, hy₁⟩, hy₂, rfl⟩,
-      simpa only [set.mem_preimage, subtype.coe_mk, set.mem_singleton_iff] using hy₂ } },
-end
+by simpa only [intrinsic_interior, preimage_singleton_eq_univ, interior_univ, image_univ,
+  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
 
 @[simp] lemma intrinsic_frontier_singleton (x : P) : intrinsic_frontier R ({x} : set P) = ∅ :=
-begin
-  rw [intrinsic_frontier_def, set.image_eq_empty],
-  convert frontier_univ,
-  exact preimage_singleton_eq_univ x,
-end
+by rw [intrinsic_frontier, preimage_singleton_eq_univ, frontier_univ, image_empty]
 
-@[simp] lemma intrinsic_closure_diff_intrinsic_interior (A : set P) :
-  intrinsic_closure R A \ intrinsic_interior R A = intrinsic_frontier R A :=
-begin
-  rw [intrinsic_frontier_def, intrinsic_closure_def, intrinsic_interior_def,
-    ←set.image_diff subtype.coe_injective],
-  refl,
-end
+@[simp] lemma intrinsic_closure_singleton (x : P) : intrinsic_closure R ({x} : set P) = {x} :=
+by simpa only [intrinsic_closure, preimage_singleton_eq_univ, closure_univ, image_univ,
+  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
 
-end basic
+end add_torsor
 
 section local_instances
 
@@ -131,25 +115,25 @@ the relative interior of the image.
 lemma affine_isometry.image_intrinsic_interior {𝕜 V V₂ P P₂ : Type*} [normed_field 𝕜]
   [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
   [normed_space 𝕜 V₂] [metric_space P] [pseudo_metric_space P₂] [normed_add_torsor V P]
-  [normed_add_torsor V₂ P₂] (φ : P →ᵃⁱ[𝕜] P₂) (A : set P) :
-  intrinsic_interior 𝕜 (φ '' A) = φ '' intrinsic_interior 𝕜 A :=
+  [normed_add_torsor V₂ P₂] (φ : P →ᵃⁱ[𝕜] P₂) (s : set P) :
+  intrinsic_interior 𝕜 (φ '' s) = φ '' intrinsic_interior 𝕜 s :=
 begin
-  rcases A.eq_empty_or_nonempty with rfl | hc,
-  { simp only [intrinsic_interior_empty, set.image_empty] },
-  haveI : nonempty A := hc.to_subtype,
-  let f := (affine_span 𝕜 A).isometry_equiv_map φ,
+  obtain rfl | hs := s.eq_empty_or_nonempty,
+  { simp only [intrinsic_interior_empty, image_empty] },
+  haveI : nonempty s := hs.to_subtype,
+  let f := (affine_span 𝕜 s).isometry_equiv_map φ,
   let f' := f.to_homeomorph,
-  have : φ.to_affine_map ∘ (coe : affine_span 𝕜 A → P) ∘ f'.symm =
-    (coe : (affine_span 𝕜 A).map φ.to_affine_map → P₂),
+  have : φ.to_affine_map ∘ (coe : affine_span 𝕜 s → P) ∘ f'.symm =
+    (coe : (affine_span 𝕜 s).map φ.to_affine_map → P₂),
   { funext x,
     exact affine_subspace.isometry_equiv_map.apply_symm_apply _ },
-  simp only [intrinsic_interior_def, ←φ.coe_to_affine_map],
-  rw [intrinsic_interior_def],
-  rw [←affine_subspace.map_span φ.to_affine_map A, ←this,
-    ←function.comp.assoc, set.image_comp _ f'.symm,
-    set.image_comp _ (coe : affine_span 𝕜 A → P), f'.symm.image_interior, f'.image_symm,
-    ←set.preimage_comp, function.comp.assoc, f'.symm_comp_self, affine_isometry.coe_to_affine_map,
-    function.comp.right_id, @set.preimage_comp _ P, φ.injective.preimage_image],
+  simp only [intrinsic_interior, ←φ.coe_to_affine_map],
+  rw [intrinsic_interior],
+  rw [←affine_subspace.map_span φ.to_affine_map s, ←this,
+    ←function.comp.assoc, image_comp _ f'.symm,
+    image_comp _ (coe : affine_span 𝕜 s → P), f'.symm.image_interior, f'.image_symm,
+    ←preimage_comp, function.comp.assoc, f'.symm_comp_self, affine_isometry.coe_to_affine_map,
+    function.comp.right_id, @preimage_comp _ P, φ.injective.preimage_image],
 end
 
 end local_instances
@@ -158,76 +142,67 @@ end local_instances
   [nontrivially_normed_field 𝕜] [complete_space 𝕜]
   {V P : Type} [normed_add_comm_group V] [normed_space 𝕜 V]
   [metric_space P] [normed_add_torsor V P]
-  (A : set P) [finite_dimensional 𝕜 V] :
-  intrinsic_closure 𝕜 A = closure A :=
+  (s : set P) [finite_dimensional 𝕜 V] :
+  intrinsic_closure 𝕜 s = closure s :=
 begin
-  simp only [intrinsic_closure_def],
+  simp only [intrinsic_closure],
   ext x,
-  simp only [mem_closure_iff, set.mem_image],
-  split,
-  { rintro ⟨x, h, rfl⟩ o ho hxo,
-    obtain ⟨z, hz₁, hz₂⟩ := h ((coe : affine_span 𝕜 A → P) ⁻¹' o)
-                   (continuous_induced_dom.is_open_preimage o ho) hxo,
+  simp only [mem_closure_iff, mem_image],
+  refine ⟨_, λ h, ⟨⟨x, _⟩, _, subtype.coe_mk _ _⟩⟩,
+  { rintro ⟨x, h, rfl⟩ t ht hx,
+    obtain ⟨z, hz₁, hz₂⟩ := h _
+                   (continuous_induced_dom.is_open_preimage t ht) hx,
     exact ⟨z, hz₁, hz₂⟩ },
-  { intro h,
-    refine ⟨⟨x, _⟩, _⟩,
-    { by_contradiction hc,
-      obtain ⟨z, hz₁, hz₂⟩ := h
-        (affine_span 𝕜 A)ᶜ
-        (affine_subspace.closed_of_finite_dimensional (affine_span 𝕜 A)).is_open_compl
-        hc,
-      exact hz₁ (subset_affine_span 𝕜 A hz₂) },
-    refine ⟨_, subtype.coe_mk _ _⟩,
-    intros o ho hxo,
-    have ho' := ho,
-    rw [is_open_induced_iff] at ho,
-    obtain ⟨o, ho, rfl⟩ := ho,
-    rw [set.mem_preimage, subtype.coe_mk] at hxo,
-    obtain ⟨w, hwo, hwA⟩ := h _ ho hxo,
-    have : w ∈ affine_span 𝕜 A := subset_affine_span 𝕜 A hwA,
-    refine ⟨⟨w, subset_affine_span 𝕜 A hwA⟩, hwo, hwA⟩ },
+  { by_contradiction hc,
+    obtain ⟨z, hz₁, hz₂⟩ := h
+      (affine_span 𝕜 s)ᶜ
+      (affine_subspace.closed_of_finite_dimensional (affine_span 𝕜 s)).is_open_compl
+      hc,
+    exact hz₁ (subset_affine_span 𝕜 s hz₂) },
+  intros t ht hx,
+  rw is_open_induced_iff at ht,
+  obtain ⟨t, ht, rfl⟩ := ht,
+  obtain ⟨w, hwo, hwA⟩ := h _ ht hx,
+  exact ⟨⟨w, subset_affine_span 𝕜 s hwA⟩, hwo, hwA⟩,
 end
 
 @[simp] lemma closure_diff_intrinsic_interior {𝕜 : Type*}
   [nontrivially_normed_field 𝕜] [complete_space 𝕜]
   {V P : Type} [normed_add_comm_group V] [normed_space 𝕜 V] [finite_dimensional 𝕜 V]
   [metric_space P] [normed_add_torsor V P]
-  (A : set P) : closure A \ intrinsic_interior 𝕜 A = intrinsic_frontier 𝕜 A :=
-(intrinsic_closure_eq_closure 𝕜 A) ▸ intrinsic_closure_diff_intrinsic_interior A
+  (s : set P) : closure s \ intrinsic_interior 𝕜 s = intrinsic_frontier 𝕜 s :=
+(intrinsic_closure_eq_closure 𝕜 s) ▸ intrinsic_closure_diff_intrinsic_interior s
 
 lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux {α β : Type*}
-  [topological_space α] [topological_space β] (φ : α ≃ₜ β) (A : set β) :
-  (interior A).nonempty ↔ (interior (φ ⁻¹' A)).nonempty :=
-begin
-  rw [←φ.image_symm, ←φ.symm.image_interior, set.nonempty_image_iff],
-end
+  [topological_space α] [topological_space β] (φ : α ≃ₜ β) (s : set β) :
+  (interior s).nonempty ↔ (interior (φ ⁻¹' s)).nonempty :=
+by rw [←φ.image_symm, ←φ.symm.image_interior, nonempty_image_iff]
 
 lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux_2 {𝕜 V₁ P₁ V₂ P₂ : Type*}
   [normed_field 𝕜] [normed_add_comm_group V₁] [normed_add_comm_group V₂]
   [pseudo_metric_space P₁] [pseudo_metric_space P₂] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]
   [normed_add_torsor V₁ P₁] [normed_add_torsor V₂ P₂]
-  (f : P₁ ≃ᵃⁱ[𝕜] P₂) (A : set P₂) :
-  affine_subspace.comap f.to_affine_equiv.to_affine_map (affine_span 𝕜 A) =
-  affine_span 𝕜 (f ⁻¹' A) :=
-f.to_affine_equiv.comap_span A
+  (f : P₁ ≃ᵃⁱ[𝕜] P₂) (s : set P₂) :
+  (affine_span 𝕜 s).comap f.to_affine_equiv.to_affine_map = affine_span 𝕜 (f ⁻¹' s) :=
+f.to_affine_equiv.comap_span s
 
-/-- The intrinsic interior of a nonempty convex set is nonempty. -/
-lemma nonempty_intrinsic_interior_of_nonempty_of_convex
+/-- The intrinsic interior of s nonempty convex set is nonempty. -/
+lemma set.nonempty.intrinsic_interior
   {V : Type*} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
-  {A : set V} (Ane : A.nonempty) (Acv : convex ℝ A) : (intrinsic_interior ℝ A).nonempty :=
+  {s : set V} (Ane : s.nonempty) (Acv : convex ℝ s) : (intrinsic_interior ℝ s).nonempty :=
 begin
-  haveI : nonempty A := set.nonempty_coe_sort.mpr Ane,
-  rw [intrinsic_interior_def, set.nonempty_image_iff],
+  haveI : nonempty s := nonempty_coe_sort.mpr Ane,
+  rw [intrinsic_interior, nonempty_image_iff],
   obtain ⟨p, hp⟩ := Ane,
-  let p' : affine_span ℝ A := ⟨p, subset_affine_span _ _ hp⟩,
+  let p' : affine_span ℝ s := ⟨p, subset_affine_span _ _ hp⟩,
   rw [nonempty_intrinsic_interior_of_nonempty_of_convex.aux
     (affine_isometry_equiv.const_vsub ℝ p').symm.to_homeomorph,
     convex.interior_nonempty_iff_affine_span_eq_top],
   { rw [affine_isometry_equiv.coe_to_homeomorph,
         ←nonempty_intrinsic_interior_of_nonempty_of_convex.aux_2
           (affine_isometry_equiv.const_vsub ℝ p').symm,
-        affine_span_coe_preimage_eq_top A],
+        affine_span_coe_preimage_eq_top s],
     exact affine_subspace.comap_top },
-  { exact convex.affine_preimage (((affine_span ℝ A).subtype).comp
+  { exact convex.affine_preimage ((affine_span ℝ s).subtype.comp
     (affine_isometry_equiv.const_vsub ℝ p').symm.to_affine_equiv.to_affine_map) Acv },
 end

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -1,0 +1,290 @@
+/-
+Copyright (c) 2022 Paul Reichert. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Reichert, Yaël Dillies
+-/
+import analysis.convex.basic
+import analysis.normed_space.add_torsor_bases
+import analysis.normed_space.basic
+import analysis.normed_space.linear_isometry
+import data.real.basic
+import data.set.pointwise.basic
+import linear_algebra.affine_space.pointwise
+
+/-!
+# Intrinsic frontier and interior
+
+This file defines the intrinsic frontier and intrinsic interior of a set.
+
+## References
+
+See chapter 8 of [Barry Simon, *Convexity*][simon2011] or chapter 1 of
+[Rolf Schneider, *Convex Bodies: The Brunn-Minkowski theory*][schneider2013].
+-/
+
+open_locale pointwise
+
+local attribute [instance, nolint fails_quickly] affine_subspace.to_normed_add_torsor
+local attribute [instance, nolint fails_quickly] affine_subspace.nonempty_map
+
+lemma affine_equiv.image_symm {R V₁ P₁ V₂ P₂ : Type} [ring R]
+  [add_comm_group V₁] [add_comm_group V₂]
+  [module R V₁] [module R V₂]
+  [add_torsor V₁ P₁] [add_torsor V₂ P₂]
+  (f : P₁ ≃ᵃ[R] P₂) :
+set.image f.symm = set.preimage f :=
+funext f.symm.to_equiv.image_eq_preimage
+
+lemma affine_equiv.comap_span {R V₁ P₁ V₂ P₂ : Type} [ring R]
+  [add_comm_group V₁] [add_comm_group V₂]
+  [module R V₁] [module R V₂]
+  [add_torsor V₁ P₁] [add_torsor V₂ P₂]
+  (f : P₁ ≃ᵃ[R] P₂) (A : set P₂) :
+affine_subspace.comap f.to_affine_map (affine_span R A) = affine_span R (f ⁻¹' A) :=
+begin
+  ext1,
+  simp only [affine_subspace.coe_comap, ←affine_equiv.image_symm],
+  simp only [←affine_equiv.coe_to_affine_map],
+  rw [←affine_subspace.map_span, affine_subspace.coe_map],
+  exact (f.to_equiv.symm.image_eq_preimage _).symm,
+end
+
+
+-- IMPORTANT
+lemma affine_isometry_equiv.comap_span {𝕜 V₁ P₁ V₂ P₂ : Type} [normed_field 𝕜]
+  [normed_add_comm_group V₁] [normed_add_comm_group V₂]
+  [pseudo_metric_space P₁] [pseudo_metric_space P₂] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]
+  [normed_add_torsor V₁ P₁] [normed_add_torsor V₂ P₂]
+  (f : P₁ ≃ᵃⁱ[𝕜] P₂) (A : set P₂) :
+affine_subspace.comap f.to_affine_equiv.to_affine_map (affine_span 𝕜 A) =
+  affine_span 𝕜 (f ⁻¹' A) :=
+f.to_affine_equiv.comap_span A
+
+
+lemma homeomorph.interior_nonempty_iff_image {α β : Type}
+  [topological_space α] [topological_space β] (φ : α ≃ₜ β) (A : set α) :
+(interior A).nonempty ↔ (interior (φ '' A)).nonempty :=
+begin
+  rw [←φ.image_interior, set.nonempty_image_iff],
+end
+
+-- IMPORTANT -> make aux lemma
+lemma homeomorph.interior_nonempty_iff_preimage {α β : Type}
+  [topological_space α] [topological_space β] (φ : α ≃ₜ β) (A : set β) :
+(interior A).nonempty ↔ (interior (φ ⁻¹' A)).nonempty :=
+begin
+  rw [←φ.image_symm, φ.interior_nonempty_iff_image, ←set.image_comp, φ.self_comp_symm,
+    set.image_id],
+end
+
+-- ==============================
+-- BEGIN intrinsic_interior.lean
+-- ==============================
+
+/-- The intrinsic interior of a set is its interior considered as a set in its affine span. -/
+def intrinsic_interior (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V] [module R V]
+  [pseudo_metric_space P] [normed_add_torsor V P] -- have to redeclare variables to ensure that
+                                                  -- all typeclasses are used
+  (A : set P) := (coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A)
+
+/-- The intrinsic frontier of a set is its frontier considered as a set in its affine span. -/
+def intrinsic_frontier (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V] [module R V]
+  [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :=
+(coe : affine_span R A → P) '' frontier ((coe : affine_span R A → P) ⁻¹' A)
+
+/-- The intrinsic closure of a set is its closure considered as a set in its affine span. -/
+def intrinsic_closure (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V] [module R V]
+  [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :=
+(coe : affine_span R A → P) '' closure ((coe : affine_span R A → P) ⁻¹' A)
+
+lemma intrinsic_interior_def (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V]
+  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
+intrinsic_interior R A =
+  (coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A) := rfl
+
+lemma intrinsic_frontier_def (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V]
+  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
+intrinsic_frontier R A =
+  (coe : affine_span R A → P) '' frontier ((coe : affine_span R A → P) ⁻¹' A) := rfl
+
+lemma intrinsic_closure_def (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V]
+  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
+intrinsic_closure R A =
+  (coe : affine_span R A → P) '' closure ((coe : affine_span R A → P) ⁻¹' A) := rfl
+
+lemma intrinsic_interior_subset {R : Type} {V P : Type} [ring R] [seminormed_add_comm_group V]
+  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
+intrinsic_interior R A ⊆ A :=
+set.image_subset_iff.mpr interior_subset
+
+lemma intrinsic_frontier_subset {R : Type} {V P : Type} [ring R] [seminormed_add_comm_group V]
+  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] {A : set P} (hA : is_closed A) :
+intrinsic_frontier R A ⊆ A :=
+set.image_subset_iff.mpr (hA.preimage continuous_induced_dom).frontier_subset
+
+@[simp]
+lemma intrinsic_interior_empty {R : Type} {V P : Type} [ring R] [seminormed_add_comm_group V]
+  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] :
+intrinsic_interior R (∅ : set P) = ∅ :=
+set.subset_empty_iff.mp $ intrinsic_interior_subset _
+
+@[simp]
+lemma intrinsic_frontier_empty {R : Type} {V P : Type} [ring R] [seminormed_add_comm_group V]
+  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] :
+intrinsic_frontier R (∅ : set P) = ∅ :=
+set.subset_empty_iff.mp $ intrinsic_frontier_subset is_closed_empty
+
+lemma preimage_singleton_eq_univ {R : Type} {V P : Type} [ring R]
+  [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
+  (x : P) : (coe : affine_span R ({x} : set P) → P) ⁻¹' {x} = set.univ :=
+begin
+  refine subset_antisymm (set.subset_univ _) _,
+  rintro ⟨y, hy⟩ -,
+  obtain rfl := (affine_subspace.mem_affine_span_singleton _ _ _ _).mp hy,
+  exact subtype.coe_mk _ _,
+end
+
+@[simp] lemma intrinsic_interior_singleton {R : Type} {V P : Type} [ring R]
+  [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
+  (x : P) : intrinsic_interior R ({x} : set P) = {x} :=
+begin
+  rw [intrinsic_interior_def, interior_eq_iff_is_open.mpr], swap,
+  { convert is_open_univ,
+    exact preimage_singleton_eq_univ x },
+  { rw [set.eq_singleton_iff_unique_mem],
+    refine ⟨⟨⟨x, _⟩, subtype.coe_mk _ _, subtype.coe_mk _ _⟩, _⟩,
+    { exact (affine_subspace.mem_affine_span_singleton _ _ _ _).mpr rfl },
+    { rintro - ⟨⟨y, hy₁⟩, hy₂, rfl⟩,
+      simpa only [set.mem_preimage, subtype.coe_mk, set.mem_singleton_iff] using hy₂ } },
+end
+
+@[simp] lemma intrinsic_frontier_singleton  {R : Type} {V P : Type} [ring R]
+  [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
+  (x : P) : intrinsic_frontier R ({x} : set P) = ∅ :=
+begin
+  rw [intrinsic_frontier_def, set.image_eq_empty],
+  convert frontier_univ,
+  exact preimage_singleton_eq_univ x,
+end
+
+@[simp] lemma intrinsic_closure_diff_intrinsic_interior {R : Type} {V P : Type} [ring R]
+  [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
+  (A : set P) :
+intrinsic_closure R A \ intrinsic_interior R A = intrinsic_frontier R A :=
+begin
+  rw [intrinsic_frontier_def, intrinsic_closure_def, intrinsic_interior_def,
+    ←set.image_diff subtype.coe_injective],
+  refl,
+end
+
+example {𝕜 V V₂ P P₂: Type}
+  [normed_field 𝕜] [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
+  [normed_space 𝕜 V₂] [metric_space P] [pseudo_metric_space P₂] [normed_add_torsor V P]
+  [normed_add_torsor V₂ P₂] (A: set P) [nonempty A] : normed_add_torsor (affine_span 𝕜 A).direction (affine_span 𝕜 A) :=
+affine_subspace.to_normed_add_torsor (affine_span 𝕜 A)
+
+/--
+The image of the intrinsic interior under an affine isometry is
+the relative interior of the image.
+-/
+@[simp] -- not sure whether this is the correct direction for simp
+lemma affine_isometry.image_intrinsic_interior {𝕜 V V₂ P P₂: Type}
+  [normed_field 𝕜] [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
+  [normed_space 𝕜 V₂] [metric_space P] [pseudo_metric_space P₂] [normed_add_torsor V P]
+  [normed_add_torsor V₂ P₂]
+  (φ : P →ᵃⁱ[𝕜] P₂) (A : set P) :
+intrinsic_interior 𝕜 (φ '' A) = φ '' intrinsic_interior 𝕜 A :=
+begin
+  rcases A.eq_empty_or_nonempty with rfl | hc,
+  { simp only [intrinsic_interior_empty, set.image_empty] },
+  haveI : nonempty A := hc.to_subtype,
+  let f := (affine_span 𝕜 A).isometry_equiv_map φ,
+  let f' := f.to_homeomorph,
+  have : φ.to_affine_map ∘ (coe : affine_span 𝕜 A → P) ∘ f'.symm =
+    (coe : (affine_span 𝕜 A).map φ.to_affine_map → P₂),
+  { funext x,
+    exact affine_subspace.isometry_equiv_map.apply_symm_apply _ },
+  simp only [intrinsic_interior_def, ←φ.coe_to_affine_map],
+  rw [intrinsic_interior_def],
+  rw [←affine_subspace.map_span φ.to_affine_map A, ←this,
+    ←function.comp.assoc, set.image_comp _ f'.symm,
+    set.image_comp _ (coe : affine_span 𝕜 A → P), f'.symm.image_interior, f'.image_symm,
+    ←set.preimage_comp, function.comp.assoc, f'.symm_comp_self, affine_isometry.coe_to_affine_map,
+    function.comp.right_id, @set.preimage_comp _ P, φ.injective.preimage_image],
+end
+
+@[simp] lemma intrinsic_closure_eq_closure (𝕜 : Type)
+  [nontrivially_normed_field 𝕜] [complete_space 𝕜]
+  {V P : Type} [normed_add_comm_group V] [normed_space 𝕜 V]
+  [metric_space P] [normed_add_torsor V P]
+  (A : set P) [finite_dimensional 𝕜 V] :
+intrinsic_closure 𝕜 A = closure A :=
+begin
+  simp only [intrinsic_closure_def],
+  ext x,
+  simp only [mem_closure_iff, set.mem_image],
+  split,
+  { rintro ⟨x, h, rfl⟩ o ho hxo,
+    obtain ⟨z, hz₁, hz₂⟩ := h ((coe : affine_span 𝕜 A → P) ⁻¹' o)
+                   (continuous_induced_dom.is_open_preimage o ho) hxo,
+    exact ⟨z, hz₁, hz₂⟩ },
+  { intro h,
+    refine ⟨⟨x, _⟩, _⟩,
+    { by_contradiction hc,
+      obtain ⟨z, hz₁, hz₂⟩ := h
+        (affine_span 𝕜 A)ᶜ
+        (affine_subspace.closed_of_finite_dimensional (affine_span 𝕜 A)).is_open_compl
+        hc,
+      exact hz₁ (subset_affine_span 𝕜 A hz₂) },
+    refine ⟨_, subtype.coe_mk _ _⟩,
+    intros o ho hxo,
+    have ho' := ho,
+    rw [is_open_induced_iff] at ho,
+    obtain ⟨o, ho, rfl⟩ := ho,
+    rw [set.mem_preimage, subtype.coe_mk] at hxo,
+    obtain ⟨w, hwo, hwA⟩ := h _ ho hxo,
+    have : w ∈ affine_span 𝕜 A := subset_affine_span 𝕜 A hwA,
+    refine ⟨⟨w, subset_affine_span 𝕜 A hwA⟩, hwo, hwA⟩ },
+end
+
+@[simp] lemma closure_diff_intrinsic_interior {𝕜 : Type}
+  [nontrivially_normed_field 𝕜] [complete_space 𝕜]
+  {V P : Type} [normed_add_comm_group V] [normed_space 𝕜 V] [finite_dimensional 𝕜 V]
+  [metric_space P] [normed_add_torsor V P]
+  (A : set P) :
+closure A \ intrinsic_interior 𝕜 A = intrinsic_frontier 𝕜 A :=
+(intrinsic_closure_eq_closure 𝕜 A) ▸ intrinsic_closure_diff_intrinsic_interior A
+
+-- @[simp] lemma intrinsic_interior_vadd {𝕜 V P : Type}
+--   [normed_field 𝕜] [seminormed_add_comm_group V] [normed_space 𝕜 V]
+--   [metric_space P] [normed_add_torsor V P] (x : V) (A : set P) :
+-- intrinsic_interior 𝕜 (x +ᵥ A) = x +ᵥ intrinsic_interior 𝕜 A :=
+-- (normed_add_torsor.vadd_affine_isometry 𝕜 P x).image_intrinsic_interior A
+
+-- TODO
+noncomputable def inclusion_affine {V : Type} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
+  (E : affine_subspace ℝ V) [nonempty E] : E →ᵃ[ℝ] V :=
+{ to_fun := coe,
+  linear := E.direction.subtype,
+  map_vadd' := by
+    { simp only [affine_subspace.coe_vadd, submodule.coe_subtype, eq_self_iff_true,
+                 forall_const] } }
+
+lemma nonempty_intrinsic_interior_of_nonempty_of_convex
+  {V : Type} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
+  {A : set V} (Ane : A.nonempty) (Acv : convex ℝ A) :
+(intrinsic_interior ℝ A).nonempty :=
+begin
+  haveI : nonempty A := set.nonempty_coe_sort.mpr Ane,
+  rw [intrinsic_interior_def, set.nonempty_image_iff],
+  obtain ⟨p, hp⟩ := Ane,
+  let p' : affine_span ℝ A := ⟨p, subset_affine_span _ _ hp⟩,
+  rw [(affine_isometry_equiv.const_vsub ℝ p').symm.to_homeomorph.interior_nonempty_iff_preimage,
+    convex.interior_nonempty_iff_affine_span_eq_top],
+  { rw [affine_isometry_equiv.coe_to_homeomorph,
+      ←affine_isometry_equiv.comap_span (affine_isometry_equiv.const_vsub ℝ p').symm,
+      affine_span_coe_preimage_eq_top A],
+    exact affine_subspace.comap_top },
+  { exact convex.affine_preimage ((inclusion_affine (affine_span ℝ A)).comp
+    (affine_isometry_equiv.const_vsub ℝ p').symm.to_affine_equiv.to_affine_map) Acv },
+end

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -77,26 +77,6 @@ mem_image _ _ _
   x ∈ intrinsic_closure 𝕜 s ↔ ∃ y, y ∈ closure (coe ⁻¹' s : set $ affine_span 𝕜 s) ∧ ↑y = x :=
 mem_image _ _ _
 
-@[simp] lemma intrinsic_interior_empty : intrinsic_interior 𝕜 (∅ : set P) = ∅ :=
-by simp [intrinsic_interior]
-
-@[simp] lemma intrinsic_frontier_empty : intrinsic_frontier 𝕜 (∅ : set P) = ∅ :=
-by simp [intrinsic_frontier]
-
-@[simp] lemma intrinsic_closure_empty : intrinsic_closure 𝕜 (∅ : set P) = ∅ :=
-by simp [intrinsic_closure]
-
-@[simp] lemma intrinsic_interior_singleton (x : P) : intrinsic_interior 𝕜 ({x} : set P) = {x} :=
-by simpa only [intrinsic_interior, preimage_coe_affine_span_singleton, interior_univ, image_univ,
-  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
-
-@[simp] lemma intrinsic_frontier_singleton (x : P) : intrinsic_frontier 𝕜 ({x} : set P) = ∅ :=
-by rw [intrinsic_frontier, preimage_coe_affine_span_singleton, frontier_univ, image_empty]
-
-@[simp] lemma intrinsic_closure_singleton (x : P) : intrinsic_closure 𝕜 ({x} : set P) = {x} :=
-by simpa only [intrinsic_closure, preimage_coe_affine_span_singleton, closure_univ, image_univ,
-  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
-
 lemma intrinsic_interior_subset : intrinsic_interior 𝕜 s ⊆ s := image_subset_iff.2 interior_subset
 
 lemma intrinsic_frontier_subset (hs : is_closed s) : intrinsic_frontier 𝕜 s ⊆ s :=
@@ -108,6 +88,34 @@ image_subset _ frontier_subset_closure
 
 lemma subset_intrinsic_closure : s ⊆ intrinsic_closure 𝕜 s :=
 λ x hx, ⟨⟨x, subset_affine_span _ _ hx⟩, subset_closure hx, rfl⟩
+
+@[simp] lemma intrinsic_interior_empty : intrinsic_interior 𝕜 (∅ : set P) = ∅ :=
+by simp [intrinsic_interior]
+
+@[simp] lemma intrinsic_frontier_empty : intrinsic_frontier 𝕜 (∅ : set P) = ∅ :=
+by simp [intrinsic_frontier]
+
+@[simp] lemma intrinsic_closure_empty : intrinsic_closure 𝕜 (∅ : set P) = ∅ :=
+by simp [intrinsic_closure]
+
+@[simp] lemma intrinsic_closure_nonempty : (intrinsic_closure 𝕜 s).nonempty ↔ s.nonempty :=
+⟨by { simp_rw nonempty_iff_ne_empty, rintro h rfl, exact h intrinsic_closure_empty },
+  nonempty.mono subset_intrinsic_closure⟩
+
+alias intrinsic_closure_nonempty ↔ set.nonempty.of_intrinsic_closure set.nonempty.intrinsic_closure
+
+attribute [protected] set.nonempty.intrinsic_closure
+
+@[simp] lemma intrinsic_interior_singleton (x : P) : intrinsic_interior 𝕜 ({x} : set P) = {x} :=
+by simpa only [intrinsic_interior, preimage_coe_affine_span_singleton, interior_univ, image_univ,
+  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
+
+@[simp] lemma intrinsic_frontier_singleton (x : P) : intrinsic_frontier 𝕜 ({x} : set P) = ∅ :=
+by rw [intrinsic_frontier, preimage_coe_affine_span_singleton, frontier_univ, image_empty]
+
+@[simp] lemma intrinsic_closure_singleton (x : P) : intrinsic_closure 𝕜 ({x} : set P) = {x} :=
+by simpa only [intrinsic_closure, preimage_coe_affine_span_singleton, closure_univ, image_univ,
+  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
 
 /-!
 Note that neither `intrinsic_interior` nor `intrinsic_frontier` is monotone.
@@ -299,7 +307,7 @@ begin
     (affine_isometry_equiv.const_vsub ℝ p').symm.to_affine_equiv.to_affine_map),
 end
 
-lemma nonempty_intrinsic_interior (hs : convex ℝ s) :
+lemma intrinsic_interior_nonempty (hs : convex ℝ s) :
   (intrinsic_interior ℝ s).nonempty ↔ s.nonempty :=
 ⟨by { simp_rw nonempty_iff_ne_empty, rintro h rfl, exact h intrinsic_interior_empty },
   set.nonempty.intrinsic_interior hs⟩

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -36,62 +36,59 @@ See chapter 8 of [Barry Simon, *Convexity*][simon2011] or chapter 1 of
 
 open_locale pointwise
 
+section basic
+
+variables (R: Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V] [module R V]
+  [pseudo_metric_space P] [normed_add_torsor V P]
+
+include V
+
 /-- The intrinsic interior of a set is its interior considered as a set in its affine span. -/
-def intrinsic_interior (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V] [module R V]
-  [pseudo_metric_space P] [normed_add_torsor V P] -- have to redeclare variables to ensure that
-                                                  -- all typeclasses are used
-  (A : set P) := (coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A)
+def intrinsic_interior (A : set P) :=
+(coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A)
 
 /-- The intrinsic frontier of a set is its frontier considered as a set in its affine span. -/
-def intrinsic_frontier (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V] [module R V]
-  [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :=
+def intrinsic_frontier (A : set P) :=
 (coe : affine_span R A → P) '' frontier ((coe : affine_span R A → P) ⁻¹' A)
 
 /-- The intrinsic closure of a set is its closure considered as a set in its affine span. -/
-def intrinsic_closure (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V] [module R V]
-  [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :=
+def intrinsic_closure (A : set P) :=
 (coe : affine_span R A → P) '' closure ((coe : affine_span R A → P) ⁻¹' A)
 
-lemma intrinsic_interior_def (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V]
-  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
+lemma intrinsic_interior_def (A : set P) :
 intrinsic_interior R A =
   (coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A) := rfl
 
-lemma intrinsic_frontier_def (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V]
-  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
+lemma intrinsic_frontier_def (A : set P) :
 intrinsic_frontier R A =
   (coe : affine_span R A → P) '' frontier ((coe : affine_span R A → P) ⁻¹' A) := rfl
 
-lemma intrinsic_closure_def (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V]
-  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
+lemma intrinsic_closure_def (A : set P) :
 intrinsic_closure R A =
   (coe : affine_span R A → P) '' closure ((coe : affine_span R A → P) ⁻¹' A) := rfl
 
-lemma intrinsic_interior_subset {R : Type*} {V P : Type*} [ring R] [seminormed_add_comm_group V]
-  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
+variables {R}
+
+lemma intrinsic_interior_subset (A : set P) :
 intrinsic_interior R A ⊆ A :=
 set.image_subset_iff.mpr interior_subset
 
-lemma intrinsic_frontier_subset {R : Type*} {V P : Type*} [ring R] [seminormed_add_comm_group V]
-  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] {A : set P} (hA : is_closed A) :
+lemma intrinsic_frontier_subset {A : set P} (hA : is_closed A) :
 intrinsic_frontier R A ⊆ A :=
 set.image_subset_iff.mpr (hA.preimage continuous_induced_dom).frontier_subset
 
 @[simp]
-lemma intrinsic_interior_empty {R : Type*} {V P : Type*} [ring R] [seminormed_add_comm_group V]
-  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] :
+lemma intrinsic_interior_empty :
 intrinsic_interior R (∅ : set P) = ∅ :=
 set.subset_empty_iff.mp $ intrinsic_interior_subset _
 
 @[simp]
-lemma intrinsic_frontier_empty {R : Type*} {V P : Type*} [ring R] [seminormed_add_comm_group V]
-  [module R V] [pseudo_metric_space P] [normed_add_torsor V P] :
+lemma intrinsic_frontier_empty :
 intrinsic_frontier R (∅ : set P) = ∅ :=
 set.subset_empty_iff.mp $ intrinsic_frontier_subset is_closed_empty
 
-lemma preimage_singleton_eq_univ {R : Type*} {V P : Type*} [ring R]
-  [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
-  (x : P) : (coe : affine_span R ({x} : set P) → P) ⁻¹' {x} = set.univ :=
+lemma preimage_singleton_eq_univ (x : P) :
+  (coe : affine_span R ({x} : set P) → P) ⁻¹' {x} = set.univ :=
 begin
   refine subset_antisymm (set.subset_univ _) _,
   rintro ⟨y, hy⟩ -,
@@ -99,9 +96,7 @@ begin
   exact subtype.coe_mk _ _,
 end
 
-@[simp] lemma intrinsic_interior_singleton {R : Type*} {V P : Type*} [ring R]
-  [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
-  (x : P) : intrinsic_interior R ({x} : set P) = {x} :=
+@[simp] lemma intrinsic_interior_singleton (x : P) : intrinsic_interior R ({x} : set P) = {x} :=
 begin
   rw [intrinsic_interior_def, interior_eq_iff_is_open.mpr], swap,
   { convert is_open_univ,
@@ -113,24 +108,22 @@ begin
       simpa only [set.mem_preimage, subtype.coe_mk, set.mem_singleton_iff] using hy₂ } },
 end
 
-@[simp] lemma intrinsic_frontier_singleton  {R : Type*} {V P : Type*} [ring R]
-  [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
-  (x : P) : intrinsic_frontier R ({x} : set P) = ∅ :=
+@[simp] lemma intrinsic_frontier_singleton (x : P) : intrinsic_frontier R ({x} : set P) = ∅ :=
 begin
   rw [intrinsic_frontier_def, set.image_eq_empty],
   convert frontier_univ,
   exact preimage_singleton_eq_univ x,
 end
 
-@[simp] lemma intrinsic_closure_diff_intrinsic_interior {R : Type*} {V P : Type*} [ring R]
-  [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
-  (A : set P) :
+@[simp] lemma intrinsic_closure_diff_intrinsic_interior (A : set P) :
 intrinsic_closure R A \ intrinsic_interior R A = intrinsic_frontier R A :=
 begin
   rw [intrinsic_frontier_def, intrinsic_closure_def, intrinsic_interior_def,
     ←set.image_diff subtype.coe_injective],
   refl,
 end
+
+end basic
 
 section local_instances
 
@@ -142,11 +135,10 @@ The image of the intrinsic interior under an affine isometry is
 the relative interior of the image.
 -/
 @[simp] -- not sure whether this is the correct direction for simp
-lemma affine_isometry.image_intrinsic_interior {𝕜 V V₂ P P₂: Type*}
-  [normed_field 𝕜] [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
+lemma affine_isometry.image_intrinsic_interior {𝕜 V V₂ P P₂ : Type*} [normed_field 𝕜]
+  [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
   [normed_space 𝕜 V₂] [metric_space P] [pseudo_metric_space P₂] [normed_add_torsor V P]
-  [normed_add_torsor V₂ P₂]
-  (φ : P →ᵃⁱ[𝕜] P₂) (A : set P) :
+  [normed_add_torsor V₂ P₂] (φ : P →ᵃⁱ[𝕜] P₂) (A : set P) :
 intrinsic_interior 𝕜 (φ '' A) = φ '' intrinsic_interior 𝕜 A :=
 begin
   rcases A.eq_empty_or_nonempty with rfl | hc,

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -3,18 +3,30 @@ Copyright (c) 2022 Paul Reichert. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Reichert, Yaël Dillies
 -/
-import analysis.convex.basic
 import analysis.normed_space.add_torsor_bases
-import analysis.normed_space.basic
 import analysis.normed_space.linear_isometry
-import data.real.basic
-import data.set.pointwise.basic
-import linear_algebra.affine_space.pointwise
 
 /-!
 # Intrinsic frontier and interior
 
-This file defines the intrinsic frontier and intrinsic interior of a set.
+This file defines the intrinsic frontier and intrinsic interior of a set in
+a normed additive torsor, e.g. a real vector space or a nonempty affine subspace thereof.
+
+## Definitions
+
+- `intrinsic_interior`: the intrinsic interior or relative interior (the interior in the affine
+  span)
+- `intrinsic_frontier`: the intrinsic frontier, intrinsic boundary or relative boundary
+- `intrinsic_closure`: the intrinsic closure, which usually equals the closure
+
+## Results
+
+The main results are:
+
+- `affine_isometry.image_intrinsic_interior`: The image of the intrinsic interior under an affine
+  isometry is the relative interior of the image.
+- `nonempty_intrinsic_interior_of_nonempty_of_convex`: The intrinsic interior of a nonempty convex
+  set is nonempty.
 
 ## References
 
@@ -215,6 +227,7 @@ affine_subspace.comap f.to_affine_equiv.to_affine_map (affine_span 𝕜 A) =
   affine_span 𝕜 (f ⁻¹' A) :=
 f.to_affine_equiv.comap_span A
 
+/-- The intrinsic interior of a nonempty convex set is nonempty. -/
 lemma nonempty_intrinsic_interior_of_nonempty_of_convex
   {V : Type*} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
   {A : set V} (Ane : A.nonempty) (Acv : convex ℝ A) :

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -9,200 +9,297 @@ import analysis.normed_space.linear_isometry
 /-!
 # Intrinsic frontier and interior
 
-This file defines the intrinsic frontier and intrinsic interior of s set in
-s normed additive torsor, e.g. s real vector space or s nonempty affine subspace thereof.
+This file defines the intrinsic frontier, interior and closure of a set in a normed additive torsor.
+These are also known as relative frontier, interior, closure.
+
+The intrinsic frontier/interior/closure of a set `s` is the frontier/interior/closure of `s`
+considered as a set in its affine span.
+
+The intrinsic interior is in general greater than the topological interior, the intrinsic frontier
+in general less than the topological frontier, and the intrinsic closure in cases of interest the
+same as the topological closure.
 
 ## Definitions
 
-- `intrinsic_interior`: the intrinsic interior or relative interior (the interior in the affine
-  span)
-- `intrinsic_frontier`: the intrinsic frontier, intrinsic boundary or relative boundary
-- `intrinsic_closure`: the intrinsic closure, which usually equals the closure
+* `intrinsic_interior`: Intrinsic interior
+* `intrinsic_frontier`: Intrinsic frontier
+* `intrinsic_closure`: Intrinsic closure
 
 ## Results
 
 The main results are:
-
-- `affine_isometry.image_intrinsic_interior`: The image of the intrinsic interior under an affine
-  isometry is the relative interior of the image.
-- `nonempty_intrinsic_interior_of_nonempty_of_convex`: The intrinsic interior of s nonempty convex
-  set is nonempty.
+* `affine_isometry.image_intrinsic_interior`/`affine_isometry.image_intrinsic_frontier`/
+  `affine_isometry.image_intrinsic_closure`: Intrinsic interiors/frontiers/closures commute with
+  taking the image under an affine isometry.
+* `set.nonempty.intrinsic_interior`: The intrinsic interior of a nonempty convex set is nonempty.
 
 ## References
 
 * Chapter 8 of [Barry Simon, *Convexity*][simon2011]
 * Chapter 1 of [Rolf Schneider, *Convex Bodies: The Brunn-Minkowski theory*][schneider2013].
+
+## TODO
+
+* `is_closed s → is_extreme 𝕜 s (intrinsic_frontier 𝕜 s)`
+* `x ∈ s → y ∈ intrinsic_interior 𝕜 s → open_segment 𝕜 x y ⊆ intrinsic_interior 𝕜 s`
 -/
 
 open set
 open_locale pointwise
 
+variables {𝕜 V W Q P : Type*}
+
 section add_torsor
-variables (R : Type*) {V P : Type*} [ring R] [add_comm_group V] [module R V] [topological_space P]
-  [add_torsor V P] {s : set P} {x : P}
+variables (𝕜) [ring 𝕜] [add_comm_group V] [module 𝕜 V] [topological_space P] [add_torsor V P]
+  {s t : set P} {x : P}
 include V
 
-/-- The intrinsic interior of s set is its interior considered as s set in its affine span. -/
-def intrinsic_interior (s : set P) : set P := coe '' interior (coe ⁻¹' s : set $ affine_span R s)
+/-- The intrinsic interior of a set is its interior considered as a set in its affine span. -/
+def intrinsic_interior (s : set P) : set P := coe '' interior (coe ⁻¹' s : set $ affine_span 𝕜 s)
 
-/-- The intrinsic frontier of s set is its frontier considered as s set in its affine span. -/
-def intrinsic_frontier (s : set P) : set P := coe '' frontier (coe ⁻¹' s : set $ affine_span R s)
+/-- The intrinsic frontier of a set is its frontier considered as a set in its affine span. -/
+def intrinsic_frontier (s : set P) : set P := coe '' frontier (coe ⁻¹' s : set $ affine_span 𝕜 s)
 
-/-- The intrinsic closure of s set is its closure considered as s set in its affine span. -/
-def intrinsic_closure (s : set P) : set P := coe '' closure (coe ⁻¹' s : set $ affine_span R s)
+/-- The intrinsic closure of a set is its closure considered as a set in its affine span. -/
+def intrinsic_closure (s : set P) : set P := coe '' closure (coe ⁻¹' s : set $ affine_span 𝕜 s)
 
-variables {R}
+variables {𝕜}
 
 @[simp] lemma mem_intrinsic_interior :
-  x ∈ intrinsic_interior R s ↔ ∃ y, y ∈ interior (coe ⁻¹' s : set $ affine_span R s) ∧ ↑y = x :=
+  x ∈ intrinsic_interior 𝕜 s ↔ ∃ y, y ∈ interior (coe ⁻¹' s : set $ affine_span 𝕜 s) ∧ ↑y = x :=
 mem_image _ _ _
 
 @[simp] lemma mem_intrinsic_frontier :
-  x ∈ intrinsic_frontier R s ↔ ∃ y, y ∈ frontier (coe ⁻¹' s : set $ affine_span R s) ∧ ↑y = x :=
+  x ∈ intrinsic_frontier 𝕜 s ↔ ∃ y, y ∈ frontier (coe ⁻¹' s : set $ affine_span 𝕜 s) ∧ ↑y = x :=
 mem_image _ _ _
 
 @[simp] lemma mem_intrinsic_closure :
-  x ∈ intrinsic_closure R s ↔ ∃ y, y ∈ closure (coe ⁻¹' s : set $ affine_span R s) ∧ ↑y = x :=
+  x ∈ intrinsic_closure 𝕜 s ↔ ∃ y, y ∈ closure (coe ⁻¹' s : set $ affine_span 𝕜 s) ∧ ↑y = x :=
 mem_image _ _ _
 
-lemma intrinsic_interior_subset : intrinsic_interior R s ⊆ s := image_subset_iff.2 interior_subset
+@[simp] lemma intrinsic_interior_empty : intrinsic_interior 𝕜 (∅ : set P) = ∅ :=
+by simp [intrinsic_interior]
 
-lemma intrinsic_frontier_subset (hs : is_closed s) : intrinsic_frontier R s ⊆ s :=
+@[simp] lemma intrinsic_frontier_empty : intrinsic_frontier 𝕜 (∅ : set P) = ∅ :=
+by simp [intrinsic_frontier]
+
+@[simp] lemma intrinsic_closure_empty : intrinsic_closure 𝕜 (∅ : set P) = ∅ :=
+by simp [intrinsic_closure]
+
+@[simp] lemma intrinsic_interior_singleton (x : P) : intrinsic_interior 𝕜 ({x} : set P) = {x} :=
+by simpa only [intrinsic_interior, preimage_coe_affine_span_singleton, interior_univ, image_univ,
+  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
+
+@[simp] lemma intrinsic_frontier_singleton (x : P) : intrinsic_frontier 𝕜 ({x} : set P) = ∅ :=
+by rw [intrinsic_frontier, preimage_coe_affine_span_singleton, frontier_univ, image_empty]
+
+@[simp] lemma intrinsic_closure_singleton (x : P) : intrinsic_closure 𝕜 ({x} : set P) = {x} :=
+by simpa only [intrinsic_closure, preimage_coe_affine_span_singleton, closure_univ, image_univ,
+  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
+
+lemma intrinsic_interior_subset : intrinsic_interior 𝕜 s ⊆ s := image_subset_iff.2 interior_subset
+
+lemma intrinsic_frontier_subset (hs : is_closed s) : intrinsic_frontier 𝕜 s ⊆ s :=
 image_subset_iff.2 (hs.preimage continuous_induced_dom).frontier_subset
 
-@[simp] lemma intrinsic_interior_empty : intrinsic_interior R (∅ : set P) = ∅ :=
-subset_empty_iff.1 intrinsic_interior_subset
+lemma intrinsic_frontier_subset_intrinsic_closure :
+  intrinsic_frontier 𝕜 s ⊆ intrinsic_closure 𝕜 s :=
+image_subset _ frontier_subset_closure
 
-@[simp] lemma intrinsic_frontier_empty : intrinsic_frontier R (∅ : set P) = ∅ :=
-subset_empty_iff.1 $ intrinsic_frontier_subset is_closed_empty
+lemma subset_intrinsic_closure : s ⊆ intrinsic_closure 𝕜 s :=
+λ x hx, ⟨⟨x, subset_affine_span _ _ hx⟩, subset_closure hx, rfl⟩
 
-lemma preimage_singleton_eq_univ (x : P) :
-  (coe : affine_span R ({x} : set P) → P) ⁻¹' {x} = univ :=
-eq_univ_of_forall $ λ y, (affine_subspace.mem_affine_span_singleton _ _ _ _).1 y.2
+/-!
+Note that neither `intrinsic_interior` nor `intrinsic_frontier` is monotone.
+-/
+
+lemma intrinsic_closure_mono (h : s ⊆ t) : intrinsic_closure 𝕜 s ⊆ intrinsic_closure 𝕜 t :=
+begin
+  refine image_subset_iff.2 (λ x hx, ⟨set.inclusion (affine_span_mono _ h) x,
+    (continuous_inclusion _).closure_preimage_subset _ $ closure_mono _ hx, rfl⟩),
+  exact λ y hy, h hy,
+end
+
+lemma interior_subset_intrinsic_interior : interior s ⊆ intrinsic_interior 𝕜 s :=
+λ x hx, ⟨⟨x, subset_affine_span _ _ $ interior_subset hx⟩,
+  preimage_interior_subset_interior_preimage continuous_subtype_coe hx, rfl⟩
+
+lemma intrinsic_closure_subset_closure : intrinsic_closure 𝕜 s ⊆ closure s :=
+image_subset_iff.2 $ continuous_subtype_coe.closure_preimage_subset _
+
+lemma intrinsic_frontier_subset_frontier : intrinsic_frontier 𝕜 s ⊆ frontier s :=
+image_subset_iff.2 $ continuous_subtype_coe.frontier_preimage_subset _
+
+lemma intrinsic_closure_subset_affine_span : intrinsic_closure 𝕜 s ⊆ affine_span 𝕜 s :=
+(image_subset_range _ _).trans subtype.range_coe.subset
 
 @[simp] lemma intrinsic_closure_diff_intrinsic_frontier (s : set P) :
-  intrinsic_closure R s \ intrinsic_frontier R s = intrinsic_interior R s :=
+  intrinsic_closure 𝕜 s \ intrinsic_frontier 𝕜 s = intrinsic_interior 𝕜 s :=
 (image_diff subtype.coe_injective _ _).symm.trans $
   by rw [closure_diff_frontier, intrinsic_interior]
 
 @[simp] lemma intrinsic_closure_diff_intrinsic_interior (s : set P) :
-  intrinsic_closure R s \ intrinsic_interior R s = intrinsic_frontier R s :=
+  intrinsic_closure 𝕜 s \ intrinsic_interior 𝕜 s = intrinsic_frontier 𝕜 s :=
 (image_diff subtype.coe_injective _ _).symm
 
-@[simp] lemma intrinsic_interior_singleton (x : P) : intrinsic_interior R ({x} : set P) = {x} :=
-by simpa only [intrinsic_interior, preimage_singleton_eq_univ, interior_univ, image_univ,
-  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
+@[simp] lemma intrinsic_interior_union_intrinsic_frontier (s : set P) :
+  intrinsic_interior 𝕜 s ∪ intrinsic_frontier 𝕜 s = intrinsic_closure 𝕜 s :=
+by simp [intrinsic_closure, intrinsic_interior, intrinsic_frontier,
+  closure_eq_interior_union_frontier, image_union]
 
-@[simp] lemma intrinsic_frontier_singleton (x : P) : intrinsic_frontier R ({x} : set P) = ∅ :=
-by rw [intrinsic_frontier, preimage_singleton_eq_univ, frontier_univ, image_empty]
+@[simp] lemma intrinsic_frontier_union_intrinsic_interior (s : set P) :
+  intrinsic_frontier 𝕜 s ∪ intrinsic_interior 𝕜 s = intrinsic_closure 𝕜 s :=
+by rw [union_comm, intrinsic_interior_union_intrinsic_frontier]
 
-@[simp] lemma intrinsic_closure_singleton (x : P) : intrinsic_closure R ({x} : set P) = {x} :=
-by simpa only [intrinsic_closure, preimage_singleton_eq_univ, closure_univ, image_univ,
-  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
+lemma is_closed_intrinsic_closure (hs : is_closed (affine_span 𝕜 s : set P)) :
+  is_closed (intrinsic_closure 𝕜 s) :=
+(closed_embedding_subtype_coe hs).is_closed_map _ is_closed_closure
+
+lemma is_closed_intrinsic_frontier (hs : is_closed (affine_span 𝕜 s : set P)) :
+  is_closed (intrinsic_frontier 𝕜 s) :=
+(closed_embedding_subtype_coe hs).is_closed_map _ is_closed_frontier
+
+@[simp] lemma affine_span_intrinsic_closure (s : set P) :
+  affine_span 𝕜 (intrinsic_closure 𝕜 s) = affine_span 𝕜 s :=
+(affine_span_le.2 intrinsic_closure_subset_affine_span).antisymm $
+  affine_span_mono _ subset_intrinsic_closure
+
+protected lemma is_closed.intrinsic_closure (hs : is_closed (coe ⁻¹' s : set $ affine_span 𝕜 s)) :
+  intrinsic_closure 𝕜 s = s :=
+begin
+  rw [intrinsic_closure, hs.closure_eq, image_preimage_eq_of_subset],
+  exact (subset_affine_span _ _).trans subtype.range_coe.superset,
+end
+
+@[simp] lemma intrinsic_closure_idem (s : set P) :
+  intrinsic_closure 𝕜 (intrinsic_closure 𝕜 s) = intrinsic_closure 𝕜 s :=
+begin
+  refine is_closed.intrinsic_closure _,
+  set t := affine_span 𝕜 (intrinsic_closure 𝕜 s) with ht,
+  clear_value t,
+  obtain rfl := ht.trans (affine_span_intrinsic_closure _),
+  rw [intrinsic_closure, preimage_image_eq _ subtype.coe_injective],
+  exact is_closed_closure,
+end
 
 end add_torsor
 
-section local_instances
+namespace affine_isometry
+variables [normed_field 𝕜] [seminormed_add_comm_group V] [seminormed_add_comm_group W]
+  [normed_space 𝕜 V] [normed_space 𝕜 W] [metric_space P] [pseudo_metric_space Q]
+  [normed_add_torsor V P] [normed_add_torsor W Q]
+include V W
 
 local attribute [instance, nolint fails_quickly] affine_subspace.to_normed_add_torsor
-local attribute [instance, nolint fails_quickly] affine_subspace.nonempty_map
+  affine_subspace.nonempty_map
 
-/--
-The image of the intrinsic interior under an affine isometry is
-the relative interior of the image.
--/
-@[simp] -- not sure whether this is the correct direction for simp
-lemma affine_isometry.image_intrinsic_interior {𝕜 V V₂ P P₂ : Type*} [normed_field 𝕜]
-  [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
-  [normed_space 𝕜 V₂] [metric_space P] [pseudo_metric_space P₂] [normed_add_torsor V P]
-  [normed_add_torsor V₂ P₂] (φ : P →ᵃⁱ[𝕜] P₂) (s : set P) :
+@[simp] lemma image_intrinsic_interior (φ : P →ᵃⁱ[𝕜] Q) (s : set P) :
   intrinsic_interior 𝕜 (φ '' s) = φ '' intrinsic_interior 𝕜 s :=
 begin
   obtain rfl | hs := s.eq_empty_or_nonempty,
   { simp only [intrinsic_interior_empty, image_empty] },
   haveI : nonempty s := hs.to_subtype,
-  let f := (affine_span 𝕜 s).isometry_equiv_map φ,
-  let f' := f.to_homeomorph,
-  have : φ.to_affine_map ∘ (coe : affine_span 𝕜 s → P) ∘ f'.symm =
-    (coe : (affine_span 𝕜 s).map φ.to_affine_map → P₂),
-  { funext x,
-    exact affine_subspace.isometry_equiv_map.apply_symm_apply _ },
-  simp only [intrinsic_interior, ←φ.coe_to_affine_map],
-  rw [intrinsic_interior],
-  rw [←affine_subspace.map_span φ.to_affine_map s, ←this,
-    ←function.comp.assoc, image_comp _ f'.symm,
-    image_comp _ (coe : affine_span 𝕜 s → P), f'.symm.image_interior, f'.image_symm,
-    ←preimage_comp, function.comp.assoc, f'.symm_comp_self, affine_isometry.coe_to_affine_map,
-    function.comp.right_id, @preimage_comp _ P, φ.injective.preimage_image],
+  let f := ((affine_span 𝕜 s).isometry_equiv_map φ).to_homeomorph,
+  have : φ.to_affine_map ∘ coe ∘ f.symm = coe :=
+    funext affine_subspace.isometry_equiv_map.apply_symm_apply,
+  rw [intrinsic_interior, intrinsic_interior, ←φ.coe_to_affine_map,
+    ←affine_subspace.map_span φ.to_affine_map s, ←this, ←function.comp.assoc, image_comp,
+    image_comp, f.symm.image_interior, f.image_symm, ←preimage_comp, function.comp.assoc,
+    f.symm_comp_self, affine_isometry.coe_to_affine_map, function.comp.right_id, preimage_comp,
+    φ.injective.preimage_image],
 end
 
-end local_instances
-
-@[simp] lemma intrinsic_closure_eq_closure (𝕜 : Type*)
-  [nontrivially_normed_field 𝕜] [complete_space 𝕜]
-  {V P : Type} [normed_add_comm_group V] [normed_space 𝕜 V]
-  [metric_space P] [normed_add_torsor V P]
-  (s : set P) [finite_dimensional 𝕜 V] :
-  intrinsic_closure 𝕜 s = closure s :=
+@[simp] lemma image_intrinsic_frontier (φ : P →ᵃⁱ[𝕜] Q) (s : set P) :
+  intrinsic_frontier 𝕜 (φ '' s) = φ '' intrinsic_frontier 𝕜 s :=
 begin
-  simp only [intrinsic_closure],
+  obtain rfl | hs := s.eq_empty_or_nonempty,
+  { simp },
+  haveI : nonempty s := hs.to_subtype,
+  let f := ((affine_span 𝕜 s).isometry_equiv_map φ).to_homeomorph,
+  have : φ.to_affine_map ∘ coe ∘ f.symm = coe :=
+    funext affine_subspace.isometry_equiv_map.apply_symm_apply,
+  rw [intrinsic_frontier, intrinsic_frontier, ←φ.coe_to_affine_map,
+    ←affine_subspace.map_span φ.to_affine_map s, ←this, ←function.comp.assoc, image_comp,
+    image_comp, f.symm.image_frontier, f.image_symm, ←preimage_comp, function.comp.assoc,
+    f.symm_comp_self, affine_isometry.coe_to_affine_map, function.comp.right_id, preimage_comp,
+    φ.injective.preimage_image],
+end
+
+@[simp] lemma image_intrinsic_closure (φ : P →ᵃⁱ[𝕜] Q) (s : set P) :
+  intrinsic_closure 𝕜 (φ '' s) = φ '' intrinsic_closure 𝕜 s :=
+begin
+  obtain rfl | hs := s.eq_empty_or_nonempty,
+  { simp },
+  haveI : nonempty s := hs.to_subtype,
+  let f := ((affine_span 𝕜 s).isometry_equiv_map φ).to_homeomorph,
+  have : φ.to_affine_map ∘ coe ∘ f.symm = coe :=
+    funext affine_subspace.isometry_equiv_map.apply_symm_apply,
+  rw [intrinsic_closure, intrinsic_closure, ←φ.coe_to_affine_map,
+    ←affine_subspace.map_span φ.to_affine_map s, ←this, ←function.comp.assoc, image_comp,
+    image_comp, f.symm.image_closure, f.image_symm, ←preimage_comp, function.comp.assoc,
+    f.symm_comp_self, affine_isometry.coe_to_affine_map, function.comp.right_id, preimage_comp,
+    φ.injective.preimage_image],
+end
+
+end affine_isometry
+
+section normed_add_torsor
+variables (𝕜) [nontrivially_normed_field 𝕜] [complete_space 𝕜] [normed_add_comm_group V]
+  [normed_space 𝕜 V] [finite_dimensional 𝕜 V] [metric_space P] [normed_add_torsor V P] (s : set P)
+include V
+
+@[simp] lemma intrinsic_closure_eq_closure : intrinsic_closure 𝕜 s = closure s :=
+begin
   ext x,
-  simp only [mem_closure_iff, mem_image],
+  simp only [mem_closure_iff, mem_intrinsic_closure],
   refine ⟨_, λ h, ⟨⟨x, _⟩, _, subtype.coe_mk _ _⟩⟩,
   { rintro ⟨x, h, rfl⟩ t ht hx,
-    obtain ⟨z, hz₁, hz₂⟩ := h _
-                   (continuous_induced_dom.is_open_preimage t ht) hx,
+    obtain ⟨z, hz₁, hz₂⟩ := h _ (continuous_induced_dom.is_open_preimage t ht) hx,
     exact ⟨z, hz₁, hz₂⟩ },
   { by_contradiction hc,
-    obtain ⟨z, hz₁, hz₂⟩ := h
-      (affine_span 𝕜 s)ᶜ
-      (affine_subspace.closed_of_finite_dimensional (affine_span 𝕜 s)).is_open_compl
-      hc,
+    obtain ⟨z, hz₁, hz₂⟩ := h _ (affine_span 𝕜 s).closed_of_finite_dimensional.is_open_compl hc,
     exact hz₁ (subset_affine_span 𝕜 s hz₂) },
-  intros t ht hx,
-  rw is_open_induced_iff at ht,
-  obtain ⟨t, ht, rfl⟩ := ht,
-  obtain ⟨w, hwo, hwA⟩ := h _ ht hx,
-  exact ⟨⟨w, subset_affine_span 𝕜 s hwA⟩, hwo, hwA⟩,
+  { rintro _ ⟨t, ht, rfl⟩ hx,
+    obtain ⟨y, hyt, hys⟩ := h _ ht hx,
+    exact ⟨⟨_, subset_affine_span 𝕜 s hys⟩, hyt, hys⟩ }
 end
 
-@[simp] lemma closure_diff_intrinsic_interior {𝕜 : Type*}
-  [nontrivially_normed_field 𝕜] [complete_space 𝕜]
-  {V P : Type} [normed_add_comm_group V] [normed_space 𝕜 V] [finite_dimensional 𝕜 V]
-  [metric_space P] [normed_add_torsor V P]
-  (s : set P) : closure s \ intrinsic_interior 𝕜 s = intrinsic_frontier 𝕜 s :=
-(intrinsic_closure_eq_closure 𝕜 s) ▸ intrinsic_closure_diff_intrinsic_interior s
+variables {𝕜}
 
-lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux {α β : Type*}
-  [topological_space α] [topological_space β] (φ : α ≃ₜ β) (s : set β) :
+@[simp] lemma closure_diff_intrinsic_interior (s : set P) :
+  closure s \ intrinsic_interior 𝕜 s = intrinsic_frontier 𝕜 s :=
+intrinsic_closure_eq_closure 𝕜 s ▸ intrinsic_closure_diff_intrinsic_interior s
+
+@[simp] lemma closure_diff_intrinsic_frontier (s : set P) :
+  closure s \ intrinsic_frontier 𝕜 s = intrinsic_interior 𝕜 s :=
+intrinsic_closure_eq_closure 𝕜 s ▸ intrinsic_closure_diff_intrinsic_frontier s
+
+end normed_add_torsor
+
+private lemma aux {α β : Type*} [topological_space α] [topological_space β] (φ : α ≃ₜ β)
+  (s : set β) :
   (interior s).nonempty ↔ (interior (φ ⁻¹' s)).nonempty :=
 by rw [←φ.image_symm, ←φ.symm.image_interior, nonempty_image_iff]
 
-lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux_2 {𝕜 V₁ P₁ V₂ P₂ : Type*}
-  [normed_field 𝕜] [normed_add_comm_group V₁] [normed_add_comm_group V₂]
-  [pseudo_metric_space P₁] [pseudo_metric_space P₂] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]
-  [normed_add_torsor V₁ P₁] [normed_add_torsor V₂ P₂]
-  (f : P₁ ≃ᵃⁱ[𝕜] P₂) (s : set P₂) :
-  (affine_span 𝕜 s).comap f.to_affine_equiv.to_affine_map = affine_span 𝕜 (f ⁻¹' s) :=
-f.to_affine_equiv.comap_span s
+variables [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V] {s : set V}
 
-/-- The intrinsic interior of s nonempty convex set is nonempty. -/
-lemma set.nonempty.intrinsic_interior
-  {V : Type*} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
-  {s : set V} (Ane : s.nonempty) (Acv : convex ℝ s) : (intrinsic_interior ℝ s).nonempty :=
+/-- The intrinsic interior of a nonempty convex set is nonempty. -/
+protected lemma set.nonempty.intrinsic_interior (hscv : convex ℝ s) (hsne : s.nonempty) :
+  (intrinsic_interior ℝ s).nonempty :=
 begin
-  haveI : nonempty s := nonempty_coe_sort.mpr Ane,
-  rw [intrinsic_interior, nonempty_image_iff],
-  obtain ⟨p, hp⟩ := Ane,
+  haveI := hsne.coe_sort,
+  obtain ⟨p, hp⟩ := hsne,
   let p' : affine_span ℝ s := ⟨p, subset_affine_span _ _ hp⟩,
-  rw [nonempty_intrinsic_interior_of_nonempty_of_convex.aux
-    (affine_isometry_equiv.const_vsub ℝ p').symm.to_homeomorph,
-    convex.interior_nonempty_iff_affine_span_eq_top],
-  { rw [affine_isometry_equiv.coe_to_homeomorph,
-        ←nonempty_intrinsic_interior_of_nonempty_of_convex.aux_2
-          (affine_isometry_equiv.const_vsub ℝ p').symm,
-        affine_span_coe_preimage_eq_top s],
-    exact affine_subspace.comap_top },
-  { exact convex.affine_preimage ((affine_span ℝ s).subtype.comp
-    (affine_isometry_equiv.const_vsub ℝ p').symm.to_affine_equiv.to_affine_map) Acv },
+  rw [intrinsic_interior, nonempty_image_iff,
+    aux (affine_isometry_equiv.const_vsub ℝ p').symm.to_homeomorph,
+    convex.interior_nonempty_iff_affine_span_eq_top, affine_isometry_equiv.coe_to_homeomorph,
+    ←affine_isometry_equiv.coe_to_affine_equiv, ←affine_equiv.comap_span,
+    affine_span_coe_preimage_eq_top, affine_subspace.comap_top],
+  exact hscv.affine_preimage ((affine_span ℝ s).subtype.comp
+    (affine_isometry_equiv.const_vsub ℝ p').symm.to_affine_equiv.to_affine_map),
 end
+
+lemma nonempty_intrinsic_interior (hs : convex ℝ s) :
+  (intrinsic_interior ℝ s).nonempty ↔ s.nonempty :=
+⟨by { simp_rw nonempty_iff_ne_empty, rintro h rfl, exact h intrinsic_interior_empty },
+  set.nonempty.intrinsic_interior hs⟩

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -27,7 +27,7 @@ open_locale pointwise
 local attribute [instance, nolint fails_quickly] affine_subspace.to_normed_add_torsor
 local attribute [instance, nolint fails_quickly] affine_subspace.nonempty_map
 
-lemma affine_equiv.image_symm {R V₁ P₁ V₂ P₂ : Type} [ring R]
+lemma affine_equiv.image_symm {R V₁ P₁ V₂ P₂ : Type*} [ring R]
   [add_comm_group V₁] [add_comm_group V₂]
   [module R V₁] [module R V₂]
   [add_torsor V₁ P₁] [add_torsor V₂ P₂]
@@ -35,7 +35,7 @@ lemma affine_equiv.image_symm {R V₁ P₁ V₂ P₂ : Type} [ring R]
 set.image f.symm = set.preimage f :=
 funext f.symm.to_equiv.image_eq_preimage
 
-lemma affine_equiv.comap_span {R V₁ P₁ V₂ P₂ : Type} [ring R]
+lemma affine_equiv.comap_span {R V₁ P₁ V₂ P₂ : Type*} [ring R]
   [add_comm_group V₁] [add_comm_group V₂]
   [module R V₁] [module R V₂]
   [add_torsor V₁ P₁] [add_torsor V₂ P₂]
@@ -49,7 +49,7 @@ begin
   exact (f.to_equiv.symm.image_eq_preimage _).symm,
 end
 
-lemma affine_isometry_equiv.comap_span {𝕜 V₁ P₁ V₂ P₂ : Type} [normed_field 𝕜]
+lemma affine_isometry_equiv.comap_span {𝕜 V₁ P₁ V₂ P₂ : Type*} [normed_field 𝕜]
   [normed_add_comm_group V₁] [normed_add_comm_group V₂]
   [pseudo_metric_space P₁] [pseudo_metric_space P₂] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]
   [normed_add_torsor V₁ P₁] [normed_add_torsor V₂ P₂]
@@ -58,6 +58,7 @@ affine_subspace.comap f.to_affine_equiv.to_affine_map (affine_span 𝕜 A) =
   affine_span 𝕜 (f ⁻¹' A) :=
 f.to_affine_equiv.comap_span A
 
+-- need 'Type' instead of 'Type*' because of the definition of '→ᵃ'...
 noncomputable def inclusion_affine {V : Type} [normed_add_comm_group V] [normed_space ℝ V]
   (E : affine_subspace ℝ V) [nonempty E] : E →ᵃ[ℝ] V :=
 { to_fun := coe,
@@ -71,59 +72,59 @@ noncomputable def inclusion_affine {V : Type} [normed_add_comm_group V] [normed_
 -- ==============================
 
 /-- The intrinsic interior of a set is its interior considered as a set in its affine span. -/
-def intrinsic_interior (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V] [module R V]
+def intrinsic_interior (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V] [module R V]
   [pseudo_metric_space P] [normed_add_torsor V P] -- have to redeclare variables to ensure that
                                                   -- all typeclasses are used
   (A : set P) := (coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A)
 
 /-- The intrinsic frontier of a set is its frontier considered as a set in its affine span. -/
-def intrinsic_frontier (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V] [module R V]
+def intrinsic_frontier (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V] [module R V]
   [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :=
 (coe : affine_span R A → P) '' frontier ((coe : affine_span R A → P) ⁻¹' A)
 
 /-- The intrinsic closure of a set is its closure considered as a set in its affine span. -/
-def intrinsic_closure (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V] [module R V]
+def intrinsic_closure (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V] [module R V]
   [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :=
 (coe : affine_span R A → P) '' closure ((coe : affine_span R A → P) ⁻¹' A)
 
-lemma intrinsic_interior_def (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V]
+lemma intrinsic_interior_def (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V]
   [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
 intrinsic_interior R A =
   (coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A) := rfl
 
-lemma intrinsic_frontier_def (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V]
+lemma intrinsic_frontier_def (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V]
   [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
 intrinsic_frontier R A =
   (coe : affine_span R A → P) '' frontier ((coe : affine_span R A → P) ⁻¹' A) := rfl
 
-lemma intrinsic_closure_def (R : Type) {V P : Type} [ring R] [seminormed_add_comm_group V]
+lemma intrinsic_closure_def (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V]
   [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
 intrinsic_closure R A =
   (coe : affine_span R A → P) '' closure ((coe : affine_span R A → P) ⁻¹' A) := rfl
 
-lemma intrinsic_interior_subset {R : Type} {V P : Type} [ring R] [seminormed_add_comm_group V]
+lemma intrinsic_interior_subset {R : Type*} {V P : Type*} [ring R] [seminormed_add_comm_group V]
   [module R V] [pseudo_metric_space P] [normed_add_torsor V P] (A : set P) :
 intrinsic_interior R A ⊆ A :=
 set.image_subset_iff.mpr interior_subset
 
-lemma intrinsic_frontier_subset {R : Type} {V P : Type} [ring R] [seminormed_add_comm_group V]
+lemma intrinsic_frontier_subset {R : Type*} {V P : Type*} [ring R] [seminormed_add_comm_group V]
   [module R V] [pseudo_metric_space P] [normed_add_torsor V P] {A : set P} (hA : is_closed A) :
 intrinsic_frontier R A ⊆ A :=
 set.image_subset_iff.mpr (hA.preimage continuous_induced_dom).frontier_subset
 
 @[simp]
-lemma intrinsic_interior_empty {R : Type} {V P : Type} [ring R] [seminormed_add_comm_group V]
+lemma intrinsic_interior_empty {R : Type*} {V P : Type*} [ring R] [seminormed_add_comm_group V]
   [module R V] [pseudo_metric_space P] [normed_add_torsor V P] :
 intrinsic_interior R (∅ : set P) = ∅ :=
 set.subset_empty_iff.mp $ intrinsic_interior_subset _
 
 @[simp]
-lemma intrinsic_frontier_empty {R : Type} {V P : Type} [ring R] [seminormed_add_comm_group V]
+lemma intrinsic_frontier_empty {R : Type*} {V P : Type*} [ring R] [seminormed_add_comm_group V]
   [module R V] [pseudo_metric_space P] [normed_add_torsor V P] :
 intrinsic_frontier R (∅ : set P) = ∅ :=
 set.subset_empty_iff.mp $ intrinsic_frontier_subset is_closed_empty
 
-lemma preimage_singleton_eq_univ {R : Type} {V P : Type} [ring R]
+lemma preimage_singleton_eq_univ {R : Type*} {V P : Type*} [ring R]
   [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
   (x : P) : (coe : affine_span R ({x} : set P) → P) ⁻¹' {x} = set.univ :=
 begin
@@ -133,7 +134,7 @@ begin
   exact subtype.coe_mk _ _,
 end
 
-@[simp] lemma intrinsic_interior_singleton {R : Type} {V P : Type} [ring R]
+@[simp] lemma intrinsic_interior_singleton {R : Type*} {V P : Type*} [ring R]
   [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
   (x : P) : intrinsic_interior R ({x} : set P) = {x} :=
 begin
@@ -147,7 +148,7 @@ begin
       simpa only [set.mem_preimage, subtype.coe_mk, set.mem_singleton_iff] using hy₂ } },
 end
 
-@[simp] lemma intrinsic_frontier_singleton  {R : Type} {V P : Type} [ring R]
+@[simp] lemma intrinsic_frontier_singleton  {R : Type*} {V P : Type*} [ring R]
   [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
   (x : P) : intrinsic_frontier R ({x} : set P) = ∅ :=
 begin
@@ -156,7 +157,7 @@ begin
   exact preimage_singleton_eq_univ x,
 end
 
-@[simp] lemma intrinsic_closure_diff_intrinsic_interior {R : Type} {V P : Type} [ring R]
+@[simp] lemma intrinsic_closure_diff_intrinsic_interior {R : Type*} {V P : Type*} [ring R]
   [seminormed_add_comm_group V] [module R V] [pseudo_metric_space P] [normed_add_torsor V P]
   (A : set P) :
 intrinsic_closure R A \ intrinsic_interior R A = intrinsic_frontier R A :=
@@ -166,7 +167,7 @@ begin
   refl,
 end
 
-example {𝕜 V V₂ P P₂: Type}
+example {𝕜 V V₂ P P₂: Type*}
   [normed_field 𝕜] [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
   [normed_space 𝕜 V₂] [metric_space P] [pseudo_metric_space P₂] [normed_add_torsor V P]
   [normed_add_torsor V₂ P₂] (A: set P) [nonempty A] :
@@ -178,7 +179,7 @@ The image of the intrinsic interior under an affine isometry is
 the relative interior of the image.
 -/
 @[simp] -- not sure whether this is the correct direction for simp
-lemma affine_isometry.image_intrinsic_interior {𝕜 V V₂ P P₂: Type}
+lemma affine_isometry.image_intrinsic_interior {𝕜 V V₂ P P₂: Type*}
   [normed_field 𝕜] [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
   [normed_space 𝕜 V₂] [metric_space P] [pseudo_metric_space P₂] [normed_add_torsor V P]
   [normed_add_torsor V₂ P₂]
@@ -203,7 +204,7 @@ begin
     function.comp.right_id, @set.preimage_comp _ P, φ.injective.preimage_image],
 end
 
-@[simp] lemma intrinsic_closure_eq_closure (𝕜 : Type)
+@[simp] lemma intrinsic_closure_eq_closure (𝕜 : Type*)
   [nontrivially_normed_field 𝕜] [complete_space 𝕜]
   {V P : Type} [normed_add_comm_group V] [normed_space 𝕜 V]
   [metric_space P] [normed_add_torsor V P]
@@ -237,7 +238,7 @@ begin
     refine ⟨⟨w, subset_affine_span 𝕜 A hwA⟩, hwo, hwA⟩ },
 end
 
-@[simp] lemma closure_diff_intrinsic_interior {𝕜 : Type}
+@[simp] lemma closure_diff_intrinsic_interior {𝕜 : Type*}
   [nontrivially_normed_field 𝕜] [complete_space 𝕜]
   {V P : Type} [normed_add_comm_group V] [normed_space 𝕜 V] [finite_dimensional 𝕜 V]
   [metric_space P] [normed_add_torsor V P]
@@ -245,7 +246,7 @@ end
 closure A \ intrinsic_interior 𝕜 A = intrinsic_frontier 𝕜 A :=
 (intrinsic_closure_eq_closure 𝕜 A) ▸ intrinsic_closure_diff_intrinsic_interior A
 
-lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux {α β : Type}
+lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux {α β : Type*}
   [topological_space α] [topological_space β] (φ : α ≃ₜ β) (A : set β) :
 (interior A).nonempty ↔ (interior (φ ⁻¹' A)).nonempty :=
 begin

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -24,31 +24,6 @@ See chapter 8 of [Barry Simon, *Convexity*][simon2011] or chapter 1 of
 
 open_locale pointwise
 
-local attribute [instance, nolint fails_quickly] affine_subspace.to_normed_add_torsor
-local attribute [instance, nolint fails_quickly] affine_subspace.nonempty_map
-
-lemma affine_isometry_equiv.comap_span {𝕜 V₁ P₁ V₂ P₂ : Type*} [normed_field 𝕜]
-  [normed_add_comm_group V₁] [normed_add_comm_group V₂]
-  [pseudo_metric_space P₁] [pseudo_metric_space P₂] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]
-  [normed_add_torsor V₁ P₁] [normed_add_torsor V₂ P₂]
-  (f : P₁ ≃ᵃⁱ[𝕜] P₂) (A : set P₂) :
-affine_subspace.comap f.to_affine_equiv.to_affine_map (affine_span 𝕜 A) =
-  affine_span 𝕜 (f ⁻¹' A) :=
-f.to_affine_equiv.comap_span A
-
--- need 'Type' instead of 'Type*' because of the definition of '→ᵃ'...
-noncomputable def inclusion_affine {V : Type} [normed_add_comm_group V] [normed_space ℝ V]
-  (E : affine_subspace ℝ V) [nonempty E] : E →ᵃ[ℝ] V :=
-{ to_fun := coe,
-  linear := E.direction.subtype,
-  map_vadd' := by
-    { simp only [affine_subspace.coe_vadd, submodule.coe_subtype, eq_self_iff_true,
-                 forall_const] } }
-
--- ==============================
--- BEGIN intrinsic_interior.lean
--- ==============================
-
 /-- The intrinsic interior of a set is its interior considered as a set in its affine span. -/
 def intrinsic_interior (R : Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V] [module R V]
   [pseudo_metric_space P] [normed_add_torsor V P] -- have to redeclare variables to ensure that
@@ -152,6 +127,11 @@ example {𝕜 V V₂ P P₂: Type*}
   normed_add_torsor (affine_span 𝕜 A).direction (affine_span 𝕜 A) :=
 affine_subspace.to_normed_add_torsor (affine_span 𝕜 A)
 
+section local_instances
+
+local attribute [instance, nolint fails_quickly] affine_subspace.to_normed_add_torsor
+local attribute [instance, nolint fails_quickly] affine_subspace.nonempty_map
+
 /--
 The image of the intrinsic interior under an affine isometry is
 the relative interior of the image.
@@ -181,6 +161,8 @@ begin
     ←set.preimage_comp, function.comp.assoc, f'.symm_comp_self, affine_isometry.coe_to_affine_map,
     function.comp.right_id, @set.preimage_comp _ P, φ.injective.preimage_image],
 end
+
+end local_instances
 
 @[simp] lemma intrinsic_closure_eq_closure (𝕜 : Type*)
   [nontrivially_normed_field 𝕜] [complete_space 𝕜]
@@ -224,6 +206,7 @@ end
 closure A \ intrinsic_interior 𝕜 A = intrinsic_frontier 𝕜 A :=
 (intrinsic_closure_eq_closure 𝕜 A) ▸ intrinsic_closure_diff_intrinsic_interior A
 
+
 lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux {α β : Type*}
   [topological_space α] [topological_space β] (φ : α ≃ₜ β) (A : set β) :
 (interior A).nonempty ↔ (interior (φ ⁻¹' A)).nonempty :=
@@ -231,8 +214,17 @@ begin
   rw [←φ.image_symm, ←φ.symm.image_interior, set.nonempty_image_iff],
 end
 
+lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux_2 {𝕜 V₁ P₁ V₂ P₂ : Type*} [normed_field 𝕜]
+  [normed_add_comm_group V₁] [normed_add_comm_group V₂]
+  [pseudo_metric_space P₁] [pseudo_metric_space P₂] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]
+  [normed_add_torsor V₁ P₁] [normed_add_torsor V₂ P₂]
+  (f : P₁ ≃ᵃⁱ[𝕜] P₂) (A : set P₂) :
+affine_subspace.comap f.to_affine_equiv.to_affine_map (affine_span 𝕜 A) =
+  affine_span 𝕜 (f ⁻¹' A) :=
+f.to_affine_equiv.comap_span A
+
 lemma nonempty_intrinsic_interior_of_nonempty_of_convex
-  {V : Type} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
+  {V : Type*} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
   {A : set V} (Ane : A.nonempty) (Acv : convex ℝ A) :
 (intrinsic_interior ℝ A).nonempty :=
 begin
@@ -244,9 +236,10 @@ begin
     (affine_isometry_equiv.const_vsub ℝ p').symm.to_homeomorph,
     convex.interior_nonempty_iff_affine_span_eq_top],
   { rw [affine_isometry_equiv.coe_to_homeomorph,
-      ←affine_isometry_equiv.comap_span (affine_isometry_equiv.const_vsub ℝ p').symm,
-      affine_span_coe_preimage_eq_top A],
+        ←nonempty_intrinsic_interior_of_nonempty_of_convex.aux_2
+          (affine_isometry_equiv.const_vsub ℝ p').symm,
+        affine_span_coe_preimage_eq_top A],
     exact affine_subspace.comap_top },
-  { exact convex.affine_preimage ((inclusion_affine (affine_span ℝ A)).comp
+  { exact convex.affine_preimage (((affine_span ℝ A).subtype).comp
     (affine_isometry_equiv.const_vsub ℝ p').symm.to_affine_equiv.to_affine_map) Acv },
 end

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -120,13 +120,6 @@ begin
   refl,
 end
 
-example {𝕜 V V₂ P P₂: Type*}
-  [normed_field 𝕜] [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
-  [normed_space 𝕜 V₂] [metric_space P] [pseudo_metric_space P₂] [normed_add_torsor V P]
-  [normed_add_torsor V₂ P₂] (A: set P) [nonempty A] :
-  normed_add_torsor (affine_span 𝕜 A).direction (affine_span 𝕜 A) :=
-affine_subspace.to_normed_add_torsor (affine_span 𝕜 A)
-
 section local_instances
 
 local attribute [instance, nolint fails_quickly] affine_subspace.to_normed_add_torsor
@@ -206,7 +199,6 @@ end
 closure A \ intrinsic_interior 𝕜 A = intrinsic_frontier 𝕜 A :=
 (intrinsic_closure_eq_closure 𝕜 A) ▸ intrinsic_closure_diff_intrinsic_interior A
 
-
 lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux {α β : Type*}
   [topological_space α] [topological_space β] (φ : α ≃ₜ β) (A : set β) :
 (interior A).nonempty ↔ (interior (φ ⁻¹' A)).nonempty :=
@@ -214,8 +206,8 @@ begin
   rw [←φ.image_symm, ←φ.symm.image_interior, set.nonempty_image_iff],
 end
 
-lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux_2 {𝕜 V₁ P₁ V₂ P₂ : Type*} [normed_field 𝕜]
-  [normed_add_comm_group V₁] [normed_add_comm_group V₂]
+lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux_2 {𝕜 V₁ P₁ V₂ P₂ : Type*}
+  [normed_field 𝕜] [normed_add_comm_group V₁] [normed_add_comm_group V₂]
   [pseudo_metric_space P₁] [pseudo_metric_space P₂] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]
   [normed_add_torsor V₁ P₁] [normed_add_torsor V₂ P₂]
   (f : P₁ ≃ᵃⁱ[𝕜] P₂) (A : set P₂) :

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -44,7 +44,7 @@ The main results are:
 * `x ∈ s → y ∈ intrinsic_interior 𝕜 s → open_segment 𝕜 x y ⊆ intrinsic_interior 𝕜 s`
 -/
 
-open set
+open affine_subspace set
 open_locale pointwise
 
 variables {𝕜 V W Q P : Type*}
@@ -108,14 +108,14 @@ attribute [protected] set.nonempty.intrinsic_closure
 
 @[simp] lemma intrinsic_interior_singleton (x : P) : intrinsic_interior 𝕜 ({x} : set P) = {x} :=
 by simpa only [intrinsic_interior, preimage_coe_affine_span_singleton, interior_univ, image_univ,
-  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
+  subtype.range_coe] using coe_affine_span_singleton _ _ _
 
 @[simp] lemma intrinsic_frontier_singleton (x : P) : intrinsic_frontier 𝕜 ({x} : set P) = ∅ :=
 by rw [intrinsic_frontier, preimage_coe_affine_span_singleton, frontier_univ, image_empty]
 
 @[simp] lemma intrinsic_closure_singleton (x : P) : intrinsic_closure 𝕜 ({x} : set P) = {x} :=
 by simpa only [intrinsic_closure, preimage_coe_affine_span_singleton, closure_univ, image_univ,
-  subtype.range_coe] using affine_subspace.coe_affine_span_singleton _ _ _
+  subtype.range_coe] using coe_affine_span_singleton _ _ _
 
 /-!
 Note that neither `intrinsic_interior` nor `intrinsic_frontier` is monotone.
@@ -208,13 +208,11 @@ begin
   { simp only [intrinsic_interior_empty, image_empty] },
   haveI : nonempty s := hs.to_subtype,
   let f := ((affine_span 𝕜 s).isometry_equiv_map φ).to_homeomorph,
-  have : φ.to_affine_map ∘ coe ∘ f.symm = coe :=
-    funext affine_subspace.isometry_equiv_map.apply_symm_apply,
-  rw [intrinsic_interior, intrinsic_interior, ←φ.coe_to_affine_map,
-    ←affine_subspace.map_span φ.to_affine_map s, ←this, ←function.comp.assoc, image_comp,
-    image_comp, f.symm.image_interior, f.image_symm, ←preimage_comp, function.comp.assoc,
-    f.symm_comp_self, affine_isometry.coe_to_affine_map, function.comp.right_id, preimage_comp,
-    φ.injective.preimage_image],
+  have : φ.to_affine_map ∘ coe ∘ f.symm = coe := funext isometry_equiv_map.apply_symm_apply,
+  rw [intrinsic_interior, intrinsic_interior, ←φ.coe_coe, ←map_span φ.to_affine_map s, ←this,
+    ←function.comp.assoc, image_comp, image_comp, f.symm.image_interior, f.image_symm,
+    ←preimage_comp, function.comp.assoc, f.symm_comp_self, affine_isometry.coe_coe,
+    function.comp.right_id, preimage_comp, φ.injective.preimage_image],
 end
 
 @[simp] lemma image_intrinsic_frontier (φ : P →ᵃⁱ[𝕜] Q) (s : set P) :
@@ -224,13 +222,11 @@ begin
   { simp },
   haveI : nonempty s := hs.to_subtype,
   let f := ((affine_span 𝕜 s).isometry_equiv_map φ).to_homeomorph,
-  have : φ.to_affine_map ∘ coe ∘ f.symm = coe :=
-    funext affine_subspace.isometry_equiv_map.apply_symm_apply,
-  rw [intrinsic_frontier, intrinsic_frontier, ←φ.coe_to_affine_map,
-    ←affine_subspace.map_span φ.to_affine_map s, ←this, ←function.comp.assoc, image_comp,
-    image_comp, f.symm.image_frontier, f.image_symm, ←preimage_comp, function.comp.assoc,
-    f.symm_comp_self, affine_isometry.coe_to_affine_map, function.comp.right_id, preimage_comp,
-    φ.injective.preimage_image],
+  have : φ.to_affine_map ∘ coe ∘ f.symm = coe := funext isometry_equiv_map.apply_symm_apply,
+  rw [intrinsic_frontier, intrinsic_frontier, ←φ.coe_coe, ←map_span φ.to_affine_map s, ←this,
+    ←function.comp.assoc, image_comp, image_comp, f.symm.image_frontier, f.image_symm,
+    ←preimage_comp, function.comp.assoc, f.symm_comp_self, affine_isometry.coe_coe,
+    function.comp.right_id, preimage_comp, φ.injective.preimage_image],
 end
 
 @[simp] lemma image_intrinsic_closure (φ : P →ᵃⁱ[𝕜] Q) (s : set P) :
@@ -240,13 +236,11 @@ begin
   { simp },
   haveI : nonempty s := hs.to_subtype,
   let f := ((affine_span 𝕜 s).isometry_equiv_map φ).to_homeomorph,
-  have : φ.to_affine_map ∘ coe ∘ f.symm = coe :=
-    funext affine_subspace.isometry_equiv_map.apply_symm_apply,
-  rw [intrinsic_closure, intrinsic_closure, ←φ.coe_to_affine_map,
-    ←affine_subspace.map_span φ.to_affine_map s, ←this, ←function.comp.assoc, image_comp,
-    image_comp, f.symm.image_closure, f.image_symm, ←preimage_comp, function.comp.assoc,
-    f.symm_comp_self, affine_isometry.coe_to_affine_map, function.comp.right_id, preimage_comp,
-    φ.injective.preimage_image],
+  have : φ.to_affine_map ∘ coe ∘ f.symm = coe := funext isometry_equiv_map.apply_symm_apply,
+  rw [intrinsic_closure, intrinsic_closure, ←φ.coe_coe, ←map_span φ.to_affine_map s, ←this,
+    ←function.comp.assoc, image_comp, image_comp, f.symm.image_closure, f.image_symm,
+    ←preimage_comp, function.comp.assoc, f.symm_comp_self, affine_isometry.coe_coe,
+    function.comp.right_id, preimage_comp, φ.injective.preimage_image],
 end
 
 end affine_isometry
@@ -301,8 +295,8 @@ begin
   rw [intrinsic_interior, nonempty_image_iff,
     aux (affine_isometry_equiv.const_vsub ℝ p').symm.to_homeomorph,
     convex.interior_nonempty_iff_affine_span_eq_top, affine_isometry_equiv.coe_to_homeomorph,
-    ←affine_isometry_equiv.coe_to_affine_equiv, ←affine_equiv.comap_span,
-    affine_span_coe_preimage_eq_top, affine_subspace.comap_top],
+    ←affine_isometry_equiv.coe_to_affine_equiv, ←comap_span, affine_span_coe_preimage_eq_top,
+    comap_top],
   exact hscv.affine_preimage ((affine_span ℝ s).subtype.comp
     (affine_isometry_equiv.const_vsub ℝ p').symm.to_affine_equiv.to_affine_map),
 end

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -44,47 +44,40 @@ variables (R: Type*) {V P : Type*} [ring R] [seminormed_add_comm_group V] [modul
 include V
 
 /-- The intrinsic interior of a set is its interior considered as a set in its affine span. -/
-def intrinsic_interior (A : set P) :=
+def intrinsic_interior (A : set P) : set P :=
 (coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A)
 
 /-- The intrinsic frontier of a set is its frontier considered as a set in its affine span. -/
-def intrinsic_frontier (A : set P) :=
+def intrinsic_frontier (A : set P) : set P :=
 (coe : affine_span R A → P) '' frontier ((coe : affine_span R A → P) ⁻¹' A)
 
 /-- The intrinsic closure of a set is its closure considered as a set in its affine span. -/
-def intrinsic_closure (A : set P) :=
+def intrinsic_closure (A : set P) : set P :=
 (coe : affine_span R A → P) '' closure ((coe : affine_span R A → P) ⁻¹' A)
 
-lemma intrinsic_interior_def (A : set P) :
-intrinsic_interior R A =
+lemma intrinsic_interior_def (A : set P) : intrinsic_interior R A =
   (coe : affine_span R A → P) '' interior ((coe : affine_span R A → P) ⁻¹' A) := rfl
 
-lemma intrinsic_frontier_def (A : set P) :
-intrinsic_frontier R A =
+lemma intrinsic_frontier_def (A : set P) : intrinsic_frontier R A =
   (coe : affine_span R A → P) '' frontier ((coe : affine_span R A → P) ⁻¹' A) := rfl
 
-lemma intrinsic_closure_def (A : set P) :
-intrinsic_closure R A =
+lemma intrinsic_closure_def (A : set P) : intrinsic_closure R A =
   (coe : affine_span R A → P) '' closure ((coe : affine_span R A → P) ⁻¹' A) := rfl
 
 variables {R}
 
-lemma intrinsic_interior_subset (A : set P) :
-intrinsic_interior R A ⊆ A :=
+lemma intrinsic_interior_subset (A : set P) : intrinsic_interior R A ⊆ A :=
 set.image_subset_iff.mpr interior_subset
 
-lemma intrinsic_frontier_subset {A : set P} (hA : is_closed A) :
-intrinsic_frontier R A ⊆ A :=
+lemma intrinsic_frontier_subset {A : set P} (hA : is_closed A) : intrinsic_frontier R A ⊆ A :=
 set.image_subset_iff.mpr (hA.preimage continuous_induced_dom).frontier_subset
 
 @[simp]
-lemma intrinsic_interior_empty :
-intrinsic_interior R (∅ : set P) = ∅ :=
+lemma intrinsic_interior_empty : intrinsic_interior R (∅ : set P) = ∅ :=
 set.subset_empty_iff.mp $ intrinsic_interior_subset _
 
 @[simp]
-lemma intrinsic_frontier_empty :
-intrinsic_frontier R (∅ : set P) = ∅ :=
+lemma intrinsic_frontier_empty : intrinsic_frontier R (∅ : set P) = ∅ :=
 set.subset_empty_iff.mp $ intrinsic_frontier_subset is_closed_empty
 
 lemma preimage_singleton_eq_univ (x : P) :
@@ -116,7 +109,7 @@ begin
 end
 
 @[simp] lemma intrinsic_closure_diff_intrinsic_interior (A : set P) :
-intrinsic_closure R A \ intrinsic_interior R A = intrinsic_frontier R A :=
+  intrinsic_closure R A \ intrinsic_interior R A = intrinsic_frontier R A :=
 begin
   rw [intrinsic_frontier_def, intrinsic_closure_def, intrinsic_interior_def,
     ←set.image_diff subtype.coe_injective],
@@ -139,7 +132,7 @@ lemma affine_isometry.image_intrinsic_interior {𝕜 V V₂ P P₂ : Type*} [nor
   [seminormed_add_comm_group V] [seminormed_add_comm_group V₂] [normed_space 𝕜 V]
   [normed_space 𝕜 V₂] [metric_space P] [pseudo_metric_space P₂] [normed_add_torsor V P]
   [normed_add_torsor V₂ P₂] (φ : P →ᵃⁱ[𝕜] P₂) (A : set P) :
-intrinsic_interior 𝕜 (φ '' A) = φ '' intrinsic_interior 𝕜 A :=
+  intrinsic_interior 𝕜 (φ '' A) = φ '' intrinsic_interior 𝕜 A :=
 begin
   rcases A.eq_empty_or_nonempty with rfl | hc,
   { simp only [intrinsic_interior_empty, set.image_empty] },
@@ -166,7 +159,7 @@ end local_instances
   {V P : Type} [normed_add_comm_group V] [normed_space 𝕜 V]
   [metric_space P] [normed_add_torsor V P]
   (A : set P) [finite_dimensional 𝕜 V] :
-intrinsic_closure 𝕜 A = closure A :=
+  intrinsic_closure 𝕜 A = closure A :=
 begin
   simp only [intrinsic_closure_def],
   ext x,
@@ -199,13 +192,12 @@ end
   [nontrivially_normed_field 𝕜] [complete_space 𝕜]
   {V P : Type} [normed_add_comm_group V] [normed_space 𝕜 V] [finite_dimensional 𝕜 V]
   [metric_space P] [normed_add_torsor V P]
-  (A : set P) :
-closure A \ intrinsic_interior 𝕜 A = intrinsic_frontier 𝕜 A :=
+  (A : set P) : closure A \ intrinsic_interior 𝕜 A = intrinsic_frontier 𝕜 A :=
 (intrinsic_closure_eq_closure 𝕜 A) ▸ intrinsic_closure_diff_intrinsic_interior A
 
 lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux {α β : Type*}
   [topological_space α] [topological_space β] (φ : α ≃ₜ β) (A : set β) :
-(interior A).nonempty ↔ (interior (φ ⁻¹' A)).nonempty :=
+  (interior A).nonempty ↔ (interior (φ ⁻¹' A)).nonempty :=
 begin
   rw [←φ.image_symm, ←φ.symm.image_interior, set.nonempty_image_iff],
 end
@@ -215,15 +207,14 @@ lemma nonempty_intrinsic_interior_of_nonempty_of_convex.aux_2 {𝕜 V₁ P₁ V�
   [pseudo_metric_space P₁] [pseudo_metric_space P₂] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]
   [normed_add_torsor V₁ P₁] [normed_add_torsor V₂ P₂]
   (f : P₁ ≃ᵃⁱ[𝕜] P₂) (A : set P₂) :
-affine_subspace.comap f.to_affine_equiv.to_affine_map (affine_span 𝕜 A) =
+  affine_subspace.comap f.to_affine_equiv.to_affine_map (affine_span 𝕜 A) =
   affine_span 𝕜 (f ⁻¹' A) :=
 f.to_affine_equiv.comap_span A
 
 /-- The intrinsic interior of a nonempty convex set is nonempty. -/
 lemma nonempty_intrinsic_interior_of_nonempty_of_convex
   {V : Type*} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
-  {A : set V} (Ane : A.nonempty) (Acv : convex ℝ A) :
-(intrinsic_interior ℝ A).nonempty :=
+  {A : set V} (Ane : A.nonempty) (Acv : convex ℝ A) : (intrinsic_interior ℝ A).nonempty :=
 begin
   haveI : nonempty A := set.nonempty_coe_sort.mpr Ane,
   rw [intrinsic_interior_def, set.nonempty_image_iff],

--- a/src/linear_algebra/affine_space/affine_equiv.lean
+++ b/src/linear_algebra/affine_space/affine_equiv.lean
@@ -184,6 +184,12 @@ e.to_equiv.apply_eq_iff_eq_symm_apply
 @[simp] lemma apply_eq_iff_eq (e : P₁ ≃ᵃ[k] P₂) {p₁ p₂ : P₁} : e p₁ = e p₂ ↔ p₁ = p₂ :=
 e.to_equiv.apply_eq_iff_eq
 
+@[simp] lemma image_symm (f : P₁ ≃ᵃ[k] P₂) (s : set P₂) : f.symm '' s = f ⁻¹' s :=
+f.symm.to_equiv.image_eq_preimage _
+
+@[simp] lemma preimage_symm (f : P₁ ≃ᵃ[k] P₂) (s : set P₁) : f.symm ⁻¹' s = f '' s :=
+(f.symm.image_symm _).symm
+
 variables (k P₁)
 
 omit V₂

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -1601,24 +1601,19 @@ lemma comap_supr {ι : Sort*} (f : P₁ →ᵃ[k] P₂) (s : ι → affine_subsp
   (infi s).comap f = ⨅ i, (s i).comap f :=
 (gc_map_comap f).u_infi
 
+@[simp] lemma comap_symm (e : P₁ ≃ᵃ[k] P₂) (s : affine_subspace k P₁) :
+  s.comap (e.symm : P₂ →ᵃ[k] P₁) = s.map e :=
+coe_injective $ e.preimage_symm _
+
+@[simp] lemma map_symm (e : P₁ ≃ᵃ[k] P₂) (s : affine_subspace k P₂) :
+  s.map (e.symm : P₂ →ᵃ[k] P₁) = s.comap e :=
+coe_injective $ e.image_symm _
+
+lemma comap_span (f : P₁ ≃ᵃ[k] P₂) (s : set P₂) :
+  (affine_span k s).comap (f : P₁ →ᵃ[k] P₂) = affine_span k (f ⁻¹' s) :=
+by rw [←map_symm, map_span, affine_equiv.coe_coe, f.image_symm]
+
 end affine_subspace
-
-namespace affine_equiv
-
-lemma image_symm (f : P₁ ≃ᵃ[k] P₂) :
-set.image f.symm = set.preimage f := funext f.symm.to_equiv.image_eq_preimage
-
-lemma comap_span (f : P₁ ≃ᵃ[k] P₂) (A : set P₂) :
-affine_subspace.comap f.to_affine_map (affine_span k A) = affine_span k (f ⁻¹' A) :=
-begin
-  ext1,
-  simp only [affine_subspace.coe_comap, ←image_symm],
-  simp only [←coe_to_affine_map],
-  rw [←affine_subspace.map_span, affine_subspace.coe_map],
-  exact (f.to_equiv.symm.image_eq_preimage _).symm,
-end
-
-end affine_equiv
 
 end map_comap
 

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -1600,6 +1600,23 @@ lemma comap_supr {ι : Sort*} (f : P₁ →ᵃ[k] P₂) (s : ι → affine_subsp
 
 end affine_subspace
 
+namespace affine_equiv
+
+lemma image_symm (f : P₁ ≃ᵃ[k] P₂) :
+set.image f.symm = set.preimage f := funext f.symm.to_equiv.image_eq_preimage
+
+lemma comap_span (f : P₁ ≃ᵃ[k] P₂) (A : set P₂) :
+affine_subspace.comap f.to_affine_map (affine_span k A) = affine_span k (f ⁻¹' A) :=
+begin
+  ext1,
+  simp only [affine_subspace.coe_comap, ←image_symm],
+  simp only [←coe_to_affine_map],
+  rw [←affine_subspace.map_span, affine_subspace.coe_map],
+  exact (f.to_equiv.symm.image_eq_preimage _).symm,
+end
+
+end affine_equiv
+
 end map_comap
 
 namespace affine_subspace

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -675,7 +675,7 @@ lemma _root_.affine_span_le {s : set P} {Q : affine_subspace k P} :
   affine_span k s ≤ Q ↔ s ⊆ (Q : set P) :=
 (affine_subspace.gi k V P).gc _ _
 
-variables (k V) {P}
+variables (k V) {P} {p₁ p₂ : P}
 
 /-- The affine span of a single point, coerced to a set, contains just
 that point. -/
@@ -689,9 +689,12 @@ end
 
 /-- A point is in the affine span of a single point if and only if
 they are equal. -/
-@[simp] lemma mem_affine_span_singleton (p1 p2 : P) :
-  p1 ∈ affine_span k ({p2} : set P) ↔ p1 = p2 :=
+@[simp] lemma mem_affine_span_singleton : p₁ ∈ affine_span k ({p₂} : set P) ↔ p₁ = p₂ :=
 by simp [←mem_coe]
+
+@[simp] lemma preimage_coe_affine_span_singleton (x : P) :
+  (coe : affine_span k ({x} : set P) → P) ⁻¹' {x} = univ :=
+eq_univ_of_forall $ λ y, (affine_subspace.mem_affine_span_singleton _ _).1 y.2
 
 /-- The span of a union of sets is the sup of their spans. -/
 lemma span_union (s t : set P) : affine_span k (s ∪ t) = affine_span k s ⊔ affine_span k t :=

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -249,6 +249,9 @@ by rw [← preimage_symm, preimage_interior]
 lemma preimage_frontier (h : α ≃ₜ β) (s : set β) : h ⁻¹' (frontier s) = frontier (h ⁻¹' s) :=
 h.is_open_map.preimage_frontier_eq_frontier_preimage h.continuous _
 
+lemma image_frontier (h : α ≃ₜ β) (s : set α) : h '' frontier s = frontier (h '' s) :=
+by rw [←preimage_symm, preimage_frontier]
+
 @[to_additive]
 lemma _root_.has_compact_mul_support.comp_homeomorph {M} [has_one M] {f : β → M}
   (hf : has_compact_mul_support f) (φ : α ≃ₜ β) : has_compact_mul_support (f ∘ φ) :=


### PR DESCRIPTION
Defines the intrinsic interior, closure and boundary of a set in a normed additive torsor (e.g., a real vector space or one of its nonempty affine subspaces).

Results:
- Simple lemmas about those definitions
- `affine_isometry.image_intrinsic_interior`: The image of the intrinsic interior under an affine isometry is the relative interior of the image.
- `set.nonempty.intrinsic_interior`: The intrinsic interior of a nonempty convex set is nonempty.

Co-authored-by: Yaël Dillies <yael.dillies@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
