### PR TITLE
[Merged by Bors] - feat(ring_theory/ring_invo): add ring_invo_class

### DIFF
--- a/src/ring_theory/ring_invo.lean
+++ b/src/ring_theory/ring_invo.lean
@@ -30,14 +30,11 @@ variables (R : Type*)
 set_option old_structure_cmd true
 
 /-- A ring involution -/
-structure ring_invo [semiring R] extends R ≃+* Rᵐᵒᵖ, R ≃ Rᵐᵒᵖ :=
+structure ring_invo [semiring R] extends R ≃+* Rᵐᵒᵖ :=
 (involution' : ∀ x, (to_fun (to_fun x).unop).unop = x)
 
 /-- The equivalence of rings underlying a ring involution. -/
 add_decl_doc ring_invo.to_ring_equiv
-
-/-- The "plain" equivalence of types underlying a ring involution. -/
-add_decl_doc ring_invo.to_equiv
 
 /-- `ring_invo_class F R S` states that `F` is a type of ring involutions.
 You should extend this class when you extend `ring_invo`. -/

--- a/src/ring_theory/ring_invo.lean
+++ b/src/ring_theory/ring_invo.lean
@@ -35,7 +35,7 @@ structure ring_invo [semiring R] extends R ≃+* Rᵐᵒᵖ :=
 You should extend this class when you extend `ring_invo`. -/
 class ring_invo_class (F : Type*) (R : out_param Type*) [semiring R]
   extends ring_equiv_class F R Rᵐᵒᵖ :=
-  (involution : ∀ (f : F) (x), (f (f x).unop).unop = x)
+(involution : ∀ (f : F) (x), (f (f x).unop).unop = x)
 
 namespace ring_invo
 variables {R} [semiring R]

--- a/src/ring_theory/ring_invo.lean
+++ b/src/ring_theory/ring_invo.lean
@@ -100,5 +100,3 @@ protected def ring_invo.id : ring_invo R :=
 instance : inhabited (ring_invo R) := ⟨ring_invo.id _⟩
 
 end comm_ring
-
-#lint

--- a/src/ring_theory/ring_invo.lean
+++ b/src/ring_theory/ring_invo.lean
@@ -27,9 +27,17 @@ Ring involution
 
 variables (R : Type*)
 
+set_option old_structure_cmd true
+
 /-- A ring involution -/
-structure ring_invo [semiring R] extends R ≃+* Rᵐᵒᵖ :=
+structure ring_invo [semiring R] extends R ≃+* Rᵐᵒᵖ, R ≃ Rᵐᵒᵖ :=
 (involution' : ∀ x, (to_fun (to_fun x).unop).unop = x)
+
+/-- The equivalence of rings underlying a ring involution. -/
+add_decl_doc ring_invo.to_ring_equiv
+
+/-- The "plain" equivalence of types underlying a ring involution. -/
+add_decl_doc ring_invo.to_equiv
 
 /-- `ring_invo_class F R S` states that `F` is a type of ring involutions.
 You should extend this class when you extend `ring_invo`. -/
@@ -39,6 +47,16 @@ class ring_invo_class (F : Type*) (R : out_param Type*) [semiring R]
 
 namespace ring_invo
 variables {R} [semiring R]
+
+instance (R : Type*) [semiring R] : ring_invo_class (ring_invo R) R :=
+{ coe := to_fun,
+  inv :=  inv_fun,
+  coe_injective' := λ e f h₁ h₂, by { cases e, cases f, congr' },
+  map_add := map_add',
+  map_mul := map_mul',
+  left_inv := left_inv,
+  right_inv := right_inv,
+  involution := involution' }
 
 /-- Construct a ring involution from a ring homomorphism. -/
 def mk' (f : R →+* Rᵐᵒᵖ) (involution : ∀ r, (f (f r).unop).unop = r) :
@@ -82,3 +100,5 @@ protected def ring_invo.id : ring_invo R :=
 instance : inhabited (ring_invo R) := ⟨ring_invo.id _⟩
 
 end comm_ring
+
+#lint

--- a/src/ring_theory/ring_invo.lean
+++ b/src/ring_theory/ring_invo.lean
@@ -67,6 +67,8 @@ def mk' (f : R →+* Rᵐᵒᵖ) (involution : ∀ r, (f (f r).unop).unop = r) :
   involution' := involution,
   .. f }
 
+/-- Helper instance for when there's too many metavariables to apply
+`fun_like.has_coe_to_fun` directly. -/
 instance : has_coe_to_fun (ring_invo R) (λ _, R → Rᵐᵒᵖ) := ⟨λ f, f.to_ring_equiv.to_fun⟩
 
 @[simp]

--- a/src/ring_theory/ring_invo.lean
+++ b/src/ring_theory/ring_invo.lean
@@ -31,6 +31,12 @@ variables (R : Type*)
 structure ring_invo [semiring R] extends R ≃+* Rᵐᵒᵖ :=
 (involution' : ∀ x, (to_fun (to_fun x).unop).unop = x)
 
+/-- `ring_invo_class F R S` states that `F` is a type of ring involutions.
+You should extend this class when you extend `ring_invo`. -/
+class ring_invo_class (F : Type*) (R : out_param Type*) [semiring R]
+  extends ring_equiv_class F R Rᵐᵒᵖ :=
+  (involution : ∀ (f : F) (x), (f (f x).unop).unop = x)
+
 namespace ring_invo
 variables {R} [semiring R]
 


### PR DESCRIPTION
By its docstring, `ring_equiv_class` yearns to be extended whenever `ring_equiv` is. The `ring_invo` structure fails to heed its call. This file is currently being ported to mathlib4, and this will help, I believe.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
