### PR TITLE
[Merged by Bors] - feat(field_theory/chevalley_warning): Binary version

### DIFF
--- a/src/field_theory/chevalley_warning.lean
+++ b/src/field_theory/chevalley_warning.lean
@@ -19,7 +19,7 @@ and `q` is notation for the cardinality of `K`.
    such that the total degree of `f` is less than `(q-1)` times the cardinality of `σ`.
    Then the evaluation of `f` on all points of `σ → K` (aka `K^σ`) sums to `0`.
    (`sum_mv_polynomial_eq_zero`)
-2. The Chevalley–Warning theorem (`char_dvd_card_solutions`).
+2. The Chevalley–Warning theorem (`char_dvd_card_solutions_family`).
    Let `f i` be a finite family of multivariate polynomials
    in finitely many variables (`X s`, `s : σ`) such that
    the sum of the total degrees of the `f i` is less than the cardinality of `σ`.
@@ -88,7 +88,7 @@ end
 
 variables [decidable_eq K] [decidable_eq σ]
 
-/-- The Chevalley–Warning theorem.
+/-- The **Chevalley–Warning theorem**, finitary version.
 Let `(f i)` be a finite family of multivariate polynomials
 in finitely many variables (`X s`, `s : σ`) over a finite field of characteristic `p`.
 Assume that the sum of the total degrees of the `f i` is less than the cardinality of `σ`.
@@ -147,7 +147,28 @@ begin
     ... ≤ (q - 1) * (f i).total_degree : total_degree_pow _ _
 end
 
-/-- The Chevalley–Warning theorem.
+/-- The **Chevalley–Warning theorem**, binary version.
+Let `f₁`, `f₂` be two multivariate polynomials in finitely many variables (`X s`, `s : σ`) over a
+finite field of characteristic `p`.
+Assume that the sum of the total degrees of `f₁` and `f₂` is less than the cardinality of `σ`.
+Then the number of common solutions of the `f₁` and `f₂` is divisible by `p`. -/
+theorem char_dvd_card_solutions₂ (p : ℕ) [char_p K p] {f₁ f₂ : mv_polynomial σ K}
+  (h : f₁.total_degree + f₂.total_degree < fintype.card σ) :
+  p ∣ fintype.card {x : σ → K // eval x f₁ = 0 ∧ eval x f₂ = 0} :=
+begin
+  let F : bool → mv_polynomial σ K := λ b, match b with
+  | ff := f₁
+  | tt := f₂
+  end,
+  have : ∑ b : bool, (F b).total_degree < fintype.card σ := (add_comm _ _).trans_lt h,
+  have key := char_dvd_card_solutions_family p this,
+  simp only [F, mem_singleton, fintype.univ_bool, mem_insert, bool.forall_bool, eq_self_iff_true,
+    false_or, forall_true_left, or_false] at key,
+  convert key,
+end
+
+
+/-- The **Chevalley–Warning theorem**, unary version.
 Let `f` be a multivariate polynomial in finitely many variables (`X s`, `s : σ`)
 over a finite field of characteristic `p`.
 Assume that the total degree of `f` is less than the cardinality of `σ`.

--- a/src/field_theory/chevalley_warning.lean
+++ b/src/field_theory/chevalley_warning.lean
@@ -186,10 +186,7 @@ theorem char_dvd_card_solutions₂ (p : ℕ) [char_p K p] {f₁ f₂ : mv_polyno
 begin
   let F : bool → mv_polynomial σ K := λ b, cond b f₂ f₁,
   have : ∑ b : bool, (F b).total_degree < fintype.card σ := (add_comm _ _).trans_lt h,
-  have key := char_dvd_card_solutions_family p this,
-  simp only [F, mem_singleton, fintype.univ_bool, mem_insert, bool.forall_bool, eq_self_iff_true,
-    false_or, forall_true_left, or_false] at key,
-  convert key,
+  simpa only [F, bool.forall_bool] using key,
 end
 
 end finite_field

--- a/src/field_theory/chevalley_warning.lean
+++ b/src/field_theory/chevalley_warning.lean
@@ -18,8 +18,8 @@ and `q` is notation for the cardinality of `K`.
 1. Let `f` be a multivariate polynomial in finitely many variables (`X s`, `s : σ`)
    such that the total degree of `f` is less than `(q-1)` times the cardinality of `σ`.
    Then the evaluation of `f` on all points of `σ → K` (aka `K^σ`) sums to `0`.
-   (`sum_mv_polynomial_eq_zero`)
-2. The Chevalley–Warning theorem (`char_dvd_card_solutions_family`).
+   (`sum_eval_eq_zero`)
+2. The Chevalley–Warning theorem (`char_dvd_card_solutions_of_sum_lt`).
    Let `f i` be a finite family of multivariate polynomials
    in finitely many variables (`X s`, `s : σ`) such that
    the sum of the total degrees of the `f i` is less than the cardinality of `σ`.
@@ -41,12 +41,12 @@ open_locale big_operators
 section finite_field
 open mv_polynomial function (hiding eval) finset finite_field
 
-variables {K σ ι : Type*} [fintype K] [field K] [fintype σ]
+variables {K σ ι : Type*} [fintype K] [field K] [fintype σ] [decidable_eq σ]
 local notation `q` := fintype.card K
 
-lemma mv_polynomial.sum_mv_polynomial_eq_zero [decidable_eq σ] (f : mv_polynomial σ K)
+lemma mv_polynomial.sum_eval_eq_zero (f : mv_polynomial σ K)
   (h : f.total_degree < (q - 1) * fintype.card σ) :
-  (∑ x, eval x f) = 0 :=
+  ∑ x, eval x f = 0 :=
 begin
   haveI : decidable_eq K := classical.dec_eq K,
   calc (∑ x, eval x f)
@@ -86,15 +86,14 @@ begin
     rw equiv.subtype_equiv_codomain_symm_apply_ne, }
 end
 
-variables [decidable_eq K] [decidable_eq σ]
+variables [decidable_eq K] (p : ℕ) [char_p K p]
 
 /-- The **Chevalley–Warning theorem**, finitary version.
 Let `(f i)` be a finite family of multivariate polynomials
 in finitely many variables (`X s`, `s : σ`) over a finite field of characteristic `p`.
 Assume that the sum of the total degrees of the `f i` is less than the cardinality of `σ`.
 Then the number of common solutions of the `f i` is divisible by `p`. -/
-theorem char_dvd_card_solutions_family (p : ℕ) [char_p K p]
-  {ι : Type*} {s : finset ι} {f : ι → mv_polynomial σ K}
+theorem char_dvd_card_solutions_of_sum_lt {s : finset ι} {f : ι → mv_polynomial σ K}
   (h : (∑ i in s, (f i).total_degree) < fintype.card σ) :
   p ∣ fintype.card {x : σ → K // ∀ i ∈ s, eval x (f i) = 0} :=
 begin
@@ -131,7 +130,7 @@ begin
   rw [← char_p.cast_eq_zero_iff K, ← key],
   show ∑ x, eval x F = 0,
   -- We are now ready to apply the main machine, proven before.
-  apply F.sum_mv_polynomial_eq_zero,
+  apply F.sum_eval_eq_zero,
   -- It remains to verify the crucial assumption of this machine
   show F.total_degree < (q - 1) * fintype.card σ,
   calc F.total_degree ≤ ∑ i in s, (1 - (f i)^(q - 1)).total_degree : total_degree_finset_prod s _
@@ -152,27 +151,24 @@ Let `(f i)` be a finite family of multivariate polynomials
 in finitely many variables (`X s`, `s : σ`) over a finite field of characteristic `p`.
 Assume that the sum of the total degrees of the `f i` is less than the cardinality of `σ`.
 Then the number of common solutions of the `f i` is divisible by `p`. -/
-theorem char_dvd_card_solutions_family' (p : ℕ) [char_p K p] [fintype ι] {f : ι → mv_polynomial σ K}
+theorem char_dvd_card_solutions_of_fintype_sum_lt [fintype ι] {f : ι → mv_polynomial σ K}
   (h : (∑ i, (f i).total_degree) < fintype.card σ) :
   p ∣ fintype.card {x : σ → K // ∀ i, eval x (f i) = 0} :=
-by simpa using char_dvd_card_solutions_family p h
+by simpa using char_dvd_card_solutions_of_sum_lt p h
 
 /-- The **Chevalley–Warning theorem**, unary version.
 Let `f` be a multivariate polynomial in finitely many variables (`X s`, `s : σ`)
 over a finite field of characteristic `p`.
 Assume that the total degree of `f` is less than the cardinality of `σ`.
 Then the number of solutions of `f` is divisible by `p`.
-See `char_dvd_card_solutions_family` for a version that takes a family of polynomials `f i`. -/
-theorem char_dvd_card_solutions (p : ℕ) [char_p K p]
-  {f : mv_polynomial σ K} (h : f.total_degree < fintype.card σ) :
+See `char_dvd_card_solutions_of_sum_lt` for a version that takes a family of polynomials `f i`. -/
+theorem char_dvd_card_solutions {f : mv_polynomial σ K} (h : f.total_degree < fintype.card σ) :
   p ∣ fintype.card {x : σ → K // eval x f = 0} :=
 begin
   let F : unit → mv_polynomial σ K := λ _, f,
-  have : ∑ i : unit, (F i).total_degree < fintype.card σ,
-  { simpa only [fintype.univ_punit, sum_singleton] using h, },
-  have key := char_dvd_card_solutions_family p this,
-  simp only [F, fintype.univ_punit, forall_eq, mem_singleton] at key,
-  convert key,
+  have : ∑ i : unit, (F i).total_degree < fintype.card σ := h,
+  simpa only [F, fintype.univ_punit, forall_eq, mem_singleton] using
+    char_dvd_card_solutions_of_sum_lt p this,
 end
 
 /-- The **Chevalley–Warning theorem**, binary version.
@@ -180,13 +176,13 @@ Let `f₁`, `f₂` be two multivariate polynomials in finitely many variables (`
 finite field of characteristic `p`.
 Assume that the sum of the total degrees of `f₁` and `f₂` is less than the cardinality of `σ`.
 Then the number of common solutions of the `f₁` and `f₂` is divisible by `p`. -/
-theorem char_dvd_card_solutions₂ (p : ℕ) [char_p K p] {f₁ f₂ : mv_polynomial σ K}
+theorem char_dvd_card_solutions_of_add_lt {f₁ f₂ : mv_polynomial σ K}
   (h : f₁.total_degree + f₂.total_degree < fintype.card σ) :
   p ∣ fintype.card {x : σ → K // eval x f₁ = 0 ∧ eval x f₂ = 0} :=
 begin
   let F : bool → mv_polynomial σ K := λ b, cond b f₂ f₁,
   have : ∑ b : bool, (F b).total_degree < fintype.card σ := (add_comm _ _).trans_lt h,
-  simpa only [F, bool.forall_bool] using char_dvd_card_solutions_family' p this,
+  simpa only [F, bool.forall_bool] using char_dvd_card_solutions_of_fintype_sum_lt p this,
 end
 
 end finite_field

--- a/src/field_theory/chevalley_warning.lean
+++ b/src/field_theory/chevalley_warning.lean
@@ -147,6 +147,24 @@ begin
     ... ≤ (q - 1) * (f i).total_degree : total_degree_pow _ _
 end
 
+/-- The **Chevalley–Warning theorem**, unary version.
+Let `f` be a multivariate polynomial in finitely many variables (`X s`, `s : σ`)
+over a finite field of characteristic `p`.
+Assume that the total degree of `f` is less than the cardinality of `σ`.
+Then the number of solutions of `f` is divisible by `p`.
+See `char_dvd_card_solutions_family` for a version that takes a family of polynomials `f i`. -/
+theorem char_dvd_card_solutions (p : ℕ) [char_p K p]
+  {f : mv_polynomial σ K} (h : f.total_degree < fintype.card σ) :
+  p ∣ fintype.card {x : σ → K // eval x f = 0} :=
+begin
+  let F : unit → mv_polynomial σ K := λ _, f,
+  have : ∑ i : unit, (F i).total_degree < fintype.card σ,
+  { simpa only [fintype.univ_punit, sum_singleton] using h, },
+  have key := char_dvd_card_solutions_family p this,
+  simp only [F, fintype.univ_punit, forall_eq, mem_singleton] at key,
+  convert key,
+end
+
 /-- The **Chevalley–Warning theorem**, binary version.
 Let `f₁`, `f₂` be two multivariate polynomials in finitely many variables (`X s`, `s : σ`) over a
 finite field of characteristic `p`.
@@ -164,25 +182,6 @@ begin
   have key := char_dvd_card_solutions_family p this,
   simp only [F, mem_singleton, fintype.univ_bool, mem_insert, bool.forall_bool, eq_self_iff_true,
     false_or, forall_true_left, or_false] at key,
-  convert key,
-end
-
-
-/-- The **Chevalley–Warning theorem**, unary version.
-Let `f` be a multivariate polynomial in finitely many variables (`X s`, `s : σ`)
-over a finite field of characteristic `p`.
-Assume that the total degree of `f` is less than the cardinality of `σ`.
-Then the number of solutions of `f` is divisible by `p`.
-See `char_dvd_card_solutions_family` for a version that takes a family of polynomials `f i`. -/
-theorem char_dvd_card_solutions (p : ℕ) [char_p K p]
-  {f : mv_polynomial σ K} (h : f.total_degree < fintype.card σ) :
-  p ∣ fintype.card {x : σ → K // eval x f = 0} :=
-begin
-  let F : unit → mv_polynomial σ K := λ _, f,
-  have : ∑ i : unit, (F i).total_degree < fintype.card σ,
-  { simpa only [fintype.univ_punit, sum_singleton] using h, },
-  have key := char_dvd_card_solutions_family p this,
-  simp only [F, fintype.univ_punit, forall_eq, mem_singleton] at key,
   convert key,
 end
 

--- a/src/field_theory/chevalley_warning.lean
+++ b/src/field_theory/chevalley_warning.lean
@@ -186,7 +186,7 @@ theorem char_dvd_card_solutions₂ (p : ℕ) [char_p K p] {f₁ f₂ : mv_polyno
 begin
   let F : bool → mv_polynomial σ K := λ b, cond b f₂ f₁,
   have : ∑ b : bool, (F b).total_degree < fintype.card σ := (add_comm _ _).trans_lt h,
-  simpa only [F, bool.forall_bool] using key,
+  simpa only [F, bool.forall_bool] using char_dvd_card_solutions_family' p this,
 end
 
 end finite_field

--- a/src/field_theory/chevalley_warning.lean
+++ b/src/field_theory/chevalley_warning.lean
@@ -41,7 +41,7 @@ open_locale big_operators
 section finite_field
 open mv_polynomial function (hiding eval) finset finite_field
 
-variables {K : Type*} {σ : Type*} [fintype K] [field K] [fintype σ]
+variables {K σ ι : Type*} [fintype K] [field K] [fintype σ]
 local notation `q` := fintype.card K
 
 lemma mv_polynomial.sum_mv_polynomial_eq_zero [decidable_eq σ] (f : mv_polynomial σ K)
@@ -147,6 +147,16 @@ begin
     ... ≤ (q - 1) * (f i).total_degree : total_degree_pow _ _
 end
 
+/-- The **Chevalley–Warning theorem**, fintype version.
+Let `(f i)` be a finite family of multivariate polynomials
+in finitely many variables (`X s`, `s : σ`) over a finite field of characteristic `p`.
+Assume that the sum of the total degrees of the `f i` is less than the cardinality of `σ`.
+Then the number of common solutions of the `f i` is divisible by `p`. -/
+theorem char_dvd_card_solutions_family' (p : ℕ) [char_p K p] [fintype ι] {f : ι → mv_polynomial σ K}
+  (h : (∑ i, (f i).total_degree) < fintype.card σ) :
+  p ∣ fintype.card {x : σ → K // ∀ i, eval x (f i) = 0} :=
+by simpa using char_dvd_card_solutions_family p h
+
 /-- The **Chevalley–Warning theorem**, unary version.
 Let `f` be a multivariate polynomial in finitely many variables (`X s`, `s : σ`)
 over a finite field of characteristic `p`.
@@ -174,10 +184,7 @@ theorem char_dvd_card_solutions₂ (p : ℕ) [char_p K p] {f₁ f₂ : mv_polyno
   (h : f₁.total_degree + f₂.total_degree < fintype.card σ) :
   p ∣ fintype.card {x : σ → K // eval x f₁ = 0 ∧ eval x f₂ = 0} :=
 begin
-  let F : bool → mv_polynomial σ K := λ b, match b with
-  | ff := f₁
-  | tt := f₂
-  end,
+  let F : bool → mv_polynomial σ K := λ b, cond b f₂ f₁,
   have : ∑ b : bool, (F b).total_degree < fintype.card σ := (add_comm _ _).trans_lt h,
   have key := char_dvd_card_solutions_family p this,
   simp only [F, mem_singleton, fintype.univ_bool, mem_insert, bool.forall_bool, eq_self_iff_true,


### PR DESCRIPTION
Derive the two multivariate polynomials version of Chevalley-Warning from the general one.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
