### PR TITLE
feat(linear_algebra/clifford): make clifford_algebra irreducible in a Lean4 compatible way

### DIFF
--- a/src/linear_algebra/clifford_algebra/basic.lean
+++ b/src/linear_algebra/clifford_algebra/basic.lean
@@ -167,9 +167,9 @@ The canonical linear map `M →ₗ[R] clifford_algebra Q`.
 @[simp]
 theorem ι_sq_scalar (m : M) : ι Q m * ι Q m = algebra_map R _ (Q m) :=
 begin
-  simp only [ι, mul_def, ←alg_hom.map_mul, ring_quot.mk_alg_hom_rel R (rel.of m), alg_hom.commutes,
-    to_ring_quot, alg_hom.to_linear_map_apply, function.comp_app, linear_map.coe_comp,
-    alg_equiv.coe_mk, alg_equiv.to_linear_map_apply, function.comp_app, alg_hom.to_linear_map_apply],
+  simp only [ι, ←alg_hom.map_mul, ring_quot.mk_alg_hom_rel R (rel.of m), alg_hom.commutes,
+    alg_hom.to_linear_map_apply, function.comp_app, linear_map.coe_comp, function.comp_app,
+    alg_equiv.coe_mk, alg_equiv.to_linear_map_apply, alg_hom.to_linear_map_apply, to_ring_quot ],
   simp [mul_def, ←alg_hom.map_mul, ring_quot.mk_alg_hom_rel R (rel.of m), alg_hom.commutes],
   refl,
 end


### PR DESCRIPTION
`clifford_algebra` is a complicated object (building on `tensor_algebra` which builds on `free_algebra`), which means Lean has difficulties working with it unless it is irreducible. In the current version, it is marked as `irreducible` after the fact, which is not Lean4-compatible. Instead, we switch to a construction as a one-field structure, which is genuinally irreducible (modelled on what is done for real numbers).

Part of #18164 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
