### PR TITLE
[Merged by Bors] - feat(data/polynomial): `adjoin_root.mk_ne_zero` lemmas

### DIFF
--- a/src/algebraic_geometry/elliptic_curve/weierstrass.lean
+++ b/src/algebraic_geometry/elliptic_curve/weierstrass.lean
@@ -401,14 +401,14 @@ variables (x : R) (y : R[X])
 
 lemma X_class_ne_zero [nontrivial R] : W.X_class x ≠ 0 :=
 adjoin_root.mk_ne_zero_of_nat_degree_lt W.monic_polynomial (C_ne_zero.2 $ X_sub_C_ne_zero x) $
-  by { rw [W.nat_degree_polynomial, nat_degree_C], norm_num }
+  by { rw [nat_degree_polynomial, nat_degree_C], norm_num1 }
 
 /-- The class of the element $Y - y(X)$ in $R[W]$ for some $y(X) \in R[X]$. -/
 @[simp] noncomputable def Y_class : W.coordinate_ring := adjoin_root.mk W.polynomial $ X - C y
 
 lemma Y_class_ne_zero [nontrivial R] : W.Y_class y ≠ 0 :=
 adjoin_root.mk_ne_zero_of_nat_degree_lt W.monic_polynomial (X_sub_C_ne_zero _) $
-  by { rw [W.nat_degree_polynomial, nat_degree_X_sub_C], norm_num }
+  by { rw [nat_degree_polynomial, nat_degree_X_sub_C], norm_num1 }
 
 /-- The ideal $\langle X - x \rangle$ of $R[W]$ for some $x \in R$. -/
 @[simp] noncomputable def X_ideal : ideal W.coordinate_ring := ideal.span {W.X_class x}

--- a/src/algebraic_geometry/elliptic_curve/weierstrass.lean
+++ b/src/algebraic_geometry/elliptic_curve/weierstrass.lean
@@ -400,25 +400,15 @@ variables (x : R) (y : R[X])
 @[simp] noncomputable def X_class : W.coordinate_ring := adjoin_root.mk W.polynomial $ C $ X - C x
 
 lemma X_class_ne_zero [nontrivial R] : W.X_class x ≠ 0 :=
-begin
-  intro hx,
-  cases ideal.mem_span_singleton'.mp (ideal.quotient.eq_zero_iff_mem.mp hx) with p hp,
-  apply_fun degree at hp,
-  rw [W.monic_polynomial.degree_mul, degree_polynomial, degree_C $ X_sub_C_ne_zero x] at hp,
-  cases p.degree; cases hp
-end
+adjoin_root.mk_ne_zero_of_nat_degree_lt W.monic_polynomial (C_ne_zero.2 $ X_sub_C_ne_zero x) $
+  by { rw [W.nat_degree_polynomial, nat_degree_C], norm_num }
 
 /-- The class of the element $Y - y(X)$ in $R[W]$ for some $y(X) \in R[X]$. -/
 @[simp] noncomputable def Y_class : W.coordinate_ring := adjoin_root.mk W.polynomial $ X - C y
 
 lemma Y_class_ne_zero [nontrivial R] : W.Y_class y ≠ 0 :=
-begin
-  intro hy,
-  cases ideal.mem_span_singleton'.mp (ideal.quotient.eq_zero_iff_mem.mp hy) with p hp,
-  apply_fun degree at hp,
-  rw [W.monic_polynomial.degree_mul, degree_polynomial, degree_X_sub_C] at hp,
-  cases p.degree; cases hp
-end
+adjoin_root.mk_ne_zero_of_nat_degree_lt W.monic_polynomial (X_sub_C_ne_zero _) $
+  by { rw [W.nat_degree_polynomial, nat_degree_X_sub_C], norm_num }
 
 /-- The ideal $\langle X - x \rangle$ of $R[W]$ for some $x \in R$. -/
 @[simp] noncomputable def X_ideal : ideal W.coordinate_ring := ideal.span {W.X_class x}

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -172,7 +172,7 @@ with_bot.gi_unbot'_bot.gc.monotone_l hpq
 lemma nat_degree_lt_nat_degree {p q : R[X]} (hp : p ≠ 0) (hpq : p.degree < q.degree) :
   p.nat_degree < q.nat_degree :=
 begin
-  by_cases hq : q = 0, { rw [hq, degree_zero] at hpq, have := not_lt_bot hpq, contradiction },
+  by_cases hq : q = 0, { exact (not_lt_bot $ hq.subst hpq).elim },
   rwa [degree_eq_nat_degree hp, degree_eq_nat_degree hq, with_bot.coe_lt_coe] at hpq
 end
 

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -169,6 +169,13 @@ lemma nat_degree_le_nat_degree [semiring S] {q : S[X]} (hpq : p.degree ≤ q.deg
   p.nat_degree ≤ q.nat_degree :=
 with_bot.gi_unbot'_bot.gc.monotone_l hpq
 
+lemma nat_degree_lt_nat_degree {p q : R[X]} (hp : p ≠ 0) (hpq : p.degree < q.degree) :
+  p.nat_degree < q.nat_degree :=
+begin
+  by_cases hq : q = 0, { rw [hq, degree_zero] at hpq, have := not_lt_bot hpq, contradiction },
+  rwa [degree_eq_nat_degree hp, degree_eq_nat_degree hq, with_bot.coe_lt_coe] at hpq
+end
+
 @[simp] lemma degree_C (ha : a ≠ 0) : degree (C a) = (0 : with_bot ℕ) :=
 by rw [degree, ← monomial_zero_left, support_monomial 0 ha, max_eq_sup_coe, sup_singleton,
     with_bot.coe_zero]

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -125,7 +125,7 @@ end
 namespace monic
 
 @[simp]
-lemma nat_degree_eq_zero_iff_eq_one {p : R[X]} (hp : p.monic) :
+lemma nat_degree_eq_zero_iff_eq_one (hp : p.monic) :
   p.nat_degree = 0 ↔ p = 1 :=
 begin
   split; intro h,
@@ -137,11 +137,11 @@ begin
 end
 
 @[simp]
-lemma degree_le_zero_iff_eq_one {p : R[X]} (hp : p.monic) :
+lemma degree_le_zero_iff_eq_one (hp : p.monic) :
   p.degree ≤ 0 ↔ p = 1 :=
 by rw [←hp.nat_degree_eq_zero_iff_eq_one, nat_degree_eq_zero_iff_degree_le_zero]
 
-lemma nat_degree_mul {p q : R[X]} (hp : p.monic) (hq : q.monic) :
+lemma nat_degree_mul (hp : p.monic) (hq : q.monic) :
   (p * q).nat_degree = p.nat_degree + q.nat_degree :=
 begin
   nontriviality R,
@@ -149,7 +149,7 @@ begin
   simp [hp.leading_coeff, hq.leading_coeff]
 end
 
-lemma degree_mul_comm {p : R[X]} (hp : p.monic) (q : R[X]) :
+lemma degree_mul_comm (hp : p.monic) (q : R[X]) :
   (p * q).degree = (q * p).degree :=
 begin
   by_cases h : q = 0,
@@ -159,14 +159,14 @@ begin
   { rwa [hp.leading_coeff, one_mul, leading_coeff_ne_zero] }
 end
 
-lemma nat_degree_mul' {p q : R[X]} (hp : p.monic) (hq : q ≠ 0) :
+lemma nat_degree_mul' (hp : p.monic) (hq : q ≠ 0) :
   (p * q).nat_degree = p.nat_degree + q.nat_degree :=
 begin
   rw [nat_degree_mul', add_comm],
   simpa [hp.leading_coeff, leading_coeff_ne_zero]
 end
 
-lemma nat_degree_mul_comm {p : R[X]} (hp : p.monic) (q : R[X]) :
+lemma nat_degree_mul_comm (hp : p.monic) (q : R[X]) :
   (p * q).nat_degree = (q * p).nat_degree :=
 begin
   by_cases h : q = 0,
@@ -187,7 +187,7 @@ lemma not_dvd_of_degree_lt (hp : monic p)
   (h0 : q ≠ 0) (hl : degree q < degree p) : ¬ p ∣ q :=
 monic.not_dvd_of_nat_degree_lt hp h0 $ nat_degree_lt_nat_degree h0 hl
 
-lemma next_coeff_mul {p q : R[X]} (hp : monic p) (hq : monic q) :
+lemma next_coeff_mul (hp : monic p) (hq : monic q) :
   next_coeff (p * q) = next_coeff p + next_coeff q :=
 begin
   nontriviality,

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -177,10 +177,10 @@ end
 
 lemma not_dvd_of_nat_degree_lt (hp : monic p)
   (h0 : q ≠ 0) (hl : nat_degree q < nat_degree p) : ¬ p ∣ q :=
-λ ⟨r, hr⟩, begin
-  have hr0 : r ≠ 0 := by { rintro rfl, exact h0 (mul_zero p ▸ hr) },
-  rw [hr, hp.nat_degree_mul' hr0] at hl,
-  exact hl.not_le (nat.le_add_right _ _),
+begin
+  rintro ⟨r, rfl⟩,
+  rw [hp.nat_degree_mul' $ right_ne_zero_of_mul h0] at hl,
+  exact hl.not_le (nat.le_add_right _ _)
 end
 
 lemma not_dvd_of_degree_lt (hp : monic p)

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -175,6 +175,18 @@ begin
   simpa [hp.leading_coeff, leading_coeff_ne_zero]
 end
 
+lemma not_dvd_of_nat_degree_lt (hp : monic p)
+  (h0 : q ≠ 0) (hl : nat_degree q < nat_degree p) : ¬ p ∣ q :=
+λ ⟨r, hr⟩, begin
+  have hr0 : r ≠ 0 := by { rintro rfl, exact h0 (mul_zero p ▸ hr) },
+  rw [hr, hp.nat_degree_mul' hr0] at hl,
+  exact hl.not_le (nat.le_add_right _ _),
+end
+
+lemma not_dvd_of_degree_lt (hp : monic p)
+  (h0 : q ≠ 0) (hl : degree q < degree p) : ¬ p ∣ q :=
+monic.not_dvd_of_nat_degree_lt hp h0 $ nat_degree_lt_nat_degree h0 hl
+
 lemma next_coeff_mul {p q : R[X]} (hp : monic p) (hq : monic q) :
   next_coeff (p * q) = next_coeff p + next_coeff q :=
 begin

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -131,12 +131,23 @@ ideal.quotient.alg_hom_ext R $ polynomial.alg_hom_ext h
 @[simp] lemma mk_eq_mk {g h : R[X]} : mk f g = mk f h ↔ f ∣ g - h :=
 ideal.quotient.eq.trans ideal.mem_span_singleton
 
+@[simp] lemma mk_eq_zero {g : R[X]} : mk f g = 0 ↔ f ∣ g :=
+mk_eq_mk.trans $ by rw sub_zero
+
 @[simp] lemma mk_self : mk f f = 0 :=
 quotient.sound' $ quotient_add_group.left_rel_apply.mpr (mem_span_singleton.2 $ by simp)
 
 @[simp] lemma mk_C (x : R) : mk f (C x) = x := rfl
 
 @[simp] lemma mk_X : mk f X = root f := rfl
+
+lemma mk_ne_zero_of_degree_lt (hf : monic f)
+  {g : R[X]} (h0 : g ≠ 0) (hd : degree g < degree f) : mk f g ≠ 0 :=
+mk_eq_zero.not.2 $ hf.not_dvd_of_degree_lt h0 hd
+
+lemma mk_ne_zero_of_nat_degree_lt (hf : monic f)
+  {g : R[X]} (h0 : g ≠ 0) (hd : nat_degree g < nat_degree f) : mk f g ≠ 0 :=
+mk_eq_zero.not.2 $ hf.not_dvd_of_nat_degree_lt h0 hd
 
 @[simp] lemma aeval_eq (p : R[X]) : aeval (root f) p = mk f p :=
 polynomial.induction_on p (λ x, by { rw aeval_C, refl })

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -239,16 +239,7 @@ end minpoly
 
 section equiv
 
-variables [algebra A S] {S' : Type*} [comm_ring S'] [algebra A S']
-
-lemma nat_degree_lt_nat_degree {p q : R[X]} (hp : p ≠ 0) (hpq : p.degree < q.degree) :
-  p.nat_degree < q.nat_degree :=
-begin
-  by_cases hq : q = 0, { rw [hq, degree_zero] at hpq, have := not_lt_bot hpq, contradiction },
-  rwa [degree_eq_nat_degree hp, degree_eq_nat_degree hq, with_bot.coe_lt_coe] at hpq
-end
-
-variables [is_domain A]
+variables [algebra A S] {S' : Type*} [comm_ring S'] [algebra A S'] [is_domain A]
 
 lemma constr_pow_aeval (pb : power_basis A S) {y : S'}
   (hy : aeval y (minpoly A pb.gen) = 0) (f : A[X]) :


### PR DESCRIPTION
+ `mk_ne_zero_of_(nat_)degree_lt`: if `f : R[X]` is monic and `g : R[X]` is nonzero with (nat_)degree less than (nat_)degree of `f`, then the image of `g` in `R[X]/(f)` is nonzero. Depends on new lemmas `monic.not_dvd_of_(nat_)degree_lt`.

+ Use it to golf `weierstrass_curve.X/Y_class_ne_zero`.

+ Move misplaced lemma `nat_degree_lt_nat_degree`.

---

(Remark: it's also possible to prove another version of these lemmas with `monic f` replaced by `no_zero_divisors R`.)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
