### PR TITLE
[Merged by Bors] - chore({ring_theory, field_theory}/*): fix imports to make #18021 less messy

### DIFF
--- a/src/field_theory/is_alg_closed/basic.lean
+++ b/src/field_theory/is_alg_closed/basic.lean
@@ -7,6 +7,7 @@ Authors: Kenny Lau
 import field_theory.perfect_closure
 import field_theory.separable
 import ring_theory.adjoin.field
+import ring_theory.localization.integral
 
 /-!
 # Algebraically Closed Field

--- a/src/field_theory/minpoly/basic.lean
+++ b/src/field_theory/minpoly/basic.lean
@@ -5,7 +5,6 @@ Authors: Chris Hughes, Johan Commelin
 -/
 import data.polynomial.field_division
 import ring_theory.integral_closure
-import ring_theory.polynomial.gauss_lemma
 
 /-!
 # Minimal polynomials

--- a/src/field_theory/minpoly/field.lean
+++ b/src/field_theory/minpoly/field.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca, Johan Commelin
 -/
 import data.polynomial.field_division
-import ring_theory.integral_closure
 import field_theory.minpoly.basic
+import ring_theory.algebraic
+import ring_theory.integral_closure
 
 /-!
 # Minimal polynomials on an algebra over a field

--- a/src/field_theory/minpoly/field.lean
+++ b/src/field_theory/minpoly/field.lean
@@ -6,7 +6,6 @@ Authors: Riccardo Brasca, Johan Commelin
 import data.polynomial.field_division
 import field_theory.minpoly.basic
 import ring_theory.algebraic
-import ring_theory.integral_closure
 
 /-!
 # Minimal polynomials on an algebra over a field

--- a/src/field_theory/minpoly/gcd_monoid.lean
+++ b/src/field_theory/minpoly/gcd_monoid.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
 import data.polynomial.field_division
-import ring_theory.polynomial.gauss_lemma
-import field_theory.minpoly.field
 import ring_theory.adjoin_root
+import field_theory.minpoly.field
+import ring_theory.polynomial.gauss_lemma
 
 /-!
 # Minimal polynomials over a GCD monoid

--- a/src/field_theory/minpoly/gcd_monoid.lean
+++ b/src/field_theory/minpoly/gcd_monoid.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
 import data.polynomial.field_division
-import ring_theory.integral_closure
 import ring_theory.polynomial.gauss_lemma
 import field_theory.minpoly.field
+import ring_theory.adjoin_root
 
 /-!
 # Minimal polynomials over a GCD monoid
@@ -120,5 +120,82 @@ begin
 end
 
 end gcd_domain
+
+section adjoin_root
+
+noncomputable theory
+
+variables {R S : Type*} [comm_ring R] [comm_ring S] [algebra R S] (x : S) (R)
+
+open algebra polynomial adjoin_root
+
+/-- The surjective algebra morphism `R[X]/(minpoly R x) → R[x]`.
+If `R` is a GCD domain and `x` is integral, this is an isomorphism,
+see `adjoin_root.minpoly.equiv_adjoin`. -/
+@[simps] def to_adjoin : adjoin_root (minpoly R x) →ₐ[R] adjoin R ({x} : set S) :=
+lift_hom _ ⟨x, self_mem_adjoin_singleton R x⟩
+  (by simp [← subalgebra.coe_eq_zero, aeval_subalgebra_coe])
+
+variables {R x}
+
+lemma to_adjoin_apply' (a : adjoin_root (minpoly R x)) : to_adjoin R x a =
+  lift_hom (minpoly R x) (⟨x, self_mem_adjoin_singleton R x⟩ : adjoin R ({x} : set S))
+  (by simp [← subalgebra.coe_eq_zero, aeval_subalgebra_coe]) a := rfl
+
+lemma to_adjoin.apply_X : to_adjoin R x (mk (minpoly R x) X) =
+  ⟨x, self_mem_adjoin_singleton R x⟩ :=
+by simp
+
+variables (R x)
+
+lemma to_adjoin.surjective : function.surjective (to_adjoin R x) :=
+begin
+  rw [← range_top_iff_surjective, _root_.eq_top_iff, ← adjoin_adjoin_coe_preimage],
+  refine adjoin_le _,
+  simp only [alg_hom.coe_range, set.mem_range],
+  rintro ⟨y₁, y₂⟩ h,
+  refine ⟨mk (minpoly R x) X, by simpa using h.symm⟩
+end
+
+variables {R} {x} [is_domain R] [normalized_gcd_monoid R] [is_domain S] [no_zero_smul_divisors R S]
+
+lemma to_adjoin.injective (hx : is_integral R x) :
+  function.injective (minpoly.to_adjoin R x) :=
+begin
+  refine (injective_iff_map_eq_zero _).2 (λ P₁ hP₁, _),
+  obtain ⟨P, hP⟩ := mk_surjective (minpoly.monic hx) P₁,
+  by_cases hPzero : P = 0,
+  { simpa [hPzero] using hP.symm },
+  have hPcont : P.content ≠ 0 := λ h, hPzero (content_eq_zero_iff.1 h),
+  rw [← hP, minpoly.to_adjoin_apply', lift_hom_mk, ← subalgebra.coe_eq_zero,
+    aeval_subalgebra_coe, set_like.coe_mk, P.eq_C_content_mul_prim_part, aeval_mul, aeval_C] at hP₁,
+  replace hP₁ := eq_zero_of_ne_zero_of_mul_left_eq_zero
+    ((map_ne_zero_iff _ (no_zero_smul_divisors.algebra_map_injective R S)).2 hPcont) hP₁,
+  obtain ⟨Q, hQ⟩ := minpoly.gcd_domain_dvd hx P.is_primitive_prim_part.ne_zero hP₁,
+  rw [P.eq_C_content_mul_prim_part] at hP,
+  simpa [hQ] using hP.symm
+end
+
+/-- The algebra isomorphism `adjoin_root (minpoly R x) ≃ₐ[R] adjoin R x` -/
+@[simps] def equiv_adjoin (hx : is_integral R x) :
+  adjoin_root (minpoly R x) ≃ₐ[R] adjoin R ({x} : set S) :=
+alg_equiv.of_bijective (minpoly.to_adjoin R x)
+  ⟨minpoly.to_adjoin.injective hx, minpoly.to_adjoin.surjective R x⟩
+
+/-- The `power_basis` of `adjoin R {x}` given by `x`. See `algebra.adjoin.power_basis` for a version
+over a field. -/
+@[simps] def _root_.algebra.adjoin.power_basis' (hx : _root_.is_integral R x) :
+  _root_.power_basis R (algebra.adjoin R ({x} : set S)) :=
+power_basis.map (adjoin_root.power_basis' (minpoly.monic hx)) (minpoly.equiv_adjoin hx)
+
+/-- The power basis given by `x` if `B.gen ∈ adjoin R {x}`. -/
+@[simps] noncomputable def _root_.power_basis.of_gen_mem_adjoin' (B : _root_.power_basis R S)
+  (hint : is_integral R x) (hx : B.gen ∈ adjoin R ({x} : set S)) :
+  _root_.power_basis R S :=
+(algebra.adjoin.power_basis' hint).map $
+  (subalgebra.equiv_of_eq _ _ $ power_basis.adjoin_eq_top_of_gen_mem_adjoin hx).trans
+  subalgebra.top_equiv
+
+end adjoin_root
 
 end minpoly

--- a/src/field_theory/minpoly/gcd_monoid.lean
+++ b/src/field_theory/minpoly/gcd_monoid.lean
@@ -31,13 +31,13 @@ open polynomial set function minpoly
 
 namespace minpoly
 
+variables {R S : Type*} [comm_ring R] [comm_ring S] [is_domain R] [is_domain S] [algebra R S]
 
 section gcd_domain
 
-variables {R S : Type*} (K L : Type*) [comm_ring R] [is_domain R] [normalized_gcd_monoid R]
-  [field K] [comm_ring S] [is_domain S] [algebra R K] [is_fraction_ring R K] [algebra R S] [field L]
-  [algebra S L] [algebra K L] [algebra R L] [is_scalar_tower R K L] [is_scalar_tower R S L]
-  {s : S} (hs : is_integral R s)
+variables (K L : Type*) [normalized_gcd_monoid R] [field K] [algebra R K] [is_fraction_ring R K]
+  [field L] [algebra S L] [algebra K L] [algebra R L] [is_scalar_tower R K L]
+  [is_scalar_tower R S L] {s : S} (hs : is_integral R s)
 
 include hs
 
@@ -125,39 +125,9 @@ section adjoin_root
 
 noncomputable theory
 
-variables {R S : Type*} [comm_ring R] [comm_ring S] [algebra R S] (x : S) (R)
-
 open algebra polynomial adjoin_root
 
-/-- The surjective algebra morphism `R[X]/(minpoly R x) → R[x]`.
-If `R` is a GCD domain and `x` is integral, this is an isomorphism,
-see `adjoin_root.minpoly.equiv_adjoin`. -/
-@[simps] def to_adjoin : adjoin_root (minpoly R x) →ₐ[R] adjoin R ({x} : set S) :=
-lift_hom _ ⟨x, self_mem_adjoin_singleton R x⟩
-  (by simp [← subalgebra.coe_eq_zero, aeval_subalgebra_coe])
-
-variables {R x}
-
-lemma to_adjoin_apply' (a : adjoin_root (minpoly R x)) : to_adjoin R x a =
-  lift_hom (minpoly R x) (⟨x, self_mem_adjoin_singleton R x⟩ : adjoin R ({x} : set S))
-  (by simp [← subalgebra.coe_eq_zero, aeval_subalgebra_coe]) a := rfl
-
-lemma to_adjoin.apply_X : to_adjoin R x (mk (minpoly R x) X) =
-  ⟨x, self_mem_adjoin_singleton R x⟩ :=
-by simp
-
-variables (R x)
-
-lemma to_adjoin.surjective : function.surjective (to_adjoin R x) :=
-begin
-  rw [← range_top_iff_surjective, _root_.eq_top_iff, ← adjoin_adjoin_coe_preimage],
-  refine adjoin_le _,
-  simp only [alg_hom.coe_range, set.mem_range],
-  rintro ⟨y₁, y₂⟩ h,
-  refine ⟨mk (minpoly R x) X, by simpa using h.symm⟩
-end
-
-variables {R} {x} [is_domain R] [normalized_gcd_monoid R] [is_domain S] [no_zero_smul_divisors R S]
+variables {R} {x : S} [normalized_gcd_monoid R] [no_zero_smul_divisors R S]
 
 lemma to_adjoin.injective (hx : is_integral R x) :
   function.injective (minpoly.to_adjoin R x) :=

--- a/src/number_theory/number_field/embeddings.lean
+++ b/src/number_theory/number_field/embeddings.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex J. Best, Xavier Roblot
 -/
 
-import number_theory.number_field.basic
 import analysis.complex.polynomial
 import data.complex.basic
 import field_theory.minpoly.gcd_monoid
+import number_theory.number_field.basic
 
 /-!
 # Embeddings of number fields

--- a/src/number_theory/number_field/embeddings.lean
+++ b/src/number_theory/number_field/embeddings.lean
@@ -7,6 +7,7 @@ Authors: Alex J. Best, Xavier Roblot
 import number_theory.number_field.basic
 import analysis.complex.polynomial
 import data.complex.basic
+import field_theory.minpoly.gcd_monoid
 
 /-!
 # Embeddings of number fields

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -410,6 +410,42 @@ end power_basis
 
 section equiv
 
+section minpoly
+
+variables [comm_ring R] [comm_ring S] [algebra R S] (x : S) (R)
+
+open algebra polynomial
+
+/-- The surjective algebra morphism `R[X]/(minpoly R x) → R[x]`.
+If `R` is a GCD domain and `x` is integral, this is an isomorphism,
+see `adjoin_root.minpoly.equiv_adjoin`. -/
+@[simps] def minpoly.to_adjoin : adjoin_root (minpoly R x) →ₐ[R] adjoin R ({x} : set S) :=
+lift_hom _ ⟨x, self_mem_adjoin_singleton R x⟩
+  (by simp [← subalgebra.coe_eq_zero, aeval_subalgebra_coe])
+
+variables {R x}
+
+lemma minpoly.to_adjoin_apply' (a : adjoin_root (minpoly R x)) : minpoly.to_adjoin R x a =
+  lift_hom (minpoly R x) (⟨x, self_mem_adjoin_singleton R x⟩ : adjoin R ({x} : set S))
+  (by simp [← subalgebra.coe_eq_zero, aeval_subalgebra_coe]) a := rfl
+
+lemma minpoly.to_adjoin.apply_X : minpoly.to_adjoin R x (mk (minpoly R x) X) =
+  ⟨x, self_mem_adjoin_singleton R x⟩ :=
+by simp
+
+variables (R x)
+
+lemma minpoly.to_adjoin.surjective : function.surjective (minpoly.to_adjoin R x) :=
+begin
+  rw [← range_top_iff_surjective, _root_.eq_top_iff, ← adjoin_adjoin_coe_preimage],
+  refine adjoin_le _,
+  simp only [alg_hom.coe_range, set.mem_range],
+  rintro ⟨y₁, y₂⟩ h,
+  refine ⟨mk (minpoly R x) X, by simpa using h.symm⟩
+end
+
+end minpoly
+
 section is_domain
 
 variables [comm_ring R] [is_domain R] [comm_ring S] [is_domain S] [algebra R S]

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro, Chris Hughes
 -/
 import algebra.algebra.basic
 import data.polynomial.field_division
-import field_theory.minpoly.gcd_monoid
+import field_theory.minpoly.basic
 import ring_theory.adjoin.basic
 import ring_theory.finite_presentation
 import ring_theory.finite_type
@@ -407,82 +407,6 @@ lemma minpoly_power_basis_gen_of_monic (hf : f.monic) (hf' : f ≠ 0 := hf.ne_ze
 by rw [minpoly_power_basis_gen hf', hf.leading_coeff, inv_one, C.map_one, mul_one]
 
 end power_basis
-
-section minpoly
-
-variables [comm_ring R] [comm_ring S] [algebra R S] (x : S) (R)
-
-open algebra polynomial
-
-/-- The surjective algebra morphism `R[X]/(minpoly R x) → R[x]`.
-
-If `R` is a GCD domain and `x` is integral, this is an isomorphism,
-see `adjoin_root.minpoly.equiv_adjoin`. -/
-@[simps] def minpoly.to_adjoin : adjoin_root (minpoly R x) →ₐ[R] adjoin R ({x} : set S) :=
-lift_hom _ ⟨x, self_mem_adjoin_singleton R x⟩
-  (by simp [← subalgebra.coe_eq_zero, aeval_subalgebra_coe])
-
-variables {R x}
-
-lemma minpoly.to_adjoin_apply' (a : adjoin_root (minpoly R x)) : minpoly.to_adjoin R x a =
-  lift_hom (minpoly R x) (⟨x, self_mem_adjoin_singleton R x⟩ : adjoin R ({x} : set S))
-  (by simp [← subalgebra.coe_eq_zero, aeval_subalgebra_coe]) a := rfl
-
-lemma minpoly.to_adjoin.apply_X : minpoly.to_adjoin R x (mk (minpoly R x) X) =
-  ⟨x, self_mem_adjoin_singleton R x⟩ :=
-by simp
-
-variables (R x)
-
-lemma minpoly.to_adjoin.surjective : function.surjective (minpoly.to_adjoin R x) :=
-begin
-  rw [← range_top_iff_surjective, _root_.eq_top_iff, ← adjoin_adjoin_coe_preimage],
-  refine adjoin_le _,
-  simp only [alg_hom.coe_range, set.mem_range],
-  rintro ⟨y₁, y₂⟩ h,
-  refine ⟨mk (minpoly R x) X, by simpa using h.symm⟩
-end
-
-variables {R} {x} [is_domain R] [normalized_gcd_monoid R] [is_domain S] [no_zero_smul_divisors R S]
-
-lemma minpoly.to_adjoin.injective (hx : is_integral R x) :
-  function.injective (minpoly.to_adjoin R x) :=
-begin
-  refine (injective_iff_map_eq_zero _).2 (λ P₁ hP₁, _),
-  obtain ⟨P, hP⟩ := mk_surjective (minpoly.monic hx) P₁,
-  by_cases hPzero : P = 0,
-  { simpa [hPzero] using hP.symm },
-  have hPcont : P.content ≠ 0 := λ h, hPzero (content_eq_zero_iff.1 h),
-  rw [← hP, minpoly.to_adjoin_apply', lift_hom_mk, ← subalgebra.coe_eq_zero,
-    aeval_subalgebra_coe, set_like.coe_mk, P.eq_C_content_mul_prim_part, aeval_mul, aeval_C] at hP₁,
-  replace hP₁ := eq_zero_of_ne_zero_of_mul_left_eq_zero
-    ((map_ne_zero_iff _ (no_zero_smul_divisors.algebra_map_injective R S)).2 hPcont) hP₁,
-  obtain ⟨Q, hQ⟩ := minpoly.gcd_domain_dvd hx P.is_primitive_prim_part.ne_zero hP₁,
-  rw [P.eq_C_content_mul_prim_part] at hP,
-  simpa [hQ] using hP.symm
-end
-
-/-- The algebra isomorphism `adjoin_root (minpoly R x) ≃ₐ[R] adjoin R x` -/
-@[simps] def minpoly.equiv_adjoin (hx : is_integral R x) :
-  adjoin_root (minpoly R x) ≃ₐ[R] adjoin R ({x} : set S) :=
-alg_equiv.of_bijective (minpoly.to_adjoin R x)
-  ⟨minpoly.to_adjoin.injective hx, minpoly.to_adjoin.surjective R x⟩
-
-/-- The `power_basis` of `adjoin R {x}` given by `x`. See `algebra.adjoin.power_basis` for a version
-over a field. -/
-@[simps] def _root_.algebra.adjoin.power_basis' (hx : _root_.is_integral R x) :
-  _root_.power_basis R (algebra.adjoin R ({x} : set S)) :=
-power_basis.map (adjoin_root.power_basis' (minpoly.monic hx)) (minpoly.equiv_adjoin hx)
-
-/-- The power basis given by `x` if `B.gen ∈ adjoin R {x}`. -/
-@[simps] noncomputable def _root_.power_basis.of_gen_mem_adjoin' (B : _root_.power_basis R S)
-  (hint : is_integral R x) (hx : B.gen ∈ adjoin R ({x} : set S)) :
-  _root_.power_basis R S :=
-(algebra.adjoin.power_basis' hint).map $
-  (subalgebra.equiv_of_eq _ _ $ power_basis.adjoin_eq_top_of_gen_mem_adjoin hx).trans
-  subalgebra.top_equiv
-
-end minpoly
 
 section equiv
 

--- a/src/ring_theory/is_adjoin_root.lean
+++ b/src/ring_theory/is_adjoin_root.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import data.polynomial.algebra_map
-import ring_theory.adjoin_root
+import field_theory.minpoly.gcd_monoid
 import ring_theory.power_basis
 
 /-!

--- a/src/ring_theory/polynomial/selmer.lean
+++ b/src/ring_theory/polynomial/selmer.lean
@@ -5,6 +5,7 @@ Authors: Thomas Browning
 -/
 
 import data.polynomial.unit_trinomial
+import ring_theory.polynomial.gauss_lemma
 import tactic.linear_combination
 
 /-!

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -8,6 +8,7 @@ import algebra.char_p.two
 import algebra.ne_zero
 import data.polynomial.ring_division
 import field_theory.finite.basic
+import field_theory.minpoly.gcd_monoid
 import field_theory.separable
 import group_theory.specific_groups.cyclic
 import number_theory.divisors


### PR DESCRIPTION
PR #18021 makes some changes to the theory of `minpoly`, which has the net effect that the structure of imports has to be changed for some files. This is a bit painful so I've decided to open a new PR instead of doing it in #18021. This PR also moves the following definitions from `ring_theory/adjoin_root.lean` to `field_theory/minpoly/gcd_monoid.lean`:
- minpoly.to_adjoin.injective
- minpoly.equiv_adjoin
- algebra.adjoin.power_basis'
- power_basis.of_gen_mem_adjoin'

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
