### PR TITLE
[Merged by Bors] - chore(topology/metric_space/isometry): rename isometric to isometry_equiv

### DIFF
--- a/src/analysis/normed/group/add_torsor.lean
+++ b/src/analysis/normed/group/add_torsor.lean
@@ -85,7 +85,7 @@ by rw [dist_comm, dist_vadd_left]
 
 /-- Isometry between the tangent space `V` of a (semi)normed add torsor `P` and `P` given by
 addition/subtraction of `x : P`. -/
-@[simps] def isometric.vadd_const (x : P) : V ≃ᵢ P :=
+@[simps] def isometry_equiv.vadd_const (x : P) : V ≃ᵢ P :=
 { to_equiv := equiv.vadd_const x,
   isometry_to_fun := isometry.of_dist_eq $ λ _ _, dist_vadd_cancel_right _ _ _ }
 
@@ -94,7 +94,7 @@ section
 variable (P)
 
 /-- Self-isometry of a (semi)normed add torsor given by addition of a constant vector `x`. -/
-@[simps] def isometric.const_vadd (x : V) : P ≃ᵢ P :=
+@[simps] def isometry_equiv.const_vadd (x : V) : P ≃ᵢ P :=
 { to_equiv := equiv.const_vadd P x,
   isometry_to_fun := isometry.of_dist_eq $ λ _ _, dist_vadd_cancel_left _ _ _ }
 
@@ -105,12 +105,12 @@ by rw [dist_eq_norm, vsub_sub_vsub_cancel_left, dist_comm, dist_eq_norm_vsub V]
 
 /-- Isometry between the tangent space `V` of a (semi)normed add torsor `P` and `P` given by
 subtraction from `x : P`. -/
-@[simps] def isometric.const_vsub (x : P) : P ≃ᵢ V :=
+@[simps] def isometry_equiv.const_vsub (x : P) : P ≃ᵢ V :=
 { to_equiv := equiv.const_vsub x,
   isometry_to_fun := isometry.of_dist_eq $ λ y z, dist_vsub_cancel_left _ _ _ }
 
 @[simp] lemma dist_vsub_cancel_right (x y z : P) : dist (x -ᵥ z) (y -ᵥ z) = dist x y :=
-(isometric.vadd_const z).symm.dist_eq x y
+(isometry_equiv.vadd_const z).symm.dist_eq x y
 
 section pointwise
 
@@ -118,15 +118,15 @@ open_locale pointwise
 
 @[simp] lemma vadd_ball (x : V) (y : P) (r : ℝ) :
   x +ᵥ metric.ball y r = metric.ball (x +ᵥ y) r :=
-(isometric.const_vadd P x).image_ball y r
+(isometry_equiv.const_vadd P x).image_ball y r
 
 @[simp] lemma vadd_closed_ball (x : V) (y : P) (r : ℝ) :
   x +ᵥ metric.closed_ball y r = metric.closed_ball (x +ᵥ y) r :=
-(isometric.const_vadd P x).image_closed_ball y r
+(isometry_equiv.const_vadd P x).image_closed_ball y r
 
 @[simp] lemma vadd_sphere (x : V) (y : P) (r : ℝ) :
   x +ᵥ metric.sphere y r = metric.sphere (x +ᵥ y) r :=
-(isometric.const_vadd P x).image_sphere y r
+(isometry_equiv.const_vadd P x).image_sphere y r
 
 end pointwise
 

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -493,7 +493,7 @@ def norm_group_seminorm : group_seminorm E := ⟨norm, norm_one', norm_mul_le', 
 
 variables {E}
 
-namespace isometric
+namespace isometry_equiv
 -- TODO This material is superseded by similar constructions such as
 -- `affine_isometry_equiv.const_vadd`; deduplicate
 
@@ -504,18 +504,18 @@ protected def mul_right (x : E) : E ≃ᵢ E :=
   .. equiv.mul_right x }
 
 @[simp, to_additive]
-lemma mul_right_to_equiv (x : E) : (isometric.mul_right x).to_equiv = equiv.mul_right x := rfl
+lemma mul_right_to_equiv (x : E) : (isometry_equiv.mul_right x).to_equiv = equiv.mul_right x := rfl
 
 @[simp, to_additive]
-lemma coe_mul_right (x : E) : (isometric.mul_right x : E → E) = λ y, y * x := rfl
+lemma coe_mul_right (x : E) : (isometry_equiv.mul_right x : E → E) = λ y, y * x := rfl
 
-@[to_additive] lemma mul_right_apply (x y : E) : (isometric.mul_right x : E → E) y = y * x := rfl
+@[to_additive] lemma mul_right_apply (x y : E) : (isometry_equiv.mul_right x : E → E) y = y * x := rfl
 
 @[simp, to_additive]
-lemma mul_right_symm (x : E) : (isometric.mul_right x).symm = isometric.mul_right x⁻¹ :=
+lemma mul_right_symm (x : E) : (isometry_equiv.mul_right x).symm = isometry_equiv.mul_right x⁻¹ :=
 ext $ λ y, rfl
 
-end isometric
+end isometry_equiv
 
 @[to_additive] lemma normed_comm_group.tendsto_nhds_one {f : α → E} {l : filter α} :
   tendsto f l (𝓝 1) ↔ ∀ ε > 0, ∀ᶠ x in l, ‖ f x ‖ < ε :=
@@ -1107,7 +1107,7 @@ by { ext, simp [mem_closed_ball, set.mem_smul_set, dist_eq_norm_div, div_eq_inv_
 by { ext, simp [mem_ball, set.mem_smul_set, dist_eq_norm_div, div_eq_inv_mul,
   ← eq_inv_mul_iff_mul_eq, mul_assoc], }
 
-namespace isometric
+namespace isometry_equiv
 
 /-- Multiplication `y ↦ x * y` as an `isometry`. -/
 @[to_additive "Addition `y ↦ x + y` as an `isometry`"]
@@ -1116,12 +1116,12 @@ protected def mul_left (x : E) : E ≃ᵢ E :=
   to_equiv := equiv.mul_left x }
 
 @[simp, to_additive] lemma mul_left_to_equiv (x : E) :
-  (isometric.mul_left x).to_equiv = equiv.mul_left x := rfl
+  (isometry_equiv.mul_left x).to_equiv = equiv.mul_left x := rfl
 
-@[simp, to_additive] lemma coe_mul_left (x : E) : ⇑(isometric.mul_left x) = (*) x := rfl
+@[simp, to_additive] lemma coe_mul_left (x : E) : ⇑(isometry_equiv.mul_left x) = (*) x := rfl
 
 @[simp, to_additive] lemma mul_left_symm (x : E) :
-  (isometric.mul_left x).symm = isometric.mul_left x⁻¹ :=
+  (isometry_equiv.mul_left x).symm = isometry_equiv.mul_left x⁻¹ :=
 ext $ λ y, rfl
 
 variables (E)
@@ -1133,11 +1133,11 @@ variables (E)
 
 variables {E}
 
-@[simp, to_additive] lemma inv_symm : (isometric.inv E).symm = isometric.inv E := rfl
-@[simp, to_additive] lemma inv_to_equiv : (isometric.inv E).to_equiv = equiv.inv E := rfl
-@[simp, to_additive] lemma coe_inv : ⇑(isometric.inv E) = has_inv.inv := rfl
+@[simp, to_additive] lemma inv_symm : (isometry_equiv.inv E).symm = isometry_equiv.inv E := rfl
+@[simp, to_additive] lemma inv_to_equiv : (isometry_equiv.inv E).to_equiv = equiv.inv E := rfl
+@[simp, to_additive] lemma coe_inv : ⇑(isometry_equiv.inv E) = has_inv.inv := rfl
 
-end isometric
+end isometry_equiv
 
 open finset
 

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -509,7 +509,8 @@ lemma mul_right_to_equiv (x : E) : (isometry_equiv.mul_right x).to_equiv = equiv
 @[simp, to_additive]
 lemma coe_mul_right (x : E) : (isometry_equiv.mul_right x : E → E) = λ y, y * x := rfl
 
-@[to_additive] lemma mul_right_apply (x y : E) : (isometry_equiv.mul_right x : E → E) y = y * x := rfl
+@[to_additive] lemma mul_right_apply (x y : E) : (isometry_equiv.mul_right x : E → E) y = y * x :=
+rfl
 
 @[simp, to_additive]
 lemma mul_right_symm (x : E) : (isometry_equiv.mul_right x).symm = isometry_equiv.mul_right x⁻¹ :=

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -32,7 +32,7 @@ lemma affine_subspace.is_closed_direction_iff (s : affine_subspace 𝕜 Q) :
   is_closed (s.direction : set W) ↔ is_closed (s : set Q) :=
 begin
   rcases s.eq_bot_or_nonempty with rfl|⟨x, hx⟩, { simp [is_closed_singleton] },
-  rw [← (isometric.vadd_const x).to_homeomorph.symm.is_closed_image,
+  rw [← (isometry_equiv.vadd_const x).to_homeomorph.symm.is_closed_image,
     affine_subspace.coe_direction_eq_vsub_set_right hx],
   refl
 end

--- a/src/analysis/normed_space/affine_isometry.lean
+++ b/src/analysis/normed_space/affine_isometry.lean
@@ -317,18 +317,18 @@ variables (e : P ≃ᵃⁱ[𝕜] P₂)
 
 protected lemma isometry : isometry e := e.to_affine_isometry.isometry
 
-/-- Reinterpret a `affine_isometry_equiv` as an `isometric`. -/
-def to_isometric : P ≃ᵢ P₂ := ⟨e.to_affine_equiv.to_equiv, e.isometry⟩
+/-- Reinterpret a `affine_isometry_equiv` as an `isometry_equiv`. -/
+def to_isometry_equiv : P ≃ᵢ P₂ := ⟨e.to_affine_equiv.to_equiv, e.isometry⟩
 
-@[simp] lemma coe_to_isometric : ⇑e.to_isometric = e := rfl
+@[simp] lemma coe_to_isometry_equiv : ⇑e.to_isometry_equiv = e := rfl
 
 include V V₂
 lemma range_eq_univ (e : P ≃ᵃⁱ[𝕜] P₂) : set.range e = set.univ :=
-by { rw ← coe_to_isometric, exact isometric.range_eq_univ _, }
+by { rw ← coe_to_isometry_equiv, exact isometry_equiv.range_eq_univ _, }
 omit V V₂
 
 /-- Reinterpret a `affine_isometry_equiv` as an `homeomorph`. -/
-def to_homeomorph : P ≃ₜ P₂ := e.to_isometric.to_homeomorph
+def to_homeomorph : P ≃ₜ P₂ := e.to_isometry_equiv.to_homeomorph
 
 @[simp] lemma coe_to_homeomorph : ⇑e.to_homeomorph = e := rfl
 
@@ -351,7 +351,7 @@ instance : inhabited (P ≃ᵃⁱ[𝕜] P) := ⟨refl 𝕜 P⟩
 
 @[simp] lemma coe_refl : ⇑(refl 𝕜 P) = id := rfl
 @[simp] lemma to_affine_equiv_refl : (refl 𝕜 P).to_affine_equiv = affine_equiv.refl 𝕜 P := rfl
-@[simp] lemma to_isometric_refl : (refl 𝕜 P).to_isometric = isometric.refl P := rfl
+@[simp] lemma to_isometry_equiv_refl : (refl 𝕜 P).to_isometry_equiv = isometry_equiv.refl P := rfl
 @[simp] lemma to_homeomorph_refl : (refl 𝕜 P).to_homeomorph = homeomorph.refl P := rfl
 omit V
 
@@ -365,7 +365,7 @@ def symm : P₂ ≃ᵃⁱ[𝕜] P :=
 @[simp] lemma symm_symm : e.symm.symm = e := ext $ λ x, rfl
 
 @[simp] lemma to_affine_equiv_symm : e.to_affine_equiv.symm = e.symm.to_affine_equiv := rfl
-@[simp] lemma to_isometric_symm : e.to_isometric.symm = e.symm.to_isometric := rfl
+@[simp] lemma to_isometry_equiv_symm : e.to_isometry_equiv.symm = e.symm.to_isometry_equiv := rfl
 @[simp] lemma to_homeomorph_symm : e.to_homeomorph.symm = e.symm.to_homeomorph := rfl
 
 include V₃

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -456,24 +456,24 @@ to_linear_isometry_injective.eq_iff
 
 protected lemma isometry : isometry e := e.to_linear_isometry.isometry
 
-/-- Reinterpret a `linear_isometry_equiv` as an `isometric`. -/
-def to_isometric : E ≃ᵢ E₂ := ⟨e.to_linear_equiv.to_equiv, e.isometry⟩
+/-- Reinterpret a `linear_isometry_equiv` as an `isometry_equiv`. -/
+def to_isometry_equiv : E ≃ᵢ E₂ := ⟨e.to_linear_equiv.to_equiv, e.isometry⟩
 
-lemma to_isometric_injective :
-  function.injective (to_isometric : (E ≃ₛₗᵢ[σ₁₂] E₂) → E ≃ᵢ E₂) :=
-λ x y h, coe_injective (congr_arg _ h : ⇑x.to_isometric = _)
+lemma to_isometry_equiv_injective :
+  function.injective (to_isometry_equiv : (E ≃ₛₗᵢ[σ₁₂] E₂) → E ≃ᵢ E₂) :=
+λ x y h, coe_injective (congr_arg _ h : ⇑x.to_isometry_equiv = _)
 
-@[simp] lemma to_isometric_inj {f g : E ≃ₛₗᵢ[σ₁₂] E₂} :
-  f.to_isometric = g.to_isometric ↔ f = g :=
-to_isometric_injective.eq_iff
+@[simp] lemma to_isometry_equiv_inj {f g : E ≃ₛₗᵢ[σ₁₂] E₂} :
+  f.to_isometry_equiv = g.to_isometry_equiv ↔ f = g :=
+to_isometry_equiv_injective.eq_iff
 
-@[simp] lemma coe_to_isometric : ⇑e.to_isometric = e := rfl
+@[simp] lemma coe_to_isometry_equiv : ⇑e.to_isometry_equiv = e := rfl
 
 lemma range_eq_univ (e : E ≃ₛₗᵢ[σ₁₂] E₂) : set.range e = set.univ :=
-by { rw ← coe_to_isometric, exact isometric.range_eq_univ _, }
+by { rw ← coe_to_isometry_equiv, exact isometry_equiv.range_eq_univ _, }
 
 /-- Reinterpret a `linear_isometry_equiv` as an `homeomorph`. -/
-def to_homeomorph : E ≃ₜ E₂ := e.to_isometric.to_homeomorph
+def to_homeomorph : E ≃ₜ E₂ := e.to_isometry_equiv.to_homeomorph
 
 lemma to_homeomorph_injective :
   function.injective (to_homeomorph : (E ≃ₛₗᵢ[σ₁₂] E₂) → E ≃ₜ E₂) :=
@@ -531,7 +531,7 @@ def symm : E₂ ≃ₛₗᵢ[σ₂₁] E :=
 @[simp] lemma symm_symm : e.symm.symm = e := ext $ λ x, rfl
 
 @[simp] lemma to_linear_equiv_symm : e.to_linear_equiv.symm = e.symm.to_linear_equiv := rfl
-@[simp] lemma to_isometric_symm : e.to_isometric.symm = e.symm.to_isometric := rfl
+@[simp] lemma to_isometry_equiv_symm : e.to_isometry_equiv.symm = e.symm.to_isometry_equiv := rfl
 @[simp] lemma to_homeomorph_symm : e.to_homeomorph.symm = e.symm.to_homeomorph := rfl
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
@@ -624,7 +624,7 @@ include σ₂₁
 
 /-- Reinterpret a `linear_isometry_equiv` as a `continuous_linear_equiv`. -/
 instance : has_coe_t (E ≃ₛₗᵢ[σ₁₂] E₂) (E ≃SL[σ₁₂] E₂) :=
-⟨λ e, ⟨e.to_linear_equiv, e.continuous, e.to_isometric.symm.continuous⟩⟩
+⟨λ e, ⟨e.to_linear_equiv, e.continuous, e.to_isometry_equiv.symm.continuous⟩⟩
 
 instance : has_coe_t (E ≃ₛₗᵢ[σ₁₂] E₂) (E →SL[σ₁₂] E₂) := ⟨λ e, ↑(e : E ≃SL[σ₁₂] E₂)⟩
 
@@ -678,27 +678,27 @@ e.isometry.diam_image s
 
 @[simp] lemma preimage_ball (x : E₂) (r : ℝ) :
   e ⁻¹' (metric.ball x r) = metric.ball (e.symm x) r :=
-e.to_isometric.preimage_ball x r
+e.to_isometry_equiv.preimage_ball x r
 
 @[simp] lemma preimage_sphere (x : E₂) (r : ℝ) :
   e ⁻¹' (metric.sphere x r) = metric.sphere (e.symm x) r :=
-e.to_isometric.preimage_sphere x r
+e.to_isometry_equiv.preimage_sphere x r
 
 @[simp] lemma preimage_closed_ball (x : E₂) (r : ℝ) :
   e ⁻¹' (metric.closed_ball x r) = metric.closed_ball (e.symm x) r :=
-e.to_isometric.preimage_closed_ball x r
+e.to_isometry_equiv.preimage_closed_ball x r
 
 @[simp] lemma image_ball (x : E) (r : ℝ) :
   e '' (metric.ball x r) = metric.ball (e x) r :=
-e.to_isometric.image_ball x r
+e.to_isometry_equiv.image_ball x r
 
 @[simp] lemma image_sphere (x : E) (r : ℝ) :
   e '' (metric.sphere x r) = metric.sphere (e x) r :=
-e.to_isometric.image_sphere x r
+e.to_isometry_equiv.image_sphere x r
 
 @[simp] lemma image_closed_ball (x : E) (r : ℝ) :
   e '' (metric.closed_ball x r) = metric.closed_ball (e x) r :=
-e.to_isometric.image_closed_ball x r
+e.to_isometry_equiv.image_closed_ball x r
 
 variables {α : Type*} [topological_space α]
 

--- a/src/analysis/normed_space/mazur_ulam.lean
+++ b/src/analysis/normed_space/mazur_ulam.lean
@@ -13,12 +13,12 @@ import linear_algebra.affine_space.midpoint
 Mazur-Ulam theorem states that an isometric bijection between two normed affine spaces over `ℝ` is
 affine. We formalize it in three definitions:
 
-* `isometric.to_real_linear_isometry_equiv_of_map_zero` : given `E ≃ᵢ F` sending `0` to `0`,
+* `isometry_equiv.to_real_linear_isometry_equiv_of_map_zero` : given `E ≃ᵢ F` sending `0` to `0`,
   returns `E ≃ₗᵢ[ℝ] F` with the same `to_fun` and `inv_fun`;
-* `isometric.to_real_linear_isometry_equiv` : given `f : E ≃ᵢ F`, returns a linear isometry
+* `isometry_equiv.to_real_linear_isometry_equiv` : given `f : E ≃ᵢ F`, returns a linear isometry
   equivalence `g : E ≃ₗᵢ[ℝ] F` with `g x = f x - f 0`.
-* `isometric.to_real_affine_isometry_equiv` : given `f : PE ≃ᵢ PF`, returns an affine isometry
-  equivalence `g : PE ≃ᵃⁱ[ℝ] PF` whose underlying `isometric` is `f`
+* `isometry_equiv.to_real_affine_isometry_equiv` : given `f : PE ≃ᵢ PF`, returns an affine isometry
+  equivalence `g : PE ≃ᵃⁱ[ℝ] PF` whose underlying `isometry_equiv` is `f`
 
 The formalization is based on [Jussi Väisälä, *A Proof of the Mazur-Ulam Theorem*][Vaisala_2003].
 
@@ -35,7 +35,7 @@ open set affine_map affine_isometry_equiv
 
 noncomputable theory
 
-namespace isometric
+namespace isometry_equiv
 
 include E
 
@@ -48,7 +48,7 @@ begin
   set z := midpoint ℝ x y,
   -- Consider the set of `e : E ≃ᵢ E` such that `e x = x` and `e y = y`
   set s := { e : PE ≃ᵢ PE | e x = x ∧ e y = y },
-  haveI : nonempty s := ⟨⟨isometric.refl PE, rfl, rfl⟩⟩,
+  haveI : nonempty s := ⟨⟨isometry_equiv.refl PE, rfl, rfl⟩⟩,
   -- On the one hand, `e` cannot send the midpoint `z` of `[x, y]` too far
   have h_bdd : bdd_above (range $ λ e : s, dist (e z) z),
   { refine ⟨dist x z + dist x z, forall_range_iff.2 $ subtype.forall.2 _⟩,
@@ -59,7 +59,7 @@ begin
   -- On the other hand, consider the map `f : (E ≃ᵢ E) → (E ≃ᵢ E)`
   -- sending each `e` to `R ∘ e⁻¹ ∘ R ∘ e`, where `R` is the point reflection in the
   -- midpoint `z` of `[x, y]`.
-  set R : PE ≃ᵢ PE := (point_reflection ℝ z).to_isometric,
+  set R : PE ≃ᵢ PE := (point_reflection ℝ z).to_isometry_equiv,
   set f : (PE ≃ᵢ PE) → (PE ≃ᵢ PE) := λ e, ((e.trans R).trans e.symm).trans R,
   -- Note that `f` doubles the value of ``dist (e z) z`
   have hf_dist : ∀ e, dist (f e z) z = 2 * dist (e z) z,
@@ -89,14 +89,14 @@ include F
 lemma map_midpoint (f : PE ≃ᵢ PF) (x y : PE) : f (midpoint ℝ x y) = midpoint ℝ (f x) (f y) :=
 begin
   set e : PE ≃ᵢ PE :=
-    ((f.trans $ (point_reflection ℝ $ midpoint ℝ (f x) (f y)).to_isometric).trans f.symm).trans
-    (point_reflection ℝ $ midpoint ℝ x y).to_isometric,
+    ((f.trans $ (point_reflection ℝ $ midpoint ℝ (f x) (f y)).to_isometry_equiv).trans f.symm).trans
+    (point_reflection ℝ $ midpoint ℝ x y).to_isometry_equiv,
   have hx : e x = x, by simp,
   have hy : e y = y, by simp,
   have hm := e.midpoint_fixed hx hy,
   simp only [e, trans_apply] at hm,
-  rwa [← eq_symm_apply, to_isometric_symm, point_reflection_symm, coe_to_isometric,
-    coe_to_isometric, point_reflection_self, symm_apply_eq, point_reflection_fixed_iff] at hm
+  rwa [← eq_symm_apply, to_isometry_equiv_symm, point_reflection_symm, coe_to_isometry_equiv,
+    coe_to_isometry_equiv, point_reflection_self, symm_apply_eq, point_reflection_fixed_iff] at hm
 end
 
 /-!
@@ -121,7 +121,7 @@ def to_real_linear_isometry_equiv_of_map_zero (f : E ≃ᵢ F) (h0 : f 0 = 0) :
 /-- **Mazur-Ulam Theorem**: if `f` is an isometric bijection between two normed vector spaces
 over `ℝ`, then `x ↦ f x - f 0` is a linear isometry equivalence. -/
 def to_real_linear_isometry_equiv (f : E ≃ᵢ F) : E ≃ₗᵢ[ℝ] F :=
-(f.trans (isometric.add_right (f 0)).symm).to_real_linear_isometry_equiv_of_map_zero
+(f.trans (isometry_equiv.add_right (f 0)).symm).to_real_linear_isometry_equiv_of_map_zero
   (by simpa only [sub_eq_add_neg] using sub_self (f 0))
 
 @[simp] lemma to_real_linear_equiv_apply (f : E ≃ᵢ F) (x : E) :
@@ -144,7 +144,7 @@ affine_isometry_equiv.mk' f
 rfl
 
 @[simp] lemma coe_to_real_affine_isometry_equiv (f : PE ≃ᵢ PF) :
-  f.to_real_affine_isometry_equiv.to_isometric = f :=
+  f.to_real_affine_isometry_equiv.to_isometry_equiv = f :=
 by { ext, refl }
 
-end isometric
+end isometry_equiv

--- a/src/measure_theory/function/conditional_expectation/basic.lean
+++ b/src/measure_theory/function/conditional_expectation/basic.lean
@@ -303,7 +303,7 @@ section complete_subspace
 
 /-! ## The subspace `Lp_meas` is complete.
 
-We define an `isometric` between `Lp_meas_subgroup` and the `Lp` space corresponding to the
+We define an `isometry_equiv` between `Lp_meas_subgroup` and the `Lp` space corresponding to the
 measure `μ.trim hm`. As a consequence, the completeness of `Lp` implies completeness of
 `Lp_meas_subgroup` (and `Lp_meas`). -/
 
@@ -488,7 +488,7 @@ variables (𝕜)
 /-- `Lp_meas_subgroup` and `Lp_meas` are isometric. -/
 def Lp_meas_subgroup_to_Lp_meas_iso [hp : fact (1 ≤ p)] :
   Lp_meas_subgroup F m p μ ≃ᵢ Lp_meas F 𝕜 m p μ :=
-isometric.refl (Lp_meas_subgroup F m p μ)
+isometry_equiv.refl (Lp_meas_subgroup F m p μ)
 
 /-- `Lp_meas` and `Lp F p (μ.trim hm)` are isometric, with a linear equivalence. -/
 def Lp_meas_to_Lp_trim_lie [hp : fact (1 ≤ p)] (hm : m ≤ m0) :

--- a/src/measure_theory/measure/hausdorff.lean
+++ b/src/measure_theory/measure/hausdorff.lean
@@ -387,13 +387,13 @@ lemma isometry_map_mk_metric (m : ℝ≥0∞ → ℝ≥0∞) {f : X → Y} (hf :
   map f (mk_metric m) = restrict (range f) (mk_metric m) :=
 by rw [← isometry_comap_mk_metric _ hf H, map_comap]
 
-lemma isometric_comap_mk_metric (m : ℝ≥0∞ → ℝ≥0∞) (f : X ≃ᵢ Y) :
+lemma isometry_equiv_comap_mk_metric (m : ℝ≥0∞ → ℝ≥0∞) (f : X ≃ᵢ Y) :
   comap f (mk_metric m) = mk_metric m :=
 isometry_comap_mk_metric _ f.isometry (or.inr f.surjective)
 
-lemma isometric_map_mk_metric (m : ℝ≥0∞ → ℝ≥0∞) (f : X ≃ᵢ Y) :
+lemma isometry_equiv_map_mk_metric (m : ℝ≥0∞ → ℝ≥0∞) (f : X ≃ᵢ Y) :
   map f (mk_metric m) = mk_metric m :=
-by rw [← isometric_comap_mk_metric _ f, map_comap_of_surjective f.surjective]
+by rw [← isometry_equiv_comap_mk_metric _ f, map_comap_of_surjective f.surjective]
 
 lemma trim_mk_metric [measurable_space X] [borel_space X] (m : ℝ≥0∞ → ℝ≥0∞) :
   (mk_metric m : outer_measure X).trim = mk_metric m :=
@@ -942,7 +942,7 @@ end
 
 end isometry
 
-namespace isometric
+namespace isometry_equiv
 
 @[simp] lemma hausdorff_measure_image (e : X ≃ᵢ Y) (d : ℝ) (s : set X) :
   μH[d] (e '' s) = μH[d] s :=
@@ -952,4 +952,4 @@ e.isometry.hausdorff_measure_image (or.inr e.surjective) s
   μH[d] (e ⁻¹' s) = μH[d] s :=
 by rw [← e.image_symm, e.symm.hausdorff_measure_image]
 
-end isometric
+end isometry_equiv

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -83,7 +83,7 @@ When `α` is compact, and `β` is a metric space, the bounded continuous maps `�
 isometric to `C(α, β)`.
 -/
 @[simps to_equiv apply symm_apply { fully_applied := ff }]
-def isometric_bounded_of_compact :
+def isometry_equiv_bounded_of_compact :
   C(α, β) ≃ᵢ (α →ᵇ β) :=
 { isometry_to_fun := λ x y, rfl,
   to_equiv := equiv_bounded_of_compact α β }
@@ -127,11 +127,11 @@ by simp only [← dist_mk_of_compact, dist_lt_iff_of_compact C0, mk_of_compact_a
 end
 
 instance [complete_space β] : complete_space (C(α, β)) :=
-(isometric_bounded_of_compact α β).complete_space
+(isometry_equiv_bounded_of_compact α β).complete_space
 
 /-- See also `continuous_map.continuous_eval'` -/
 @[continuity] lemma continuous_eval : continuous (λ p : C(α, β) × α, p.1 p.2) :=
-continuous_eval.comp ((isometric_bounded_of_compact α β).continuous.prod_map continuous_id)
+continuous_eval.comp ((isometry_equiv_bounded_of_compact α β).continuous.prod_map continuous_id)
 
 /-- See also `continuous_map.continuous_eval_const` -/
 @[continuity] lemma continuous_eval_const (x : α) : continuous (λ f : C(α, β), f x) :=
@@ -259,8 +259,8 @@ rfl
 
 
 @[simp]
-lemma linear_isometry_bounded_of_compact_to_isometric :
-  (linear_isometry_bounded_of_compact α E 𝕜).to_isometric = (isometric_bounded_of_compact α E) :=
+lemma linear_isometry_bounded_of_compact_to_isometry_equiv :
+  (linear_isometry_bounded_of_compact α E 𝕜).to_isometry_equiv = (isometry_equiv_bounded_of_compact α E) :=
 rfl
 
 @[simp]

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -260,7 +260,8 @@ rfl
 
 @[simp]
 lemma linear_isometry_bounded_of_compact_to_isometry_equiv :
-  (linear_isometry_bounded_of_compact α E 𝕜).to_isometry_equiv = (isometry_equiv_bounded_of_compact α E) :=
+  (linear_isometry_bounded_of_compact α E 𝕜).to_isometry_equiv =
+    (isometry_equiv_bounded_of_compact α E) :=
 rfl
 
 @[simp]

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -67,7 +67,7 @@ private def isometry_rel : nonempty_compacts ℓ_infty_ℝ → nonempty_compacts
 
 /-- This is indeed an equivalence relation -/
 private lemma is_equivalence_isometry_rel : equivalence isometry_rel :=
-⟨λ x, ⟨isometric.refl _⟩, λ x y ⟨e⟩, ⟨e.symm⟩, λ x y z ⟨e⟩ ⟨f⟩, ⟨e.trans f⟩⟩
+⟨λ x, ⟨isometry_equiv.refl _⟩, λ x y ⟨e⟩, ⟨e.symm⟩, λ x y z ⟨e⟩ ⟨f⟩, ⟨e.trans f⟩⟩
 
 /-- setoid instance identifying two isometric nonempty compact subspaces of ℓ^∞(ℝ) -/
 instance isometry_rel.setoid : setoid (nonempty_compacts ℓ_infty_ℝ) :=
@@ -93,13 +93,13 @@ begin
   simp only [to_GH_space, quotient.eq],
   refine ⟨λ h, _, _⟩,
   { rcases setoid.symm h with ⟨e⟩,
-    have f := (Kuratowski_embedding.isometry X).isometric_on_range.trans e,
+    have f := (Kuratowski_embedding.isometry X).isometry_equiv_on_range.trans e,
     use [λ x, f x, isometry_subtype_coe.comp f.isometry],
     rw [range_comp, f.range_eq_univ, set.image_univ, subtype.range_coe],
     refl },
   { rintros ⟨Ψ, ⟨isomΨ, rangeΨ⟩⟩,
-    have f := ((Kuratowski_embedding.isometry X).isometric_on_range.symm.trans
-               isomΨ.isometric_on_range).symm,
+    have f := ((Kuratowski_embedding.isometry X).isometry_equiv_on_range.symm.trans
+               isomΨ.isometry_equiv_on_range).symm,
     have E : (range Ψ ≃ᵢ nonempty_compacts.Kuratowski_embedding X) =
         (p ≃ᵢ range (Kuratowski_embedding X)),
       by { dunfold nonempty_compacts.Kuratowski_embedding, rw [rangeΨ]; refl },
@@ -127,7 +127,7 @@ end
 
 /-- Two nonempty compact spaces have the same image in `GH_space` if and only if they are
 isometric. -/
-lemma to_GH_space_eq_to_GH_space_iff_isometric {X : Type u} [metric_space X] [compact_space X]
+lemma to_GH_space_eq_to_GH_space_iff_isometry_equiv {X : Type u} [metric_space X] [compact_space X]
   [nonempty X] {Y : Type v} [metric_space Y] [compact_space Y] [nonempty Y] :
   to_GH_space X = to_GH_space Y ↔ nonempty (X ≃ᵢ Y) :=
 ⟨begin
@@ -137,15 +137,15 @@ lemma to_GH_space_eq_to_GH_space_iff_isometric {X : Type u} [metric_space X] [co
              (nonempty_compacts.Kuratowski_embedding Y))
           = ((range (Kuratowski_embedding X)) ≃ᵢ (range (Kuratowski_embedding Y))),
     by { dunfold nonempty_compacts.Kuratowski_embedding, refl },
-  have f := (Kuratowski_embedding.isometry X).isometric_on_range,
-  have g := (Kuratowski_embedding.isometry Y).isometric_on_range.symm,
+  have f := (Kuratowski_embedding.isometry X).isometry_equiv_on_range,
+  have g := (Kuratowski_embedding.isometry Y).isometry_equiv_on_range.symm,
   exact ⟨f.trans $ (cast I e).trans g⟩
 end,
 begin
   rintro ⟨e⟩,
   simp only [to_GH_space, quotient.eq],
-  have f := (Kuratowski_embedding.isometry X).isometric_on_range.symm,
-  have g := (Kuratowski_embedding.isometry Y).isometric_on_range,
+  have f := (Kuratowski_embedding.isometry X).isometry_equiv_on_range.symm,
+  have g := (Kuratowski_embedding.isometry Y).isometry_equiv_on_range,
   have I : ((range (Kuratowski_embedding X)) ≃ᵢ (range (Kuratowski_embedding Y))) =
     ((nonempty_compacts.Kuratowski_embedding X) ≃ᵢ
       (nonempty_compacts.Kuratowski_embedding Y)),
@@ -408,9 +408,9 @@ instance : metric_space GH_space :=
       { exact Hausdorff_edist_ne_top_of_nonempty_of_bounded (range_nonempty _)
           (range_nonempty _) hΦ.bounded hΨ.bounded } },
     have T : ((range Ψ) ≃ᵢ y.rep) = ((range Φ) ≃ᵢ y.rep), by rw this,
-    have eΨ := cast T Ψisom.isometric_on_range.symm,
-    have e := Φisom.isometric_on_range.trans eΨ,
-    rw [← x.to_GH_space_rep, ← y.to_GH_space_rep, to_GH_space_eq_to_GH_space_iff_isometric],
+    have eΨ := cast T Ψisom.isometry_equiv_on_range.symm,
+    have e := Φisom.isometry_equiv_on_range.trans eΨ,
+    rw [← x.to_GH_space_rep, ← y.to_GH_space_rep, to_GH_space_eq_to_GH_space_iff_isometry_equiv],
     exact ⟨e⟩
   end,
   dist_triangle := λ x y z, begin
@@ -1016,9 +1016,9 @@ begin
   have : ∀ n, (X3 n).to_GH_space = u n,
   { assume n,
     rw [nonempty_compacts.to_GH_space, ← (u n).to_GH_space_rep,
-        to_GH_space_eq_to_GH_space_iff_isometric],
+        to_GH_space_eq_to_GH_space_iff_isometry_equiv],
     constructor,
-    convert (isom n).isometric_on_range.symm, },
+    convert (isom n).isometry_equiv_on_range.symm, },
   -- Finally, we have proved the convergence of `u n`
   exact ⟨L.to_GH_space, by simpa only [this] using M⟩
 end

--- a/src/topology/metric_space/hausdorff_dimension.lean
+++ b/src/topology/metric_space/hausdorff_dimension.lean
@@ -387,7 +387,7 @@ end antilipschitz_with
 lemma isometry.dimH_image (hf : isometry f) (s : set X) : dimH (f '' s) = dimH s :=
 le_antisymm (hf.lipschitz.dimH_image_le _) (hf.antilipschitz.le_dimH_image _)
 
-namespace isometric
+namespace isometry_equiv
 
 @[simp] lemma dimH_image (e : X ≃ᵢ Y) (s : set X) : dimH (e '' s) = dimH s :=
 e.isometry.dimH_image s
@@ -398,7 +398,7 @@ by rw [← e.image_symm, e.symm.dimH_image]
 lemma dimH_univ (e : X ≃ᵢ Y) : dimH (univ : set X) = dimH (univ : set Y) :=
 by rw [← e.dimH_preimage univ, preimage_univ]
 
-end isometric
+end isometry_equiv
 
 namespace continuous_linear_equiv
 

--- a/src/topology/metric_space/isometry.lean
+++ b/src/topology/metric_space/isometry.lean
@@ -233,7 +233,7 @@ end
 
 /-- `α` and `β` are isometric if there is an isometric bijection between them. -/
 @[nolint has_nonempty_instance] -- such a bijection need not exist
-structure isometry_equiv (α : Type*) (β : Type*) [pseudo_emetric_space α] [pseudo_emetric_space β]
+structure isometry_equiv (α β : Type*) [pseudo_emetric_space α] [pseudo_emetric_space β]
   extends α ≃ β :=
 (isometry_to_fun  : isometry to_fun)
 

--- a/src/topology/metric_space/isometry.lean
+++ b/src/topology/metric_space/isometry.lean
@@ -233,13 +233,13 @@ end
 
 /-- `α` and `β` are isometric if there is an isometric bijection between them. -/
 @[nolint has_nonempty_instance] -- such a bijection need not exist
-structure isometric (α : Type*) (β : Type*) [pseudo_emetric_space α] [pseudo_emetric_space β]
+structure isometry_equiv (α : Type*) (β : Type*) [pseudo_emetric_space α] [pseudo_emetric_space β]
   extends α ≃ β :=
 (isometry_to_fun  : isometry to_fun)
 
-infix ` ≃ᵢ `:25 := isometric
+infix ` ≃ᵢ `:25 := isometry_equiv
 
-namespace isometric
+namespace isometry_equiv
 
 section pseudo_emetric_space
 variables [pseudo_emetric_space α] [pseudo_emetric_space β] [pseudo_emetric_space γ]
@@ -310,7 +310,7 @@ def simps.apply (h : α ≃ᵢ β) : α → β := h
 /-- See Note [custom simps projection] -/
 def simps.symm_apply (h : α ≃ᵢ β) : β → α := h.symm
 
-initialize_simps_projections isometric
+initialize_simps_projections isometry_equiv
   (to_equiv_to_fun → apply, to_equiv_inv_fun → symm_apply)
 
 @[simp] lemma symm_symm (h : α ≃ᵢ β) : h.symm.symm = h := to_equiv_inj h.to_equiv.symm_symm
@@ -394,9 +394,9 @@ h.to_homeomorph.comp_continuous_iff'
 
 /-- The group of isometries. -/
 instance : group (α ≃ᵢ α) :=
-  { one := isometric.refl _,
+  { one := isometry_equiv.refl _,
     mul := λ e₁ e₂, e₂.trans e₁,
-    inv := isometric.symm,
+    inv := isometry_equiv.symm,
     mul_assoc := λ e₁ e₂ e₃, rfl,
     one_mul := λ e, ext $ λ _, rfl,
     mul_one := λ e, ext $ λ _, rfl,
@@ -414,7 +414,7 @@ lemma mul_apply (e₁ e₂ : α ≃ᵢ α) (x : α) : (e₁ * e₂) x = e₁ (e�
 
 protected lemma complete_space [complete_space β] (e : α ≃ᵢ β) : complete_space α :=
 complete_space_of_is_complete_univ $ is_complete_of_complete_image e.isometry.uniform_inducing $
-  by rwa [set.image_univ, isometric.range_eq_univ, ← complete_space_iff_is_complete_univ]
+  by rwa [set.image_univ, isometry_equiv.range_eq_univ, ← complete_space_iff_is_complete_univ]
 
 lemma complete_space_iff (e : α ≃ᵢ β) : complete_space α ↔ complete_space β :=
 by { split; introI H, exacts [e.symm.complete_space, e.complete_space] }
@@ -460,12 +460,12 @@ by rw [← h.preimage_symm, h.symm.preimage_closed_ball, symm_symm]
 
 end pseudo_metric_space
 
-end isometric
+end isometry_equiv
 
 /-- An isometry induces an isometric isomorphism between the source space and the
 range of the isometry. -/
 @[simps to_equiv apply { simp_rhs := tt }]
-def isometry.isometric_on_range [emetric_space α] [pseudo_emetric_space β] {f : α → β}
+def isometry.isometry_equiv_on_range [emetric_space α] [pseudo_emetric_space β] {f : α → β}
   (h : isometry f) : α ≃ᵢ range f :=
 { isometry_to_fun := λx y, by simpa [subtype.edist_eq] using h x y,
   to_equiv := equiv.of_injective f h.injective }


### PR DESCRIPTION
The name for isometric bijections is changed to `isometry_equiv`, to be consistent with `linear_isometry_equiv` and `affine_isometry_equiv`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
