### PR TITLE
[Merged by Bors] - feat(algebra/triv_sq_zero_ext): lemmas about pow, and ring structure

### DIFF
--- a/src/algebra/triv_sq_zero_ext.lean
+++ b/src/algebra/triv_sq_zero_ext.lean
@@ -327,7 +327,7 @@ instance [monoid R] [add_monoid M] [distrib_mul_action R M] : mul_one_class (tsz
   .. triv_sq_zero_ext.has_mul }
 
 instance [add_monoid_with_one R] [add_monoid M] : add_monoid_with_one (tsze R M) :=
-{ nat_cast := λ n, (n, 0),
+{ nat_cast := λ n, inl n,
   nat_cast_zero := by simp [nat.cast],
   nat_cast_succ := λ _, by ext; simp [nat.cast],
   .. triv_sq_zero_ext.add_monoid,
@@ -341,7 +341,7 @@ instance [add_monoid_with_one R] [add_monoid M] : add_monoid_with_one (tsze R M)
   (inl n : tsze R M) = n := rfl
 
 instance [add_group_with_one R] [add_group M] : add_group_with_one (tsze R M) :=
-{ int_cast := λ z, (z, 0),
+{ int_cast := λ z, inl z,
   int_cast_of_nat := λ n, ext (int.cast_coe_nat _) rfl,
   int_cast_neg_succ_of_nat := λ n, ext (int.cast_neg_succ_of_nat _) neg_zero.symm,
   .. triv_sq_zero_ext.add_group,

--- a/src/algebra/triv_sq_zero_ext.lean
+++ b/src/algebra/triv_sq_zero_ext.lean
@@ -196,9 +196,13 @@ variables (M)
   (inl (r₁ + r₂) : tsze R M) = inl r₁ + inl r₂ :=
 ext rfl (add_zero 0).symm
 
-@[simp] lemma inl_neg [has_neg R] [add_group M] (r : R) :
+@[simp] lemma inl_neg [has_neg R] [sub_neg_zero_monoid M] (r : R) :
   (inl (-r) : tsze R M) = -inl r :=
 ext rfl neg_zero.symm
+
+@[simp] lemma inl_sub [has_sub R] [sub_neg_zero_monoid M] (r₁ r₂ : R) :
+  (inl (r₁ - r₂) : tsze R M) = inl r₁ - inl r₂ :=
+ext rfl (sub_zero _).symm
 
 @[simp] lemma inl_smul [monoid S] [add_monoid M] [has_smul S R] [distrib_mul_action S M]
   (s : S) (r : R) : (inl (s • r) : tsze R M) = s • inl r :=
@@ -215,9 +219,13 @@ variables (R)
   (inr (m₁ + m₂) : tsze R M) = inr m₁ + inr m₂ :=
 ext (add_zero 0).symm rfl
 
-@[simp] lemma inr_neg [add_group R] [has_neg M] (m : M) :
+@[simp] lemma inr_neg [sub_neg_zero_monoid R] [has_neg M] (m : M) :
   (inr (-m) : tsze R M) = -inr m :=
 ext neg_zero.symm rfl
+
+@[simp] lemma inr_sub [sub_neg_zero_monoid R] [has_sub M] (m₁ m₂ : M) :
+  (inr (m₁ - m₂) : tsze R M) = inr m₁ - inr m₂ :=
+ext (sub_zero _).symm rfl
 
 @[simp] lemma inr_smul [has_zero R] [has_zero S] [smul_with_zero S R] [has_smul S M]
   (r : S) (m : M) : (inr (r • m) : tsze R M) = r • inr m :=

--- a/src/algebra/triv_sq_zero_ext.lean
+++ b/src/algebra/triv_sq_zero_ext.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kenny Lau
+Authors: Kenny Lau, Eric Wieser
 -/
 
 import algebra.algebra.basic
@@ -113,6 +113,9 @@ prod.has_zero
 instance [has_add R] [has_add M] : has_add (tsze R M) :=
 prod.has_add
 
+instance [has_sub R] [has_sub M] : has_sub (tsze R M) :=
+prod.has_sub
+
 instance [has_neg R] [has_neg M] : has_neg (tsze R M) :=
 prod.has_neg
 
@@ -173,6 +176,11 @@ prod.module
 
 @[simp] lemma fst_neg [has_neg R] [has_neg M] (x : tsze R M) : (-x).fst = -x.fst := rfl
 @[simp] lemma snd_neg [has_neg R] [has_neg M] (x : tsze R M) : (-x).snd = -x.snd := rfl
+
+@[simp] lemma fst_sub [has_sub R] [has_sub M] (x₁ x₂ : tsze R M) :
+  (x₁ - x₂).fst = x₁.fst - x₂.fst := rfl
+@[simp] lemma snd_sub [has_sub R] [has_sub M] (x₁ x₂ : tsze R M) :
+  (x₁ - x₂).snd = x₁.snd - x₂.snd := rfl
 
 @[simp] lemma fst_smul [has_smul S R] [has_smul S M] (s : S) (x : tsze R M) :
   (s • x).fst = s • x.fst := rfl

--- a/src/algebra/triv_sq_zero_ext.lean
+++ b/src/algebra/triv_sq_zero_ext.lean
@@ -345,6 +345,11 @@ instance [comm_monoid R] [add_monoid M] [distrib_mul_action R M] : has_pow (tsze
   (x : tsze R M) (n : ℕ) :
   snd (x ^ n) = n • x.fst ^ n.pred • x.snd := rfl
 
+@[simp] lemma inl_pow [comm_monoid R] [add_monoid M] [distrib_mul_action R M]
+  (r : R) (n : ℕ) :
+  (inl r ^ n : tsze R M) = inl (r ^ n) :=
+ext rfl $ by simp
+
 instance [comm_monoid R] [add_monoid M] [distrib_mul_action R M] : monoid (tsze R M) :=
 { mul_assoc := λ x y z, ext (mul_assoc x.1 y.1 z.1) $
     show (x.1 * y.1) • z.2 + z.1 • (x.1 • y.2 + y.1 • x.2) =

--- a/src/algebra/triv_sq_zero_ext.lean
+++ b/src/algebra/triv_sq_zero_ext.lean
@@ -325,6 +325,27 @@ instance [add_monoid_with_one R] [add_monoid M] : add_monoid_with_one (tsze R M)
   .. triv_sq_zero_ext.add_monoid,
   .. triv_sq_zero_ext.has_one }
 
+@[simp] lemma fst_nat_cast [add_monoid_with_one R] [add_monoid M] (n : ℕ) :
+  (n : tsze R M).fst = n := rfl
+@[simp] lemma snd_nat_cast [add_monoid_with_one R] [add_monoid M] (n : ℕ) :
+  (n : tsze R M).snd = 0 := rfl
+@[simp] lemma inl_nat_cast [add_monoid_with_one R] [add_monoid M] (n : ℕ) :
+  (inl n : tsze R M) = n := rfl
+
+instance [add_group_with_one R] [add_group M] : add_group_with_one (tsze R M) :=
+{ int_cast := λ z, (z, 0),
+  int_cast_of_nat := λ n, ext (int.cast_coe_nat _) rfl,
+  int_cast_neg_succ_of_nat := λ n, ext (int.cast_neg_succ_of_nat _) neg_zero.symm,
+  .. triv_sq_zero_ext.add_group,
+  .. triv_sq_zero_ext.add_monoid_with_one }
+
+@[simp] lemma fst_int_cast [add_group_with_one R] [add_group M] (z : ℤ) :
+  (z : tsze R M).fst = z := rfl
+@[simp] lemma snd_int_cast [add_group_with_one R] [add_group M] (z : ℤ) :
+  (z : tsze R M).snd = 0 := rfl
+@[simp] lemma inl_int_cast [add_group_with_one R] [add_group M] (z : ℤ) :
+  (inl z : tsze R M) = z := rfl
+
 instance [semiring R] [add_comm_monoid M] [module R M] : non_assoc_semiring (tsze R M) :=
 { zero_mul := λ x, ext (zero_mul x.1) $ show (0 : R) • x.2 + x.1 • 0 = 0,
     by rw [zero_smul, zero_add, smul_zero],
@@ -341,6 +362,10 @@ instance [semiring R] [add_comm_monoid M] [module R M] : non_assoc_semiring (tsz
   .. triv_sq_zero_ext.add_monoid_with_one,
   .. triv_sq_zero_ext.mul_one_class,
   .. triv_sq_zero_ext.add_comm_monoid }
+
+instance [ring R] [add_comm_group M] [module R M] : non_assoc_ring (tsze R M) :=
+{ .. triv_sq_zero_ext.add_group_with_one,
+  .. triv_sq_zero_ext.non_assoc_semiring }
 
 instance [comm_monoid R] [add_monoid M] [distrib_mul_action R M] : has_pow (tsze R M) ℕ :=
 ⟨λ x n, ⟨x.fst^n, n • x.fst ^ n.pred • x.snd⟩⟩
@@ -383,17 +408,8 @@ instance [comm_semiring R] [add_comm_monoid M] [module R M] : comm_semiring (tsz
 { .. triv_sq_zero_ext.comm_monoid,
   .. triv_sq_zero_ext.non_assoc_semiring }
 
-instance [add_group_with_one R] [add_group M] : add_group_with_one (tsze R M) :=
-{ int_cast := λ z, (z, 0),
-  int_cast_of_nat := λ n, ext (int.cast_coe_nat _) rfl,
-  int_cast_neg_succ_of_nat := λ n, ext (int.cast_neg_succ_of_nat _) neg_zero.symm,
-  .. triv_sq_zero_ext.add_group,
-  .. triv_sq_zero_ext.add_monoid_with_one }
-
 instance [comm_ring R] [add_comm_group M] [module R M] : comm_ring (tsze R M) :=
-{ .. triv_sq_zero_ext.comm_monoid,
-  .. triv_sq_zero_ext.add_comm_group,
-  .. triv_sq_zero_ext.add_group_with_one,
+{ .. triv_sq_zero_ext.non_assoc_ring,
   .. triv_sq_zero_ext.comm_semiring }
 
 variables (R M)


### PR DESCRIPTION
`snd_pow : snd (x ^ n) = n • x.fst ^ n.pred • x.snd` captures the use of dual numbers in automatic differentiation.

Also add myself to the authors, since I've done some work on this file in the past.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
