### PR TITLE
[Merged by Bors] - feat(algebra/group/basic): reduce additivity checks to one case

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -657,7 +657,7 @@ end subtraction_comm_monoid
   (i.e. satisfies `f a c = f a b * f b c`), we may assume `r a b` and `r b c` are satisfied. -/
 @[to_additive additive_of_is_total "If a binary function from a type equipped with a total relation
   `r` to an additive monoid is anti-symmetric (i.e. satisfies `f a b + f b a = 0`), in order to show
-  it is multiplicative (i.e. satisfies `f a c = f a b + f b c`), we may assume `r a b` and `r b c`
+  it is additive (i.e. satisfies `f a c = f a b + f b c`), we may assume `r a b` and `r b c`
   are satisfied."]
 lemma multiplicative_of_is_total [monoid β] (f : α → α → β) (r : α → α → Prop) [t : is_total α r]
   (hswap : ∀ a b, f a b * f b a = 1)

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -655,11 +655,11 @@ end subtraction_comm_monoid
 /-- If a binary function from a type equipped with a total relation `r` to a monoid is
   anti-symmetric (i.e. satisfies `f a b * f b a = 1`), in order to show it is multiplicative
   (i.e. satisfies `f a c = f a b * f b c`), we may assume `r a b` and `r b c` are satisfied. -/
-@[to_additive additive_of_total "If a binary function from a type equipped with a total relation `r`
-  to an additive monoid is anti-symmetric (i.e. satisfies `f a b + f b a = 0`), in order to show it
-  is multiplicative (i.e. satisfies `f a c = f a b + f b c`), we may assume `r a b` and `r b c`
+@[to_additive additive_of_is_total "If a binary function from a type equipped with a total relation
+  `r` to an additive monoid is anti-symmetric (i.e. satisfies `f a b + f b a = 0`), in order to show
+  it is multiplicative (i.e. satisfies `f a c = f a b + f b c`), we may assume `r a b` and `r b c`
   are satisfied."]
-lemma multiplicative_of_total [monoid β] (f : α → α → β) (r : α → α → Prop) [t : is_total α r]
+lemma multiplicative_of_is_total [monoid β] (f : α → α → β) (r : α → α → Prop) [t : is_total α r]
   (hswap : ∀ a b, f a b * f b a = 1)
   (hmul : ∀ {a b c}, r a b → r b c → f a c = f a b * f b c)
   (a b c : α) : f a c = f a b * f b c :=

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -665,9 +665,9 @@ lemma multiplicative_of_is_total [monoid β] (f : α → α → β) (r : α → 
   (a b c : α) : f a c = f a b * f b c :=
 begin
   suffices : ∀ b c, r b c → f a c = f a b * f b c,
-  obtain hbc | hcb := t.total b c,
-  { exact this b c hbc },
-  { rw [this c b hcb, mul_assoc, hswap c b, mul_one] },
+  { obtain hbc | hcb := t.total b c,
+    { exact this b c hbc },
+    { rw [this c b hcb, mul_assoc, hswap c b, mul_one] } },
   intros b c hbc,
   obtain hab | hba := t.total a b,
   { exact hmul hab hbc },

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -652,26 +652,46 @@ lemma bit1_sub [has_one M] (a b : M) : bit1 (a - b) = bit1 a - bit0 b :=
 
 end subtraction_comm_monoid
 
+section multiplicative
+
+variables [monoid β] (p r : α → α → Prop) [is_total α r] (f : α → α → β)
+
+@[to_additive additive_of_symmetric_of_is_total]
+lemma multiplicative_of_symmetric_of_is_total
+  (hsymm : symmetric p) (hf_swap : ∀ {a b}, p a b → f a b * f b a = 1)
+  (hmul : ∀ {a b c}, r a b → r b c → p a b → p b c → p a c → f a c = f a b * f b c)
+  {a b c : α} (pab : p a b) (pbc : p b c) (pac : p a c) : f a c = f a b * f b c :=
+begin
+  suffices : ∀ {b c}, r b c → p a b → p b c → p a c → f a c = f a b * f b c,
+  { obtain rbc | rcb := total_of r b c,
+    { exact this rbc pab pbc pac },
+    { rw [this rcb pac (hsymm pbc) pab, mul_assoc, hf_swap (hsymm pbc), mul_one] } },
+  intros b c rbc pab pbc pac,
+  obtain rab | rba := total_of r a b,
+  { exact hmul rab rbc pab pbc pac },
+  rw [← one_mul (f a c), ← hf_swap pab, mul_assoc],
+  obtain rac | rca := total_of r a c,
+  { rw [hmul rba rac (hsymm pab) pac pbc] },
+  { rw [hmul rbc rca pbc (hsymm pac) (hsymm pab), mul_assoc, hf_swap (hsymm pac), mul_one] },
+end
+
 /-- If a binary function from a type equipped with a total relation `r` to a monoid is
   anti-symmetric (i.e. satisfies `f a b * f b a = 1`), in order to show it is multiplicative
-  (i.e. satisfies `f a c = f a b * f b c`), we may assume `r a b` and `r b c` are satisfied. -/
+  (i.e. satisfies `f a c = f a b * f b c`), we may assume `r a b` and `r b c` are satisfied.
+  We allow restricting to a subset specified by a predicate `p`. -/
 @[to_additive additive_of_is_total "If a binary function from a type equipped with a total relation
   `r` to an additive monoid is anti-symmetric (i.e. satisfies `f a b + f b a = 0`), in order to show
   it is additive (i.e. satisfies `f a c = f a b + f b c`), we may assume `r a b` and `r b c`
-  are satisfied."]
-lemma multiplicative_of_is_total [monoid β] (f : α → α → β) (r : α → α → Prop) [t : is_total α r]
-  (hswap : ∀ a b, f a b * f b a = 1)
-  (hmul : ∀ {a b c}, r a b → r b c → f a c = f a b * f b c)
-  (a b c : α) : f a c = f a b * f b c :=
+  are satisfied. We allow restricting to a subset specified by a predicate `p`."]
+lemma multiplicative_of_is_total (p : α → Prop)
+  (hswap : ∀ {a b}, p a → p b → f a b * f b a = 1)
+  (hmul : ∀ {a b c}, r a b → r b c → p a → p b → p c → f a c = f a b * f b c)
+  {a b c : α} (pa : p a) (pb : p b) (pc : p c) : f a c = f a b * f b c :=
 begin
-  suffices : ∀ b c, r b c → f a c = f a b * f b c,
-  { obtain hbc | hcb := t.total b c,
-    { exact this b c hbc },
-    { rw [this c b hcb, mul_assoc, hswap c b, mul_one] } },
-  intros b c hbc,
-  obtain hab | hba := t.total a b,
-  { exact hmul hab hbc },
-  obtain hac | hca := t.total a c,
-  { rw [hmul hba hac, ← mul_assoc, hswap a b, one_mul] },
-  { rw [← one_mul (f a c), ← hswap a b, hmul hbc hca, mul_assoc, mul_assoc, hswap c a, mul_one] },
+  apply multiplicative_of_symmetric_of_is_total (λ a b, p a ∧ p b) r f (λ _ _, and.swap),
+  { simp_rw and_imp, exact @hswap },
+  { exact λ a b c rab rbc pab pbc pac, hmul rab rbc pab.1 pab.2 pac.2 },
+  exacts [⟨pa, pb⟩, ⟨pb, pc⟩, ⟨pa, pc⟩],
 end
+
+end multiplicative

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -651,3 +651,27 @@ lemma bit1_sub [has_one M] (a b : M) : bit1 (a - b) = bit1 a - bit0 b :=
 (congr_arg (+ (1 : M)) $ bit0_sub a b : _).trans $ sub_add_eq_add_sub _ _ _
 
 end subtraction_comm_monoid
+
+/-- If a binary function from a type equipped with a total relation `r` to a monoid is
+  anti-symmetric (i.e. satisfies `f a b * f b a = 1`), in order to show it is multiplicative
+  (i.e. satisfies `f a c = f a b * f b c`), we may assume `r a b` and `r b c` are satisfied. -/
+@[to_additive additive_of_total "If a binary function from a type equipped with a total relation `r`
+  to an additive monoid is anti-symmetric (i.e. satisfies `f a b + f b a = 0`), in order to show it
+  is multiplicative (i.e. satisfies `f a c = f a b + f b c`), we may assume `r a b` and `r b c`
+  are satisfied."]
+lemma multiplicative_of_total [monoid β] (f : α → α → β) (r : α → α → Prop) [t : is_total α r]
+  (hswap : ∀ a b, f a b * f b a = 1)
+  (hmul : ∀ {a b c}, r a b → r b c → f a c = f a b * f b c)
+  (a b c : α) : f a c = f a b * f b c :=
+begin
+  have := _,
+  obtain hbc | hcb := t.total b c,
+  { revert b c, exact this },
+  { rw [this c b hcb, mul_assoc, hswap c b, mul_one] },
+  intros b c hbc,
+  obtain hab | hba := t.total a b,
+  { exact hmul hab hbc },
+  obtain hac | hca := t.total a c,
+  { rw [hmul hba hac, ← mul_assoc, hswap a b, one_mul] },
+  { rw [← one_mul (f a c), ← hswap a b, hmul hbc hca, mul_assoc, mul_assoc, hswap c a, mul_one] },
+end

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -664,9 +664,9 @@ lemma multiplicative_of_is_total [monoid β] (f : α → α → β) (r : α → 
   (hmul : ∀ {a b c}, r a b → r b c → f a c = f a b * f b c)
   (a b c : α) : f a c = f a b * f b c :=
 begin
-  have := _,
+  suffices : ∀ b c, r b c → f a c = f a b * f b c,
   obtain hbc | hcb := t.total b c,
-  { revert b c, exact this },
+  { exact this b c hbc },
   { rw [this c b hcb, mul_assoc, hswap c b, mul_one] },
   intros b c hbc,
   obtain hab | hba := t.total a b,


### PR DESCRIPTION
---

Can be used to reduce lemmas like [interval_integral.integral_add_adjacent_intervals](https://leanprover-community.github.io/mathlib_docs/measure_theory/integral/interval_integral.html#interval_integral.integral_add_adjacent_intervals) to one case. Intended to be used in [#18040](https://github.com/leanprover-community/mathlib/pull/18040#discussion_r1062838151).

ported in https://github.com/leanprover-community/mathlib4/pull/1519
an earlier version ported in https://github.com/leanprover-community/mathlib4/pull/1399

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
