### PR TITLE
[Merged by Bors] - chore(*): remove references to porting PRs

### DIFF
--- a/src/algebra/abs.lean
+++ b/src/algebra/abs.lean
@@ -8,7 +8,6 @@ Authors: Christopher Hoskin
 # Absolute value
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/477
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines a notational class `has_abs` which adds the unary operator `abs` and the notation

--- a/src/algebra/char_zero/defs.lean
+++ b/src/algebra/char_zero/defs.lean
@@ -9,7 +9,6 @@ import data.int.cast.defs
 # Characteristic zero
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/661
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A ring `R` is called of characteristic zero if every natural number `n` is non-zero when considered

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -13,7 +13,6 @@ import order.monotone.basic
 # Covariants and contravariants
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/467
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file contains general lemmas and instances to work with the interactions between a relation and

--- a/src/algebra/divisibility/basic.lean
+++ b/src/algebra/divisibility/basic.lean
@@ -11,7 +11,6 @@ import algebra.hom.group
 # Divisibility
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/833
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the basics of the divisibility relation in the context of `(comm_)` `monoid`s.

--- a/src/algebra/divisibility/units.lean
+++ b/src/algebra/divisibility/units.lean
@@ -11,7 +11,6 @@ import algebra.group.units
 # Lemmas about divisibility and units
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/848
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/euclidean_domain/basic.lean
+++ b/src/algebra/euclidean_domain/basic.lean
@@ -13,7 +13,6 @@ import algebra.ring.basic
 # Lemmas about Euclidean domains
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/919
 > Any changes to this file require a corresponding PR to mathlib4.
 
 ## Main statements

--- a/src/algebra/euclidean_domain/defs.lean
+++ b/src/algebra/euclidean_domain/defs.lean
@@ -12,7 +12,6 @@ import algebra.ring.defs
 # Euclidean domains
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/871
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file introduces Euclidean domains and provides the extended Euclidean algorithm. To be precise,

--- a/src/algebra/field/basic.lean
+++ b/src/algebra/field/basic.lean
@@ -12,7 +12,6 @@ import algebra.ring.inj_surj
 # Lemmas about division (semi)rings and (semi)fields
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/975
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/field/defs.lean
+++ b/src/algebra/field/defs.lean
@@ -10,7 +10,6 @@ import algebra.ring.defs
 # Division (semi)rings and (semi)fields
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/668
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file introduces fields and division rings (also known as skewfields) and proves some basic

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -10,7 +10,6 @@ import algebra.group.defs
 # Basic lemmas about semigroups, monoids, and groups
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/457
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file lists various basic lemmas about semigroups, monoids, and groups. Most proofs are

--- a/src/algebra/group/commutator.lean
+++ b/src/algebra/group/commutator.lean
@@ -11,7 +11,6 @@ import data.bracket
 # The bracket on a group given by commutator.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/582
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/group/commute.lean
+++ b/src/algebra/group/commute.lean
@@ -9,7 +9,6 @@ import algebra.group.semiconj
 # Commuting pairs of elements in monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/750
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We define the predicate `commute a b := a * b = b * a` and provide some operations on terms `(h :

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -10,7 +10,6 @@ import logic.function.basic
 # Typeclasses for (semi)groups and monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/457
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define typeclasses for algebraic structures with one binary operation.

--- a/src/algebra/group/ext.lean
+++ b/src/algebra/group/ext.lean
@@ -9,7 +9,6 @@ import algebra.hom.group
 # Extensionality lemmas for monoid and group structures
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/850
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we prove extensionality lemmas for `monoid` and higher algebraic structures with one

--- a/src/algebra/group/inj_surj.lean
+++ b/src/algebra/group/inj_surj.lean
@@ -11,7 +11,6 @@ import data.int.cast.basic
 # Lifting algebraic data classes along injective/surjective maps
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/707
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides definitions that are meant to deal with

--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -13,7 +13,6 @@ import data.int.cast.defs
 # Group structures on the multiplicative and additive opposites
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/912
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 universes u v

--- a/src/algebra/group/order_synonym.lean
+++ b/src/algebra/group/order_synonym.lean
@@ -11,7 +11,6 @@ import order.synonym
 # Group structure on the order type synonyms
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/651
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Transfer algebraic instances from `α` to `αᵒᵈ` and `lex α`.

--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -11,7 +11,6 @@ import algebra.hom.units
 # Monoid, group etc structures on `M × N`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/968
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define one-binop (`monoid`, `group` etc) structures on `M × N`. We also prove

--- a/src/algebra/group/semiconj.lean
+++ b/src/algebra/group/semiconj.lean
@@ -11,7 +11,6 @@ import algebra.group.units
 # Semiconjugate elements of a semigroup
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/717
 > Any changes to this file require a corresponding PR to mathlib4.
 
 ## Main definitions

--- a/src/algebra/group/type_tags.lean
+++ b/src/algebra/group/type_tags.lean
@@ -10,7 +10,6 @@ import data.finite.defs
 # Type tags that turn additive structures into multiplicative, and vice versa
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/832
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We define two type tags:

--- a/src/algebra/group/ulift.lean
+++ b/src/algebra/group/ulift.lean
@@ -11,7 +11,6 @@ import algebra.group_with_zero.inj_surj
 # `ulift` instances for groups and monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/906
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines instances for group, monoid, semigroup and related structures on `ulift` types.

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -11,7 +11,6 @@ import tactic.nontriviality
 # Units (i.e., invertible elements) of a monoid
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/549
 > Any changes to this file require a corresponding PR to mathlib4.
 
 An element of a `monoid` is a unit if it has a two-sided inverse.

--- a/src/algebra/group/with_one/basic.lean
+++ b/src/algebra/group/with_one/basic.lean
@@ -10,7 +10,6 @@ import algebra.hom.equiv.basic
 # More operations on `with_one` and `with_zero`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/922
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines various bundled morphisms on `with_one` and `with_zero`

--- a/src/algebra/group/with_one/defs.lean
+++ b/src/algebra/group/with_one/defs.lean
@@ -10,7 +10,6 @@ import algebra.ring.defs
 # Adjoining a zero/one to semigroups and related algebraic structures
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/841
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file contains different results about adjoining an element to an algebraic structure which then

--- a/src/algebra/group/with_one/units.lean
+++ b/src/algebra/group/with_one/units.lean
@@ -10,7 +10,6 @@ import algebra.group_with_zero.units.basic
 # Isomorphism between a group and the units of itself adjoined with `0`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/955
 > Any changes to this file require a corresponding PR to mathlib4.
 
 ## Notes

--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -11,7 +11,6 @@ import algebra.group.type_tags
 # Power operations on monoids and groups
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/874
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The power operation on monoids and groups.

--- a/src/algebra/group_power/identities.lean
+++ b/src/algebra/group_power/identities.lean
@@ -9,7 +9,6 @@ import tactic.ring
 # Identities
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/531
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file contains some "named" commutative ring identities.

--- a/src/algebra/group_power/ring.lean
+++ b/src/algebra/group_power/ring.lean
@@ -15,7 +15,6 @@ import data.nat.order.basic
 # Power operations on monoids with zero, semirings, and rings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/979
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides additional lemmas about the natural power operator on rings and semirings.

--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -11,7 +11,6 @@ import algebra.group.order_synonym
 # Groups with an adjoined zero element
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/669
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file describes structures that are not usually studied on their own right in mathematics,

--- a/src/algebra/group_with_zero/commute.lean
+++ b/src/algebra/group_with_zero/commute.lean
@@ -11,7 +11,6 @@ import tactic.nontriviality
 # Lemmas about commuting elements in a `monoid_with_zero` or a `group_with_zero`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/762
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/group_with_zero/defs.lean
+++ b/src/algebra/group_with_zero/defs.lean
@@ -11,7 +11,6 @@ import algebra.ne_zero
 # Typeclasses for groups with an adjoined zero element
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/563
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides just the typeclass definitions, and the projection lemmas that expose their

--- a/src/algebra/group_with_zero/divisibility.lean
+++ b/src/algebra/group_with_zero/divisibility.lean
@@ -11,7 +11,6 @@ import algebra.divisibility.units
 # Divisibility in groups with zero.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/870
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Lemmas about divisibility in groups and monoids with zero.

--- a/src/algebra/group_with_zero/inj_surj.lean
+++ b/src/algebra/group_with_zero/inj_surj.lean
@@ -10,7 +10,6 @@ import algebra.group_with_zero.defs
 # Lifting groups with zero along injective/surjective maps
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/722
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/group_with_zero/semiconj.lean
+++ b/src/algebra/group_with_zero/semiconj.lean
@@ -10,7 +10,6 @@ import algebra.group.semiconj
 # Lemmas about semiconjugate elements in a `group_with_zero`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/757
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/group_with_zero/units/basic.lean
+++ b/src/algebra/group_with_zero/units/basic.lean
@@ -12,7 +12,6 @@ import tactic.assert_exists
 # Lemmas about units in a `monoid_with_zero` or a `group_with_zero`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/735
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We also define `ring.inverse`, a globally defined function on any ring

--- a/src/algebra/group_with_zero/units/lemmas.lean
+++ b/src/algebra/group_with_zero/units/lemmas.lean
@@ -11,7 +11,6 @@ import group_theory.group_action.units
 # Further lemmas about units in a `monoid_with_zero` or a `group_with_zero`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/920
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/hierarchy_design.lean
+++ b/src/algebra/hierarchy_design.lean
@@ -9,7 +9,6 @@ import tactic.doc_commands
 # Documentation of the algebraic hierarchy
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/657
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A library note giving advice on modifying the algebraic hierarchy.

--- a/src/algebra/hom/commute.lean
+++ b/src/algebra/hom/commute.lean
@@ -11,7 +11,6 @@ import algebra.group.commute
 # Multiplicative homomorphisms respect semiconjugation and commutation.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/831
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/hom/embedding.lean
+++ b/src/algebra/hom/embedding.lean
@@ -10,7 +10,6 @@ import logic.embedding.basic
 # The embedding of a cancellative semigroup into itself by multiplication by a fixed element.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/764
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/hom/equiv/basic.lean
+++ b/src/algebra/hom/equiv/basic.lean
@@ -12,7 +12,6 @@ import data.pi.algebra
 # Multiplicative and additive equivs
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/835
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define two extensions of `equiv` called `add_equiv` and `mul_equiv`, which are

--- a/src/algebra/hom/equiv/type_tags.lean
+++ b/src/algebra/hom/equiv/type_tags.lean
@@ -10,7 +10,6 @@ import algebra.group.type_tags
 # Additive and multiplicative equivalences associated to `multiplicative` and `additive`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/943
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/hom/equiv/units/basic.lean
+++ b/src/algebra/hom/equiv/units/basic.lean
@@ -10,7 +10,6 @@ import algebra.hom.units
 # Multiplicative and additive equivalence acting on units.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/895
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/hom/equiv/units/group_with_zero.lean
+++ b/src/algebra/hom/equiv/units/group_with_zero.lean
@@ -10,7 +10,6 @@ import algebra.group_with_zero.units.basic
 # Multiplication by a nonzero element in a `group_with_zero` is a permutation.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/901
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/hom/group.lean
+++ b/src/algebra/hom/group.lean
@@ -13,7 +13,6 @@ import data.fun_like.basic
 # Monoid and group homomorphisms
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/659
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the bundled structures for monoid and group homomorphisms. Namely, we define

--- a/src/algebra/hom/ring.lean
+++ b/src/algebra/hom/ring.lean
@@ -14,7 +14,6 @@ import data.set.image
 # Homomorphisms of semirings and rings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/958
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines bundled homomorphisms of (non-unital) semirings and rings. As with monoid and

--- a/src/algebra/hom/units.lean
+++ b/src/algebra/hom/units.lean
@@ -9,7 +9,6 @@ import algebra.group.units
 # Monoid homomorphisms and units
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/745
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file allows to lift monoid homomorphisms to group homomorphisms of their units subgroups. It

--- a/src/algebra/homology/complex_shape.lean
+++ b/src/algebra/homology/complex_shape.lean
@@ -10,7 +10,6 @@ import logic.relation
 # Shapes of homological complexes
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/635
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We define a structure `complex_shape ι` for describing the shapes of homological complexes

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -12,7 +12,6 @@ import algebra.ring.defs
 # Invertible elements
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/930
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines a typeclass `invertible a` for elements `a` with a two-sided

--- a/src/algebra/ne_zero.lean
+++ b/src/algebra/ne_zero.lean
@@ -9,7 +9,6 @@ import logic.basic
 # `ne_zero` typeclass
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/557
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We create a typeclass `ne_zero n` which carries around the fact that `(n : R) ≠ 0`.

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -11,7 +11,6 @@ import logic.nontrivial
 # Multiplicative opposite and algebraic operations on it
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/644
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define `mul_opposite α = αᵐᵒᵖ` to be the multiplicative opposite of `α`. It inherits

--- a/src/algebra/order/field/canonical/basic.lean
+++ b/src/algebra/order/field/canonical/basic.lean
@@ -9,7 +9,6 @@ import algebra.order.field.canonical.defs
 # Lemmas about canonically ordered semifields.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1018
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/order/field/canonical/defs.lean
+++ b/src/algebra/order/field/canonical/defs.lean
@@ -11,7 +11,6 @@ import algebra.order.with_zero
 # Canonically ordered semifields
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/985
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/order/field/defs.lean
+++ b/src/algebra/order/field/defs.lean
@@ -10,7 +10,6 @@ import algebra.order.ring.defs
 # Linear ordered (semi)fields
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/905
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A linear ordered (semi)field is a (semi)field equipped with a linear order such that

--- a/src/algebra/order/field/inj_surj.lean
+++ b/src/algebra/order/field/inj_surj.lean
@@ -11,7 +11,6 @@ import algebra.order.ring.inj_surj
 # Pulling back linearly ordered fields along injective maps.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1017
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/order/group/abs.lean
+++ b/src/algebra/order/group/abs.lean
@@ -11,7 +11,6 @@ import order.min_max
 # Absolute values in ordered groups.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/896
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/group/defs.lean
+++ b/src/algebra/order/group/defs.lean
@@ -11,7 +11,6 @@ import algebra.order.monoid.cancel.defs
 # Ordered groups
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/869
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file develops the basics of ordered groups.

--- a/src/algebra/order/group/densely_ordered.lean
+++ b/src/algebra/order/group/densely_ordered.lean
@@ -11,7 +11,6 @@ import algebra.order.monoid.order_dual
 # Lemmas about densely linearly ordered groups.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/956
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/group/inj_surj.lean
+++ b/src/algebra/order/group/inj_surj.lean
@@ -11,7 +11,6 @@ import algebra.order.group.instances
 # Pull back ordered groups along injective maps.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/916
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/group/instances.lean
+++ b/src/algebra/order/group/instances.lean
@@ -10,7 +10,6 @@ import algebra.order.monoid.order_dual
 # Additional instances for ordered commutative groups.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/890
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/order/group/min_max.lean
+++ b/src/algebra/order/group/min_max.lean
@@ -10,7 +10,6 @@ import algebra.order.monoid.min_max
 # `min` and `max` in linearly ordered groups.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/933
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/group/order_iso.lean
+++ b/src/algebra/order/group/order_iso.lean
@@ -10,7 +10,6 @@ import algebra.hom.equiv.units.basic
 # Inverse and multiplication as order isomorphisms in ordered groups
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/895
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/order/group/prod.lean
+++ b/src/algebra/order/group/prod.lean
@@ -10,7 +10,6 @@ import algebra.order.monoid.prod
 # Products of ordered commutative groups.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1026
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/group/type_tags.lean
+++ b/src/algebra/order/group/type_tags.lean
@@ -6,10 +6,9 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 import algebra.order.group.instances
 import algebra.order.monoid.type_tags
 
-/-! # Ordered group structures on `multiplicative α` and `additive α`. 
+/-! # Ordered group structures on `multiplicative α` and `additive α`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/921
 > Any changes to this file require a corresponding PR to mathlib4.-/
 
 variables {α : Type*}

--- a/src/algebra/order/group/units.lean
+++ b/src/algebra/order/group/units.lean
@@ -11,7 +11,6 @@ import algebra.order.monoid.units
 # Adjoining a top element to a `linear_ordered_add_comm_group_with_top`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/898
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/group/with_top.lean
+++ b/src/algebra/order/group/with_top.lean
@@ -10,7 +10,6 @@ import algebra.order.monoid.with_top
 # Adjoining a top element to a `linear_ordered_add_comm_group_with_top`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/946
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/hom/basic.lean
+++ b/src/algebra/order/hom/basic.lean
@@ -9,7 +9,6 @@ import algebra.hom.group
 # Algebraic order homomorphism classes
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/627
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines hom classes for common properties at the intersection of order theory and algebra.

--- a/src/algebra/order/hom/monoid.lean
+++ b/src/algebra/order/hom/monoid.lean
@@ -13,7 +13,6 @@ import order.hom.basic
 # Ordered monoid and group homomorphisms
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/944
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines morphisms between (additive) ordered monoids.

--- a/src/algebra/order/monoid/basic.lean
+++ b/src/algebra/order/monoid/basic.lean
@@ -11,7 +11,6 @@ import order.hom.basic
 # Ordered monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/872
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file develops some additional material on ordered monoids.

--- a/src/algebra/order/monoid/cancel/basic.lean
+++ b/src/algebra/order/monoid/cancel/basic.lean
@@ -10,7 +10,6 @@ import algebra.order.monoid.cancel.defs
 # Basic results on ordered cancellative monoids.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/883
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We pull back ordered cancellative monoids along injective maps.

--- a/src/algebra/order/monoid/cancel/defs.lean
+++ b/src/algebra/order/monoid/cancel/defs.lean
@@ -9,7 +9,6 @@ import algebra.order.monoid.defs
 # Ordered cancellative monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/774
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/monoid/canonical/defs.lean
+++ b/src/algebra/order/monoid/canonical/defs.lean
@@ -12,7 +12,6 @@ import algebra.order.monoid.defs
 # Canonically ordered monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/778
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/monoid/defs.lean
+++ b/src/algebra/order/monoid/defs.lean
@@ -10,7 +10,6 @@ import order.bounded_order
 # Ordered monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/771
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides the definitions of ordered monoids.

--- a/src/algebra/order/monoid/lemmas.lean
+++ b/src/algebra/order/monoid/lemmas.lean
@@ -11,7 +11,6 @@ import order.min_max
 # Ordered monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/608
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file develops the basics of ordered monoids.

--- a/src/algebra/order/monoid/min_max.lean
+++ b/src/algebra/order/monoid/min_max.lean
@@ -10,7 +10,6 @@ import algebra.order.monoid.lemmas
 # Lemmas about `min` and `max` in an ordered monoid.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/763
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/monoid/nat_cast.lean
+++ b/src/algebra/order/monoid/nat_cast.lean
@@ -11,7 +11,6 @@ import data.nat.cast.defs
 # Order of numerials in an `add_monoid_with_one`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/893
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/monoid/order_dual.lean
+++ b/src/algebra/order/monoid/order_dual.lean
@@ -7,10 +7,9 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 import algebra.group.order_synonym
 import algebra.order.monoid.cancel.defs
 
-/-! # Ordered monoid structures on the order dual. 
+/-! # Ordered monoid structures on the order dual.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/786
 > Any changes to this file require a corresponding PR to mathlib4.-/
 
 universes u

--- a/src/algebra/order/monoid/prod.lean
+++ b/src/algebra/order/monoid/prod.lean
@@ -7,10 +7,9 @@ import algebra.group.prod
 import algebra.order.monoid.cancel.defs
 import algebra.order.monoid.canonical.defs
 
-/-! # Products of ordered monoids 
+/-! # Products of ordered monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/987
 > Any changes to this file require a corresponding PR to mathlib4.-/
 
 namespace prod

--- a/src/algebra/order/monoid/to_mul_bot.lean
+++ b/src/algebra/order/monoid/to_mul_bot.lean
@@ -9,7 +9,6 @@ import algebra.order.monoid.type_tags
 
 /-!
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1024
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Making an additive monoid multiplicative then adding a zero is the same as adding a bottom

--- a/src/algebra/order/monoid/type_tags.lean
+++ b/src/algebra/order/monoid/type_tags.lean
@@ -7,10 +7,9 @@ import algebra.group.type_tags
 import algebra.order.monoid.cancel.defs
 import algebra.order.monoid.canonical.defs
 
-/-! # Ordered monoid structures on `multiplicative α` and `additive α`. 
+/-! # Ordered monoid structures on `multiplicative α` and `additive α`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/873
 > Any changes to this file require a corresponding PR to mathlib4.-/
 
 universes u

--- a/src/algebra/order/monoid/units.lean
+++ b/src/algebra/order/monoid/units.lean
@@ -11,7 +11,6 @@ import algebra.group.units
 # Units in ordered monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/873
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/monoid/with_top.lean
+++ b/src/algebra/order/monoid/with_top.lean
@@ -8,10 +8,9 @@ import algebra.order.monoid.order_dual
 import algebra.order.monoid.with_zero.basic
 import data.nat.cast.defs
 
-/-! # Adjoining top/bottom elements to ordered monoids. 
+/-! # Adjoining top/bottom elements to ordered monoids.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/902
 > Any changes to this file require a corresponding PR to mathlib4.-/
 
 universes u v

--- a/src/algebra/order/monoid/with_zero/basic.lean
+++ b/src/algebra/order/monoid/with_zero/basic.lean
@@ -10,7 +10,6 @@ import algebra.group_with_zero.basic
 # An instance orphaned from `algebra.order.monoid.with_zero.defs`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/851
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We put this here to minimise imports: if you can move it back into

--- a/src/algebra/order/monoid/with_zero/defs.lean
+++ b/src/algebra/order/monoid/with_zero/defs.lean
@@ -11,7 +11,6 @@ import algebra.order.zero_le_one
 # Adjoining a zero element to an ordered monoid.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/851
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/positive/ring.lean
+++ b/src/algebra/order/positive/ring.lean
@@ -10,7 +10,6 @@ import algebra.ring.inj_surj
 # Algebraic structures on the set of positive numbers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/911
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define various instances (`add_semigroup`, `ordered_comm_monoid` etc) on the

--- a/src/algebra/order/ring/abs.lean
+++ b/src/algebra/order/ring/abs.lean
@@ -12,7 +12,6 @@ import algebra.order.group.abs
 # Absolute values in linear ordered rings.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/929
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/ring/canonical.lean
+++ b/src/algebra/order/ring/canonical.lean
@@ -11,7 +11,6 @@ import group_theory.group_action.defs
 # Canoncially ordered rings and semirings.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/905
 > Any changes to this file require a corresponding PR to mathlib4.
 
 * `canonically_ordered_comm_semiring`

--- a/src/algebra/order/ring/char_zero.lean
+++ b/src/algebra/order/ring/char_zero.lean
@@ -10,7 +10,6 @@ import algebra.order.ring.defs
 # Strict ordered semiring have characteristic zero
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/905
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/ring/cone.lean
+++ b/src/algebra/order/ring/cone.lean
@@ -9,7 +9,6 @@ import algebra.order.ring.defs
 # Constructing an ordered ring from a ring with a specified positive cone.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/935
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/order/ring/defs.lean
+++ b/src/algebra/order/ring/defs.lean
@@ -20,7 +20,6 @@ import algebra.group.units
 # Ordered rings and semirings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/905
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file develops the basics of ordered (semi)rings.

--- a/src/algebra/order/ring/inj_surj.lean
+++ b/src/algebra/order/ring/inj_surj.lean
@@ -11,7 +11,6 @@ import algebra.ring.inj_surj
 # Pulling back ordered rings along injective maps.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/917
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/order/ring/lemmas.lean
+++ b/src/algebra/order/ring/lemmas.lean
@@ -10,7 +10,6 @@ import algebra.group_with_zero.defs
 # Multiplication by ·positive· elements is monotonic
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/482
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Let `α` be a type with `<` and `0`.  We use the type `{x : α // 0 < x}` of positive elements of `α`

--- a/src/algebra/order/sub/basic.lean
+++ b/src/algebra/order/sub/basic.lean
@@ -12,7 +12,6 @@ import algebra.order.sub.defs
 # Additional results about ordered Subtraction
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/936
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/algebra/order/sub/canonical.lean
+++ b/src/algebra/order/sub/canonical.lean
@@ -10,7 +10,6 @@ import algebra.order.sub.defs
 # Lemmas about subtraction in canonically ordered monoids
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/814
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/sub/defs.lean
+++ b/src/algebra/order/sub/defs.lean
@@ -12,7 +12,6 @@ import order.lattice
 # Ordered Subtraction
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/732
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves lemmas relating (truncated) subtraction with an order. We provide a class

--- a/src/algebra/order/sub/with_top.lean
+++ b/src/algebra/order/sub/with_top.lean
@@ -10,7 +10,6 @@ import algebra.order.monoid.with_top
 # Lemma about subtraction in ordered monoids with a top element adjoined.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/932
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/order/with_zero.lean
+++ b/src/algebra/order/with_zero.lean
@@ -15,7 +15,6 @@ import algebra.order.monoid.type_tags
 # Linearly ordered commutative groups and monoids with a zero element adjoined
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/903
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file sets up a special class of linearly ordered commutative monoids

--- a/src/algebra/order/zero_le_one.lean
+++ b/src/algebra/order/zero_le_one.lean
@@ -10,7 +10,6 @@ import algebra.ne_zero
 # Typeclass expressing `0 ≤ 1`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/893
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/pempty_instances.lean
+++ b/src/algebra/pempty_instances.lean
@@ -11,7 +11,6 @@ import tactic.to_additive
 # Instances on pempty
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/615
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file collects facts about algebraic structures on the (universe-polymorphic) empty type, e.g.

--- a/src/algebra/quotient.lean
+++ b/src/algebra/quotient.lean
@@ -9,7 +9,6 @@ import tactic.basic
 # Algebraic quotients
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/643
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines notation for algebraic quotients, e.g. quotient groups `G ⧸ H`,

--- a/src/algebra/regular/basic.lean
+++ b/src/algebra/regular/basic.lean
@@ -11,7 +11,6 @@ import algebra.group_with_zero.basic
 # Regular elements
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/758
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We introduce left-regular, right-regular and regular elements, along with their `to_additive`

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -11,7 +11,6 @@ import algebra.opposites
 # Semirings and rings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/830
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file gives lemmas about semirings, rings and domains.

--- a/src/algebra/ring/commute.lean
+++ b/src/algebra/ring/commute.lean
@@ -11,7 +11,6 @@ import algebra.group.commute
 # Semirings and rings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/759
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file gives lemmas about semirings, rings and domains.

--- a/src/algebra/ring/defs.lean
+++ b/src/algebra/ring/defs.lean
@@ -11,7 +11,6 @@ import data.int.cast.defs
 # Semirings and rings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/655
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines semirings, rings and domains. This is analogous to `algebra.group.defs` and

--- a/src/algebra/ring/divisibility.lean
+++ b/src/algebra/ring/divisibility.lean
@@ -10,7 +10,6 @@ import algebra.ring.defs
 # Lemmas about divisibility in rings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/864
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/ring/idempotents.lean
+++ b/src/algebra/ring/idempotents.lean
@@ -12,7 +12,6 @@ import tactic.nth_rewrite
 # Idempotents
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/918
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines idempotents for an arbitary multiplication and proves some basic results,

--- a/src/algebra/ring/inj_surj.lean
+++ b/src/algebra/ring/inj_surj.lean
@@ -11,7 +11,6 @@ import algebra.group_with_zero.inj_surj
 # Pulling back rings along injective maps, and pushing them forward along surjective maps.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/734
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 universes u v w x

--- a/src/algebra/ring/order_synonym.lean
+++ b/src/algebra/ring/order_synonym.lean
@@ -10,7 +10,6 @@ import algebra.group.order_synonym
 # Ring structure on the order type synonyms
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/671
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Transfer algebraic instances from `α` to `αᵒᵈ` and `lex α`.

--- a/src/algebra/ring/regular.lean
+++ b/src/algebra/ring/regular.lean
@@ -10,7 +10,6 @@ import algebra.ring.defs
 # Lemmas about regular elements in rings.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/795
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/algebra/ring/semiconj.lean
+++ b/src/algebra/ring/semiconj.lean
@@ -10,7 +10,6 @@ import algebra.ring.defs
 # Semirings and rings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/751
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file gives lemmas about semirings, rings and domains.

--- a/src/algebra/ring/units.lean
+++ b/src/algebra/ring/units.lean
@@ -10,7 +10,6 @@ import algebra.group.units
 # Units in semirings and rings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/746
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 universes u v w x

--- a/src/category_theory/category/Rel.lean
+++ b/src/category_theory/category/Rel.lean
@@ -7,7 +7,6 @@ import category_theory.category.basic
 
 /-!
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/822
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The category of types with binary relations as morphisms.

--- a/src/category_theory/category/basic.lean
+++ b/src/category_theory/category/basic.lean
@@ -9,7 +9,6 @@ import combinatorics.quiver.basic
 # Categories
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/749
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Defines a category, as a type class parametrised by the type of objects.

--- a/src/category_theory/concrete_category/bundled.lean
+++ b/src/category_theory/concrete_category/bundled.lean
@@ -9,7 +9,6 @@ import tactic.lint
 # Bundled types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/514
 > Any changes to this file require a corresponding PR to mathlib4.
 
 `bundled c` provides a uniform structure for bundling a type equipped with a type class.

--- a/src/category_theory/functor/basic.lean
+++ b/src/category_theory/functor/basic.lean
@@ -10,7 +10,6 @@ import category_theory.category.basic
 # Functors
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/749
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Defines a functor between categories, extending a `prefunctor` between quivers.

--- a/src/category_theory/functor/category.lean
+++ b/src/category_theory/functor/category.lean
@@ -10,7 +10,6 @@ import category_theory.isomorphism
 # The category of functors and natural transformations between two fixed categories.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/749
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We provide the category instance on `C ⥤ D`, with morphisms the natural transformations.

--- a/src/category_theory/functor/functorial.lean
+++ b/src/category_theory/functor/functorial.lean
@@ -9,7 +9,6 @@ import category_theory.functor.basic
 # Unbundled functors, as a typeclass decorating the object-level function.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/822
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/category_theory/isomorphism.lean
+++ b/src/category_theory/isomorphism.lean
@@ -9,7 +9,6 @@ import category_theory.functor.basic
 # Isomorphisms
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/749
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines isomorphisms between objects of a category.

--- a/src/category_theory/natural_isomorphism.lean
+++ b/src/category_theory/natural_isomorphism.lean
@@ -10,7 +10,6 @@ import category_theory.isomorphism
 # Natural isomorphisms
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/820
 > Any changes to this file require a corresponding PR to mathlib4.
 
 For the most part, natural isomorphisms are just another sort of isomorphism.

--- a/src/category_theory/natural_transformation.lean
+++ b/src/category_theory/natural_transformation.lean
@@ -9,7 +9,6 @@ import category_theory.functor.basic
 # Natural transformations
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/749
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Defines natural transformations between functors.

--- a/src/category_theory/thin.lean
+++ b/src/category_theory/thin.lean
@@ -10,7 +10,6 @@ import category_theory.isomorphism
 # Thin categories
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/822
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A thin category (also known as a sparse category) is a category with at most one morphism between

--- a/src/combinatorics/quiver/arborescence.lean
+++ b/src/combinatorics/quiver/arborescence.lean
@@ -12,7 +12,6 @@ import combinatorics.quiver.path
 # Arborescences
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/997
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A quiver `V` is an arborescence (or directed rooted tree) when we have a root vertex `root : V` such

--- a/src/combinatorics/quiver/basic.lean
+++ b/src/combinatorics/quiver/basic.lean
@@ -9,7 +9,6 @@ import data.opposite
 # Quivers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/749
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This module defines quivers. A quiver on a type `V` of vertices assigns to every

--- a/src/combinatorics/quiver/cast.lean
+++ b/src/combinatorics/quiver/cast.lean
@@ -11,7 +11,6 @@ import combinatorics.quiver.path
 # Rewriting arrows and paths along vertex equalities
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/990
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This files defines `hom.cast` and `path.cast` (and associated lemmas) in order to allow

--- a/src/combinatorics/quiver/connected_component.lean
+++ b/src/combinatorics/quiver/connected_component.lean
@@ -10,7 +10,6 @@ import combinatorics.quiver.symmetric
 ## Weakly connected components
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/836
 > Any changes to this file require a corresponding PR to mathlib4.
 
 

--- a/src/combinatorics/quiver/path.lean
+++ b/src/combinatorics/quiver/path.lean
@@ -10,7 +10,6 @@ import logic.lemmas
 # Paths in quivers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/811
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Given a quiver `V`, we define the type of paths from `a : V` to `b : V` as an inductive

--- a/src/combinatorics/quiver/push.lean
+++ b/src/combinatorics/quiver/push.lean
@@ -9,7 +9,6 @@ import combinatorics.quiver.basic
 # Pushing a quiver structure along a map
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/868
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Given a map `σ : V → W` and a `quiver` instance on `V`, this files defines a `quiver` instance

--- a/src/combinatorics/quiver/subquiver.lean
+++ b/src/combinatorics/quiver/subquiver.lean
@@ -10,7 +10,6 @@ import combinatorics.quiver.basic
 ## Wide subquivers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/828
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A wide subquiver `H` of a quiver `H` consists of a subset of the edge set `a ⟶ b` for

--- a/src/control/applicative.lean
+++ b/src/control/applicative.lean
@@ -10,7 +10,6 @@ import control.functor
 # `applicative` instances
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/798
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides `applicative` instances for concrete functors:

--- a/src/control/equiv_functor.lean
+++ b/src/control/equiv_functor.lean
@@ -9,7 +9,6 @@ import logic.equiv.defs
 # Functions functorial with respect to equivalences
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/649
 > Any changes to this file require a corresponding PR to mathlib4.
 
 An `equiv_functor` is a function from `Type → Type` equipped with the additional data of

--- a/src/control/functor.lean
+++ b/src/control/functor.lean
@@ -10,7 +10,6 @@ import control.basic
 # Functors
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/612
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This module provides additional lemmas, definitions, and instances for `functor`s.

--- a/src/control/monad/basic.lean
+++ b/src/control/monad/basic.lean
@@ -10,7 +10,6 @@ import tactic.basic
 # Monad
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/752
 > Any changes to this file require a corresponding PR to mathlib4.
 
 ## Attributes

--- a/src/control/traversable/basic.lean
+++ b/src/control/traversable/basic.lean
@@ -10,7 +10,6 @@ import tactic.ext
 # Traversable type class
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/788
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Type classes for traversing collections. The concepts and laws are taken from

--- a/src/control/traversable/lemmas.lean
+++ b/src/control/traversable/lemmas.lean
@@ -10,7 +10,6 @@ import control.traversable.basic
 # Traversing collections
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/948
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves basic properties of traversable and applicative functors and defines

--- a/src/control/ulift.lean
+++ b/src/control/ulift.lean
@@ -8,7 +8,6 @@ Authors: Scott Morrison, Jannis Limperg
 # Monadic instances for `ulift` and `plift`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/638
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define `monad` and `is_lawful_monad` instances on `plift` and `ulift`. -/

--- a/src/data/bool/basic.lean
+++ b/src/data/bool/basic.lean
@@ -8,7 +8,6 @@ Authors: Leonardo de Moura, Jeremy Avigad
 # booleans
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/534
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves various trivial lemmas about booleans and their

--- a/src/data/bool/set.lean
+++ b/src/data/bool/set.lean
@@ -10,7 +10,6 @@ import data.set.image
 # Booleans and set operations
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/960
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file contains two trivial lemmas about `bool`, `set.univ`, and `set.range`.

--- a/src/data/bracket.lean
+++ b/src/data/bracket.lean
@@ -8,7 +8,6 @@ Authors: Patrick Lutz, Oliver Nash
 # Bracket Notation
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/480
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides notation which can be used for the Lie bracket, for the commutator of two

--- a/src/data/char.lean
+++ b/src/data/char.lean
@@ -8,7 +8,6 @@ Authors: Mario Carneiro
 # More `char` instances
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/609
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides a `linear_order` instance on `char`. `char` is the type of Unicode scalar values.

--- a/src/data/countable/defs.lean
+++ b/src/data/countable/defs.lean
@@ -9,7 +9,6 @@ import data.finite.defs
 # Countable types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/736
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define a typeclass saying that a given `Sort*` is countable. See also `encodable`

--- a/src/data/dlist/basic.lean
+++ b/src/data/dlist/basic.lean
@@ -9,7 +9,6 @@ import data.dlist
 # Difference list
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/616
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides a few results about `dlist`, which is defined in core Lean.

--- a/src/data/fin/fin2.lean
+++ b/src/data/fin/fin2.lean
@@ -8,7 +8,6 @@ Authors: Mario Carneiro
 # Inductive type variant of `fin`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/478
 > Any changes to this file require a corresponding PR to mathlib4.
 
 `fin` is defined as a subtype of `ℕ`. This file defines an equivalent type, `fin2`, which is

--- a/src/data/finite/defs.lean
+++ b/src/data/finite/defs.lean
@@ -9,7 +9,6 @@ import logic.equiv.basic
 # Definition of the `finite` typeclass
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/698
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines a typeclass `finite` saying that `α : Sort*` is finite. A type is `finite` if it

--- a/src/data/fun_like/basic.lean
+++ b/src/data/fun_like/basic.lean
@@ -12,7 +12,6 @@ import tactic.norm_cast
 # Typeclass for a type `F` with an injective map to `A → B`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/541
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This typeclass is primarily for use by homomorphisms like `monoid_hom` and `linear_map`.

--- a/src/data/fun_like/embedding.lean
+++ b/src/data/fun_like/embedding.lean
@@ -10,7 +10,6 @@ import data.fun_like.basic
 # Typeclass for a type `F` with an injective map to `A ↪ B`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/541
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This typeclass is primarily for use by embeddings such as `rel_embedding`.

--- a/src/data/fun_like/equiv.lean
+++ b/src/data/fun_like/equiv.lean
@@ -10,7 +10,6 @@ import data.fun_like.embedding
 # Typeclass for a type `F` with an injective map to `A ≃ B`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/541
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This typeclass is primarily for use by isomorphisms like `monoid_equiv` and `linear_equiv`.

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -10,7 +10,6 @@ import order.monotone.basic
 # Basic instances on the integers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/584
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file contains:

--- a/src/data/int/cast/basic.lean
+++ b/src/data/int/cast/basic.lean
@@ -10,7 +10,6 @@ import algebra.group.basic
 # Cast of integers (additional theorems)
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/670
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves additional properties about the *canonical* homomorphism from

--- a/src/data/int/cast/defs.lean
+++ b/src/data/int/cast/defs.lean
@@ -9,7 +9,6 @@ import data.nat.cast.defs
 # Cast of integers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/641
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the *canonical* homomorphism from the integers into an

--- a/src/data/int/cast/field.lean
+++ b/src/data/int/cast/field.lean
@@ -11,7 +11,6 @@ import algebra.group_with_zero.units.lemmas
 # Cast of integers into fields
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1016
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file concerns the canonical homomorphism `ℤ → F`, where `F` is a field.

--- a/src/data/int/cast/lemmas.lean
+++ b/src/data/int/cast/lemmas.lean
@@ -10,7 +10,6 @@ import data.nat.cast.basic
 # Cast of integers (additional theorems)
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/995
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves additional properties about the *canonical* homomorphism from

--- a/src/data/int/cast/prod.lean
+++ b/src/data/int/cast/prod.lean
@@ -10,7 +10,6 @@ import data.nat.cast.prod
 # The product of two `add_group_with_one`s.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1015
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/data/int/div.lean
+++ b/src/data/int/div.lean
@@ -11,7 +11,6 @@ import algebra.ring.regular
 # Lemmas relating `/` in `ℤ` with the ordering.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1011
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/data/int/dvd/basic.lean
+++ b/src/data/int/dvd/basic.lean
@@ -10,7 +10,6 @@ import data.nat.cast.basic
 # Basic lemmas about the divisibility relation in `ℤ`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/996
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/data/int/order/basic.lean
+++ b/src/data/int/order/basic.lean
@@ -13,7 +13,6 @@ import tactic.assert_exists
 # Order instances on the integers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/938
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file contains:

--- a/src/data/int/units.lean
+++ b/src/data/int/units.lean
@@ -12,7 +12,6 @@ import algebra.ring.units
 # Lemmas about units in `ℤ`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/807
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/data/lazy_list.lean
+++ b/src/data/lazy_list.lean
@@ -8,7 +8,6 @@ Authors: Leonardo de Moura
 # Lazy lists
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/686
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The type `lazy_list α` is a lazy list with elements of type `α`.

--- a/src/data/list/defs.lean
+++ b/src/data/list/defs.lean
@@ -11,7 +11,6 @@ import data.rbtree.default_lt
 ## Definitions on lists
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/803
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file contains various definitions on lists. It does not contain

--- a/src/data/list/lex.lean
+++ b/src/data/list/lex.lean
@@ -9,7 +9,6 @@ import order.rel_classes
 # Lexicographic ordering of lists.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/672
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The lexicographic order on `list α` is defined by `L < M` iff

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -11,7 +11,6 @@ import algebra.ring.defs
 # Basic operations on the natural numbers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/729
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file contains:

--- a/src/data/nat/cast/basic.lean
+++ b/src/data/nat/cast/basic.lean
@@ -15,7 +15,6 @@ import algebra.group.opposite
 # Cast of natural numbers (additional theorems)
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/980
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves additional properties about the *canonical* homomorphism from

--- a/src/data/nat/cast/defs.lean
+++ b/src/data/nat/cast/defs.lean
@@ -10,7 +10,6 @@ import algebra.ne_zero
 # Cast of natural numbers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/641
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the *canonical* homomorphism from the natural numbers into an

--- a/src/data/nat/cast/prod.lean
+++ b/src/data/nat/cast/prod.lean
@@ -10,7 +10,6 @@ import algebra.group.prod
 # The product of two `add_monoid_with_one`s.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1010
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/data/nat/cast/with_top.lean
+++ b/src/data/nat/cast/with_top.lean
@@ -10,7 +10,6 @@ import data.nat.basic
 # Lemma about the coercion `ℕ → with_bot ℕ`.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1019
 > Any changes to this file require a corresponding PR to mathlib4.
 
 An orphaned lemma about casting from `ℕ` to `with_bot ℕ`,

--- a/src/data/nat/gcd/basic.lean
+++ b/src/data/nat/gcd/basic.lean
@@ -11,7 +11,6 @@ import data.nat.order.lemmas
 # Definitions and properties of `nat.gcd`, `nat.lcm`, and `nat.coprime`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/965
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Generalizations of these are provided in a later file as `gcd_monoid.gcd` and

--- a/src/data/nat/order/basic.lean
+++ b/src/data/nat/order/basic.lean
@@ -10,7 +10,6 @@ import data.nat.basic
 # The natural numbers as a linearly ordered commutative semiring
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/907
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We also have a variety of lemmas which have been deferred from `data.nat.basic` because it is

--- a/src/data/nat/order/lemmas.lean
+++ b/src/data/nat/order/lemmas.lean
@@ -12,7 +12,6 @@ import algebra.group_with_zero.divisibility
 # Further lemmas about the natural numbers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/927
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The distinction between this file and `data.nat.order.basic` is not particularly clear.

--- a/src/data/nat/psub.lean
+++ b/src/data/nat/psub.lean
@@ -9,7 +9,6 @@ import data.nat.basic
 # Partial predecessor and partial subtraction on the natural numbers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/806
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The usual definition of natural number subtraction (`nat.sub`) returns 0 as a "garbage value" for

--- a/src/data/nat/set.lean
+++ b/src/data/nat/set.lean
@@ -10,7 +10,6 @@ import data.set.image
 ### Recursion on the natural numbers and `set.range`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/961
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/data/nat/units.lean
+++ b/src/data/nat/units.lean
@@ -6,10 +6,9 @@ Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import data.nat.basic
 import algebra.group.units
 
-/-! # The units of the natural numbers as a `monoid` and `add_monoid` 
+/-! # The units of the natural numbers as a `monoid` and `add_monoid`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/805
 > Any changes to this file require a corresponding PR to mathlib4.-/
 
 namespace nat

--- a/src/data/nat/upto.lean
+++ b/src/data/nat/upto.lean
@@ -9,7 +9,6 @@ import data.nat.order.basic
 # `nat.upto`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1020
 > Any changes to this file require a corresponding PR to mathlib4.
 
 `nat.upto p`, with `p` a predicate on `ℕ`, is a subtype of elements `n : ℕ` such that no value

--- a/src/data/num/basic.lean
+++ b/src/data/num/basic.lean
@@ -8,7 +8,6 @@ Authors: Leonardo de Moura, Mario Carneiro
 # Binary representation of integers using inductive types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/607
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Note: Unlike in Coq, where this representation is preferred because of

--- a/src/data/opposite.lean
+++ b/src/data/opposite.lean
@@ -9,7 +9,6 @@ import logic.equiv.defs
 # Opposites
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/650
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define a type synonym `opposite α := α`, denoted by `αᵒᵖ` and two synonyms for the

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -11,7 +11,6 @@ import tactic.basic
 # Option of a type
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/493
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file develops the basic theory of option types.

--- a/src/data/option/defs.lean
+++ b/src/data/option/defs.lean
@@ -8,7 +8,6 @@ Authors: Mario Carneiro
 # Extra definitions on `option`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/504
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines more operations involving `option α`. Lemmas about them are located in other

--- a/src/data/option/n_ary.lean
+++ b/src/data/option/n_ary.lean
@@ -9,7 +9,6 @@ import data.option.basic
 # Binary map of options
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/656
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the binary map of `option`. This is mostly useful to define pointwise operations

--- a/src/data/pequiv.lean
+++ b/src/data/pequiv.lean
@@ -10,7 +10,6 @@ import data.set.basic
 # Partial Equivalences
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1008
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file, we define partial equivalences `pequiv`, which are a bijection between a subset of `α`

--- a/src/data/pi/algebra.lean
+++ b/src/data/pi/algebra.lean
@@ -16,7 +16,6 @@ import data.prod.basic
 # Instances and theorems on pi types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/564
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides basic definitions and notation instances for Pi types.

--- a/src/data/pnat/defs.lean
+++ b/src/data/pnat/defs.lean
@@ -10,7 +10,6 @@ import algebra.ne_zero
 # The positive natural numbers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/604
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file contains the definitions, and basic results.

--- a/src/data/prod/basic.lean
+++ b/src/data/prod/basic.lean
@@ -10,7 +10,6 @@ import logic.function.basic
 # Extra facts about `prod`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/545
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines `prod.swap : α × β → β × α` and proves various simple lemmas about `prod`.

--- a/src/data/prod/lex.lean
+++ b/src/data/prod/lex.lean
@@ -9,7 +9,6 @@ import order.bounded_order
 # Lexicographic order
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/783
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the lexicographic relation for pairs of orders, partial orders and linear orders.

--- a/src/data/prod/pprod.lean
+++ b/src/data/prod/pprod.lean
@@ -9,7 +9,6 @@ import logic.basic
 # Extra facts about `pprod`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/496
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/data/psigma/order.lean
+++ b/src/data/psigma/order.lean
@@ -10,7 +10,6 @@ import order.bounded_order
 # Lexicographic order on a sigma type
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/815
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the lexicographic order on `Σₗ' i, α i`. `a` is less than `b` if its summand is

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -9,7 +9,6 @@ import logic.relator
 # Quotient types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/559
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This module extends the core library's treatment of quotient types (`init.data.quot`).

--- a/src/data/rat/init.lean
+++ b/src/data/rat/init.lean
@@ -10,7 +10,6 @@ import logic.basic
 # The definition of the Rational Numbers
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/575
 > Any changes to this file require a corresponding PR to mathlib4.
 
 ## Summary

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -10,7 +10,6 @@ import logic.function.iterate
 # Basic properties of sets
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/892
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Sets in Lean are homogeneous; all their elements have the same type. Sets whose elements

--- a/src/data/set/bool_indicator.lean
+++ b/src/data/set/bool_indicator.lean
@@ -10,7 +10,6 @@ import data.set.image
 # Indicator function valued in bool
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/988
 > Any changes to this file require a corresponding PR to mathlib4.
 
 See also `set.indicator` and `set.piecewise`.

--- a/src/data/set/image.lean
+++ b/src/data/set/image.lean
@@ -9,7 +9,6 @@ import data.set.basic
 # Images and preimages of sets
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/949
 > Any changes to this file require a corresponding PR to mathlib4.
 
 ## Main definitions

--- a/src/data/set/n_ary.lean
+++ b/src/data/set/n_ary.lean
@@ -9,7 +9,6 @@ import data.set.prod
 # N-ary images of sets
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/969
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines `finset.image₂`, the binary image of finsets. This is the finset version of

--- a/src/data/set/opposite.lean
+++ b/src/data/set/opposite.lean
@@ -10,7 +10,6 @@ import data.set.image
 # The opposite of a set
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/983
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The opposite of a set `s` is simply the set obtained by taking the opposite of each member of `s`.

--- a/src/data/set/prod.lean
+++ b/src/data/set/prod.lean
@@ -9,7 +9,6 @@ import data.set.image
 # Sets in product and pi types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1004
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the product of sets in `α × β` and in `Π i, α i` along with the diagonal of a

--- a/src/data/set/sigma.lean
+++ b/src/data/set/sigma.lean
@@ -9,7 +9,6 @@ import data.set.image
 # Sets in sigma types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/982
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines `set.sigma`, the indexed sum of sets.

--- a/src/data/set_like/basic.lean
+++ b/src/data/set_like/basic.lean
@@ -10,7 +10,6 @@ import tactic.monotonicity.basic
 # Typeclass for types with a set-like extensionality property
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/993
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The `has_mem` typeclass is used to let terms of a type have elements.

--- a/src/data/sigma/basic.lean
+++ b/src/data/sigma/basic.lean
@@ -12,7 +12,6 @@ import logic.function.basic
 # Sigma types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/479
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves basic results about sigma types.

--- a/src/data/sigma/lex.lean
+++ b/src/data/sigma/lex.lean
@@ -10,7 +10,6 @@ import order.rel_classes
 # Lexicographic order on a sigma type
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/646
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This defines the lexicographical order of two arbitrary relations on a sigma type and proves some

--- a/src/data/sigma/order.lean
+++ b/src/data/sigma/order.lean
@@ -10,7 +10,6 @@ import order.bounded_order
 # Orders on a sigma type
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/887
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines two orders on a sigma type:

--- a/src/data/stream/defs.lean
+++ b/src/data/stream/defs.lean
@@ -8,7 +8,6 @@ Authors: Leonardo de Moura
 # Definition of `stream` and functions on streams
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/665
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A stream `stream α` is an infinite sequence of elements of `α`. One can also think about it as an

--- a/src/data/subtype.lean
+++ b/src/data/subtype.lean
@@ -11,7 +11,6 @@ import tactic.simps
 # Subtypes
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/546
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides basic API for subtypes, which are defined in core.

--- a/src/data/sum/basic.lean
+++ b/src/data/sum/basic.lean
@@ -10,7 +10,6 @@ import tactic.basic
 # Disjoint union of types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/497
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves basic results about the sum type `α ⊕ β`.

--- a/src/data/sum/order.lean
+++ b/src/data/sum/order.lean
@@ -9,7 +9,6 @@ import order.hom.basic
 # Orders on a sum type
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/880
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the disjoint sum and the linear (aka lexicographic) sum of two orders and provides

--- a/src/data/two_pointing.lean
+++ b/src/data/two_pointing.lean
@@ -10,7 +10,6 @@ import logic.nontrivial
 # Two-pointings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/984
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines `two_pointing α`, the type of two pointings of `α`. A two-pointing is the data of

--- a/src/data/ulift.lean
+++ b/src/data/ulift.lean
@@ -9,7 +9,6 @@ import logic.equiv.basic
 # Extra lemmas about `ulift` and `plift`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/703
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we provide `subsingleton`, `unique`, `decidable_eq`, and `is_empty` instances for

--- a/src/group_theory/eckmann_hilton.lean
+++ b/src/group_theory/eckmann_hilton.lean
@@ -9,7 +9,6 @@ import algebra.group.defs
 # Eckmann-Hilton argument
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/626
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The Eckmann-Hilton argument says that if a type carries two monoid structures that distribute

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -13,7 +13,6 @@ import logic.embedding.basic
 # Definitions of group actions
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/854
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines a hierarchy of group action type-classes on top of the previously defined

--- a/src/group_theory/group_action/option.lean
+++ b/src/group_theory/group_action/option.lean
@@ -9,7 +9,6 @@ import group_theory.group_action.defs
 # Option instances for additive and multiplicative actions
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/884
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines instances for additive and multiplicative actions on `option` type. Scalar

--- a/src/group_theory/group_action/sigma.lean
+++ b/src/group_theory/group_action/sigma.lean
@@ -9,7 +9,6 @@ import group_theory.group_action.defs
 # Sigma instances for additive and multiplicative actions
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/885
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines instances for arbitrary sum of additive and multiplicative actions.

--- a/src/group_theory/group_action/sum.lean
+++ b/src/group_theory/group_action/sum.lean
@@ -9,7 +9,6 @@ import group_theory.group_action.defs
 # Sum instances for additive and multiplicative actions
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/882
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines instances for additive and multiplicative actions on the binary `sum` type.

--- a/src/group_theory/group_action/units.lean
+++ b/src/group_theory/group_action/units.lean
@@ -8,7 +8,6 @@ import group_theory.group_action.defs
 /-! # Group actions on and by `Mˣ`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/878
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides the action of a unit on a type `α`, `has_smul Mˣ α`, in the presence of

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -10,7 +10,6 @@ import tactic.reserved_notation
 # Basic logic properties
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/484
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file is one of the earliest imports in mathlib.

--- a/src/logic/embedding/basic.lean
+++ b/src/logic/embedding/basic.lean
@@ -14,7 +14,6 @@ import logic.equiv.basic
 # Injective functions
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/700
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/logic/embedding/set.lean
+++ b/src/logic/embedding/set.lean
@@ -10,7 +10,6 @@ import data.set.image
 # Interactions between embeddings and sets.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/986
 > Any changes to this file require a corresponding PR to mathlib4.
 
 -/

--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -15,7 +15,6 @@ import logic.function.conjugate
 # Equivalence between types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/631
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we continue the work on equivalences begun in `logic/equiv/defs.lean`, defining

--- a/src/logic/equiv/defs.lean
+++ b/src/logic/equiv/defs.lean
@@ -10,7 +10,6 @@ import logic.unique
 # Equivalence between types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/550
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define two types:

--- a/src/logic/equiv/embedding.lean
+++ b/src/logic/equiv/embedding.lean
@@ -9,7 +9,6 @@ import logic.embedding.set
 # Equivalences on embeddings
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1021
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file shows some advanced equivalences on embeddings, useful for constructing larger

--- a/src/logic/equiv/option.lean
+++ b/src/logic/equiv/option.lean
@@ -12,7 +12,6 @@ import logic.equiv.defs
 # Equivalences for `option α`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/674
 > Any changes to this file require a corresponding PR to mathlib4.
 
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -11,7 +11,6 @@ import tactic.cache
 # Miscellaneous function constructions and lemmas
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/511
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/logic/function/conjugate.lean
+++ b/src/logic/function/conjugate.lean
@@ -9,7 +9,6 @@ import logic.function.basic
 # Semiconjugate and commuting maps
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/533
 > Any changes to this file require a corresponding PR to mathlib4.
 
 We define the following predicates:

--- a/src/logic/function/iterate.lean
+++ b/src/logic/function/iterate.lean
@@ -9,7 +9,6 @@ import logic.function.conjugate
 # Iterations of a function
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/585
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we prove simple properties of `nat.iterate f n` a.k.a. `f^[n]`:

--- a/src/logic/is_empty.lean
+++ b/src/logic/is_empty.lean
@@ -10,7 +10,6 @@ import tactic.protected
 # Types that are empty
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/486
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define a typeclass `is_empty`, which expresses that a type has no elements.

--- a/src/logic/lemmas.lean
+++ b/src/logic/lemmas.lean
@@ -13,7 +13,6 @@ import logic.basic
 # More basic logic properties
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/537
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A few more logic lemmas. These are in their own file, rather than `logic.basic`, because it is

--- a/src/logic/nonempty.lean
+++ b/src/logic/nonempty.lean
@@ -9,7 +9,6 @@ import logic.basic
 # Nonempty types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/487
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves a few extra facts about `nonempty`, which is defined in core Lean.

--- a/src/logic/nontrivial.lean
+++ b/src/logic/nontrivial.lean
@@ -12,7 +12,6 @@ import logic.unique
 # Nontrivial types
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/547
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A type is *nontrivial* if it contains at least two elements. This is useful in particular for rings

--- a/src/logic/pairwise.lean
+++ b/src/logic/pairwise.lean
@@ -10,7 +10,6 @@ import tactic.basic
 # Relations holding pairwise
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/622
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines pairwise relations.

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -10,7 +10,6 @@ import logic.relator
 # Relation closures
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/565
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the reflexive, transitive, and reflexive transitive closures of relations.

--- a/src/logic/relator.lean
+++ b/src/logic/relator.lean
@@ -10,7 +10,6 @@ import logic.basic
 # Relator for functions, pairs, sums, and lists.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/385
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -10,7 +10,6 @@ import logic.is_empty
 # Types with a unique term
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/512
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we define a typeclass `unique`,

--- a/src/order/antisymmetrization.lean
+++ b/src/order/antisymmetrization.lean
@@ -10,7 +10,6 @@ import logic.relation
 # Turning a preorder into a partial order
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/876
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file allows to make a preorder into a partial order by quotienting out the elements `a`, `b`

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -10,7 +10,6 @@ import data.subtype
 # Basic definitions about `≤` and `<`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/556
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves basic results about orders, provides extensive dot notation, defines useful order

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -9,7 +9,6 @@ import order.heyting.basic
 # (Generalized) Boolean algebras
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/794
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A Boolean algebra is a bounded distributive lattice with a complement operator. Boolean algebras

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -10,7 +10,6 @@ import data.option.basic
 # ⊤ and ⊥, bounded lattices and variants
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/697
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines top and bottom elements (greatest and least elements) of a type, the bounded

--- a/src/order/compare.lean
+++ b/src/order/compare.lean
@@ -9,7 +9,6 @@ import order.synonym
 # Comparison
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/569
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides basic results about orderings and comparison in linear orders.

--- a/src/order/directed.lean
+++ b/src/order/directed.lean
@@ -11,7 +11,6 @@ import order.max
 # Directed indexed families and sets
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/963
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines directed indexed families and directed sets. An indexed family/set is

--- a/src/order/disjoint.lean
+++ b/src/order/disjoint.lean
@@ -9,7 +9,6 @@ import order.bounded_order
 # Disjointness and complements
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/773
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines `disjoint`, `codisjoint`, and the `is_compl` predicate.

--- a/src/order/game_add.lean
+++ b/src/order/game_add.lean
@@ -10,7 +10,6 @@ import logic.relation
 # Game addition relation
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/645
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines, given relations `rα : α → α → Prop` and `rβ : β → β → Prop`, a relation

--- a/src/order/heyting/basic.lean
+++ b/src/order/heyting/basic.lean
@@ -9,7 +9,6 @@ import order.prop_instances
 # Heyting algebras
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/793
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines Heyting, co-Heyting and bi-Heyting algebras.

--- a/src/order/heyting/boundary.lean
+++ b/src/order/heyting/boundary.lean
@@ -9,7 +9,6 @@ import order.boolean_algebra
 # Co-Heyting boundary
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/844
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The boundary of an element of a co-Heyting algebra is the intersection of its Heyting negation with

--- a/src/order/hom/basic.lean
+++ b/src/order/hom/basic.lean
@@ -13,7 +13,6 @@ import order.disjoint
 # Order homomorphisms
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/804
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines order homomorphisms, which are bundled monotone functions. A preorder

--- a/src/order/iterate.lean
+++ b/src/order/iterate.lean
@@ -10,7 +10,6 @@ import order.monotone.basic
 # Inequalities on iterates
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/648
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we prove some inequalities comparing `f^[n] x` and `g^[n] x` where `f` and `g` are

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -11,7 +11,6 @@ import tactic.pi_instances
 # (Semi-)lattices
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/642
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Semilattices are partially ordered sets with join (greatest lower bound, or `sup`) or

--- a/src/order/max.lean
+++ b/src/order/max.lean
@@ -9,7 +9,6 @@ import order.synonym
 # Minimal/maximal and bottom/top elements
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/567
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines predicates for elements to be minimal/maximal or bottom/top and typeclasses

--- a/src/order/min_max.lean
+++ b/src/order/min_max.lean
@@ -9,7 +9,6 @@ import order.lattice
 # `max` and `min`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/728
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file proves basic properties about maxima and minima on a `linear_order`.

--- a/src/order/monotone/basic.lean
+++ b/src/order/monotone/basic.lean
@@ -11,7 +11,6 @@ import order.rel_classes
 # Monotonicity
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/591
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines (strictly) monotone/antitone functions. Contrary to standard mathematical usage,

--- a/src/order/prop_instances.lean
+++ b/src/order/prop_instances.lean
@@ -11,7 +11,6 @@ import order.with_bot
 # The order on `Prop`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/792
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Instances on `Prop` such as `distrib_lattice`, `bounded_order`, `linear_order`.

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -10,7 +10,6 @@ import logic.is_empty
 # Unbundled relation classes
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/560
 > Any changes to this file require a corresponding PR to mathlib4.
 
 In this file we prove some properties of `is_*` classes defined in `init.algebra.classes`. The main

--- a/src/order/rel_iso/basic.lean
+++ b/src/order/rel_iso/basic.lean
@@ -11,7 +11,6 @@ import order.rel_classes
 # Relation homomorphisms, embeddings, isomorphisms
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/772
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines relation homomorphisms, embeddings, isomorphisms and order embeddings and

--- a/src/order/rel_iso/group.lean
+++ b/src/order/rel_iso/group.lean
@@ -10,7 +10,6 @@ import order.rel_iso.basic
 # Relation isomorphisms form a group
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/813
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 

--- a/src/order/rel_iso/set.lean
+++ b/src/order/rel_iso/set.lean
@@ -10,7 +10,6 @@ import logic.embedding.set
 # Interactions between relation homomorphisms and sets
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/1005
 > Any changes to this file require a corresponding PR to mathlib4.
 
 It is likely that there are better homes for many of these statement,

--- a/src/order/symm_diff.lean
+++ b/src/order/symm_diff.lean
@@ -11,7 +11,6 @@ import logic.equiv.basic
 # Symmetric difference and bi-implication
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/842
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file defines the symmetric difference and bi-implication operators in (co-)Heyting algebras.

--- a/src/order/synonym.lean
+++ b/src/order/synonym.lean
@@ -11,7 +11,6 @@ import order.basic
 # Type synonyms
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/562
 > Any changes to this file require a corresponding PR to mathlib4.
 
 This file provides two type synonyms for order theory:

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -10,7 +10,6 @@ import data.set.image
 # Well-founded relations
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/970
 > Any changes to this file require a corresponding PR to mathlib4.
 
 A relation is well-founded if it can be used for induction: for each `x`, `(∀ y, r y x → P y) → P x`

--- a/src/order/with_bot.lean
+++ b/src/order/with_bot.lean
@@ -9,7 +9,6 @@ import order.bounded_order
 # `with_bot`, `with_top`
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/776
 > Any changes to this file require a corresponding PR to mathlib4.
 
 Adding a `bot` or a `top` to an order.

--- a/src/ring_theory/coprime/basic.lean
+++ b/src/ring_theory/coprime/basic.lean
@@ -10,7 +10,6 @@ import group_theory.group_action.units
 # Coprime elements of a ring
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> https://github.com/leanprover-community/mathlib4/pull/899
 > Any changes to this file require a corresponding PR to mathlib4.
 
 ## Main definitions


### PR DESCRIPTION
These no longer reflect the yaml file (which doesn't really track PR numbers any more). Since the next version of the bot will remove them, let's remove them manually first so that the bot diffs are easier to follow.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
