### PR TITLE
[Merged by Bors] - fix(tactic/{norm_num, abel}): do not do syntactic matches on typeclass instances

### DIFF
--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -416,6 +416,9 @@ apply_nolint tactic.abel.eval_add doc_blame
 apply_nolint tactic.abel.eval_atom doc_blame
 apply_nolint tactic.abel.eval_neg doc_blame
 apply_nolint tactic.abel.eval_smul doc_blame
+apply_nolint tactic.abel.int_smul_instg doc_blame
+apply_nolint tactic.abel.nat_smul_inst doc_blame
+apply_nolint tactic.abel.nat_smul_instg doc_blame
 apply_nolint tactic.abel.normal_expr doc_blame
 apply_nolint tactic.abel.normal_expr.e doc_blame
 apply_nolint tactic.abel.normal_expr.pp doc_blame

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -315,14 +315,16 @@ meta def eval (c : context) : expr → tactic (normal_expr × expr)
   return (e', c.app ``unfold_zsmul c.inst [e₁, e₂, e', p])
 | e@`(@has_smul.smul nat %%α %%inst %%e₁ %%e₂) := do
   let inst' := c.iapp ``nat_smul_inst [],
-  is_def_eq inst inst',
-  eval_smul' c eval ff e e₁ e₂
+  mcond (succeeds (is_def_eq inst inst'))
+    (eval_smul' c eval ff e e₁ e₂)
+    (eval_atom c e)
 | e@`(@has_smul.smul int %%α %%inst %%e₁ %%e₂) := do
   -- if we're not a group there's no canonical instance available
   tt ← pure c.is_group | eval_atom c e,
   let inst' := c.app ``int_smul_instg c.inst [],
-  is_def_eq inst inst',
-  eval_smul' c eval tt e e₁ e₂
+  mcond (succeeds (is_def_eq inst inst'))
+    (eval_smul' c eval tt e e₁ e₂)
+    (eval_atom c e)
 | e@`(smul %%e₁ %%e₂) := eval_smul' c eval ff e e₁ e₂
 | e@`(smulg %%e₁ %%e₂) := eval_smul' c eval tt e e₁ e₂
 | e@`(@has_zero.zero _ _) := mcond (succeeds (is_def_eq e c.α0))

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -189,6 +189,10 @@ meta def eval_neg (c : context) : normal_expr → tactic (normal_expr × expr)
   return (term' c (n', -n.2) x a',
     c.app ``term_neg c.inst [n.1, x, a, n', a', h₁, h₂])
 
+def nat_smul_inst {α} [add_comm_monoid α] : has_smul ℕ α := by apply_instance
+def nat_smul_instg {α} [add_comm_group α] : has_smul ℕ α := by apply_instance
+def int_smul_instg {α} [add_comm_group α] : has_smul ℤ α := by apply_instance
+
 def smul {α} [add_comm_monoid α] (n : ℕ) (x : α) : α := n • x
 def smulg {α} [add_comm_group α] (n : ℤ) (x : α) : α := n • x
 
@@ -309,9 +313,13 @@ meta def eval (c : context) : expr → tactic (normal_expr × expr)
   guardb c.is_group,
   (e', p) ← eval $ c.iapp ``smul [e₁, e₂],
   return (e', c.app ``unfold_zsmul c.inst [e₁, e₂, e', p])
-| e@`(@has_smul.smul nat _ add_monoid.has_smul_nat %%e₁ %%e₂) :=
+| e@`(@has_smul.smul nat %%α %%inst %%e₁ %%e₂) := do
+  let inst' := c.iapp ``nat_smul_inst [],
+  is_def_eq inst inst',
   eval_smul' c eval ff e e₁ e₂
-| e@`(@has_smul.smul int _ sub_neg_monoid.has_smul_int %%e₁ %%e₂) :=
+| e@`(@has_smul.smul int %%α %%inst %%e₁ %%e₂) := do
+  let inst' := c.iapp `tactic.abel.int_smul_inst [],
+  is_def_eq inst inst',
   eval_smul' c eval tt e e₁ e₂
 | e@`(smul %%e₁ %%e₂) := eval_smul' c eval ff e e₁ e₂
 | e@`(smulg %%e₁ %%e₂) := eval_smul' c eval tt e e₁ e₂

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -318,7 +318,9 @@ meta def eval (c : context) : expr → tactic (normal_expr × expr)
   is_def_eq inst inst',
   eval_smul' c eval ff e e₁ e₂
 | e@`(@has_smul.smul int %%α %%inst %%e₁ %%e₂) := do
-  let inst' := c.iapp `tactic.abel.int_smul_inst [],
+  -- if we're not a group there's no canonical instance available
+  tt ← pure c.is_group | eval_atom c e,
+  let inst' := c.app ``int_smul_instg c.inst [],
   is_def_eq inst inst',
   eval_smul' c eval tt e e₁ e₂
 | e@`(smul %%e₁ %%e₂) := eval_smul' c eval ff e e₁ e₂

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -189,12 +189,12 @@ meta def eval_neg (c : context) : normal_expr → tactic (normal_expr × expr)
   return (term' c (n', -n.2) x a',
     c.app ``term_neg c.inst [n.1, x, a, n', a', h₁, h₂])
 
-def nat_smul_inst {α} [add_comm_monoid α] : has_smul ℕ α := by apply_instance
-def nat_smul_instg {α} [add_comm_group α] : has_smul ℕ α := by apply_instance
-def int_smul_instg {α} [add_comm_group α] : has_smul ℤ α := by apply_instance
+@[nolint doc_blame] def nat_smul_inst {α} [add_comm_monoid α] : has_smul ℕ α := by apply_instance
+@[nolint doc_blame] def nat_smul_instg {α} [add_comm_group α] : has_smul ℕ α := by apply_instance
+@[nolint doc_blame] def int_smul_instg {α} [add_comm_group α] : has_smul ℤ α := by apply_instance
 
-def smul {α} [add_comm_monoid α] (n : ℕ) (x : α) : α := n • x
-def smulg {α} [add_comm_group α] (n : ℤ) (x : α) : α := n • x
+@[nolint doc_blame] def smul {α} [add_comm_monoid α] (n : ℕ) (x : α) : α := n • x
+@[nolint doc_blame] def smulg {α} [add_comm_group α] (n : ℤ) (x : α) : α := n • x
 
 theorem zero_smul {α} [add_comm_monoid α] (c) : smul c (0 : α) = 0 :=
 by simp [smul, nsmul_zero]

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -189,12 +189,12 @@ meta def eval_neg (c : context) : normal_expr → tactic (normal_expr × expr)
   return (term' c (n', -n.2) x a',
     c.app ``term_neg c.inst [n.1, x, a, n', a', h₁, h₂])
 
-@[nolint doc_blame] def nat_smul_inst {α} [add_comm_monoid α] : has_smul ℕ α := by apply_instance
-@[nolint doc_blame] def nat_smul_instg {α} [add_comm_group α] : has_smul ℕ α := by apply_instance
-@[nolint doc_blame] def int_smul_instg {α} [add_comm_group α] : has_smul ℤ α := by apply_instance
+def nat_smul_inst {α} [add_comm_monoid α] : has_smul ℕ α := by apply_instance
+def nat_smul_instg {α} [add_comm_group α] : has_smul ℕ α := by apply_instance
+def int_smul_instg {α} [add_comm_group α] : has_smul ℤ α := by apply_instance
 
-@[nolint doc_blame] def smul {α} [add_comm_monoid α] (n : ℕ) (x : α) : α := n • x
-@[nolint doc_blame] def smulg {α} [add_comm_group α] (n : ℤ) (x : α) : α := n • x
+def smul {α} [add_comm_monoid α] (n : ℕ) (x : α) : α := n • x
+def smulg {α} [add_comm_group α] (n : ℤ) (x : α) : α := n • x
 
 theorem zero_smul {α} [add_comm_monoid α] (c) : smul c (0 : α) = 0 :=
 by simp [smul, nsmul_zero]

--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -1076,8 +1076,6 @@ meta def prove_zpow (ic zc nc : instance_cache) (a : expr) (na : ℚ) (b : expr)
     pure (ic, zc, nc, c, p)
   end
 
-#check @div_inv_monoid.has_pow
-
 /-- Evaluates expressions of the form `a ^ b`, `monoid.npow a b` or `nat.pow a b`. -/
 meta def eval_pow : expr → tactic (expr × expr)
 | `(@has_pow.pow %%α %%β %%m %%e₁ %%e₂) := do

--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -1076,14 +1076,21 @@ meta def prove_zpow (ic zc nc : instance_cache) (a : expr) (na : ℚ) (b : expr)
     pure (ic, zc, nc, c, p)
   end
 
+#check @div_inv_monoid.has_pow
+
 /-- Evaluates expressions of the form `a ^ b`, `monoid.npow a b` or `nat.pow a b`. -/
 meta def eval_pow : expr → tactic (expr × expr)
-| `(@has_pow.pow %%α _ %%m %%e₁ %%e₂) := do
+| `(@has_pow.pow %%α %%β %%m %%e₁ %%e₂) := do
   n₁ ← e₁.to_rat,
   c ← mk_instance_cache α,
-  match m with
-  | `(@monoid.has_pow %%_ %%_) := prod.snd <$> prove_pow e₁ n₁ c e₂
-  | `(@div_inv_monoid.has_pow %%_ %%_) := do
+  match β with
+  | `(ℕ) := do
+    (c, m') ← c.mk_app ``monoid.has_pow [],
+    is_def_eq m m',
+    prod.snd <$> prove_pow e₁ n₁ c e₂
+  | `(ℤ) := do
+    (c, m') ← c.mk_app ``div_inv_monoid.has_pow [],
+    is_def_eq m m',
     zc ← mk_instance_cache `(ℤ),
     nc ← mk_instance_cache `(ℕ),
     (prod.snd ∘ prod.snd ∘ prod.snd) <$> prove_zpow c zc nc e₁ n₁ e₂

--- a/src/tactic/ring_exp.lean
+++ b/src/tactic/ring_exp.lean
@@ -1408,16 +1408,17 @@ meta def eval : expr → ring_exp_m (ex sum)
   pf ← mk_app_class ``div_pf dri [ps, qs, psqs.pretty, psqs_pf],
   pure (psqs.set_info e pf)) <|> eval_base e
 | e@`(@has_pow.pow _ _ %%hp_instance %%ps %%qs) := do
+  ctx ← get_context,
   ps' ← eval ps,
   qs' ← in_exponent $ eval qs,
   psqs ← pow ps' qs',
   psqs_pf ← psqs.proof_term,
-  (do has_pow_pf ← match hp_instance with
-  | `(monoid.has_pow) := lift $ mk_eq_refl e
-  | _ := lift $ fail "has_pow instance must be nat.has_pow or monoid.has_pow"
-  end,
-  pf ← lift $ mk_eq_trans has_pow_pf psqs_pf,
-  pure $ psqs.set_info e pf) <|> eval_base e
+  (do
+    lift (is_def_eq hp_instance ctx.info_b.hp_instance
+          <|> fail "has_pow instance must be nat.has_pow or monoid.has_pow"),
+    has_pow_pf ← lift $ mk_eq_refl e,
+    pf ← lift $ mk_eq_trans has_pow_pf psqs_pf,
+    pure $ psqs.set_info e pf) <|> eval_base e
 | ps := eval_base ps
 
 /--

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -18,6 +18,10 @@ example [add_comm_monoid α] (x : ℕ → α) : ((2 : ℕ) • x) = x + x := by 
 example [add_comm_group α] (x : ℕ → α) : ((2 : ℕ) • x) = x + x := by abel1
 example [add_comm_group α] (x : ℕ → α) : ((2 : ℤ) • x) = x + x := by abel1
 
+-- even if there's an instance we don't recognize, we treat it as an atom
+example [add_comm_group α] [has_smul ℕ α] (x : ℕ → α) :
+  ((2 : ℕ) • x) + ((2 : ℕ) • x) = (2 : ℤ) • ((2 : ℕ) • x) := by abel1
+
 -- `abel!` should see through terms that are definitionally equal,
 def id' (x : α) := x
 example [add_comm_group α] : a + b - b - id' a = 0 :=

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -1,4 +1,5 @@
 import tactic.abel
+import algebra.group.pi
 variables {α : Type*} {a b : α}
 
 example [add_comm_monoid α] : a + (b + a) = a + a + b := by abel
@@ -10,6 +11,12 @@ example [add_comm_group α] (a b : α) : a-2•b = a -2•b := by abel
 example [add_comm_group α] (a : α) : 0 + a = a := by abel1
 example [add_comm_group α] (n : ℕ) (a : α) : n • a = n • a := by abel1
 example [add_comm_group α] (n : ℕ) (a : α) : 0 + n • a = n • a := by abel1
+
+-- instances do not have to syntactically be
+-- `add_monoid.has_smul_nat` or `sub_neg_monoid.has_smul_int`
+example [add_comm_monoid α] (x : ℕ → α) : ((2 : ℕ) • x) = x + x := by abel1
+example [add_comm_group α] (x : ℕ → α) : ((2 : ℕ) • x) = x + x := by abel1
+example [add_comm_group α] (x : ℕ → α) : ((2 : ℤ) • x) = x + x := by abel1
 
 -- `abel!` should see through terms that are definitionally equal,
 def id' (x : α) := x

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -5,6 +5,7 @@ Authors: Simon Hudon, Mario Carneiro
 -/
 
 import tactic.norm_num
+import algebra.ring.pi
 
 /-!
 # Tests for `norm_num` extensions
@@ -302,6 +303,10 @@ example : (- ((- (((66 - 86) - 36) / 94) - 3) / - - (77 / (56 - - - 79))) + 87) 
   (312254/3619 : α) := by norm_num
 
 example : 2 ^ 13 - 1 = int.of_nat 8191 := by norm_num
+
+-- `^` and `•` do not have to match `monoid.has_pow` and `add_monoid.has_smul` syntactically
+example {α} [ring α] : (2 ^ 3 : ℕ → α) = 8 := by norm_num
+example {α} [ring α] : (2 • 3 : ℕ → α) = 6 := by norm_num
 
 /-! Test the behaviour of removing one `norm_num` extension tactic. -/
 section remove_extension

--- a/test/ring_exp.lean
+++ b/test/ring_exp.lean
@@ -1,6 +1,7 @@
 import tactic.ring_exp
 import tactic.zify
 import algebra.group_with_zero.power
+import algebra.ring.pi
 import tactic.field_simp
 
 universes u
@@ -74,6 +75,9 @@ example (a b : ℚ) : (a * b) ^ 1000000 = (b * a) ^ 1000000 := by ring_exp
 
 example (n : ℕ) : 2 ^ (n + 1 + 1)  = 2 * 2 ^ (n + 1) :=
 by ring_exp_eq
+
+-- power does not have to be a syntactic match to `monoid.has_pow`
+example {α} [comm_ring α] (x : ℕ → α) : (x ^ 2 * x) = x ^ 3 := by ring_exp
 
 end exponentiation
 


### PR DESCRIPTION
Specifically, this remove syntactic matches on `has_pow` and `has_smul` instances in favor of unification.
In all cases there is a cache we can exploit to avoid looking up the preferred instance from scratch every time.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
