### PR TITLE
[Merged by Bors] - feat(geometry/euclidean/angle/unoriented/affine): more collinearity lemmas

### DIFF
--- a/src/geometry/euclidean/angle/unoriented/affine.lean
+++ b/src/geometry/euclidean/angle/unoriented/affine.lean
@@ -409,4 +409,34 @@ begin
       exact h.wbtw.collinear } }
 end
 
+/-- If the angle between three points is 0, they are collinear. -/
+lemma collinear_of_angle_eq_zero {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = 0) :
+  collinear ℝ ({p₁, p₂, p₃} : set P) :=
+collinear_iff_eq_or_eq_or_angle_eq_zero_or_angle_eq_pi.2 $ or.inr $ or.inr $ or.inl h
+
+/-- If the angle between three points is π, they are collinear. -/
+lemma collinear_of_angle_eq_pi {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = π) :
+  collinear ℝ ({p₁, p₂, p₃} : set P) :=
+collinear_iff_eq_or_eq_or_angle_eq_zero_or_angle_eq_pi.2 $ or.inr $ or.inr $ or.inr h
+
+/-- If three points are not collinear, the angle between them is nonzero. -/
+lemma angle_ne_zero_of_not_collinear {p₁ p₂ p₃ : P} (h : ¬collinear ℝ ({p₁, p₂, p₃} : set P)) :
+  ∠ p₁ p₂ p₃ ≠ 0 :=
+mt collinear_of_angle_eq_zero h
+
+/-- If three points are not collinear, the angle between them is not π. -/
+lemma angle_ne_pi_of_not_collinear {p₁ p₂ p₃ : P} (h : ¬collinear ℝ ({p₁, p₂, p₃} : set P)) :
+  ∠ p₁ p₂ p₃ ≠ π :=
+mt collinear_of_angle_eq_pi h
+
+/-- If three points are not collinear, the angle between them is positive. -/
+lemma angle_pos_of_not_collinear {p₁ p₂ p₃ : P} (h : ¬collinear ℝ ({p₁, p₂, p₃} : set P)) :
+  0 < ∠ p₁ p₂ p₃ :=
+(angle_nonneg _ _ _).lt_of_ne (angle_ne_zero_of_not_collinear h).symm
+
+/-- If three points are not collinear, the angle between them is less than π. -/
+lemma angle_lt_pi_of_not_collinear {p₁ p₂ p₃ : P} (h : ¬collinear ℝ ({p₁, p₂, p₃} : set P)) :
+  ∠ p₁ p₂ p₃ < π :=
+(angle_le_pi _ _ _).lt_of_ne $ angle_ne_pi_of_not_collinear h
+
 end euclidean_geometry


### PR DESCRIPTION
These lemmas relating collinearity and angles of zero or pi are less general than the existing
`collinear_iff_eq_or_eq_or_angle_eq_zero_or_angle_eq_pi` from which they are deduced, but may be more convenient to use.  Suggested by review of #17993.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
