### PR TITLE
[Merged by Bors] - feat(data/nat/with_bot): `n < m → n + 1 ≤ m`

### DIFF
--- a/src/data/nat/with_bot.lean
+++ b/src/data/nat/with_bot.lean
@@ -71,6 +71,12 @@ end
 lemma lt_one_iff_le_zero {x : with_bot ℕ} : x < 1 ↔ x ≤ 0 :=
 not_iff_not.mp (by simpa using one_le_iff_zero_lt)
 
+lemma add_one_le_of_lt {n m : with_bot ℕ} (h : n < m) : n + 1 ≤ m :=
+begin
+  cases n, { exact bot_le },
+  cases m, exacts [(not_lt_bot h).elim, with_bot.some_le_some.2 (with_bot.some_lt_some.1 h)],
+end
+
 end with_bot
 
 end nat


### PR DESCRIPTION
ported in https://github.com/leanprover-community/mathlib4/pull/1519

---

The converse is not true when `n` and `m` are both bot.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
