### PR TITLE
[Merged by Bors] - feat(algebra/order/ring/with_top): ring covariance & ordered ring typeclasses for `with_bot`

### DIFF
--- a/src/algebra/order/monoid/with_top.lean
+++ b/src/algebra/order/monoid/with_top.lean
@@ -31,6 +31,12 @@ variables [has_one α]
 @[simp, norm_cast, to_additive] lemma coe_eq_one {a : α} : (a : with_top α) = 1 ↔ a = 1 :=
 coe_eq_coe
 
+@[simp, norm_cast, to_additive coe_nonneg]
+lemma one_le_coe [has_le α] {a : α} : 1 ≤ (a : with_top α) ↔ 1 ≤ a := coe_le_coe
+
+@[simp, norm_cast, to_additive coe_le_zero]
+lemma coe_le_one [has_le α] {a : α} : (a : with_top α) ≤ 1 ↔ a ≤ 1 := coe_le_coe
+
 @[simp, norm_cast, to_additive coe_pos]
 lemma one_lt_coe [has_lt α] {a : α} : 1 < (a : with_top α) ↔ 1 < a := coe_lt_coe
 
@@ -360,13 +366,19 @@ lemma coe_one [has_one α] : ((1 : α) : with_bot α) = 1 := rfl
 lemma coe_eq_one [has_one α] {a : α} : (a : with_bot α) = 1 ↔ a = 1 :=
 with_top.coe_eq_one
 
-@[norm_cast, to_additive coe_pos]
+@[simp, norm_cast, to_additive coe_nonneg]
+lemma one_le_coe [has_one α] [has_le α] {a : α} : 1 ≤ (a : with_bot α) ↔ 1 ≤ a := coe_le_coe
+
+@[simp, norm_cast, to_additive coe_le_zero]
+lemma coe_le_one [has_one α] [has_le α] {a : α} : (a : with_bot α) ≤ 1 ↔ a ≤ 1 := coe_le_coe
+
+@[simp, norm_cast, to_additive coe_pos]
 lemma one_lt_coe [has_one α] [has_lt α] {a : α} : 1 < (a : with_bot α) ↔ 1 < a := coe_lt_coe
 
-@[norm_cast, to_additive coe_lt_zero]
+@[simp, norm_cast, to_additive coe_lt_zero]
 lemma coe_lt_one [has_one α] [has_lt α] {a : α} : (a : with_bot α) < 1 ↔ a < 1 := coe_lt_coe
 
-@[to_additive] protected lemma map_one {β} [has_one α] (f : α → β) :
+@[simp, to_additive] protected lemma map_one {β} [has_one α] (f : α → β) :
   (1 : with_bot α).map f = (f 1 : with_bot β) := rfl
 
 @[norm_cast] lemma coe_nat [add_monoid_with_one α] (n : ℕ) : ((n : α) : with_bot α) = n := rfl

--- a/src/algebra/order/ring/with_top.lean
+++ b/src/algebra/order/ring/with_top.lean
@@ -13,7 +13,7 @@ import algebra.order.ring.canonical
 > Any changes to this file require a corresponding PR to mathlib4.
 
 The main results of this section are `with_top.canonically_ordered_comm_semiring` and
-`with_bot.comm_monoid_with_zero`.
+`with_bot.ordered_comm_semiring`.
 -/
 
 variables {α : Type*}
@@ -259,17 +259,114 @@ with_top.comm_monoid_with_zero
 instance [canonically_ordered_comm_semiring α] [nontrivial α] : comm_semiring (with_bot α) :=
 with_top.comm_semiring
 
-instance [canonically_ordered_comm_semiring α] [nontrivial α] : pos_mul_mono (with_bot α) :=
-pos_mul_mono_iff_covariant_pos.2 ⟨begin
-    rintros ⟨x, x0⟩ a b h, simp only [subtype.coe_mk],
-    lift x to α using x0.ne_bot,
-    induction a using with_bot.rec_bot_coe, { simp_rw [mul_bot x0.ne.symm, bot_le] },
-    induction b using with_bot.rec_bot_coe, { exact absurd h (bot_lt_coe a).not_le },
-    simp only [← coe_mul, coe_le_coe] at *,
-    exact mul_le_mul_left' h x,
-  end ⟩
+instance [mul_zero_class α] [preorder α] [pos_mul_mono α] :
+  pos_mul_mono (with_bot α) :=
+⟨begin
+  rintros ⟨x, x0⟩ a b h, simp only [subtype.coe_mk],
+  rcases eq_or_ne x 0 with rfl | x0', { simp, },
+  lift x to α, { rintro ⟨rfl⟩, exact (with_bot.bot_lt_coe (0 : α)).not_le x0, },
+  induction a using with_bot.rec_bot_coe, { simp_rw [mul_bot x0', bot_le] },
+  induction b using with_bot.rec_bot_coe, { exact absurd h (bot_lt_coe a).not_le },
+  simp only [← coe_mul, coe_le_coe] at *,
+  norm_cast at x0,
+  exact mul_le_mul_of_nonneg_left h x0,
+end ⟩
 
-instance [canonically_ordered_comm_semiring α] [nontrivial α] : mul_pos_mono (with_bot α) :=
-pos_mul_mono_iff_mul_pos_mono.mp infer_instance
+instance [mul_zero_class α] [preorder α] [mul_pos_mono α] :
+  mul_pos_mono (with_bot α) :=
+⟨begin
+  rintros ⟨x, x0⟩ a b h, simp only [subtype.coe_mk],
+  rcases eq_or_ne x 0 with rfl | x0', { simp, },
+  lift x to α, { rintro ⟨rfl⟩, exact (with_bot.bot_lt_coe (0 : α)).not_le x0, },
+  induction a using with_bot.rec_bot_coe, { simp_rw [bot_mul x0', bot_le] },
+  induction b using with_bot.rec_bot_coe, { exact absurd h (bot_lt_coe a).not_le },
+  simp only [← coe_mul, coe_le_coe] at *,
+  norm_cast at x0,
+  exact mul_le_mul_of_nonneg_right h x0,
+end ⟩
+
+instance [mul_zero_class α] [preorder α] [pos_mul_strict_mono α] :
+  pos_mul_strict_mono (with_bot α) :=
+⟨begin
+  rintros ⟨x, x0⟩ a b h, simp only [subtype.coe_mk],
+  lift x to α using x0.ne_bot,
+  induction b using with_bot.rec_bot_coe, { exact absurd h not_lt_bot, },
+  induction a using with_bot.rec_bot_coe, { simp_rw [mul_bot x0.ne.symm, ← coe_mul, bot_lt_coe], },
+  simp only [← coe_mul, coe_lt_coe] at *,
+  norm_cast at x0,
+  exact mul_lt_mul_of_pos_left h x0,
+end ⟩
+
+instance [mul_zero_class α] [preorder α] [mul_pos_strict_mono α] :
+  mul_pos_strict_mono (with_bot α) :=
+⟨begin
+  rintros ⟨x, x0⟩ a b h, simp only [subtype.coe_mk],
+  lift x to α using x0.ne_bot,
+  induction b using with_bot.rec_bot_coe, { exact absurd h not_lt_bot, },
+  induction a using with_bot.rec_bot_coe, { simp_rw [bot_mul x0.ne.symm, ← coe_mul, bot_lt_coe], },
+  simp only [← coe_mul, coe_lt_coe] at *,
+  norm_cast at x0,
+  exact mul_lt_mul_of_pos_right h x0,
+end ⟩
+
+instance [mul_zero_class α] [preorder α] [pos_mul_reflect_lt α] :
+  pos_mul_reflect_lt (with_bot α) :=
+⟨begin
+  rintros ⟨x, x0⟩ a b h, simp only [subtype.coe_mk] at h,
+  rcases eq_or_ne x 0 with rfl | x0', { simpa using h, },
+  lift x to α, { rintro ⟨rfl⟩, exact (with_bot.bot_lt_coe (0 : α)).not_le x0, },
+  induction b using with_bot.rec_bot_coe, { rw [mul_bot x0'] at h, exact absurd h bot_le.not_lt, },
+  induction a using with_bot.rec_bot_coe, { exact with_bot.bot_lt_coe _, },
+  simp only [← coe_mul, coe_lt_coe] at *,
+  norm_cast at x0,
+  exact lt_of_mul_lt_mul_left h x0,
+end ⟩
+
+instance [mul_zero_class α] [preorder α] [mul_pos_reflect_lt α] :
+  mul_pos_reflect_lt (with_bot α) :=
+⟨begin
+  rintros ⟨x, x0⟩ a b h, simp only [subtype.coe_mk] at h,
+  rcases eq_or_ne x 0 with rfl | x0', { simpa using h, },
+  lift x to α, { rintro ⟨rfl⟩, exact (with_bot.bot_lt_coe (0 : α)).not_le x0, },
+  induction b using with_bot.rec_bot_coe, { rw [bot_mul x0'] at h, exact absurd h bot_le.not_lt, },
+  induction a using with_bot.rec_bot_coe, { exact with_bot.bot_lt_coe _, },
+  simp only [← coe_mul, coe_lt_coe] at *,
+  norm_cast at x0,
+  exact lt_of_mul_lt_mul_right h x0,
+end ⟩
+
+instance [mul_zero_class α] [preorder α] [pos_mul_mono_rev α] :
+  pos_mul_mono_rev (with_bot α) :=
+⟨begin
+  rintros ⟨x, x0⟩ a b h, simp only [subtype.coe_mk] at h,
+  lift x to α using x0.ne_bot,
+  induction a using with_bot.rec_bot_coe, { exact bot_le, },
+  induction b using with_bot.rec_bot_coe,
+  { rw [mul_bot x0.ne.symm, ← coe_mul] at h, exact absurd h (bot_lt_coe (x * a)).not_le, },
+  simp only [← coe_mul, coe_le_coe] at *,
+  norm_cast at x0,
+  exact le_of_mul_le_mul_left h x0,
+end ⟩
+
+instance [mul_zero_class α] [preorder α] [mul_pos_mono_rev α] :
+  mul_pos_mono_rev (with_bot α) :=
+⟨begin
+  rintros ⟨x, x0⟩ a b h, simp only [subtype.coe_mk] at h,
+  lift x to α using x0.ne_bot,
+  induction a using with_bot.rec_bot_coe, { exact bot_le, },
+  induction b using with_bot.rec_bot_coe,
+  { rw [bot_mul x0.ne.symm, ← coe_mul] at h, exact absurd h (bot_lt_coe (a * x)).not_le, },
+  simp only [← coe_mul, coe_le_coe] at *,
+  norm_cast at x0,
+  exact le_of_mul_le_mul_right h x0,
+end ⟩
+
+instance [canonically_ordered_comm_semiring α] [nontrivial α] :
+  ordered_comm_semiring (with_bot α) :=
+{ mul_le_mul_of_nonneg_left  := λ _ _ _, mul_le_mul_of_nonneg_left,
+  mul_le_mul_of_nonneg_right := λ _ _ _, mul_le_mul_of_nonneg_right,
+  .. with_bot.zero_le_one_class,
+  .. with_bot.ordered_add_comm_monoid,
+  .. with_bot.comm_semiring, }
 
 end with_bot

--- a/src/data/nat/with_bot.lean
+++ b/src/data/nat/with_bot.lean
@@ -53,12 +53,12 @@ begin
   exact add_eq_three_iff
 end
 
-@[simp] lemma coe_nonneg {n : ℕ} : 0 ≤ (n : with_bot ℕ) :=
+lemma coe_nonneg {n : ℕ} : 0 ≤ (n : with_bot ℕ) :=
 by { rw [← with_bot.coe_zero, with_bot.coe_le_coe], exact nat.zero_le _ }
 
 @[simp] lemma lt_zero_iff (n : with_bot ℕ) : n < 0 ↔ n = ⊥ :=
 option.cases_on n dec_trivial $ λ n, iff_of_false
-  (by simp [with_bot.some_eq_coe]) (λ h, option.no_confusion h)
+  (by simp [with_bot.some_eq_coe, coe_nonneg]) (λ h, option.no_confusion h)
 
 lemma one_le_iff_zero_lt {x : with_bot ℕ} : 1 ≤ x ↔ 0 < x :=
 begin


### PR DESCRIPTION
mathlib4 PR: https://github.com/leanprover-community/mathlib4/pull/1508


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
