### PR TITLE
[Merged by Bors] - chore: remove uses of and.rec

### DIFF
--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -46,7 +46,7 @@ theorem ext : ∀ {z w : ℂ}, z.re = w.re → z.im = w.im → z = w
 | ⟨zr, zi⟩ ⟨_, _⟩ rfl rfl := rfl
 
 theorem ext_iff {z w : ℂ} : z = w ↔ z.re = w.re ∧ z.im = w.im :=
-⟨λ H, by simp [H], and.rec ext⟩
+⟨λ H, by simp [H], λ h, ext h.1 h.2⟩
 
 theorem re_surjective : surjective re := λ x, ⟨⟨x, 0⟩, rfl⟩
 theorem im_surjective : surjective im := λ y, ⟨⟨0, y⟩, rfl⟩

--- a/src/data/fin/tuple/basic.lean
+++ b/src/data/fin/tuple/basic.lean
@@ -165,7 +165,7 @@ end
 lemma cons_injective_iff {α} {x₀ : α} {x : fin n → α} :
   function.injective (cons x₀ x : fin n.succ → α) ↔ x₀ ∉ set.range x ∧ function.injective x  :=
 begin
-  refine ⟨λ h, ⟨_, _⟩, and.rec cons_injective_of_injective⟩,
+  refine ⟨λ h, ⟨_, _⟩, λ h, cons_injective_of_injective h.1 h.2⟩,
   { rintros ⟨i, hi⟩,
     replace h := @h i.succ 0,
     simpa [hi, succ_ne_zero] using h, },

--- a/src/data/list/dedup.lean
+++ b/src/data/list/dedup.lean
@@ -35,7 +35,7 @@ pw_filter_cons_of_pos $ by simpa only [forall_mem_ne] using h
 
 @[simp] theorem mem_dedup {a : α} {l : list α} : a ∈ dedup l ↔ a ∈ l :=
 by simpa only [dedup, forall_mem_ne, not_not] using not_congr (@forall_mem_pw_filter α (≠) _
-  (λ x y z xz, not_and_distrib.1 $ mt (and.rec eq.trans) xz) a l)
+  (λ x y z xz, not_and_distrib.1 $ mt (λ h, eq.trans h.1 h.2) xz) a l)
 
 @[simp] theorem dedup_cons_of_mem {a : α} {l : list α} (h : a ∈ l) :
   dedup (a :: l) = dedup l :=


### PR DESCRIPTION

---
The trick of writing `and.rec f` instead of  `λ h, f h.1 h.2` is very clever, but it's not readable and it makes porting annoying so I made a PR to get rid of it in unported files
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
