### PR TITLE
feat(algebra/hom/group_action): add two lemmas

### DIFF
--- a/src/algebra/hom/group.lean
+++ b/src/algebra/hom/group.lean
@@ -1041,6 +1041,12 @@ add_decl_doc add_monoid_hom.has_zero
 @[simp, to_additive] lemma monoid_hom.one_apply [mul_one_class M] [mul_one_class N]
   (x : M) : (1 : M →* N) x = 1 := rfl
 
+@[simp, to_additive] lemma one_hom.coe_monoid_hom_one [monoid M] [monoid N] :
+  monoid_hom.to_one_hom (1 : M →* N) = 1 := rfl
+
+@[simp, to_additive] lemma one_hom.coe_one [monoid M] [monoid N] (x : M) :
+  one_hom.to_fun (1 : one_hom M N) x = 1 := rfl
+
 @[simp, to_additive] lemma one_hom.one_comp [has_one M] [has_one N] [has_one P] (f : one_hom M N) :
   (1 : one_hom N P).comp f = 1 := rfl
 @[simp, to_additive] lemma one_hom.comp_one [has_one M] [has_one N] [has_one P] (f : one_hom N P) :

--- a/src/algebra/hom/group_action.lean
+++ b/src/algebra/hom/group_action.lean
@@ -258,12 +258,6 @@ end semiring
 
 end distrib_mul_action_hom
 
-@[simp] lemma zero_hom.coe_add_monoid_hom_zero {A B : Type*} [add_monoid A] [add_monoid B] :
-  add_monoid_hom.to_zero_hom (0 : A →+ B) = 0 := rfl
-
-@[simp] lemma zero_hom.coe_zero {A B : Type*} [add_monoid A] [add_monoid B] (x : A) :
-  zero_hom.to_fun (0 : zero_hom A B) x = 0 := rfl
-
 /-- Equivariant ring homomorphisms. -/
 @[nolint has_nonempty_instance]
 structure mul_semiring_action_hom extends R →+[M] S, R →+* S.

--- a/src/algebra/hom/group_action.lean
+++ b/src/algebra/hom/group_action.lean
@@ -258,6 +258,12 @@ end semiring
 
 end distrib_mul_action_hom
 
+@[simp] lemma zero_hom.coe_add_monoid_hom_zero {A B : Type*} [add_monoid A] [add_monoid B] :
+  add_monoid_hom.to_zero_hom (0 : A →+ B) = 0 := rfl
+
+@[simp] lemma zero_hom.coe_zero {A B : Type*} [add_monoid A] [add_monoid B] (x : A) :
+  zero_hom.to_fun (0 : zero_hom A B) x = 0 := rfl
+
 /-- Equivariant ring homomorphisms. -/
 @[nolint has_nonempty_instance]
 structure mul_semiring_action_hom extends R →+[M] S, R →+* S.


### PR DESCRIPTION
These weird lemmas put things back into simp normal form. They're not needed in mathlib3 apparently, but because of various changes in lean 4 it would be convenient to have them in mathlib4 right now, and this file is currently being ported.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
