### PR TITLE
chore(data/string): move lt from basic to defs

### DIFF
--- a/src/data/buffer/parser/basic.lean
+++ b/src/data/buffer/parser/basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Yakov Pechersky. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yakov Pechersky
 -/
-import data.string.basic
+import data.string.defs
 import data.buffer.basic
 import data.nat.digits
 import data.buffer.parser

--- a/src/data/multiset/sort.lean
+++ b/src/data/multiset/sort.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 -/
 import data.list.sort
 import data.multiset.basic
-import data.string.basic
+import data.string.defs
 
 /-!
 # Construct a sorted list from a multiset.

--- a/src/data/string/basic.lean
+++ b/src/data/string/basic.lean
@@ -14,26 +14,6 @@ Supplementary theorems about the `string` type.
 
 namespace string
 
-/-- `<` on string iterators. This coincides with `<` on strings as lists. -/
-def ltb : iterator → iterator → bool
-| s₁ s₂ := begin
-  cases s₂.has_next, {exact ff},
-  cases h₁ : s₁.has_next, {exact tt},
-  exact if s₁.curr = s₂.curr then
-    have s₁.next.2.length < s₁.2.length, from
-    match s₁, h₁ with ⟨_, a::l⟩, h := nat.lt_succ_self _ end,
-    ltb s₁.next s₂.next
-  else s₁.curr < s₂.curr,
-end
-using_well_founded {rel_tac :=
-  λ _ _, `[exact ⟨_, measure_wf (λ s, s.1.2.length)⟩]}
-
-instance has_lt' : has_lt string :=
-⟨λ s₁ s₂, ltb s₁.mk_iterator s₂.mk_iterator⟩
-
-instance decidable_lt : @decidable_rel string (<) :=
-by apply_instance -- short-circuit type class inference
-
 @[simp] theorem lt_iff_to_list_lt :
   ∀ {s₁ s₂ : string}, s₁ < s₂ ↔ s₁.to_list < s₂.to_list
 | ⟨i₁⟩ ⟨i₂⟩ :=

--- a/src/data/string/defs.lean
+++ b/src/data/string/defs.lean
@@ -33,6 +33,11 @@ instance has_lt' : has_lt string :=
 instance decidable_lt : @decidable_rel string (<) :=
 by apply_instance -- short-circuit type class inference
 
+instance has_le : has_le string := ⟨λ s₁ s₂, ¬ s₂ < s₁⟩
+
+instance decidable_le : @decidable_rel string (≤) :=
+by apply_instance -- short-circuit type class inference
+
 /-- `s.split_on c` tokenizes `s : string` on `c : char`. -/
 def split_on (s : string) (c : char) : list string :=
 split (= c) s

--- a/src/data/string/defs.lean
+++ b/src/data/string/defs.lean
@@ -13,6 +13,26 @@ This file defines a bunch of functions for the `string` datatype.
 
 namespace string
 
+/-- `<` on string iterators. This coincides with `<` on strings as lists. -/
+def ltb : iterator → iterator → bool
+| s₁ s₂ := begin
+  cases s₂.has_next, {exact ff},
+  cases h₁ : s₁.has_next, {exact tt},
+  exact if s₁.curr = s₂.curr then
+    have s₁.next.2.length < s₁.2.length, from
+    match s₁, h₁ with ⟨_, a::l⟩, h := nat.lt_succ_self _ end,
+    ltb s₁.next s₂.next
+  else s₁.curr < s₂.curr,
+end
+using_well_founded {rel_tac :=
+  λ _ _, `[exact ⟨_, measure_wf (λ s, s.1.2.length)⟩]}
+
+instance has_lt' : has_lt string :=
+⟨λ s₁ s₂, ltb s₁.mk_iterator s₂.mk_iterator⟩
+
+instance decidable_lt : @decidable_rel string (<) :=
+by apply_instance -- short-circuit type class inference
+
 /-- `s.split_on c` tokenizes `s : string` on `c : char`. -/
 def split_on (s : string) (c : char) : list string :=
 split (= c) s


### PR DESCRIPTION

---
This will make the mathlib port much easier. `data.string.basic` is an important file in the hierarchy because the definition of `lt` is used in `data.multiset.sort`. `data.string.basic` is also very difficult to port. This PR moves the definitions to `defs` which is already ported.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
