### PR TITLE
[Merged by Bors] - chore(analysis/normed_space/lp_equiv): fix docs

### DIFF
--- a/src/analysis/normed_space/lp_equiv.lean
+++ b/src/analysis/normed_space/lp_equiv.lean
@@ -8,16 +8,16 @@ import analysis.normed_space.pi_Lp
 import topology.continuous_function.bounded
 
 /-!
-# Equivalences among $$L^p$$ spaces
+# Equivalences among $L^p$ spaces
 
-In this file we collect a variety of equivalences among various $$L^p$$ spaces.  In particular,
+In this file we collect a variety of equivalences among various $L^p$ spaces.  In particular,
 when `α` is a `fintype`, given `E : α → Type u` and `p : ℝ≥0∞`, there is a natural linear isometric
 equivalence `lp_pi_Lpₗᵢ : lp E p ≃ₗᵢ pi_Lp p E`. In addition, when `α` is a discrete topological
 space, the bounded continuous functions `α →ᵇ β` correspond exactly to `lp (λ _, β) ∞`. Here there
 can be more structure, including ring and algebra structures, and we implement these equivalences
 accordingly as well.
 
-We keep this as a separate file so that the various $$L^p$$ space files don't import the others.
+We keep this as a separate file so that the various $L^p$ space files don't import the others.
 
 Recall that `pi_Lp` is just a type synonym for `Π i, E i` but given a different metric and norm
 structure, although the topological, uniform and bornological structures coincide definitionally.


### PR DESCRIPTION
Note that [in the current docs](https://leanprover-community.github.io/mathlib_docs/analysis/normed_space/lp_equiv.html), $L^p$ shows on its own line. This is because the $L^p$ are written using double $s, which is wrong.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
