### PR TITLE
[Merged by Bors] - feat(algebra, linear_algebra): unique instances over the trivial ring

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -263,14 +263,13 @@ as an instance because Lean has no way to guess `R`. -/
 protected theorem module.subsingleton (R M : Type*) [semiring R] [subsingleton R]
   [add_comm_monoid M] [module R M] :
   subsingleton M :=
-⟨λ x y, by rw [← one_smul R x, ← one_smul R y, subsingleton.elim (1:R) 0, zero_smul, zero_smul]⟩
+mul_action_with_zero.subsingleton R M
 
 /-- A semiring is `nontrivial` provided that there exists a nontrivial module over this semiring. -/
 protected theorem module.nontrivial (R M : Type*) [semiring R] [nontrivial M] [add_comm_monoid M]
   [module R M] :
   nontrivial R :=
-(subsingleton_or_nontrivial R).resolve_left $ λ hR, not_subsingleton M $
-  by exactI module.subsingleton R M
+mul_action_with_zero.nontrivial R M
 
 @[priority 910] -- see Note [lower instance priority]
 instance semiring.to_module [semiring R] : module R R :=

--- a/src/algebra/smul_with_zero.lean
+++ b/src/algebra/smul_with_zero.lean
@@ -132,9 +132,14 @@ instance monoid_with_zero.to_opposite_mul_action_with_zero : mul_action_with_zer
 { ..mul_zero_class.to_opposite_smul_with_zero R,
   ..monoid.to_opposite_mul_action R }
 
-lemma subsingleton_of_mul_action_with_zero
+protected lemma mul_action_with_zero.subsingleton
   [mul_action_with_zero R M] [subsingleton R] : subsingleton M :=
-⟨λ m m', by rw [←one_smul R m, ←one_smul R m', subsingleton.elim (1 : R) 0, zero_smul, zero_smul]⟩
+⟨λ x y, by rw [←one_smul R x, ←one_smul R y, subsingleton.elim (1 : R) 0, zero_smul, zero_smul]⟩
+
+protected lemma mul_action_with_zero.nontrivial
+  [mul_action_with_zero R M] [nontrivial M] : nontrivial R :=
+(subsingleton_or_nontrivial R).resolve_left $ λ hR, not_subsingleton M $
+  by exactI mul_action_with_zero.subsingleton R M
 
 variables {R M} [mul_action_with_zero R M] [has_zero M'] [has_smul R M']
 

--- a/src/algebra/smul_with_zero.lean
+++ b/src/algebra/smul_with_zero.lean
@@ -132,6 +132,10 @@ instance monoid_with_zero.to_opposite_mul_action_with_zero : mul_action_with_zer
 { ..mul_zero_class.to_opposite_smul_with_zero R,
   ..monoid.to_opposite_mul_action R }
 
+lemma subsingleton_of_mul_action_with_zero
+  [mul_action_with_zero R M] [subsingleton R] : subsingleton M :=
+⟨λ m m', by rw [←one_smul R m, ←one_smul R m', subsingleton.elim (1 : R) 0, zero_smul, zero_smul]⟩
+
 variables {R M} [mul_action_with_zero R M] [has_zero M'] [has_smul R M']
 
 /-- Pullback a `mul_action_with_zero` structure along an injective zero-preserving homomorphism.

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -667,7 +667,7 @@ end
 lemma orthonormal_basis_one_dim (b : orthonormal_basis ι ℝ ℝ) :
   ⇑b = (λ _, (1 : ℝ)) ∨ ⇑b = (λ _, (-1 : ℝ)) :=
 begin
-  haveI : unique ι, from b.to_basis.unique,
+  haveI : unique ι, from finite_dimensional.basis.unique b.to_basis,
   have : b default = 1 ∨ b default = - 1,
   { have : ‖b default‖ = 1, from b.orthonormal.1 _,
     rwa [real.norm_eq_abs, abs_eq (zero_le_one : (0 : ℝ) ≤ 1)] at this },

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -667,7 +667,7 @@ end
 lemma orthonormal_basis_one_dim (b : orthonormal_basis ι ℝ ℝ) :
   ⇑b = (λ _, (1 : ℝ)) ∨ ⇑b = (λ _, (-1 : ℝ)) :=
 begin
-  haveI : unique ι, from finite_dimensional.basis.unique b.to_basis,
+  haveI : unique ι, from b.to_basis.unique,
   have : b default = 1 ∨ b default = - 1,
   { have : ‖b default‖ = 1, from b.orthonormal.1 _,
     rwa [real.norm_eq_abs, abs_eq (zero_le_one : (0 : ℝ) ≤ 1)] at this },

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1478,14 +1478,16 @@ namespace linear_equiv
 section add_comm_monoid
 
 section subsingleton
-variables [semiring R] [semiring R₂] [semiring R₃] [semiring R₄]
-variables [add_comm_monoid M] [add_comm_monoid M₂] [add_comm_monoid M₃] [add_comm_monoid M₄]
+variables [semiring R] [semiring R₂]
+variables [add_comm_monoid M] [add_comm_monoid M₂]
 variables [module R M] [module R₂ M₂]
-variables [subsingleton M] [subsingleton M₂]
 variables {σ₁₂ : R →+* R₂} {σ₂₁ : R₂ →+* R}
 variables [ring_hom_inv_pair σ₁₂ σ₂₁] [ring_hom_inv_pair σ₂₁ σ₁₂]
 
 include σ₂₁
+section module
+variables [subsingleton M] [subsingleton M₂]
+
 /-- Between two zero modules, the zero map is an equivalence. -/
 instance : has_zero (M ≃ₛₗ[σ₁₂] M₂) :=
 ⟨{ to_fun := 0,
@@ -1507,6 +1509,11 @@ instance : unique (M ≃ₛₗ[σ₁₂] M₂) :=
 { uniq := λ f, to_linear_map_injective (subsingleton.elim _ _),
   default := 0 }
 omit σ₂₁
+
+end module
+
+instance unique_of_subsingleton [subsingleton R] [subsingleton R₂] : unique (M ≃ₛₗ[σ₁₂] M₂) :=
+by { haveI := module.subsingleton R M, haveI := module.subsingleton R₂ M₂, apply_instance }
 
 end subsingleton
 

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -94,6 +94,8 @@ namespace basis
 
 instance : inhabited (basis ι R (ι →₀ R)) := ⟨basis.of_repr (linear_equiv.refl _ _)⟩
 
+instance [subsingleton R] : unique (basis ι R M) := ⟨⟨⟨default⟩⟩, λ ⟨b⟩, by rw subsingleton.elim b⟩
+
 variables (b b₁ : basis ι R M) (i : ι) (c : R) (x : M)
 
 section repr

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -90,11 +90,12 @@ structure basis := of_repr :: (repr : M ≃ₗ[R] (ι →₀ R))
 
 end
 
+instance unique_basis [subsingleton R] : unique (basis ι R M) :=
+⟨⟨⟨default⟩⟩, λ ⟨b⟩, by rw subsingleton.elim b⟩
+
 namespace basis
 
 instance : inhabited (basis ι R (ι →₀ R)) := ⟨basis.of_repr (linear_equiv.refl _ _)⟩
-
-instance [subsingleton R] : unique (basis ι R M) := ⟨⟨⟨default⟩⟩, λ ⟨b⟩, by rw subsingleton.elim b⟩
 
 variables (b b₁ : basis ι R M) (i : ι) (c : R) (x : M)
 

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -210,7 +210,7 @@ begin
 end
 
 /-- Given a basis of a division ring over itself indexed by a type `ι`, then `ι` is `unique`. -/
-noncomputable def basis.unique {ι : Type*} (b : basis ι K K) : unique ι :=
+noncomputable def _root_.basis.unique {ι : Type*} (b : basis ι K K) : unique ι :=
 begin
   have A : cardinal.mk ι = ↑(finite_dimensional.finrank K K) :=
     (finite_dimensional.finrank_eq_card_basis' b).symm,


### PR DESCRIPTION
Also generalizes module.subsingleton to mul_action_with_zero. 

matches https://github.com/leanprover-community/mathlib4/pull/1519

---


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
