### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/basis): `reindex` API

### DIFF
--- a/src/analysis/convex/combination.lean
+++ b/src/analysis/convex/combination.lean
@@ -461,19 +461,18 @@ lemma mem_Icc_of_mem_std_simplex (hf : f ∈ std_simplex R ι) (x) :
 
 /-- The convex hull of an affine basis is the intersection of the half-spaces defined by the
 corresponding barycentric coordinates. -/
-lemma convex_hull_affine_basis_eq_nonneg_barycentric {ι : Type*} (b : affine_basis ι R E) :
-  convex_hull R (range b.points) = { x | ∀ i, 0 ≤ b.coord i x } :=
+lemma affine_basis.convex_hull_eq_nonneg_coord {ι : Type*} (b : affine_basis ι R E) :
+  convex_hull R (range b) = {x | ∀ i, 0 ≤ b.coord i x} :=
 begin
   rw convex_hull_range_eq_exists_affine_combination,
   ext x,
-  split,
+  refine ⟨_, λ hx, _⟩,
   { rintros ⟨s, w, hw₀, hw₁, rfl⟩ i,
     by_cases hi : i ∈ s,
     { rw b.coord_apply_combination_of_mem hi hw₁,
       exact hw₀ i hi, },
     { rw b.coord_apply_combination_of_not_mem hi hw₁, }, },
-  { intros hx,
-    have hx' : x ∈ affine_span R (range b.points),
+  { have hx' : x ∈ affine_span R (range b),
     { rw b.tot, exact affine_subspace.mem_top R E x, },
     obtain ⟨s, w, hw₁, rfl⟩ := (mem_affine_span_iff_eq_affine_combination R E).mp hx',
     refine ⟨s, w, _, hw₁, rfl⟩,

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -470,7 +470,7 @@ funext (b.reindex_apply e)
 
 @[simp] protected lemma repr_reindex
   (b : orthonormal_basis ι 𝕜 E) (e : ι ≃ ι') (x : E) (i' : ι') :
-  ((b.reindex e).repr x) i' = (b.repr x) (e.symm i') :=
+  (b.reindex e).repr x i' = b.repr x (e.symm i') :=
 by { classical,
   rw [orthonormal_basis.repr_apply_apply, b.repr_apply_apply, orthonormal_basis.coe_reindex] }
 

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -468,7 +468,7 @@ end
   ⇑(b.reindex e) = ⇑b ∘ ⇑(e.symm) :=
 funext (b.reindex_apply e)
 
-@[simp] protected lemma reindex_repr
+@[simp] protected lemma repr_reindex
   (b : orthonormal_basis ι 𝕜 E) (e : ι ≃ ι') (x : E) (i' : ι') :
   ((b.reindex e).repr x) i' = (b.repr x) (e.symm i') :=
 by { classical,

--- a/src/analysis/normed_space/add_torsor_bases.lean
+++ b/src/analysis/normed_space/add_torsor_bases.lean
@@ -56,17 +56,17 @@ TODO Restate this result for affine spaces (instead of vector spaces) once the d
 convexity is generalised to this setting. -/
 lemma affine_basis.interior_convex_hull {ι E : Type*} [finite ι] [normed_add_comm_group E]
   [normed_space ℝ E] (b : affine_basis ι ℝ E) :
-  interior (convex_hull ℝ (range b.points)) = {x | ∀ i, 0 < b.coord i x} :=
+  interior (convex_hull ℝ (range b)) = {x | ∀ i, 0 < b.coord i x} :=
 begin
   casesI subsingleton_or_nontrivial ι,
   { -- The zero-dimensional case.
-    have : range (b.points) = univ,
+    have : range b = univ,
       from affine_subspace.eq_univ_of_subsingleton_span_eq_top (subsingleton_range _) b.tot,
     simp [this] },
   { -- The positive-dimensional case.
     haveI : finite_dimensional ℝ E := b.finite_dimensional,
-    have : convex_hull ℝ (range b.points) = ⋂ i, (b.coord i)⁻¹' Ici 0,
-    { rw [convex_hull_affine_basis_eq_nonneg_barycentric b, set_of_forall], refl },
+    have : convex_hull ℝ (range b) = ⋂ i, (b.coord i)⁻¹' Ici 0,
+    { rw [b.convex_hull_eq_nonneg_coord, set_of_forall], refl },
     ext,
     simp only [this, interior_Inter, ← is_open_map.preimage_interior_eq_interior_preimage
       (is_open_map_barycentric_coord b _) (continuous_barycentric_coord b _),
@@ -132,7 +132,7 @@ top_unique $ is_open_interior.affine_span_eq_top hs ▸
   (affine_span_mono _ interior_subset).trans_eq (affine_span_convex_hull _)
 
 lemma affine_basis.centroid_mem_interior_convex_hull {ι} [fintype ι] (b : affine_basis ι ℝ V) :
-  finset.univ.centroid ℝ b.points ∈ interior (convex_hull ℝ (range b.points)) :=
+  finset.univ.centroid ℝ b ∈ interior (convex_hull ℝ (range b)) :=
 begin
   haveI := b.nonempty,
   simp only [b.interior_convex_hull, mem_set_of_eq, b.coord_apply_centroid (finset.mem_univ _),
@@ -144,7 +144,7 @@ lemma interior_convex_hull_nonempty_iff_affine_span_eq_top [finite_dimensional �
 begin
   refine ⟨affine_span_eq_top_of_nonempty_interior, λ h, _⟩,
   obtain ⟨t, hts, b, hb⟩ := affine_basis.exists_affine_subbasis h,
-  suffices : (interior (convex_hull ℝ (range b.points))).nonempty,
+  suffices : (interior (convex_hull ℝ (range b))).nonempty,
   { rw [hb, subtype.range_coe_subtype, set_of_mem_eq] at this,
     refine this.mono _,
     mono* },

--- a/src/data/set/image.lean
+++ b/src/data/set/image.lean
@@ -29,13 +29,13 @@ import data.set.basic
 set, sets, image, preimage, pre-image, range
 
 -/
-universes u v
 
-open function
+open function set
+
+universes u v
+variables {α β γ : Type*} {ι ι' : Sort*}
 
 namespace set
-
-variables {α β γ : Type*} {ι : Sort*}
 
 /-! ### Inverse image -/
 
@@ -911,8 +911,7 @@ end subsingleton
 end set
 
 namespace function
-
-variables {ι ι' : Sort*} {α : Type*} {β : Type*} {f : α → β}
+variables {f : α → β}
 
 open set
 
@@ -950,10 +949,6 @@ lemma surjective.range_comp {f : ι → ι'} (hf : surjective f) (g : ι' → α
   range (g ∘ f) = range g :=
 ext $ λ y, (@surjective.exists _ _ _ hf (λ x, g x = y)).symm
 
-@[simp] lemma range_comp_equiv {E : Type*} (f : ι' → α) [equiv_like E ι ι'] (e : E) :
-  range (f ∘ e) = range f :=
-(equiv_like.surjective _).range_comp _
-
 lemma injective.mem_range_iff_exists_unique (hf : injective f) {b : β} :
   b ∈ range f ↔ ∃! a, f a = b :=
 ⟨λ ⟨a, h⟩, ⟨a, h, λ a' ha, hf (ha.trans h.symm)⟩, exists_unique.exists⟩
@@ -982,12 +977,19 @@ by rw [← preimage_comp, h.comp_eq_id, preimage_id]
 
 end function
 
+namespace equiv_like
+variables {E : Type*} [equiv_like E ι ι']
+include ι
+
+@[simp] lemma range_comp (f : ι' → α) (e : E) : set.range (f ∘ e) = set.range f :=
+(equiv_like.surjective _).range_comp _
+
+end equiv_like
+
 /-! ### Image and preimage on subtypes -/
 
 namespace subtype
 open set
-
-variable {α : Type*}
 
 lemma coe_image {p : α → Prop} {s : set (subtype p)} :
   coe '' s = {x | ∃h : p x, (⟨x, h⟩ : subtype p) ∈ s} :=
@@ -1110,9 +1112,9 @@ open function
 /-! ### Injectivity and surjectivity lemmas for image and preimage -/
 
 section image_preimage
-variables {α : Type u} {β : Type v} {f : α → β}
-@[simp]
-lemma preimage_injective : injective (preimage f) ↔ surjective f :=
+variables {f : α → β}
+
+@[simp] lemma preimage_injective : injective (preimage f) ↔ surjective f :=
 begin
   refine ⟨λ h y, _, surjective.preimage_injective⟩,
   obtain ⟨x, hx⟩ : (f ⁻¹' {y}).nonempty,
@@ -1157,7 +1159,7 @@ end set
 /-! ### Disjoint lemmas for image and preimage -/
 
 section disjoint
-variables {α β γ : Type*} {f : α → β} {s t : set α}
+variables {f : α → β} {s t : set α}
 
 lemma disjoint.preimage (f : α → β) {s t : set β} (h : disjoint s t) :
   disjoint (f ⁻¹' s) (f ⁻¹' t) :=

--- a/src/data/set/image.lean
+++ b/src/data/set/image.lean
@@ -950,9 +950,9 @@ lemma surjective.range_comp {f : ι → ι'} (hf : surjective f) (g : ι' → α
   range (g ∘ f) = range g :=
 ext $ λ y, (@surjective.exists _ _ _ hf (λ x, g x = y)).symm
 
--- This lemma is mostly here to help with simp lemmas about `basis.reindex`/`affine_basis.reindex`
-@[simp] lemma range_comp_equiv (f : ι' → α) (e : ι ≃ ι') : range (f ∘ e) = range f :=
-e.surjective.range_comp _
+@[simp] lemma range_comp_equiv {E : Type*} (f : ι' → α) [equiv_like E ι ι'] (e : E) :
+  range (f ∘ e) = range f :=
+(equiv_like.surjective _).range_comp _
 
 lemma injective.mem_range_iff_exists_unique (hf : injective f) {b : β} :
   b ∈ range f ↔ ∃! a, f a = b :=

--- a/src/data/set/image.lean
+++ b/src/data/set/image.lean
@@ -950,6 +950,8 @@ lemma surjective.range_comp {ι' : Sort*} {f : ι → ι'} (hf : surjective f) (
   range (g ∘ f) = range g :=
 ext $ λ y, (@surjective.exists _ _ _ hf (λ x, g x = y)).symm
 
+@[simp] lemma range_comp_equiv : range (f ∘ e) = range f := e.surjective.range_comp _
+
 lemma injective.mem_range_iff_exists_unique (hf : injective f) {b : β} :
   b ∈ range f ↔ ∃! a, f a = b :=
 ⟨λ ⟨a, h⟩, ⟨a, h, λ a' ha, hf (ha.trans h.symm)⟩, exists_unique.exists⟩

--- a/src/data/set/image.lean
+++ b/src/data/set/image.lean
@@ -912,7 +912,7 @@ end set
 
 namespace function
 
-variables {ι : Sort*} {α : Type*} {β : Type*} {f : α → β}
+variables {ι ι' : Sort*} {α : Type*} {β : Type*} {f : α → β}
 
 open set
 
@@ -946,11 +946,13 @@ lemma surjective.preimage_subset_preimage_iff {s t : set β} (hf : surjective f)
   f ⁻¹' s ⊆ f ⁻¹' t ↔ s ⊆ t :=
 by { apply preimage_subset_preimage_iff, rw [hf.range_eq], apply subset_univ }
 
-lemma surjective.range_comp {ι' : Sort*} {f : ι → ι'} (hf : surjective f) (g : ι' → α) :
+lemma surjective.range_comp {f : ι → ι'} (hf : surjective f) (g : ι' → α) :
   range (g ∘ f) = range g :=
 ext $ λ y, (@surjective.exists _ _ _ hf (λ x, g x = y)).symm
 
-@[simp] lemma range_comp_equiv : range (f ∘ e) = range f := e.surjective.range_comp _
+-- This lemma is mostly here to help with simp lemmas about `basis.reindex`/`affine_basis.reindex`
+@[simp] lemma range_comp_equiv (f : ι' → α) (e : ι ≃ ι') : range (f ∘ e) = range f :=
+e.surjective.range_comp _
 
 lemma injective.mem_range_iff_exists_unique (hf : injective f) {b : β} :
   b ∈ range f ↔ ∃! a, f a = b :=

--- a/src/linear_algebra/affine_space/basis.lean
+++ b/src/linear_algebra/affine_space/basis.lean
@@ -27,7 +27,7 @@ barycentric coordinate of `q : P` is `1 - fᵢ (q -ᵥ p i)`.
  * `affine_basis`: a structure representing an affine basis of an affine space.
  * `affine_basis.coord`: the map `P →ᵃ[k] k` corresponding to `i : ι`.
  * `affine_basis.coord_apply_eq`: the behaviour of `affine_basis.coord i` on `p i`.
- * `affine_basis.coord_apply_neq`: the behaviour of `affine_basis.coord i` on `p j` when `j ≠ i`.
+ * `affine_basis.coord_apply_ne`: the behaviour of `affine_basis.coord i` on `p j` when `j ≠ i`.
  * `affine_basis.coord_apply`: the behaviour of `affine_basis.coord i` on `p j` for general `j`.
  * `affine_basis.coord_apply_combination`: the characterisation of `affine_basis.coord i` in terms
     of affine combinations, i.e., `affine_basis.coord i (w₀ p₀ + w₁ p₁ + ⋯) = wᵢ`.
@@ -44,26 +44,35 @@ open set
 universes u₁ u₂ u₃ u₄
 
 /-- An affine basis is a family of affine-independent points whose span is the top subspace. -/
+@[protect_proj]
 structure affine_basis (ι : Type u₁) (k : Type u₂) {V : Type u₃} (P : Type u₄)
   [add_comm_group V] [affine_space V P] [ring k] [module k V] :=
-(points : ι → P)
-(ind : affine_independent k points)
-(tot : affine_span k (range points) = ⊤)
+(to_fun : ι → P)
+(ind' : affine_independent k to_fun)
+(tot' : affine_span k (range to_fun) = ⊤)
 
-variables {ι : Type u₁} {k : Type u₂} {V : Type u₃} {P : Type u₄}
-variables [add_comm_group V] [affine_space V P]
+variables {ι ι' k V P : Type*} [add_comm_group V] [affine_space V P]
 
 namespace affine_basis
 
 section ring
 
-variables [ring k] [module k V] (b : affine_basis ι k P)
+variables [ring k] [module k V] (b : affine_basis ι k P) {s : finset ι} {i j : ι} (e : ι ≃ ι')
+include V
+
+instance fun_like : fun_like (affine_basis ι k P) ι (λ _, P) :=
+{ coe := affine_basis.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr' }
+
+@[ext]
+lemma ext {b₁ b₂ : affine_basis ι k P} (h : (b₁ : ι → P) = b₂) : b₁ = b₂ := fun_like.coe_injective h
+
+lemma ind : affine_independent k b := b.ind'
+lemma tot : affine_span k (range b) = ⊤ := b.tot'
 
 /-- The unique point in a single-point space is the simplest example of an affine basis. -/
 instance : inhabited (affine_basis punit k punit) :=
-⟨{ points := id,
-   ind    := affine_independent_of_subsingleton k id,
-   tot    := by simp }⟩
+⟨⟨id, affine_independent_of_subsingleton k id, by simp⟩⟩
 
 include b
 
@@ -72,34 +81,46 @@ not_is_empty_iff.mp $ λ hι,
   by simpa only [@range_eq_empty _ _ hι, affine_subspace.span_empty, bot_ne_top] using b.tot
 
 /-- Composition of an affine basis and an equivalence of index types. -/
-def comp_equiv {ι'} (e : ι' ≃ ι) : affine_basis ι' k P :=
-⟨b.points ∘ e, b.ind.comp_embedding e.to_embedding, by { rw [e.surjective.range_comp], exact b.3 }⟩
+def reindex (e : ι ≃ ι') : affine_basis ι' k P :=
+⟨b ∘ e.symm, b.ind.comp_embedding e.symm.to_embedding,
+  by { rw [e.symm.surjective.range_comp], exact b.3 }⟩
+
+@[simp] lemma reindex_apply (i' : ι') : b.reindex e i' = b (e.symm i') := rfl
+
+@[simp, norm_cast] lemma coe_reindex : ⇑(b.reindex e) = b ∘ e.symm := rfl
+
+@[simp] lemma reindex_refl : b.reindex (equiv.refl _) = b := ext rfl
 
 /-- Given an affine basis for an affine space `P`, if we single out one member of the family, we
 obtain a linear basis for the model space `V`.
 
-The linear basis correpsonding to the singled-out member `i : ι` is indexed by `{j : ι // j ≠ i}`
-and its `j`th element is `points j -ᵥ points i`. (See `basis_of_apply`.) -/
+The linear basis corresponding to the singled-out member `i : ι` is indexed by `{j : ι // j ≠ i}`
+and its `j`th element is `b j -ᵥ b i`. (See `basis_of_apply`.) -/
 noncomputable def basis_of (i : ι) : basis {j : ι // j ≠ i} k V :=
-basis.mk ((affine_independent_iff_linear_independent_vsub k b.points i).mp b.ind)
+basis.mk ((affine_independent_iff_linear_independent_vsub k b i).mp b.ind)
 begin
-  suffices : submodule.span k (range (λ (j : {x // x ≠ i}), b.points ↑j -ᵥ b.points i)) =
-             vector_span k (range b.points),
+  suffices : submodule.span k (range (λ (j : {x // x ≠ i}), b ↑j -ᵥ b i)) =
+             vector_span k (range b),
   { rw [this, ← direction_affine_span, b.tot, affine_subspace.direction_top], exact le_rfl },
   conv_rhs { rw ← image_univ, },
-  rw vector_span_image_eq_span_vsub_set_right_ne k b.points (mem_univ i),
+  rw vector_span_image_eq_span_vsub_set_right_ne k b (mem_univ i),
   congr,
   ext v,
   simp,
 end
 
 @[simp] lemma basis_of_apply (i : ι) (j : {j : ι // j ≠ i}) :
-  b.basis_of i j = b.points ↑j -ᵥ b.points i :=
+  b.basis_of i j = b ↑j -ᵥ b i :=
 by simp [basis_of]
+
+@[simp] lemma basis_of_reindex (i : ι') :
+  (b.reindex e).basis_of i =
+    (b.basis_of $ e.symm i).reindex (e.subtype_equiv $ λ _, e.eq_symm_apply.not) :=
+by { ext j, simp }
 
 /-- The `i`th barycentric coordinate of a point. -/
 noncomputable def coord (i : ι) : P →ᵃ[k] k :=
-{ to_fun    := λ q, 1 - (b.basis_of i).sum_coords (q -ᵥ b.points i),
+{ to_fun    := λ q, 1 - (b.basis_of i).sum_coords (q -ᵥ b i),
   linear    := -(b.basis_of i).sum_coords,
   map_vadd' := λ q v, by rw [vadd_vsub_assoc, linear_map.map_add, vadd_eq_add, linear_map.neg_apply,
     sub_add_eq_sub_sub_swap, add_comm, sub_eq_add_neg], }
@@ -108,42 +129,41 @@ noncomputable def coord (i : ι) : P →ᵃ[k] k :=
   (b.coord i).linear = -(b.basis_of i).sum_coords :=
 rfl
 
-@[simp] lemma coord_apply_eq (i : ι) :
-  b.coord i (b.points i) = 1 :=
+@[simp] lemma coord_reindex [fintype ι] [fintype ι'] (i : ι') :
+  (b.reindex e).coord i = b.coord (e.symm i) :=
+by { ext, classical, simp [affine_basis.coord] }
+
+@[simp] lemma coord_apply_eq (i : ι) : b.coord i (b i) = 1 :=
 by simp only [coord, basis.coe_sum_coords, linear_equiv.map_zero, linear_equiv.coe_coe,
   sub_zero, affine_map.coe_mk, finsupp.sum_zero_index, vsub_self]
 
-@[simp] lemma coord_apply_neq (i j : ι) (h : j ≠ i) :
-  b.coord i (b.points j) = 0 :=
-by rw [coord, affine_map.coe_mk, ← subtype.coe_mk j h, ← b.basis_of_apply i ⟨j, h⟩,
+@[simp] lemma coord_apply_ne (h : i ≠ j) : b.coord i (b j) = 0 :=
+by rw [coord, affine_map.coe_mk, ← subtype.coe_mk j h.symm, ← b.basis_of_apply,
   basis.sum_coords_self_apply, sub_self]
 
-lemma coord_apply [decidable_eq ι] (i j : ι) :
-  b.coord i (b.points j) = if i = j then 1 else 0 :=
-by { cases eq_or_ne i j; simp [h.symm], simp [h], }
+lemma coord_apply [decidable_eq ι] (i j : ι) : b.coord i (b j) = if i = j then 1 else 0 :=
+by cases eq_or_ne i j; simp [h]
 
-@[simp] lemma coord_apply_combination_of_mem
-  {s : finset ι} {i : ι} (hi : i ∈ s) {w : ι → k} (hw : s.sum w = 1) :
-  b.coord i (s.affine_combination b.points w) = w i :=
+@[simp] lemma coord_apply_combination_of_mem (hi : i ∈ s) {w : ι → k} (hw : s.sum w = 1) :
+  b.coord i (s.affine_combination b w) = w i :=
 begin
   classical,
   simp only [coord_apply, hi, finset.affine_combination_eq_linear_combination, if_true, mul_boole,
-    hw, function.comp_app, smul_eq_mul, s.sum_ite_eq, s.map_affine_combination b.points w hw],
+    hw, function.comp_app, smul_eq_mul, s.sum_ite_eq, s.map_affine_combination b w hw],
 end
 
-@[simp] lemma coord_apply_combination_of_not_mem
-  {s : finset ι} {i : ι} (hi : i ∉ s) {w : ι → k} (hw : s.sum w = 1) :
-  b.coord i (s.affine_combination b.points w) = 0 :=
+@[simp] lemma coord_apply_combination_of_not_mem (hi : i ∉ s) {w : ι → k} (hw : s.sum w = 1) :
+  b.coord i (s.affine_combination b w) = 0 :=
 begin
   classical,
   simp only [coord_apply, hi, finset.affine_combination_eq_linear_combination, if_false, mul_boole,
-    hw, function.comp_app, smul_eq_mul, s.sum_ite_eq, s.map_affine_combination b.points w hw],
+    hw, function.comp_app, smul_eq_mul, s.sum_ite_eq, s.map_affine_combination b w hw],
 end
 
 @[simp] lemma sum_coord_apply_eq_one [fintype ι] (q : P) :
   ∑ i, b.coord i q = 1 :=
 begin
-  have hq : q ∈ affine_span k (range b.points), { rw b.tot, exact affine_subspace.mem_top k V q, },
+  have hq : q ∈ affine_span k (range b), { rw b.tot, exact affine_subspace.mem_top k V q, },
   obtain ⟨w, hw, rfl⟩ := eq_affine_combination_of_mem_affine_span_of_fintype hq,
   convert hw,
   ext i,
@@ -151,9 +171,9 @@ begin
 end
 
 @[simp] lemma affine_combination_coord_eq_self [fintype ι] (q : P) :
-  finset.univ.affine_combination b.points (λ i, b.coord i q) = q :=
+  finset.univ.affine_combination b (λ i, b.coord i q) = q :=
 begin
-  have hq : q ∈ affine_span k (range b.points), { rw b.tot, exact affine_subspace.mem_top k V q, },
+  have hq : q ∈ affine_span k (range b), { rw b.tot, exact affine_subspace.mem_top k V q, },
   obtain ⟨w, hw, rfl⟩ := eq_affine_combination_of_mem_affine_span_of_fintype hq,
   congr,
   ext i,
@@ -163,7 +183,7 @@ end
 /-- A variant of `affine_basis.affine_combination_coord_eq_self` for the special case when the
 affine space is a module so we can talk about linear combinations. -/
 @[simp] lemma linear_combination_coord_eq_self [fintype ι] (b : affine_basis ι k V) (v : V) :
-  ∑ i, (b.coord i v) • (b.points i) = v :=
+  ∑ i, b.coord i v • b i = v :=
 begin
   have hb := b.affine_combination_coord_eq_self v,
   rwa finset.univ.affine_combination_eq_linear_combination _ _ (b.sum_coord_apply_eq_one v) at hb,
@@ -179,7 +199,7 @@ end
   (b.coord i : P → k) = 1 :=
 begin
   ext q,
-  have hp : (range b.points).subsingleton,
+  have hp : (range b).subsingleton,
   { rw ← image_univ,
     apply subsingleton.image,
     apply subsingleton_of_subsingleton, },
@@ -187,7 +207,7 @@ begin
   let s : finset ι := {i},
   have hi : i ∈ s, { simp, },
   have hw : s.sum (function.const ι (1 : k)) = 1, { simp, },
-  have hq : q = s.affine_combination b.points (function.const ι (1 : k)), { simp, },
+  have hq : q = s.affine_combination b (function.const ι (1 : k)), { simp, },
   rw [pi.one_apply, hq, b.coord_apply_combination_of_mem hi hw],
 end
 
@@ -202,7 +222,7 @@ begin
   have hj : j ∈ s, { simp, },
   let w : ι → k := λ j', if j' = i then x else 1-x,
   have hw : s.sum w = 1, { simp [hij, finset.sum_ite, finset.filter_insert, finset.filter_eq'], },
-  use s.affine_combination b.points w,
+  use s.affine_combination b w,
   simp [b.coord_apply_combination_of_mem hi hw],
 end
 
@@ -231,12 +251,12 @@ include V
 
 @[simp] lemma coord_apply_centroid [char_zero k] (b : affine_basis ι k P) {s : finset ι} {i : ι}
   (hi : i ∈ s) :
-  b.coord i (s.centroid k b.points) = (s.card : k) ⁻¹ :=
+  b.coord i (s.centroid k b) = (s.card : k) ⁻¹ :=
 by rw [finset.centroid, b.coord_apply_combination_of_mem hi
   (s.sum_centroid_weights_eq_one_of_nonempty _ ⟨i, hi⟩), finset.centroid_weights]
 
 lemma exists_affine_subbasis {t : set P} (ht : affine_span k t = ⊤) :
-  ∃ (s ⊆ t) (b : affine_basis ↥s k P), b.points = coe :=
+  ∃ (s ⊆ t) (b : affine_basis ↥s k P), ⇑b = coe :=
 begin
   obtain ⟨s, hst, h_tot, h_ind⟩ := exists_affine_independent k V t,
   refine ⟨s, hst, ⟨coe, h_ind, _⟩, rfl⟩,
@@ -245,7 +265,7 @@ end
 
 variables (k V P)
 
-lemma exists_affine_basis : ∃ (s : set P) (b : affine_basis ↥s k P), b.points = coe :=
+lemma exists_affine_basis : ∃ (s : set P) (b : affine_basis ↥s k P), ⇑b = coe :=
 let ⟨s, _, hs⟩ := exists_affine_subbasis (affine_subspace.span_univ k V P) in ⟨s, hs⟩
 
 end division_ring

--- a/src/linear_algebra/affine_space/basis.lean
+++ b/src/linear_algebra/affine_space/basis.lean
@@ -58,6 +58,11 @@ namespace affine_basis
 section ring
 
 variables [ring k] [module k V] (b : affine_basis ι k P) {s : finset ι} {i j : ι} (e : ι ≃ ι')
+
+/-- The unique point in a single-point space is the simplest example of an affine basis. -/
+instance : inhabited (affine_basis punit k punit) :=
+⟨⟨id, affine_independent_of_subsingleton k id, by simp⟩⟩
+
 include V
 
 instance fun_like : fun_like (affine_basis ι k P) ι (λ _, P) :=
@@ -70,10 +75,6 @@ lemma ext {b₁ b₂ : affine_basis ι k P} (h : (b₁ : ι → P) = b₂) : b�
 lemma ind : affine_independent k b := b.ind'
 lemma tot : affine_span k (range b) = ⊤ := b.tot'
 
-/-- The unique point in a single-point space is the simplest example of an affine basis. -/
-instance : inhabited (affine_basis punit k punit) :=
-⟨⟨id, affine_independent_of_subsingleton k id, by simp⟩⟩
-
 include b
 
 protected lemma nonempty : nonempty ι :=
@@ -85,9 +86,8 @@ def reindex (e : ι ≃ ι') : affine_basis ι' k P :=
 ⟨b ∘ e.symm, b.ind.comp_embedding e.symm.to_embedding,
   by { rw [e.symm.surjective.range_comp], exact b.3 }⟩
 
-@[simp] lemma reindex_apply (i' : ι') : b.reindex e i' = b (e.symm i') := rfl
-
 @[simp, norm_cast] lemma coe_reindex : ⇑(b.reindex e) = b ∘ e.symm := rfl
+@[simp] lemma reindex_apply (i' : ι') : b.reindex e i' = b (e.symm i') := rfl
 
 @[simp] lemma reindex_refl : b.reindex (equiv.refl _) = b := ext rfl
 
@@ -129,7 +129,7 @@ noncomputable def coord (i : ι) : P →ᵃ[k] k :=
   (b.coord i).linear = -(b.basis_of i).sum_coords :=
 rfl
 
-@[simp] lemma coord_reindex [fintype ι] [fintype ι'] (i : ι') :
+@[simp] lemma coord_reindex (i : ι') :
   (b.reindex e).coord i = b.coord (e.symm i) :=
 by { ext, classical, simp [affine_basis.coord] }
 
@@ -189,8 +189,9 @@ begin
   rwa finset.univ.affine_combination_eq_linear_combination _ _ (b.sum_coord_apply_eq_one v) at hb,
 end
 
-lemma ext_elem [fintype ι] {q₁ q₂ : P} (h : ∀ i, b.coord i q₁ = b.coord i q₂) : q₁ = q₂ :=
+lemma ext_elem [finite ι] {q₁ q₂ : P} (h : ∀ i, b.coord i q₁ = b.coord i q₂) : q₁ = q₂ :=
 begin
+  casesI nonempty_fintype ι,
   rw [← b.affine_combination_coord_eq_self q₁, ← b.affine_combination_coord_eq_self q₂],
   simp only [h],
 end

--- a/src/linear_algebra/affine_space/finite_dimensional.lean
+++ b/src/linear_algebra/affine_space/finite_dimensional.lean
@@ -266,6 +266,12 @@ begin
     exact hi.affine_span_eq_of_le_of_card_eq_finrank_add_one le_top hc, },
 end
 
+lemma affine.simplex.span_eq_top [finite_dimensional k V] {n : ℕ} (T : affine.simplex k V n)
+  (hrank : finrank k V = n) :
+  affine_span k (set.range T.points) = ⊤ :=
+by rw [affine_independent.affine_span_eq_top_iff_card_eq_finrank_add_one T.independent,
+  fintype.card_fin, hrank]
+
 /-- The `vector_span` of adding a point to a finite-dimensional subspace is finite-dimensional. -/
 instance finite_dimensional_vector_span_insert (s : affine_subspace k P)
   [finite_dimensional k s.direction] (p : P) :
@@ -765,7 +771,7 @@ lemma exists_affine_basis_of_finite_dimensional [fintype ι] [finite_dimensional
 begin
   obtain ⟨s, b, hb⟩ := affine_basis.exists_affine_basis k V P,
   lift s to finset P using b.finite_set,
-  refine ⟨b.comp_equiv $ fintype.equiv_of_card_eq _⟩,
+  refine ⟨b.reindex $ fintype.equiv_of_card_eq _⟩,
   rw [h, ← b.card_eq_finrank_add_one]
 end
 

--- a/src/linear_algebra/affine_space/matrix.lean
+++ b/src/linear_algebra/affine_space/matrix.lean
@@ -39,7 +39,7 @@ noncomputable def to_matrix {ι' : Type*} (q : ι' → P) : matrix ι' ι k :=
 rfl
 
 @[simp] lemma to_matrix_self [decidable_eq ι] :
-  b.to_matrix b.points = (1 : matrix ι ι k) :=
+  b.to_matrix b = (1 : matrix ι ι k) :=
 begin
   ext i j,
   rw [to_matrix_apply, coord_apply, matrix.one_eq_pi_single, pi.single_apply],
@@ -74,7 +74,7 @@ coordinates of `p` with respect `b` has a left inverse, then `p` spans the entir
 lemma affine_span_eq_top_of_to_matrix_left_inv [decidable_eq ι] [nontrivial k]
   (p : ι' → P) {A : matrix ι ι' k} (hA : A ⬝ b.to_matrix p = 1) : affine_span k (range p) = ⊤ :=
 begin
-  suffices : ∀ i, b.points i ∈ affine_span k (range p),
+  suffices : ∀ i, b i ∈ affine_span k (range p),
   { rw [eq_top_iff, ← b.tot, affine_span_le],
     rintros q ⟨i, rfl⟩,
     exact this i, },
@@ -85,7 +85,7 @@ begin
                 ... = ∑ l, ∑ j, (A i j) * b.to_matrix p j l : by rw finset.sum_comm
                 ... = ∑ l, (A ⬝ b.to_matrix p) i l : rfl
                 ... = 1 : by simp [hA, matrix.one_apply, finset.filter_eq], },
-  have hbi : b.points i = finset.univ.affine_combination p (A i),
+  have hbi : b i = finset.univ.affine_combination p (A i),
   { apply b.ext_elem,
     intros j,
     rw [b.coord_apply, finset.univ.map_affine_combination _ _ hAi,
@@ -100,7 +100,7 @@ end
 
 See also `affine_basis.to_matrix_inv_mul_affine_basis_to_matrix`. -/
 @[simp] lemma to_matrix_vec_mul_coords (x : P) :
-  (b.to_matrix b₂.points).vec_mul (b₂.coords x) = b.coords x :=
+  (b.to_matrix b₂).vec_mul (b₂.coords x) = b.coords x :=
 begin
   ext j,
   change _ = b.coord j x,
@@ -112,17 +112,17 @@ end
 variables [decidable_eq ι]
 
 lemma to_matrix_mul_to_matrix :
-  (b.to_matrix b₂.points) ⬝ (b₂.to_matrix b.points) = 1 :=
+  (b.to_matrix b₂) ⬝ (b₂.to_matrix b) = 1 :=
 begin
   ext l m,
-  change (b₂.to_matrix b.points).vec_mul (b.coords (b₂.points l)) m = _,
+  change (b₂.to_matrix b).vec_mul (b.coords (b₂ l)) m = _,
   rw [to_matrix_vec_mul_coords, coords_apply, ← to_matrix_apply, to_matrix_self],
 end
 
 lemma is_unit_to_matrix :
-  is_unit (b.to_matrix b₂.points) :=
-⟨{ val     := b.to_matrix b₂.points,
-   inv     := b₂.to_matrix b.points,
+  is_unit (b.to_matrix b₂) :=
+⟨{ val     := b.to_matrix b₂,
+   inv     := b₂.to_matrix b,
    val_inv := b.to_matrix_mul_to_matrix b₂,
    inv_val := b₂.to_matrix_mul_to_matrix b, }, rfl⟩
 
@@ -136,7 +136,7 @@ begin
            b.affine_span_eq_top_of_to_matrix_left_inv p hA'⟩, },
   { rintros ⟨h_tot, h_ind⟩,
     let b' : affine_basis ι k P := ⟨p, h_tot, h_ind⟩,
-    change is_unit (b.to_matrix b'.points),
+    change is_unit (b.to_matrix b'),
     exact b.is_unit_to_matrix b', },
 end
 
@@ -150,7 +150,7 @@ variables (b b₂ : affine_basis ι k P)
 
 See also `affine_basis.to_matrix_vec_mul_coords`. -/
 @[simp] lemma to_matrix_inv_vec_mul_to_matrix (x : P) :
-  (b.to_matrix b₂.points)⁻¹.vec_mul (b.coords x) = b₂.coords x :=
+  (b.to_matrix b₂)⁻¹.vec_mul (b.coords x) = b₂.coords x :=
 begin
   have hu := b.is_unit_to_matrix b₂,
   rw matrix.is_unit_iff_is_unit_det at hu,
@@ -161,7 +161,7 @@ end
 /-- If we fix a background affine basis `b`, then for any other basis `b₂`, we can characterise
 the barycentric coordinates provided by `b₂` in terms of determinants relative to `b`. -/
 lemma det_smul_coords_eq_cramer_coords (x : P) :
-  (b.to_matrix b₂.points).det • b₂.coords x = (b.to_matrix b₂.points)ᵀ.cramer (b.coords x) :=
+  (b.to_matrix b₂).det • b₂.coords x = (b.to_matrix b₂)ᵀ.cramer (b.coords x) :=
 begin
   have hu := b.is_unit_to_matrix b₂,
   rw matrix.is_unit_iff_is_unit_det at hu,

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -361,7 +361,7 @@ by ext i'; show (finsupp.dom_lcongr e : _ ≃ₗ[R] _) (b.repr x) i' = _; simp
 eq_of_apply_eq $ λ i, by simp
 
 lemma range_reindex : set.range (b.reindex e) = set.range b :=
-by rw [coe_reindex, range_comp_equiv]
+by rw [coe_reindex, equiv_like.range_comp]
 
 @[simp] lemma sum_coords_reindex : (b.reindex e).sum_coords = b.sum_coords :=
 begin

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -358,12 +358,15 @@ by rw coe_reindex_repr
 @[simp] lemma reindex_refl : b.reindex (equiv.refl ι) = b :=
 eq_of_apply_eq $ λ i, by simp
 
-/-- `simp` normal form version of `range_reindex` -/
-@[simp] lemma range_reindex' : set.range (b ∘ e.symm) = set.range b :=
-by rw [range_comp, equiv.range_eq_univ, set.image_univ]
-
 lemma range_reindex : set.range (b.reindex e) = set.range b :=
 by rw [coe_reindex, range_reindex']
+
+@[simp] lemma sum_coords_reindex : (b.reindex e).sum_coords = b.sum_coords :=
+begin
+  ext x,
+  simp only [coe_sum_coords_of_fintype, fintype.sum_apply, basis.coord_apply, reindex_repr],
+  exact e.symm.sum_comp _,
+end
 
 /-- `b.reindex_range` is a basis indexed by `range b`, the basis vectors themselves. -/
 def reindex_range : basis (range b) R M :=

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -354,12 +354,16 @@ by rw [linear_equiv.symm_trans_apply, finsupp.dom_lcongr_symm, finsupp.dom_lcong
 @[simp] lemma coe_reindex : (b.reindex e : ι' → M) = b ∘ e.symm :=
 funext (b.reindex_apply e)
 
+lemma repr_reindex_apply (i' : ι') : (b.reindex e).repr x i' = b.repr x (e.symm i') :=
+show (finsupp.dom_lcongr e : _ ≃ₗ[R] _) (b.repr x) i' = _, by simp
+
 @[simp] lemma repr_reindex : (b.reindex e).repr x = (b.repr x).map_domain e :=
-by ext i'; show (finsupp.dom_lcongr e : _ ≃ₗ[R] _) (b.repr x) i' = _; simp
+fun_like.ext _ _ $ by simp [repr_reindex_apply]
 
 @[simp] lemma reindex_refl : b.reindex (equiv.refl ι) = b :=
 eq_of_apply_eq $ λ i, by simp
 
+/-- `simp` can prove this as `basis.coe_reindex` + `equiv_like.range_comp` -/
 lemma range_reindex : set.range (b.reindex e) = set.range b :=
 by rw [coe_reindex, equiv_like.range_comp]
 

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -359,7 +359,7 @@ by rw coe_reindex_repr
 eq_of_apply_eq $ λ i, by simp
 
 lemma range_reindex : set.range (b.reindex e) = set.range b :=
-by rw [coe_reindex, range_reindex']
+by rw [coe_reindex, range_comp_equiv]
 
 @[simp] lemma sum_coords_reindex : (b.reindex e).sum_coords = b.sum_coords :=
 begin

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -101,9 +101,20 @@ variables (b b₁ : basis ι R M) (i : ι) (c : R) (x : M)
 
 section repr
 
+@[ext] lemma repr_injective : injective (repr : basis ι R M → M ≃ₗ[R] (ι →₀ R)) :=
+λ f g h, by cases f; cases g; congr'
+
 /-- `b i` is the `i`th basis vector. -/
-instance : has_coe_to_fun (basis ι R M) (λ _, ι → M) :=
-{ coe := λ b i, b.repr.symm (finsupp.single i 1) }
+instance fun_like : fun_like (basis ι R M) ι (λ _, M) :=
+{ coe := λ b i, b.repr.symm (finsupp.single i 1),
+  coe_injective' := λ f g h, repr_injective $ linear_equiv.symm_bijective.injective begin
+    ext x,
+    rw [←finsupp.sum_single x, map_finsupp_sum, map_finsupp_sum],
+    congr' with i r,
+    have := congr_fun h i,
+    dsimp at this,
+    rw [←mul_one r, ←finsupp.smul_single', linear_equiv.map_smul, linear_equiv.map_smul, this],
+  end }
 
 @[simp] lemma coe_of_repr (e : M ≃ₗ[R] (ι →₀ R)) :
   ⇑(of_repr e) = λ i, e.symm (finsupp.single i 1) :=

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -101,7 +101,7 @@ variables (b b₁ : basis ι R M) (i : ι) (c : R) (x : M)
 
 section repr
 
-@[ext] lemma repr_injective : injective (repr : basis ι R M → M ≃ₗ[R] (ι →₀ R)) :=
+lemma repr_injective : injective (repr : basis ι R M → M ≃ₗ[R] (ι →₀ R)) :=
 λ f g h, by cases f; cases g; congr'
 
 /-- `b i` is the `i`th basis vector. -/
@@ -286,15 +286,11 @@ begin
 end
 
 /-- Two bases are equal if they assign the same coordinates. -/
-lemma eq_of_repr_eq_repr {b₁ b₂ : basis ι R M} (h : ∀ x i, b₁.repr x i = b₂.repr x i) :
-  b₁ = b₂ :=
-have b₁.repr = b₂.repr, by { ext, apply h },
-by { cases b₁, cases b₂, simpa }
+lemma eq_of_repr_eq_repr {b₁ b₂ : basis ι R M} (h : ∀ x i, b₁.repr x i = b₂.repr x i) : b₁ = b₂ :=
+by { ext, apply h }
 
 /-- Two bases are equal if their basis vectors are the same. -/
-@[ext] lemma eq_of_apply_eq {b₁ b₂ : basis ι R M} (h : ∀ i, b₁ i = b₂ i) : b₁ = b₂ :=
-suffices b₁.repr = b₂.repr, by { cases b₁, cases b₂, simpa },
-repr_eq_iff'.mpr (λ i, by rw [h, b₂.repr_self])
+@[ext] lemma eq_of_apply_eq {b₁ b₂ : basis ι R M} : (∀ i, b₁ i = b₂ i) → b₁ = b₂ := fun_like.ext _ _
 
 end ext
 
@@ -358,13 +354,8 @@ by rw [linear_equiv.symm_trans_apply, finsupp.dom_lcongr_symm, finsupp.dom_lcong
 @[simp] lemma coe_reindex : (b.reindex e : ι' → M) = b ∘ e.symm :=
 funext (b.reindex_apply e)
 
-@[simp] lemma coe_repr_reindex : ((b.reindex e).repr x : ι' → R) = b.repr x ∘ e.symm :=
-funext $ λ i',
-show (finsupp.dom_lcongr e : _ ≃ₗ[R] _) (b.repr x) i' = _,
-by simp
-
 @[simp] lemma repr_reindex : (b.reindex e).repr x = (b.repr x).map_domain e :=
-by ext; rw [coe_repr_reindex, finsupp.map_domain_equiv_apply]
+by ext i'; show (finsupp.dom_lcongr e : _ ≃ₗ[R] _) (b.repr x) i' = _; simp
 
 @[simp] lemma reindex_refl : b.reindex (equiv.refl ι) = b :=
 eq_of_apply_eq $ λ i, by simp

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -287,7 +287,7 @@ end
 
 /-- Two bases are equal if they assign the same coordinates. -/
 lemma eq_of_repr_eq_repr {b₁ b₂ : basis ι R M} (h : ∀ x i, b₁.repr x i = b₂.repr x i) : b₁ = b₂ :=
-by { ext, apply h }
+repr_injective $ by { ext, apply h }
 
 /-- Two bases are equal if their basis vectors are the same. -/
 @[ext] lemma eq_of_apply_eq {b₁ b₂ : basis ι R M} : (∀ i, b₁ i = b₂ i) → b₁ = b₂ := fun_like.ext _ _

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -347,13 +347,13 @@ by rw [linear_equiv.symm_trans_apply, finsupp.dom_lcongr_symm, finsupp.dom_lcong
 @[simp] lemma coe_reindex : (b.reindex e : ι' → M) = b ∘ e.symm :=
 funext (b.reindex_apply e)
 
-@[simp] lemma coe_reindex_repr : ((b.reindex e).repr x : ι' → R) = b.repr x ∘ e.symm :=
+@[simp] lemma coe_repr_reindex : ((b.reindex e).repr x : ι' → R) = b.repr x ∘ e.symm :=
 funext $ λ i',
 show (finsupp.dom_lcongr e : _ ≃ₗ[R] _) (b.repr x) i' = _,
 by simp
 
-@[simp] lemma reindex_repr (i' : ι') : (b.reindex e).repr x i' = b.repr x (e.symm i') :=
-by rw coe_reindex_repr
+@[simp] lemma repr_reindex : (b.reindex e).repr x = (b.repr x).map_domain e :=
+by ext; rw [coe_repr_reindex, finsupp.map_domain_equiv_apply]
 
 @[simp] lemma reindex_refl : b.reindex (equiv.refl ι) = b :=
 eq_of_apply_eq $ λ i, by simp
@@ -364,8 +364,8 @@ by rw [coe_reindex, range_comp_equiv]
 @[simp] lemma sum_coords_reindex : (b.reindex e).sum_coords = b.sum_coords :=
 begin
   ext x,
-  simp only [coe_sum_coords_of_fintype, fintype.sum_apply, basis.coord_apply, reindex_repr],
-  exact e.symm.sum_comp _,
+  simp only [coe_sum_coords, repr_reindex],
+  exact finsupp.sum_map_domain_index (λ _, rfl) (λ _ _ _, rfl),
 end
 
 /-- `b.reindex_range` is a basis indexed by `range b`, the basis vectors themselves. -/
@@ -443,7 +443,7 @@ lemma reindex_finset_range_repr_self (i : ι) :
     finsupp.single ⟨b i, finset.mem_image_of_mem b (finset.mem_univ i)⟩ 1 :=
 begin
   ext ⟨bi, hbi⟩,
-  rw [reindex_finset_range, reindex_repr, reindex_range_repr_self],
+  rw [reindex_finset_range, repr_reindex, finsupp.map_domain_equiv_apply, reindex_range_repr_self],
   convert finsupp.single_apply_left ((equiv.refl M).subtype_equiv _).symm.injective _ _ _,
   refl
 end

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -215,7 +215,8 @@ lemma basis.to_matrix_reindex' [decidable_eq ι] [decidable_eq ι']
   (b : basis ι R M) (v : ι' → M) (e : ι ≃ ι') :
   (b.reindex e).to_matrix v = matrix.reindex_alg_equiv _ e (b.to_matrix (v ∘ e)) :=
 by { ext, simp only [basis.to_matrix_apply, basis.repr_reindex, matrix.reindex_alg_equiv_apply,
-        matrix.reindex_apply, matrix.submatrix_apply, function.comp_app, e.apply_symm_apply, finsupp.map_domain_equiv_apply] }
+        matrix.reindex_apply, matrix.submatrix_apply, function.comp_app, e.apply_symm_apply,
+        finsupp.map_domain_equiv_apply] }
 
 end fintype
 

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -215,7 +215,7 @@ lemma basis.to_matrix_reindex' [decidable_eq ι] [decidable_eq ι']
   (b : basis ι R M) (v : ι' → M) (e : ι ≃ ι') :
   (b.reindex e).to_matrix v = matrix.reindex_alg_equiv _ e (b.to_matrix (v ∘ e)) :=
 by { ext, simp only [basis.to_matrix_apply, basis.repr_reindex, matrix.reindex_alg_equiv_apply,
-        matrix.reindex_apply, matrix.submatrix_apply, function.comp_app, e.apply_symm_apply] }
+        matrix.reindex_apply, matrix.submatrix_apply, function.comp_app, e.apply_symm_apply, finsupp.map_domain_equiv_apply] }
 
 end fintype
 
@@ -244,7 +244,8 @@ matrix.invertible_of_left_inverse _ _ (basis.to_matrix_mul_to_matrix_flip _ _)
 lemma basis.to_matrix_reindex
   (b : basis ι R M) (v : ι' → M) (e : ι ≃ ι') :
   (b.reindex e).to_matrix v = (b.to_matrix v).submatrix e.symm id :=
-by { ext, simp only [basis.to_matrix_apply, basis.repr_reindex, matrix.submatrix_apply, id.def] }
+by { ext, simp only [basis.to_matrix_apply, basis.repr_reindex, matrix.submatrix_apply, id.def,
+  finsupp.map_domain_equiv_apply] }
 
 @[simp]
 lemma basis.to_matrix_map (b : basis ι R M) (f : M ≃ₗ[R] N) (v : ι → N) :

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -214,7 +214,7 @@ by { haveI := classical.dec_eq ι',
 lemma basis.to_matrix_reindex' [decidable_eq ι] [decidable_eq ι']
   (b : basis ι R M) (v : ι' → M) (e : ι ≃ ι') :
   (b.reindex e).to_matrix v = matrix.reindex_alg_equiv _ e (b.to_matrix (v ∘ e)) :=
-by { ext, simp only [basis.to_matrix_apply, basis.reindex_repr, matrix.reindex_alg_equiv_apply,
+by { ext, simp only [basis.to_matrix_apply, basis.repr_reindex, matrix.reindex_alg_equiv_apply,
         matrix.reindex_apply, matrix.submatrix_apply, function.comp_app, e.apply_symm_apply] }
 
 end fintype
@@ -244,7 +244,7 @@ matrix.invertible_of_left_inverse _ _ (basis.to_matrix_mul_to_matrix_flip _ _)
 lemma basis.to_matrix_reindex
   (b : basis ι R M) (v : ι' → M) (e : ι ≃ ι') :
   (b.reindex e).to_matrix v = (b.to_matrix v).submatrix e.symm id :=
-by { ext, simp only [basis.to_matrix_apply, basis.reindex_repr, matrix.submatrix_apply, id.def] }
+by { ext, simp only [basis.to_matrix_apply, basis.repr_reindex, matrix.submatrix_apply, id.def] }
 
 @[simp]
 lemma basis.to_matrix_map (b : basis ι R M) (f : M ≃ₗ[R] N) (v : ι → N) :

--- a/src/linear_algebra/matrix/spectrum.lean
+++ b/src/linear_algebra/matrix/spectrum.lean
@@ -99,13 +99,13 @@ begin
       linear_map.coe_single, pi_Lp.equiv_symm_single, linear_equiv.symm_symm,
       eigenvector_basis, to_lin'_apply],
     simp only [basis.to_matrix, basis.coe_to_orthonormal_basis_repr, basis.equiv_fun_apply],
-    simp_rw [orthonormal_basis.coe_to_basis_repr_apply, orthonormal_basis.reindex_repr,
+    simp_rw [orthonormal_basis.coe_to_basis_repr_apply, orthonormal_basis.repr_reindex,
       linear_equiv.symm_symm, pi_Lp.linear_equiv_apply, pi_Lp.equiv_single, mul_vec_single,
       mul_one],
     refl },
   { simp only [diagonal_mul, (∘), eigenvalues, eigenvector_basis],
     rw [basis.to_matrix_apply,
-      orthonormal_basis.coe_to_basis_repr_apply, orthonormal_basis.reindex_repr,
+      orthonormal_basis.coe_to_basis_repr_apply, orthonormal_basis.repr_reindex,
       eigenvalues₀, pi_Lp.basis_fun_apply, pi_Lp.equiv_symm_single] }
 end
 


### PR DESCRIPTION
Rename and change arguments to `affine_basis.comp_equiv` so that it matches `basis.reindex`. Provide lemmas for its interaction with other `affine_basis` constructions.

Make `affine_basis` follow the `fun_like` design, replacing `affine_basis.points` by a function coercion.

Fix a few names all around:
* `affine_basis.coord_apply_neq` → `affine_basis.coord_apply_ne`
* `convex_hull_affine_basis_eq_nonneg_barycentric` → `affine_basis.convex_hull_eq_nonneg_coord`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Match https://github.com/leanprover-community/mathlib4/pull/1616

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
