### PR TITLE
[Merged by Bors] - fix(tactic/ring): perform definitional rather than syntactic matches on `^`

### DIFF
--- a/test/ring.lean
+++ b/test/ring.lean
@@ -95,3 +95,10 @@ begin
   success_if_fail {{ ring_nf {recursive := ff} }},
   ring_nf
 end
+
+-- instances do not have to syntactically be `monoid.has_pow`
+example {R} [comm_semiring R] (x : ℕ → R) : x ^ 2 = x * x := by ring
+
+-- even if there's an instance we don't recognize, we treat it as an atom
+example {R} [field R] (x : ℕ → R) :
+  (x ^ (2 : ℤ)) ^ 2 = (x ^ (2 : ℤ)) * (x ^ (2 : ℤ)) := by ring


### PR DESCRIPTION
This code is copied from a similar pattern for `has_div.div` a few lines up.

Follows on from #18129

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
