### PR TITLE
[Merged by Bors] - chore(test/gmonoid): Add a test of the gmonoid API

### DIFF
--- a/test/gmonoid.lean
+++ b/test/gmonoid.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2021 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import algebra.direct_sum.ring
+import data.fin.tuple.basic
+
+/-! # Tuples `fin na → α` form a graded monoid with `*` as `fin.append`
+
+Defining multiplication as concatenation isn't particularly canonical, so we do not provide
+this in mathlib. We could safely provide this instance on a type alias, but for now we just put
+this in `tests` to verify that this definition is possible. -/
+
+namespace fin
+
+variables {α : Type*} {α' : Type*} {na nb nc : ℕ}
+
+example {α : Type*} : graded_monoid.gmonoid (λ n, fin n → α) :=
+{ mul := λ i j, fin.append,
+  one := fin.elim0,
+  one_mul := λ b, sigma_eq_of_eq_comp_cast _ (elim0'_append _),
+  mul_one := λ a, sigma_eq_of_eq_comp_cast _ (append_elim0' _),
+  mul_assoc := λ a b c,
+    sigma_eq_of_eq_comp_cast (add_assoc _ _ _) $ (append_assoc a.2 b.2 c.2).trans rfl,
+  gnpow := λ n i a, repeat n a,
+  gnpow_zero' := λ a, sigma_eq_of_eq_comp_cast _ (repeat_zero _),
+  gnpow_succ' := λ a n, sigma_eq_of_eq_comp_cast _ (repeat_succ _ _) }
+
+end fin

--- a/test/gmonoid.lean
+++ b/test/gmonoid.lean
@@ -6,7 +6,7 @@ Authors: Eric Wieser
 import algebra.direct_sum.ring
 import data.fin.tuple.basic
 
-/-! # Tuples `fin na → α` form a graded monoid with `*` as `fin.append`
+/-! # Tuples `fin n → α` form a graded monoid with `*` as `fin.append`
 
 Defining multiplication as concatenation isn't particularly canonical, so we do not provide
 this in mathlib. We could safely provide this instance on a type alias, but for now we just put


### PR DESCRIPTION
This is taken from my CICM 2022 paper. I don't think the instance is canonical enough to be in mathlib, but it's useful to have a test that verifies it can be constructed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
