### PR TITLE
[Merged by Bors] - fix(scripts/add_port_comments): do not add PR numbers to port comments

### DIFF
--- a/.github/workflows/add_port_comment.yml
+++ b/.github/workflows/add_port_comment.yml
@@ -29,7 +29,7 @@ jobs:
           script: |
             proc = await exec.getExecOutput("python", ["./scripts/add_port_comments.py"]);
             console.log(proc.stdout);
-            core.setOutput("PR_LIST", proc.stdout); 
+            core.setOutput("FILE_LIST", proc.stdout);
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
@@ -40,12 +40,11 @@ jobs:
           author: leanprover-community-bot <leanprover.community@gmail.com>
           body: |
             Regenerated from the [port status wiki page](https://github.com/leanprover-community/mathlib/wiki/mathlib4-port-status).
-            Relates to the following PRs:
-            ${{ steps.generate-message.outputs.PR_LIST }}
+            Relates to the following files:
+            ${{ steps.generate-message.outputs.FILE_LIST }}
 
             ---
             I am a bot; please check that I have not put a comment in a bad place before running `bors merge`!
-            If the PRs above don't match the file they are listed after, that means the port status page is wrong.
           labels: |
             easy
             awaiting-review

--- a/scripts/add_port_comments.py
+++ b/scripts/add_port_comments.py
@@ -16,7 +16,6 @@ src_path = Path(__file__).parent.parent / 'src'
 def make_comment(fstatus):
     return textwrap.dedent(f"""\
     > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-    > https://github.com/leanprover-community/mathlib4/pull/{fstatus.mathlib4_pr}
     > Any changes to this file require a corresponding PR to mathlib4.""")
 
 def replace_range(src: str, pos: int, end_pos: int, new: str) -> str:
@@ -109,7 +108,7 @@ for iname, f_status in status.file_statuses.items():
             continue
         if new_fcontent == fcontent:
             continue
-        print(f'* `{iname}`: https://github.com/leanprover-community/mathlib4/pull/{f_status.mathlib4_pr}')
+        print(f'* `{iname}`')
         with open(fname, 'w') as f:
             f.write(new_fcontent)
 if missing_docstrings:


### PR DESCRIPTION
The now-automated port status YAML file no longer contains accurate PR numbers; many refer to ad-hoc ports rather than the real port. Since the PR numbers can no longer be trusted, we just omit them; both from the comment and the bot's commit message.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #18031

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Tested and working in https://github.com/leanprover-community/mathlib/commit/4830f7dd15005e9b8dd08afd63843b1d871c5c3d
