### PR TITLE
[Merged by Bors] - chore(algebra/order/ring/canonical): use implicit variables

### DIFF
--- a/src/algebra/order/ring/canonical.lean
+++ b/src/algebra/order/ring/canonical.lean
@@ -81,7 +81,7 @@ variables [canonically_ordered_comm_semiring α] {a b : α}
 
 @[priority 100] -- see Note [lower instance priority]
 instance to_no_zero_divisors : no_zero_divisors α :=
-⟨canonically_ordered_comm_semiring.eq_zero_or_eq_zero_of_mul_eq_zero⟩
+⟨λ a b h, canonically_ordered_comm_semiring.eq_zero_or_eq_zero_of_mul_eq_zero h⟩
 
 @[priority 100] -- see Note [lower instance priority]
 instance to_covariant_mul_le : covariant_class α α (*) (≤) :=

--- a/src/algebra/order/ring/canonical.lean
+++ b/src/algebra/order/ring/canonical.lean
@@ -38,7 +38,7 @@ not the integers or other ordered groups. -/
 @[protect_proj, ancestor canonically_ordered_add_monoid comm_semiring]
 class canonically_ordered_comm_semiring (α : Type*) extends
   canonically_ordered_add_monoid α, comm_semiring α :=
-(eq_zero_or_eq_zero_of_mul_eq_zero : ∀ a b : α, a * b = 0 → a = 0 ∨ b = 0)
+(eq_zero_or_eq_zero_of_mul_eq_zero : ∀ {a b : α}, a * b = 0 → a = 0 ∨ b = 0)
 
 section strict_ordered_semiring
 variables [strict_ordered_semiring α] {a b c d : α}


### PR DESCRIPTION
Make implicitness of variables for `eq_zero_or_eq_zero_of_mul_eq_zero` consistent in `canonically_ordered_comm_semiring` and `no_zero_divisors_`. See the discussion in https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Data.2ESet.2ESemiring

Corresponds to [#1545](https://github.com/leanprover-community/mathlib4/pull/1545).

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
