### PR TITLE
feat(category_theory): Internal categories

### DIFF
--- a/src/category_theory/internal_category/basic.lean
+++ b/src/category_theory/internal_category/basic.lean
@@ -36,12 +36,20 @@ namespace category_theory
 
 universes v u
 
+/--
+A quiver internal to a category `𝔸`.
+-/
 structure internal_quiver (𝔸 : Type u) [category.{v} 𝔸] :=
 (Obj Arr : 𝔸)
 (s t : Arr ⟶ Obj)
 
 open internal_quiver
 
+/--
+An internal category without the composition axioms. Defining
+this first allows us to define functions to simply state the
+axioms of an internal category.
+-/
 structure internal_category_struct (𝔸 : Type u) [category.{v} 𝔸]
 extends internal_quiver 𝔸 :=
 (e : Obj ⟶ Arr)
@@ -80,14 +88,32 @@ instance comp : has_pullback 𝔻.t 𝔻.s := 𝔻.has_comp'
 instance assocₗ : has_pullback (𝔻.c ≫ 𝔻.t) 𝔻.s := 𝔻.has_assocₗ'
 instance assocᵣ : has_pullback 𝔻.t (𝔻.c ≫ 𝔻.s) := 𝔻.has_assocᵣ'
 
+/--
+The object `𝔻.Arr ×[𝔻.Obj] 𝔻.Arr`.
+-/
 def Arr_x_Arr' : 𝔸 := pullback 𝔻.t 𝔻.s
+
+/--
+The object `(𝔻.Arr ×[𝔻.Obj] 𝔻.Arr) ×[𝔻.Obj] 𝔻.Arr`.
+-/
 def Arr_x_Arr_x_Arrₗ' : 𝔸 := pullback (𝔻.c ≫ 𝔻.t) 𝔻.s
+
+/--
+The object `𝔻.Arr ×[𝔻.Obj] (𝔻.Arr ×[𝔻.Obj] 𝔻.Arr)`.
+-/
 def Arr_x_Arr_x_Arrᵣ' : 𝔸 := pullback 𝔻.t (𝔻.c ≫ 𝔻.s)
 
+/--
+The unique arrow `(𝔻.Arr ×[𝔻.Obj] 𝔻.Arr) ×[𝔻.Obj] 𝔻.Arr ⟶ 𝔻.Arr ×[𝔻.Obj] 𝔻.Arr`
+induced by `pullback.fst ≫ pullback.snd` and `pullback.snd`.
+-/
 def l_to_r_pair : Arr_x_Arr_x_Arrₗ' 𝔻 ⟶ Arr_x_Arr' 𝔻 :=
 pullback.lift (pullback.fst ≫ pullback.snd) pullback.snd
 (by {simp only [category.assoc, ← 𝔻.comp_target], exact pullback.condition})
 
+/--
+The associator to be used in the definition of an internal category.
+-/
 def associator' : Arr_x_Arr_x_Arrₗ' 𝔻 ⟶ Arr_x_Arr_x_Arrᵣ' 𝔻 :=
 pullback.lift (pullback.fst ≫ pullback.fst) (l_to_r_pair 𝔻)
 (by {
@@ -96,22 +122,45 @@ pullback.lift (pullback.fst ≫ pullback.fst) (l_to_r_pair 𝔻)
   by apply pullback.lift_fst,
   rw [pullback.condition, ← category.assoc, ← h, category.assoc, ← 𝔻.comp_source]})
 
+/--
+Given the composition `c` to be used in an internal category `𝔻`, define the unique
+morphism `(𝔻.Arr ×[𝔻.Obj] 𝔻.Arr) ×[𝔻.Obj] 𝔻.Arr ⟶ 𝔻.Arr ×[𝔻.Obj] 𝔻.Arr`
+induced by `pullback.fst ≫ c` and `pullback.snd`.
+-/
 def c_x_id₁' : Arr_x_Arr_x_Arrₗ' 𝔻 ⟶ Arr_x_Arr' 𝔻 :=
 pullback.lift (pullback.fst ≫ 𝔻.c) pullback.snd
 (by {simp only [category.assoc, ← 𝔻.comp_target], apply pullback.condition})
 
+/--
+Given the composition `c` to be used in an internal category `𝔻`, define the unique
+morphism `𝔻.Arr ×[𝔻.Obj] (𝔻.Arr ×[𝔻.Obj] 𝔻.Arr) ⟶ 𝔻.Arr ×[𝔻.Obj] 𝔻.Arr`
+induced by `pullback.fst` and `pullback.snd ≫ c`.
+-/
 def id₁_x_c' : Arr_x_Arr_x_Arrᵣ' 𝔻 ⟶ Arr_x_Arr' 𝔻 :=
 pullback.lift pullback.fst (pullback.snd ≫ 𝔻.c)
 (by {simp only [category.assoc, ← 𝔻.comp_target], apply pullback.condition})
 
+/--
+Given the source `s` and identity-assigning morphism `e` to be used in an internal
+category `𝔻`, define the unique morphism `𝔻.Arr ⟶ 𝔻.Arr ×[𝔻.Obj] 𝔻.Arr` induced
+by `s ≫ e` and `𝟙 𝔻.Arr`.
+-/
 def e_x_id₁' : 𝔻.Arr ⟶ Arr_x_Arr' 𝔻 :=
 pullback.lift (𝔻.s ≫ 𝔻.e) (𝟙 𝔻.Arr) (by simp)
 
+/--
+Given the target `t` and identity-assigning morphism `e` to be used in an internal
+category `𝔻`, define the unique morphism `𝔻.Arr ⟶ 𝔻.Arr ×[𝔻.Obj] 𝔻.Arr` induced
+by `𝟙 𝔻.Arr` and `t ≫ e`.
+-/
 def id₁_x_e' : 𝔻.Arr ⟶ Arr_x_Arr' 𝔻 :=
 pullback.lift (𝟙 𝔻.Arr) (𝔻.t ≫ 𝔻.e) (by simp)
 
 end
 
+/--
+Defines a category internal to a category `𝔸`.
+-/
 structure internal_category (𝔸 : Type u) [category.{v} 𝔸]
 extends internal_category_struct 𝔸 :=
 (assoc' : associator' _ ≫ id₁_x_c' _ ≫ c = c_x_id₁' _ ≫ c . obviously)
@@ -130,16 +179,52 @@ section
 
 variables (𝔻 : internal_category 𝔸)
 
+/--
+The un-ticked version of `Arr_x_Arr'`, intended for `internal_category`
+rather than `internal_category_struct`.
+-/
 def Arr_x_Arr : 𝔸 := Arr_x_Arr' 𝔻.to_internal_category_struct
+
+/--
+The un-ticked version of `Arr_x_Arr_x_Arrₗ'`, intended for `internal_category`
+rather than `internal_category_struct`.
+-/
 def Arr_x_Arr_x_Arrₗ : 𝔸 := Arr_x_Arr_x_Arrₗ' 𝔻.to_internal_category_struct
+
+/--
+The un-ticked version of `Arr_x_Arr_x_Arrᵣ'`, intended for `internal_category`
+rather than `internal_category_struct`.
+-/
 def Arr_x_Arr_x_Arrᵣ : 𝔸 := Arr_x_Arr_x_Arrᵣ' 𝔻.to_internal_category_struct
 
+/--
+The un-ticked version of `id₁_x_e'`, intended for `internal_category`
+rather than `internal_category_struct`.
+-/
 def id₁_x_e := id₁_x_e' 𝔻.to_internal_category_struct
 
+/--
+The un-ticked version of `e_x_id₁'`, intended for `internal_category`
+rather than `internal_category_struct`.
+-/
 def e_x_id₁ := e_x_id₁' 𝔻.to_internal_category_struct
 
+/--
+The un-ticked version of `c_x_id₁'`, intended for `internal_category`
+rather than `internal_category_struct`.
+-/
 def c_x_id₁ := c_x_id₁' 𝔻.to_internal_category_struct
+
+/--
+The un-ticked version of `id₁_x_c'`, intended for `internal_category`
+rather than `internal_category_struct`.
+-/
 def id₁_x_c := id₁_x_c' 𝔻.to_internal_category_struct
+
+/--
+The un-ticked version of `associator'`, intended for `internal_category`
+rather than `internal_category_struct`.
+-/
 def associator := associator' 𝔻.to_internal_category_struct
 
 @[simp]

--- a/src/category_theory/internal_category/basic.lean
+++ b/src/category_theory/internal_category/basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Zach Murray. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Zach Murray.
+Authors: Zach Murray
 -/
 import category_theory.category.basic
 import category_theory.limits.shapes.pullbacks
@@ -20,8 +20,8 @@ A category internal to a category `𝔸` consists of the following data in `𝔸
 * An identity-assigning morphism `e : Obj ⟶ Arr`, and
 * A composition morphism `c : Arr ₜ×ₛ Arr ⟶ Arr`,
 
-satisfying the typical category axioms. We do not ask that `𝔸` have all pullbacks, only those used in specifying
-the contents and axioms of an internal category.
+satisfying the typical category axioms. We do not ask that `𝔸` have all pullbacks, only those used
+in specifying the contents and axioms of an internal category.
 
 ## Notation
 
@@ -91,11 +91,10 @@ pullback.lift (pullback.fst ≫ pullback.snd) pullback.snd
 def associator' : Arr_x_Arr_x_Arrₗ' 𝔻 ⟶ Arr_x_Arr_x_Arrᵣ' 𝔻 :=
 pullback.lift (pullback.fst ≫ pullback.fst) (l_to_r_pair 𝔻)
 (by {
-      rw category.assoc,
-      have h : l_to_r_pair 𝔻 ≫ pullback.fst = pullback.fst ≫ pullback.snd,
-        by apply pullback.lift_fst,
-      rw [pullback.condition, ← category.assoc, ← h,
-                             category.assoc, ← 𝔻.comp_source]})
+  rw category.assoc,
+  have h : l_to_r_pair 𝔻 ≫ pullback.fst = pullback.fst ≫ pullback.snd,
+  by apply pullback.lift_fst,
+  rw [pullback.condition, ← category.assoc, ← h, category.assoc, ← 𝔻.comp_source]})
 
 def c_x_id₁' : Arr_x_Arr_x_Arrₗ' 𝔻 ⟶ Arr_x_Arr' 𝔻 :=
 pullback.lift (pullback.fst ≫ 𝔻.c) pullback.snd
@@ -165,40 +164,37 @@ lemma pullback.lift_associate_comp_left :
   pullback.lift (pullback.lift f g h₁) h (by simpa) ≫ c_x_id₁ 𝔼 =
   pullback.lift (pullback.lift f g h₁ ≫ 𝔼.c) h (by simpa) :=
 begin
-apply pullback.lift_unique,
-repeat {
-  dunfold c_x_id₁,
-  dunfold c_x_id₁',
-  simp
-},
+  apply pullback.lift_unique,
+  repeat {
+    dunfold c_x_id₁,
+    dunfold c_x_id₁',
+   simp }
 end
 
 lemma pullback.lift_associate_comp_right :
   pullback.lift f (pullback.lift g h h₂) (by simpa) ≫ id₁_x_c 𝔼 =
   pullback.lift f (pullback.lift g h h₂ ≫ 𝔼.c) (by simpa) :=
 begin
-apply pullback.lift_unique,
-repeat {
-  dunfold id₁_x_c,
-  dunfold id₁_x_c',
-  simp
-}
+  apply pullback.lift_unique,
+  repeat {
+    dunfold id₁_x_c,
+    dunfold id₁_x_c',
+    simp }
 end
 
 lemma pullback.lift_associator :
   pullback.lift (pullback.lift f g h₁) h (by simpa) ≫ associator 𝔼 =
   pullback.lift f (pullback.lift g h h₂) (by simpa) :=
 begin
-apply pullback.lift_unique,
+  apply pullback.lift_unique,
 
-repeat {
-  dunfold associator,
-  dunfold associator',
-  simp,
-},
-dunfold l_to_r_pair,
-rw ← pullback.lift_comp,
-simp,
+  repeat {
+    dunfold associator,
+    dunfold associator',
+    simp },
+  dunfold l_to_r_pair,
+  rw ← pullback.lift_comp,
+  simp
 end
 
 @[simp]
@@ -206,11 +202,12 @@ lemma pullback.lift_assoc :
   pullback.lift (pullback.lift f g h₁ ≫ 𝔼.c) h (by simpa) ≫ 𝔼.c =
   pullback.lift f (pullback.lift g h h₂ ≫ 𝔼.c) (by simpa) ≫ 𝔼.c :=
 begin
-rw [← pullback.lift_associate_comp_left, ← pullback.lift_associate_comp_right, ← pullback.lift_associator],
-dunfold associator,
-dunfold c_x_id₁,
-dunfold id₁_x_c,
-simp only [category.assoc, 𝔼.assoc],
+  rw [← pullback.lift_associate_comp_left, ← pullback.lift_associate_comp_right,
+      ← pullback.lift_associator],
+  dunfold associator,
+  dunfold c_x_id₁,
+  dunfold id₁_x_c,
+  simp only [category.assoc, 𝔼.assoc]
 end
 
 end
@@ -223,26 +220,24 @@ variables {𝔻 𝔼 : internal_category 𝔸}
 lemma pullback.lift_id_left {X : 𝔸} (f : X ⟶ 𝔼.Arr) :
   pullback.lift (f ≫ 𝔼.s ≫ 𝔼.e) f (by simp) = f ≫ e_x_id₁ 𝔼 :=
 begin
-symmetry,
-apply pullback.lift_unique,
-repeat {
-  dunfold e_x_id₁,
-  dunfold e_x_id₁',
-  simp,
-}
+  symmetry,
+  apply pullback.lift_unique,
+  repeat {
+    dunfold e_x_id₁,
+    dunfold e_x_id₁',
+    simp }
 end
 
 @[simp]
 lemma pullback.lift_id_right {X : 𝔸} (f : X ⟶ 𝔼.Arr) :
   pullback.lift f (f ≫ 𝔼.t ≫ 𝔼.e) (by simp) = f ≫ id₁_x_e 𝔼 :=
 begin
-symmetry,
-apply pullback.lift_unique,
-repeat {
-  dunfold id₁_x_e,
-  dunfold id₁_x_e',
-  simp,
-}
+  symmetry,
+  apply pullback.lift_unique,
+  repeat {
+    dunfold id₁_x_e,
+    dunfold id₁_x_e',
+    simp }
 end
 
 end

--- a/src/category_theory/internal_category/basic.lean
+++ b/src/category_theory/internal_category/basic.lean
@@ -1,0 +1,252 @@
+/-
+Copyright (c) 2023 Zach Murray. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Zach Murray.
+-/
+import category_theory.category.basic
+import category_theory.limits.shapes.pullbacks
+open category_theory
+open category_theory.limits
+
+/-!
+# Internal Categories
+
+In this file we define categories internal to other categories.
+
+A category internal to a category `𝔸` consists of the following data in `𝔸`:
+* An object `Obj : 𝔸` of objects,
+* An object `Arr : 𝔸` of arrows,
+* Source and target morphisms `s,t : Arr ⟶ Obj`,
+* An identity-assigning morphism `e : Obj ⟶ Arr`, and
+* A composition morphism `c : Arr ₜ×ₛ Arr ⟶ Arr`,
+
+satisfying the typical category axioms. We do not ask that `𝔸` have all pullbacks, only those used in specifying
+the contents and axioms of an internal category.
+
+## Notation
+
+To make the axioms more readable, we implement a number of notations, such as `e_x_id₁` for
+`e × 𝟙 C₁ : Obj × Arr ⟶ Arr` and
+`Arr_x_Arr_x_Arrₗ` for `(Arr × Arr) × Arr`.
+-/
+
+noncomputable theory
+
+namespace category_theory
+
+universes v u
+
+structure internal_quiver (𝔸 : Type u) [category.{v} 𝔸] :=
+(Obj Arr : 𝔸)
+(s t : Arr ⟶ Obj)
+
+open internal_quiver
+
+structure internal_category_struct (𝔸 : Type u) [category.{v} 𝔸]
+extends internal_quiver 𝔸 :=
+(e : Obj ⟶ Arr)
+(has_comp' : has_pullback t s)
+(c : pullback t s ⟶ Arr)
+(has_assocₗ' : has_pullback (c ≫ t) s)
+(has_assocᵣ': has_pullback t (c ≫ s))
+(id_source' : e ≫ s = 𝟙 Obj . obviously)
+(id_target' : e ≫ t = 𝟙 Obj . obviously)
+(comp_source' : c ≫ s = pullback.fst ≫ s . obviously)
+(comp_target' : c ≫ t = pullback.snd ≫ t . obviously)
+
+open internal_category_struct
+
+restate_axiom internal_category_struct.has_comp'
+restate_axiom internal_category_struct.has_assocₗ'
+restate_axiom internal_category_struct.has_assocᵣ'
+restate_axiom internal_category_struct.id_source'
+restate_axiom internal_category_struct.id_target'
+restate_axiom internal_category_struct.comp_source'
+restate_axiom internal_category_struct.comp_target'
+attribute [simp] internal_category_struct.id_source
+attribute [simp] internal_category_struct.id_target
+attribute [simp] internal_category_struct.comp_source
+attribute [simp] internal_category_struct.comp_target
+
+section
+
+variables {𝔸 : Type u} [category.{v} 𝔸]
+
+section
+
+variable (𝔻 : internal_category_struct 𝔸)
+
+instance comp : has_pullback 𝔻.t 𝔻.s := 𝔻.has_comp'
+instance assocₗ : has_pullback (𝔻.c ≫ 𝔻.t) 𝔻.s := 𝔻.has_assocₗ'
+instance assocᵣ : has_pullback 𝔻.t (𝔻.c ≫ 𝔻.s) := 𝔻.has_assocᵣ'
+
+def Arr_x_Arr' : 𝔸 := pullback 𝔻.t 𝔻.s
+def Arr_x_Arr_x_Arrₗ' : 𝔸 := pullback (𝔻.c ≫ 𝔻.t) 𝔻.s
+def Arr_x_Arr_x_Arrᵣ' : 𝔸 := pullback 𝔻.t (𝔻.c ≫ 𝔻.s)
+
+def l_to_r_pair : Arr_x_Arr_x_Arrₗ' 𝔻 ⟶ Arr_x_Arr' 𝔻 :=
+pullback.lift (pullback.fst ≫ pullback.snd) pullback.snd
+(by {simp only [category.assoc, ← 𝔻.comp_target], exact pullback.condition})
+
+def associator' : Arr_x_Arr_x_Arrₗ' 𝔻 ⟶ Arr_x_Arr_x_Arrᵣ' 𝔻 :=
+pullback.lift (pullback.fst ≫ pullback.fst) (l_to_r_pair 𝔻)
+(by {
+      rw category.assoc,
+      have h : l_to_r_pair 𝔻 ≫ pullback.fst = pullback.fst ≫ pullback.snd,
+        by apply pullback.lift_fst,
+      rw [pullback.condition, ← category.assoc, ← h,
+                             category.assoc, ← 𝔻.comp_source]})
+
+def c_x_id₁' : Arr_x_Arr_x_Arrₗ' 𝔻 ⟶ Arr_x_Arr' 𝔻 :=
+pullback.lift (pullback.fst ≫ 𝔻.c) pullback.snd
+(by {simp only [category.assoc, ← 𝔻.comp_target], apply pullback.condition})
+
+def id₁_x_c' : Arr_x_Arr_x_Arrᵣ' 𝔻 ⟶ Arr_x_Arr' 𝔻 :=
+pullback.lift pullback.fst (pullback.snd ≫ 𝔻.c)
+(by {simp only [category.assoc, ← 𝔻.comp_target], apply pullback.condition})
+
+def e_x_id₁' : 𝔻.Arr ⟶ Arr_x_Arr' 𝔻 :=
+pullback.lift (𝔻.s ≫ 𝔻.e) (𝟙 𝔻.Arr) (by simp)
+
+def id₁_x_e' : 𝔻.Arr ⟶ Arr_x_Arr' 𝔻 :=
+pullback.lift (𝟙 𝔻.Arr) (𝔻.t ≫ 𝔻.e) (by simp)
+
+end
+
+structure internal_category (𝔸 : Type u) [category.{v} 𝔸]
+extends internal_category_struct 𝔸 :=
+(assoc' : associator' _ ≫ id₁_x_c' _ ≫ c = c_x_id₁' _ ≫ c . obviously)
+(id_left' : e_x_id₁' _≫ c = 𝟙 Arr . obviously)
+(id_right' : id₁_x_e' _ ≫ c = 𝟙 Arr . obviously)
+
+restate_axiom internal_category.assoc'
+restate_axiom internal_category.id_left'
+restate_axiom internal_category.id_right'
+attribute [simp] internal_category.id_left
+attribute [simp] internal_category.id_right
+
+open internal_category
+
+section
+
+variables (𝔻 : internal_category 𝔸)
+
+def Arr_x_Arr : 𝔸 := Arr_x_Arr' 𝔻.to_internal_category_struct
+def Arr_x_Arr_x_Arrₗ : 𝔸 := Arr_x_Arr_x_Arrₗ' 𝔻.to_internal_category_struct
+def Arr_x_Arr_x_Arrᵣ : 𝔸 := Arr_x_Arr_x_Arrᵣ' 𝔻.to_internal_category_struct
+
+def id₁_x_e := id₁_x_e' 𝔻.to_internal_category_struct
+
+def e_x_id₁ := e_x_id₁' 𝔻.to_internal_category_struct
+
+def c_x_id₁ := c_x_id₁' 𝔻.to_internal_category_struct
+def id₁_x_c := id₁_x_c' 𝔻.to_internal_category_struct
+def associator := associator' 𝔻.to_internal_category_struct
+
+@[simp]
+lemma internal_category.id_left₂ : e_x_id₁ 𝔻 ≫ 𝔻.c = 𝟙 𝔻.Arr :=
+𝔻.id_left
+
+@[simp]
+lemma internal_category.id_right₂ : id₁_x_e 𝔻 ≫ 𝔻.c = 𝟙 𝔻.Arr :=
+𝔻.id_right
+
+end
+
+section
+
+variables {𝔻 𝔼 : internal_category 𝔸}
+          {X : 𝔸} (f g h : X ⟶ 𝔼.Arr)
+          (h₁ : f ≫ 𝔼.t = g ≫ 𝔼.s) (h₂ : g ≫ 𝔼.t = h ≫ 𝔼.s)
+
+include h₁ h₂
+
+lemma pullback.lift_associate_comp_left :
+  pullback.lift (pullback.lift f g h₁) h (by simpa) ≫ c_x_id₁ 𝔼 =
+  pullback.lift (pullback.lift f g h₁ ≫ 𝔼.c) h (by simpa) :=
+begin
+apply pullback.lift_unique,
+repeat {
+  dunfold c_x_id₁,
+  dunfold c_x_id₁',
+  simp
+},
+end
+
+lemma pullback.lift_associate_comp_right :
+  pullback.lift f (pullback.lift g h h₂) (by simpa) ≫ id₁_x_c 𝔼 =
+  pullback.lift f (pullback.lift g h h₂ ≫ 𝔼.c) (by simpa) :=
+begin
+apply pullback.lift_unique,
+repeat {
+  dunfold id₁_x_c,
+  dunfold id₁_x_c',
+  simp
+}
+end
+
+lemma pullback.lift_associator :
+  pullback.lift (pullback.lift f g h₁) h (by simpa) ≫ associator 𝔼 =
+  pullback.lift f (pullback.lift g h h₂) (by simpa) :=
+begin
+apply pullback.lift_unique,
+
+repeat {
+  dunfold associator,
+  dunfold associator',
+  simp,
+},
+dunfold l_to_r_pair,
+rw ← pullback.lift_comp,
+simp,
+end
+
+@[simp]
+lemma pullback.lift_assoc :
+  pullback.lift (pullback.lift f g h₁ ≫ 𝔼.c) h (by simpa) ≫ 𝔼.c =
+  pullback.lift f (pullback.lift g h h₂ ≫ 𝔼.c) (by simpa) ≫ 𝔼.c :=
+begin
+rw [← pullback.lift_associate_comp_left, ← pullback.lift_associate_comp_right, ← pullback.lift_associator],
+dunfold associator,
+dunfold c_x_id₁,
+dunfold id₁_x_c,
+simp only [category.assoc, 𝔼.assoc],
+end
+
+end
+
+section
+
+variables {𝔻 𝔼 : internal_category 𝔸}
+
+@[simp]
+lemma pullback.lift_id_left {X : 𝔸} (f : X ⟶ 𝔼.Arr) :
+  pullback.lift (f ≫ 𝔼.s ≫ 𝔼.e) f (by simp) = f ≫ e_x_id₁ 𝔼 :=
+begin
+symmetry,
+apply pullback.lift_unique,
+repeat {
+  dunfold e_x_id₁,
+  dunfold e_x_id₁',
+  simp,
+}
+end
+
+@[simp]
+lemma pullback.lift_id_right {X : 𝔸} (f : X ⟶ 𝔼.Arr) :
+  pullback.lift f (f ≫ 𝔼.t ≫ 𝔼.e) (by simp) = f ≫ id₁_x_e 𝔼 :=
+begin
+symmetry,
+apply pullback.lift_unique,
+repeat {
+  dunfold id₁_x_e,
+  dunfold id₁_x_e',
+  simp,
+}
+end
+
+end
+
+end
+
+end category_theory

--- a/src/category_theory/internal_category/basic.lean
+++ b/src/category_theory/internal_category/basic.lean
@@ -245,3 +245,4 @@ end
 end
 
 end category_theory
+#lint

--- a/src/category_theory/internal_functor/basic.lean
+++ b/src/category_theory/internal_functor/basic.lean
@@ -33,6 +33,9 @@ universes v u
 
 variables {𝔸 : Type u} [category.{v} 𝔸]
 
+/--
+A morphism of internal quivers `𝔻` and `𝔼`, denoted by `𝔻 ⟹' 𝔼`.
+-/
 structure internal_prefunctor (𝔻 𝔼 : internal_quiver 𝔸) :=
 (obj : 𝔻.Obj ⟶ 𝔼.Obj)
 (arr : 𝔻.Arr ⟶ 𝔼.Arr)
@@ -48,6 +51,9 @@ attribute [simp, reassoc] internal_prefunctor.resp_target
 
 infixr ` ⟹' ` : 26 := internal_prefunctor
 
+/--
+The identity internal prefunctor of an internal quiver `𝔻`, given by `ι' 𝔻`.
+-/
 def id_internal_prefunctor (𝔻 : internal_quiver 𝔸) : 𝔻 ⟹' 𝔻 :=
 { obj := 𝟙 𝔻.Obj,
   arr := 𝟙 𝔻.Arr }
@@ -62,11 +68,16 @@ lemma id_internal_prefunctor.obj (𝔻 : internal_quiver 𝔸) :
 lemma id_internal_prefunctor.arr (𝔻 : internal_quiver 𝔸) :
   (ι' 𝔻).arr = 𝟙 𝔻.Arr := rfl
 
+instance (𝔻 : internal_quiver 𝔸) : inhabited (internal_prefunctor 𝔻 𝔻) :=
+⟨id_internal_prefunctor 𝔻⟩
+
 section
 
 variables {𝔻 𝔼 𝔽 : internal_quiver 𝔸}
 
--- Helper function for defining composition of internal prefunctors.
+/--
+Helper function for defining composition of internal prefunctors.
+-/
 private def comp_helper (F : 𝔻 ⟹' 𝔼) (G : 𝔼 ⟹' 𝔽) :
   ∀ {f : 𝔻.Arr ⟶ 𝔻.Obj} {g : 𝔼.Arr ⟶ 𝔼.Obj} {h : 𝔽.Arr ⟶ 𝔽.Obj},
   f ≫ F.obj = F.arr ≫ g →
@@ -77,6 +88,9 @@ begin
   rw [← category.assoc, h₁, category.assoc, h₂, ← category.assoc],
 end
 
+/--
+The composition of internal prefunctors `F` and `G`, given by `F ›' G`.
+-/
 def internal_prefunctor_comp (F : 𝔻 ⟹' 𝔼) (G : 𝔼 ⟹' 𝔽) : 𝔻 ⟹' 𝔽 :=
 { obj := F.obj ≫ G.obj,
   arr := F.arr ≫ G.arr,
@@ -103,6 +117,12 @@ section
 
 variables {𝔻 𝔼 : internal_category 𝔸}
 
+/--
+Given an internal prefunctor `F` of `𝔻 𝔼 : internal_category 𝔸`, returns the
+unique morphism `arr_x_arr' F : Arr_x_Arr 𝔻 ⟶ Arr_x_Arr 𝔼`, i.e.
+`F₁ × F₁ : 𝔻.Arr ×[𝔻.Obj] 𝔻.Arr ⟶ 𝔼.Arr ×[𝔼.Obj] 𝔼.Arr`, induced by
+`pullback.fst ≫ F.arr` and `pullback.snd ≫ F.arr`.
+-/
 def arr_x_arr' (F : 𝔻.to_internal_quiver ⟹' 𝔼.to_internal_quiver) :
   Arr_x_Arr 𝔻 ⟶ Arr_x_Arr 𝔼 :=
 pullback.lift (pullback.fst ≫ F.arr) (pullback.snd ≫ F.arr)
@@ -112,6 +132,9 @@ pullback.lift (pullback.fst ≫ F.arr) (pullback.snd ≫ F.arr)
 
 end
 
+/--
+Given internal categories `𝔻` and `𝔼`, defines internal functors `𝔻 ⟹ 𝔼`.
+-/
 structure internal_functor (𝔻 𝔼 : internal_category 𝔸)
 extends internal_prefunctor 𝔻.to_internal_quiver 𝔼.to_internal_quiver :=
 (resp_id' : 𝔻.e ≫ arr = obj ≫ 𝔼.e . obviously)
@@ -128,6 +151,12 @@ section
 
 variables {𝔻 𝔼 : internal_category 𝔸}
 
+/--
+Given an internal functor `F` of `𝔻 𝔼 : internal_category 𝔸`, returns the
+unique morphism `arr_x_arr' F : Arr_x_Arr 𝔻 ⟶ Arr_x_Arr 𝔼`, i.e.
+`F₁ × F₁ : 𝔻.Arr ×[𝔻.Obj] 𝔻.Arr ⟶ 𝔼.Arr ×[𝔼.Obj] 𝔼.Arr`, induced by
+`pullback.fst ≫ F.arr` and `pullback.snd ≫ F.arr`.
+-/
 def arr_x_arr (F : 𝔻 ⟹ 𝔼) : Arr_x_Arr 𝔻 ⟶ Arr_x_Arr 𝔼 :=
 arr_x_arr' F.to_internal_prefunctor
 
@@ -152,6 +181,9 @@ begin
   repeat {simp}
 end
 
+/--
+The identity internal prefunctor of an internal category `𝔻`, given by `ι 𝔻`.
+-/
 def id_internal_functor (𝔻 : internal_category 𝔸) : 𝔻 ⟹ 𝔻 :=
 { obj := (ι' 𝔻.to_internal_quiver).obj,
   arr := (ι' 𝔻.to_internal_quiver).arr,
@@ -171,6 +203,9 @@ lemma id_internal_functor.obj (𝔻 : internal_category 𝔸) :
 lemma id_internal_functor.arr (𝔻 : internal_category 𝔸) :
   (ι 𝔻).arr = 𝟙 𝔻.Arr := rfl
 
+instance (𝔻 : internal_category 𝔸) : inhabited (internal_functor 𝔻 𝔻) :=
+⟨id_internal_functor 𝔻⟩
+
 section
 
 variables {𝔻 𝔼 𝔽 : internal_category 𝔸}
@@ -186,6 +221,9 @@ begin
   repeat {dunfold arr_x_arr', simp}
 end
 
+/--
+The composition of internal functors `F` and `G`, given by `F › G`.
+-/
 def internal_functor_comp (F : 𝔻 ⟹ 𝔼) (G : 𝔼 ⟹ 𝔽) : 𝔻 ⟹ 𝔽 :=
 { obj := F.obj ≫ G.obj,
   arr := F.arr ≫ G.arr,

--- a/src/category_theory/internal_functor/basic.lean
+++ b/src/category_theory/internal_functor/basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Zach Murray. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Zach Murray.
+Authors: Zach Murray
 -/
 import category_theory.category.basic
 import category_theory.limits.shapes.pullbacks
@@ -49,10 +49,8 @@ attribute [simp, reassoc] internal_prefunctor.resp_target
 infixr ` ⟹' ` : 26 := internal_prefunctor
 
 def id_internal_prefunctor (𝔻 : internal_quiver 𝔸) : 𝔻 ⟹' 𝔻 :=
-{
-  obj := 𝟙 𝔻.Obj,
-  arr := 𝟙 𝔻.Arr,
-}
+{ obj := 𝟙 𝔻.Obj,
+  arr := 𝟙 𝔻.Arr }
 
 notation `ι'` := id_internal_prefunctor
 
@@ -75,17 +73,15 @@ private def comp_helper (F : 𝔻 ⟹' 𝔼) (G : 𝔼 ⟹' 𝔽) :
   g ≫ G.obj = G.arr ≫ h →
   f ≫ (F.obj ≫ G.obj) = (F.arr ≫ G.arr) ≫ h :=
 begin
-intros f g h h₁ h₂,
-rw [← category.assoc, h₁, category.assoc, h₂, ← category.assoc],
+  intros f g h h₁ h₂,
+  rw [← category.assoc, h₁, category.assoc, h₂, ← category.assoc],
 end
 
 def internal_prefunctor_comp (F : 𝔻 ⟹' 𝔼) (G : 𝔼 ⟹' 𝔽) : 𝔻 ⟹' 𝔽 :=
-{
-  obj := F.obj ≫ G.obj,
+{ obj := F.obj ≫ G.obj,
   arr := F.arr ≫ G.arr,
   resp_source' := by {rw ← category.assoc, simp [F.resp_source, G.resp_source]},
-  resp_target' := by {rw ← category.assoc, simp [F.resp_target, G.resp_target]},
-}
+  resp_target' := by {rw ← category.assoc, simp [F.resp_target, G.resp_target]} }
 
 infixr ` ›' `:80 := internal_prefunctor_comp
 
@@ -112,8 +108,7 @@ def arr_x_arr' (F : 𝔻.to_internal_quiver ⟹' 𝔼.to_internal_quiver) :
 pullback.lift (pullback.fst ≫ F.arr) (pullback.snd ≫ F.arr)
 (by {
   rw [category.assoc, ← F.resp_target, ← category.assoc, pullback.condition],
-  simp [F.resp_source],
-})
+  simp [F.resp_source] })
 
 end
 
@@ -152,22 +147,19 @@ end
 lemma id_internal_prefunctor_to_identity (𝔻 : internal_category 𝔸) :
   arr_x_arr' (ι' 𝔻.to_internal_quiver) = 𝟙 (Arr_x_Arr 𝔻) :=
 begin
-symmetry,
-apply pullback.lift_unique,
-repeat {simp},
+  symmetry,
+  apply pullback.lift_unique,
+  repeat {simp}
 end
 
 def id_internal_functor (𝔻 : internal_category 𝔸) : 𝔻 ⟹ 𝔻 :=
-{
-  obj := (ι' 𝔻.to_internal_quiver).obj,
+{ obj := (ι' 𝔻.to_internal_quiver).obj,
   arr := (ι' 𝔻.to_internal_quiver).arr,
   resp_comp' := by {
     have h : 𝔻.c ≫ (ι' 𝔻.to_internal_quiver).arr =
       arr_x_arr' (ι' 𝔻.to_internal_quiver) ≫ 𝔻.c,
     by {simp, dunfold Arr_x_Arr, dunfold Arr_x_Arr', simp},
-    exact h,
-  }
-}
+    exact h } }
 
 notation `ι` := id_internal_functor
 
@@ -189,14 +181,13 @@ lemma comp_arr_x_arr'
   (G : 𝔼.to_internal_quiver ⟹' 𝔽.to_internal_quiver) :
   arr_x_arr' (F ›' G) = arr_x_arr' F ≫ arr_x_arr' G :=
 begin
-symmetry,
-apply pullback.lift_unique,
-repeat {dunfold arr_x_arr', simp},
+  symmetry,
+  apply pullback.lift_unique,
+  repeat {dunfold arr_x_arr', simp}
 end
 
 def internal_functor_comp (F : 𝔻 ⟹ 𝔼) (G : 𝔼 ⟹ 𝔽) : 𝔻 ⟹ 𝔽 :=
-{
-  obj := F.obj ≫ G.obj,
+{ obj := F.obj ≫ G.obj,
   arr := F.arr ≫ G.arr,
   resp_source' := comp_helper _ _ F.resp_source G.resp_source,
   resp_target' := comp_helper _ _ F.resp_target G.resp_target,
@@ -204,11 +195,10 @@ def internal_functor_comp (F : 𝔻 ⟹ 𝔼) (G : 𝔼 ⟹ 𝔽) : 𝔻 ⟹ �
     rw ← category.assoc,
     simp [F.resp_id, G.resp_id],
   },
-  resp_comp' := by {
-    calc 𝔻.c ≫ F.arr ≫ G.arr = (arr_x_arr' F.to_internal_prefunctor ≫ 𝔼.c) ≫ G.arr : by simp [← F.resp_comp]
-                          ... = arr_x_arr' (_ ›' _) ≫ 𝔽.c                             : by simp [G.resp_comp],
-  },
-}
+  resp_comp' := calc
+    𝔻.c ≫ F.arr ≫ G.arr
+        = (arr_x_arr' F.to_internal_prefunctor ≫ 𝔼.c) ≫ G.arr : by simp [← F.resp_comp]
+    ... = arr_x_arr' (_ ›' _) ≫ 𝔽.c                             : by simp [G.resp_comp] }
 
 infixr ` › `:80 := internal_functor_comp
 
@@ -225,10 +215,11 @@ lemma pullback.lift.internal_map.left
   (F : 𝔼 ⟹ 𝔽) (f g : 𝔻.Arr ⟶ 𝔼.Arr) (h : f ≫ 𝔼.t = g ≫ 𝔼.s) :
   pullback.lift f g h ≫ arr_x_arr F =
   pullback.lift (f ≫ F.arr) (g ≫ F.arr)
-    (by {simp only [category.assoc, ← F.resp_source, ← F.resp_target], rw [← category.assoc], simp [h]}) :=
+    (by {simp only [category.assoc, ← F.resp_source, ← F.resp_target], rw [← category.assoc],
+         simp [h]}) :=
 begin
-apply pullback.lift_unique,
-repeat {simp},
+  apply pullback.lift_unique,
+  repeat {simp}
 end
 
 end
@@ -237,9 +228,9 @@ end
 lemma internal_prefunctor.ext {𝔻 𝔼 : internal_quiver 𝔸} {F G : 𝔻 ⟹' 𝔼}
   (h₁ : F.obj = G.obj) (h₂ : F.arr = G.arr) : F = G :=
 begin
-cases F,
-cases G,
-congr',
+  cases F,
+  cases G,
+  congr'
 end
 
 section
@@ -249,36 +240,36 @@ variables {𝔻 𝔼 : internal_category 𝔸}
 lemma internal_prefunctor_to_functor_equality {F G : 𝔻 ⟹ 𝔼} :
   F = G ↔ F.to_internal_prefunctor = G.to_internal_prefunctor :=
 begin
-split,
+  split,
 
-rintros rfl, refl,
+  rintros rfl, refl,
 
-intro h,
-cases F,
-cases G,
-congr',
+  intro h,
+  cases F,
+  cases G,
+  congr'
 end
 
 @[ext]
 lemma internal_functor.ext {F G : 𝔻 ⟹ 𝔼}
   (h₁ : F.obj = G.obj) (h₂ : F.arr = G.arr) : F = G :=
 begin
-rw internal_prefunctor_to_functor_equality,
-apply internal_prefunctor.ext,
-exact h₁,
-exact h₂,
+  rw internal_prefunctor_to_functor_equality,
+  apply internal_prefunctor.ext,
+  exact h₁,
+  exact h₂
 end
 
 lemma internal_functor_comp_idₗ (F : 𝔻 ⟹ 𝔼) : ι 𝔻 › F = F :=
 begin
-ext,
-repeat {simp},
+  ext,
+  repeat {simp}
 end
 
 lemma internal_functor_comp_idᵣ (F : 𝔻 ⟹ 𝔼) : F › ι 𝔼 = F :=
 begin
-ext,
-repeat {simp},
+  ext,
+  repeat {simp}
 end
 
 end
@@ -287,8 +278,8 @@ lemma internal_functor_comp_assoc {𝔻 𝔼 𝔽 𝔾 : internal_category 𝔸}
   (F : 𝔻 ⟹ 𝔼) (G : 𝔼 ⟹ 𝔽) (H : 𝔽 ⟹ 𝔾) :
   (F › G) › H = F › G › H :=
 begin
-ext,
-repeat {simp},
+  ext,
+  repeat {simp}
 end
 
 end category_theory

--- a/src/category_theory/internal_functor/basic.lean
+++ b/src/category_theory/internal_functor/basic.lean
@@ -1,0 +1,294 @@
+/-
+Copyright (c) 2023 Zach Murray. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Zach Murray.
+-/
+import category_theory.category.basic
+import category_theory.limits.shapes.pullbacks
+import category_theory.internal_category.basic
+open category_theory
+open category_theory.limits
+
+/-!
+# Internal Functors
+
+Defines a functor of internal categories.
+
+# Notation
+
+Each notation for internal functors has a corresponding internal prefunctor notation
+ending with an apostrophe.
+  - `⟹` : Internal functor arrow.
+  - `ι` : Identity internal functor.
+  - `›` : Diagrammatically-written composition of internal functors.
+  - `arr_x_arr` : Given an internal functor `F : 𝔻 ⟹ 𝔼`, returns
+     the arrow `F₁ × F₁ : 𝔻₁ × 𝔻₁ ⟶ 𝔼₁ × 𝔼₁`.
+-/
+
+noncomputable theory
+
+namespace category_theory
+
+universes v u
+
+variables {𝔸 : Type u} [category.{v} 𝔸]
+
+structure internal_prefunctor (𝔻 𝔼 : internal_quiver 𝔸) :=
+(obj : 𝔻.Obj ⟶ 𝔼.Obj)
+(arr : 𝔻.Arr ⟶ 𝔼.Arr)
+(resp_source' : 𝔻.s ≫ obj = arr ≫ 𝔼.s . obviously)
+(resp_target' : 𝔻.t ≫ obj = arr ≫ 𝔼.t . obviously)
+
+open internal_prefunctor
+
+restate_axiom internal_prefunctor.resp_source'
+restate_axiom internal_prefunctor.resp_target'
+attribute [simp, reassoc] internal_prefunctor.resp_source
+attribute [simp, reassoc] internal_prefunctor.resp_target
+
+infixr ` ⟹' ` : 26 := internal_prefunctor
+
+def id_internal_prefunctor (𝔻 : internal_quiver 𝔸) : 𝔻 ⟹' 𝔻 :=
+{
+  obj := 𝟙 𝔻.Obj,
+  arr := 𝟙 𝔻.Arr,
+}
+
+notation `ι'` := id_internal_prefunctor
+
+@[simp]
+lemma id_internal_prefunctor.obj (𝔻 : internal_quiver 𝔸) :
+  (ι' 𝔻).obj = 𝟙 𝔻.Obj := rfl
+
+@[simp]
+lemma id_internal_prefunctor.arr (𝔻 : internal_quiver 𝔸) :
+  (ι' 𝔻).arr = 𝟙 𝔻.Arr := rfl
+
+section
+
+variables {𝔻 𝔼 𝔽 : internal_quiver 𝔸}
+
+-- Helper function for defining composition of internal prefunctors.
+private def comp_helper (F : 𝔻 ⟹' 𝔼) (G : 𝔼 ⟹' 𝔽) :
+  ∀ {f : 𝔻.Arr ⟶ 𝔻.Obj} {g : 𝔼.Arr ⟶ 𝔼.Obj} {h : 𝔽.Arr ⟶ 𝔽.Obj},
+  f ≫ F.obj = F.arr ≫ g →
+  g ≫ G.obj = G.arr ≫ h →
+  f ≫ (F.obj ≫ G.obj) = (F.arr ≫ G.arr) ≫ h :=
+begin
+intros f g h h₁ h₂,
+rw [← category.assoc, h₁, category.assoc, h₂, ← category.assoc],
+end
+
+def internal_prefunctor_comp (F : 𝔻 ⟹' 𝔼) (G : 𝔼 ⟹' 𝔽) : 𝔻 ⟹' 𝔽 :=
+{
+  obj := F.obj ≫ G.obj,
+  arr := F.arr ≫ G.arr,
+  resp_source' := by {rw ← category.assoc, simp [F.resp_source, G.resp_source]},
+  resp_target' := by {rw ← category.assoc, simp [F.resp_target, G.resp_target]},
+}
+
+infixr ` ›' `:80 := internal_prefunctor_comp
+
+section
+
+variables {F : 𝔻 ⟹' 𝔼} {G : 𝔼 ⟹' 𝔽}
+
+@[simp]
+lemma internal_prefunctor_comp.obj : (F ›' G).obj = F.obj ≫ G.obj := rfl
+
+@[simp]
+lemma internal_prefunctor_comp.arr : (F ›' G).arr = F.arr ≫ G.arr := rfl
+
+end
+
+end
+
+section
+
+variables {𝔻 𝔼 : internal_category 𝔸}
+
+def arr_x_arr' (F : 𝔻.to_internal_quiver ⟹' 𝔼.to_internal_quiver) :
+  Arr_x_Arr 𝔻 ⟶ Arr_x_Arr 𝔼 :=
+pullback.lift (pullback.fst ≫ F.arr) (pullback.snd ≫ F.arr)
+(by {
+  rw [category.assoc, ← F.resp_target, ← category.assoc, pullback.condition],
+  simp [F.resp_source],
+})
+
+end
+
+structure internal_functor (𝔻 𝔼 : internal_category 𝔸)
+extends internal_prefunctor 𝔻.to_internal_quiver 𝔼.to_internal_quiver :=
+(resp_id' : 𝔻.e ≫ arr = obj ≫ 𝔼.e . obviously)
+(resp_comp' : 𝔻.c ≫ arr = arr_x_arr' to_internal_prefunctor ≫ 𝔼.c . obviously)
+
+restate_axiom internal_functor.resp_id'
+restate_axiom internal_functor.resp_comp'
+
+infixr ` ⟹ `:26 := internal_functor
+
+open internal_functor
+
+section
+
+variables {𝔻 𝔼 : internal_category 𝔸}
+
+def arr_x_arr (F : 𝔻 ⟹ 𝔼) : Arr_x_Arr 𝔻 ⟶ Arr_x_Arr 𝔼 :=
+arr_x_arr' F.to_internal_prefunctor
+
+@[simp]
+lemma arr_x_arr.fst (F : 𝔻 ⟹ 𝔼) :
+  arr_x_arr F ≫ pullback.fst = pullback.fst ≫ F.arr :=
+by {apply pullback.lift_fst}
+
+@[simp]
+lemma arr_x_arr.snd (F : 𝔻 ⟹ 𝔼) :
+  arr_x_arr F ≫ pullback.snd = pullback.snd ≫ F.arr :=
+by apply pullback.lift_snd
+
+end
+
+@[simp]
+lemma id_internal_prefunctor_to_identity (𝔻 : internal_category 𝔸) :
+  arr_x_arr' (ι' 𝔻.to_internal_quiver) = 𝟙 (Arr_x_Arr 𝔻) :=
+begin
+symmetry,
+apply pullback.lift_unique,
+repeat {simp},
+end
+
+def id_internal_functor (𝔻 : internal_category 𝔸) : 𝔻 ⟹ 𝔻 :=
+{
+  obj := (ι' 𝔻.to_internal_quiver).obj,
+  arr := (ι' 𝔻.to_internal_quiver).arr,
+  resp_comp' := by {
+    have h : 𝔻.c ≫ (ι' 𝔻.to_internal_quiver).arr =
+      arr_x_arr' (ι' 𝔻.to_internal_quiver) ≫ 𝔻.c,
+    by {simp, dunfold Arr_x_Arr, dunfold Arr_x_Arr', simp},
+    exact h,
+  }
+}
+
+notation `ι` := id_internal_functor
+
+@[simp]
+lemma id_internal_functor.obj (𝔻 : internal_category 𝔸) :
+  (ι 𝔻).obj = 𝟙 𝔻.Obj := rfl
+
+@[simp]
+lemma id_internal_functor.arr (𝔻 : internal_category 𝔸) :
+  (ι 𝔻).arr = 𝟙 𝔻.Arr := rfl
+
+section
+
+variables {𝔻 𝔼 𝔽 : internal_category 𝔸}
+
+@[simp]
+lemma comp_arr_x_arr'
+  (F : 𝔻.to_internal_quiver ⟹' 𝔼.to_internal_quiver)
+  (G : 𝔼.to_internal_quiver ⟹' 𝔽.to_internal_quiver) :
+  arr_x_arr' (F ›' G) = arr_x_arr' F ≫ arr_x_arr' G :=
+begin
+symmetry,
+apply pullback.lift_unique,
+repeat {dunfold arr_x_arr', simp},
+end
+
+def internal_functor_comp (F : 𝔻 ⟹ 𝔼) (G : 𝔼 ⟹ 𝔽) : 𝔻 ⟹ 𝔽 :=
+{
+  obj := F.obj ≫ G.obj,
+  arr := F.arr ≫ G.arr,
+  resp_source' := comp_helper _ _ F.resp_source G.resp_source,
+  resp_target' := comp_helper _ _ F.resp_target G.resp_target,
+  resp_id' := by {
+    rw ← category.assoc,
+    simp [F.resp_id, G.resp_id],
+  },
+  resp_comp' := by {
+    calc 𝔻.c ≫ F.arr ≫ G.arr = (arr_x_arr' F.to_internal_prefunctor ≫ 𝔼.c) ≫ G.arr : by simp [← F.resp_comp]
+                          ... = arr_x_arr' (_ ›' _) ≫ 𝔽.c                             : by simp [G.resp_comp],
+  },
+}
+
+infixr ` › `:80 := internal_functor_comp
+
+@[simp]
+lemma internal_functor_comp.obj (F : 𝔻 ⟹ 𝔼) (G : 𝔼 ⟹ 𝔽) :
+  (F › G).obj = F.obj ≫ G.obj := rfl
+
+@[simp]
+lemma internal_functor_comp.arr (F : 𝔻 ⟹ 𝔼) (G : 𝔼 ⟹ 𝔽) :
+  (F › G).arr = F.arr ≫ G.arr := rfl
+
+@[simp]
+lemma pullback.lift.internal_map.left
+  (F : 𝔼 ⟹ 𝔽) (f g : 𝔻.Arr ⟶ 𝔼.Arr) (h : f ≫ 𝔼.t = g ≫ 𝔼.s) :
+  pullback.lift f g h ≫ arr_x_arr F =
+  pullback.lift (f ≫ F.arr) (g ≫ F.arr)
+    (by {simp only [category.assoc, ← F.resp_source, ← F.resp_target], rw [← category.assoc], simp [h]}) :=
+begin
+apply pullback.lift_unique,
+repeat {simp},
+end
+
+end
+
+@[ext]
+lemma internal_prefunctor.ext {𝔻 𝔼 : internal_quiver 𝔸} {F G : 𝔻 ⟹' 𝔼}
+  (h₁ : F.obj = G.obj) (h₂ : F.arr = G.arr) : F = G :=
+begin
+cases F,
+cases G,
+congr',
+end
+
+section
+
+variables {𝔻 𝔼 : internal_category 𝔸}
+
+lemma internal_prefunctor_to_functor_equality {F G : 𝔻 ⟹ 𝔼} :
+  F = G ↔ F.to_internal_prefunctor = G.to_internal_prefunctor :=
+begin
+split,
+
+rintros rfl, refl,
+
+intro h,
+cases F,
+cases G,
+congr',
+end
+
+@[ext]
+lemma internal_functor.ext {F G : 𝔻 ⟹ 𝔼}
+  (h₁ : F.obj = G.obj) (h₂ : F.arr = G.arr) : F = G :=
+begin
+rw internal_prefunctor_to_functor_equality,
+apply internal_prefunctor.ext,
+exact h₁,
+exact h₂,
+end
+
+lemma internal_functor_comp_idₗ (F : 𝔻 ⟹ 𝔼) : ι 𝔻 › F = F :=
+begin
+ext,
+repeat {simp},
+end
+
+lemma internal_functor_comp_idᵣ (F : 𝔻 ⟹ 𝔼) : F › ι 𝔼 = F :=
+begin
+ext,
+repeat {simp},
+end
+
+end
+
+lemma internal_functor_comp_assoc {𝔻 𝔼 𝔽 𝔾 : internal_category 𝔸}
+  (F : 𝔻 ⟹ 𝔼) (G : 𝔼 ⟹ 𝔽) (H : 𝔽 ⟹ 𝔾) :
+  (F › G) › H = F › G › H :=
+begin
+ext,
+repeat {simp},
+end
+
+end category_theory

--- a/src/category_theory/internal_functor/category.lean
+++ b/src/category_theory/internal_functor/category.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Zach Murray. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Zach Murray.
+Authors: Zach Murray
 -/
 import category_theory.category.basic
 import category_theory.limits.shapes.pullbacks
@@ -26,11 +26,9 @@ variables {𝔸 : Type u} [category.{v} 𝔸]
           (𝔻 𝔼 : internal_category 𝔸)
 
 instance internal_functor.category : category.{_} (𝔻 ⟹ 𝔼) :=
-{
-  hom := λ F G, internal_nat_trans F G,
+{ hom := λ F G, internal_nat_trans F G,
   id := λ F, internal_nat_trans.id F,
-  comp := λ _ _ _  α β, vcomp α β,
-}
+  comp := λ _ _ _  α β, vcomp α β }
 
 lemma vcomp_app' {F G H : 𝔻 ⟹ 𝔼} (α : F ⟶ G) (β : G ⟶ H) :
   (α ≫ β).app = pullback.lift α.app β.app (by simp) ≫ 𝔼.c := rfl

--- a/src/category_theory/internal_functor/category.lean
+++ b/src/category_theory/internal_functor/category.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2023 Zach Murray. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Zach Murray.
+-/
+import category_theory.category.basic
+import category_theory.limits.shapes.pullbacks
+import category_theory.internal_category.basic
+import category_theory.internal_functor.basic
+import category_theory.internal_natural_transformation
+open category_theory
+open category_theory.limits
+
+/-!
+# The Category of Internal Functors
+
+Defines the category of functors and natural transformations between two fixed internal categories.
+-/
+
+noncomputable theory
+
+namespace category_theory
+
+universes v u
+variables {𝔸 : Type u} [category.{v} 𝔸]
+          (𝔻 𝔼 : internal_category 𝔸)
+
+instance internal_functor.category : category.{_} (𝔻 ⟹ 𝔼) :=
+{
+  hom := λ F G, internal_nat_trans F G,
+  id := λ F, internal_nat_trans.id F,
+  comp := λ _ _ _  α β, vcomp α β,
+}
+
+lemma vcomp_app' {F G H : 𝔻 ⟹ 𝔼} (α : F ⟶ G) (β : G ⟶ H) :
+  (α ≫ β).app = pullback.lift α.app β.app (by simp) ≫ 𝔼.c := rfl
+
+@[simp]
+lemma id_app' (F : 𝔻 ⟹ 𝔼) : 𝟙 F = internal_nat_trans.id F := rfl
+
+end category_theory

--- a/src/category_theory/internal_natural_transformation.lean
+++ b/src/category_theory/internal_natural_transformation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Zach Murray. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Zach Murray.
+Authors: Zach Murray
 -/
 import category_theory.category.basic
 import category_theory.limits.shapes.pullbacks
@@ -43,9 +43,9 @@ attribute [simp] internal_nat_trans_struct.resp_target
 protected lemma internal_nat_trans_struct.ext {F G : 𝔻 ⟹ 𝔼} {α β : internal_nat_trans_struct F G}
   (h : α.app = β.app) : α = β :=
 begin
-cases α,
-cases β,
-congr',
+  cases α,
+  cases β,
+  congr',
 end
 
 lemma internal_nat_trans_struct_lift₁ {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans_struct F G) :
@@ -64,32 +64,32 @@ restate_axiom internal_nat_trans.naturality'
 protected lemma internal_nat_trans.ext {F G : 𝔻 ⟹ 𝔼} {α β : internal_nat_trans F G}
   (h : α.app = β.app) : α = β :=
 begin
-cases α,
-cases β,
-congr',
-exact category_theory.internal_nat_trans_struct.ext h,
+  cases α,
+  cases β,
+  congr',
+  exact category_theory.internal_nat_trans_struct.ext h,
 end
 
 def vcomp {F G H : 𝔻 ⟹ 𝔼}
   (α : internal_nat_trans F G) (β : internal_nat_trans G H) :
   internal_nat_trans F H :=
-{
-  app := pullback.lift α.app β.app (by simp) ≫ 𝔼.c,
-  naturality' := by {
-    calc pullback.lift F.arr (𝔻.t ≫ pullback.lift α.app β.app (by simp) ≫ 𝔼.c) (by simp) ≫ 𝔼.c
-          = pullback.lift (pullback.lift F.arr (𝔻.t ≫ α.app) (by simp) ≫ 𝔼.c) (𝔻.t ≫ β.app) (by simp) ≫ 𝔼.c : by simp [pullback.lift_comp]
-      ... = pullback.lift (𝔻.s ≫ α.app) (pullback.lift (𝔻.s ≫ β.app) H.arr (by simp) ≫ 𝔼.c) (by simp) ≫ 𝔼.c : by simp [α.naturality, β.naturality]
-      ... = pullback.lift (𝔻.s ≫ pullback.lift α.app β.app (by simp) ≫ 𝔼.c) H.arr (by simp) ≫ 𝔼.c            : by {simp only [← category.assoc, ← pullback.lift_comp], rw pullback.lift_assoc}
-  }
-}
+{ app := pullback.lift α.app β.app (by simp) ≫ 𝔼.c,
+  naturality' := calc
+    pullback.lift F.arr (𝔻.t ≫ pullback.lift α.app β.app (by simp) ≫ 𝔼.c) (by simp) ≫ 𝔼.c
+        = pullback.lift (pullback.lift F.arr (𝔻.t ≫ α.app) (by simp) ≫ 𝔼.c) (𝔻.t ≫ β.app)
+          (by simp) ≫ 𝔼.c :
+      by simp [pullback.lift_comp]
+    ... = pullback.lift (𝔻.s ≫ α.app) (pullback.lift (𝔻.s ≫ β.app) H.arr (by simp) ≫ 𝔼.c)
+          (by simp) ≫ 𝔼.c :
+      by simp [α.naturality, β.naturality]
+    ... = pullback.lift (𝔻.s ≫ pullback.lift α.app β.app (by simp) ≫ 𝔼.c) H.arr (by simp) ≫ 𝔼.c :
+      by {simp only [← category.assoc, ← pullback.lift_comp], rw pullback.lift_assoc} }
 
 namespace internal_nat_trans
 
 protected def id (F : 𝔻 ⟹ 𝔼) :
   internal_nat_trans F F :=
-{
-  app := F.obj ≫ 𝔼.e,
-}
+{ app := F.obj ≫ 𝔼.e }
 
 @[simp]
 protected lemma id_app' (F : 𝔻 ⟹ 𝔼) : (internal_nat_trans.id F).app = F.obj ≫ 𝔼.e := rfl
@@ -104,34 +104,34 @@ lemma vcomp_app {F G H : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) (β : inte
 lemma vcomp_id_comp {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) :
   vcomp (internal_nat_trans.id F) α = α :=
 begin
-ext,
-simp only [vcomp, internal_nat_trans.id, ← α.resp_source, category.assoc],
-simp,
+  ext,
+  simp only [vcomp, internal_nat_trans.id, ← α.resp_source, category.assoc],
+  simp,
 end
 
 @[simp]
 lemma vcomp_id_comp_app {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) :
   pullback.lift (internal_nat_trans.id F).app α.app (by simp) ≫ 𝔼.c = α.app :=
 begin
-rw ← vcomp_app,
-simp,
+  rw ← vcomp_app,
+  simp,
 end
 
 @[simp]
 lemma vcomp_comp_id {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) :
   vcomp α (internal_nat_trans.id G) = α :=
 begin
-ext,
-simp only [vcomp, internal_nat_trans.id, ← α.resp_target, category.assoc],
-simp,
+  ext,
+  simp only [vcomp, internal_nat_trans.id, ← α.resp_target, category.assoc],
+  simp,
 end
 
 @[simp]
 lemma vcomp_comp_id_app {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) :
   pullback.lift α.app (internal_nat_trans.id G).app (by simp) ≫ 𝔼.c = α.app :=
 begin
-simp only [← vcomp_app],
-simp,
+  simp only [← vcomp_app],
+  simp,
 end
 
 @[simp]
@@ -139,11 +139,12 @@ lemma vcomp_assoc {F G H K : 𝔻 ⟹ 𝔼}
   (α : internal_nat_trans F G) (β : internal_nat_trans G H) (η : internal_nat_trans H K) :
   vcomp (vcomp α β) η = vcomp α (vcomp β η) :=
 begin
-ext,
-dunfold vcomp,
-simp,
+  ext,
+  dunfold vcomp,
+  simp,
 end
 
 end
 
 end category_theory
+#lint

--- a/src/category_theory/internal_natural_transformation.lean
+++ b/src/category_theory/internal_natural_transformation.lean
@@ -28,43 +28,22 @@ section
 variables {𝔻 𝔼 : internal_category 𝔸}
 
 /--
-The data of a natural transformation without naturality.
--/
-structure internal_nat_trans_struct (F G : 𝔻 ⟹ 𝔼) :=
-(app : 𝔻.Obj ⟶ 𝔼.Arr)
-(resp_source' : app ≫ 𝔼.s = F.obj . obviously)
-(resp_target' : app ≫ 𝔼.t = G.obj . obviously)
-
-open internal_nat_trans_struct
-
-restate_axiom internal_nat_trans_struct.resp_source'
-restate_axiom internal_nat_trans_struct.resp_target'
-attribute [simp] internal_nat_trans_struct.resp_source
-attribute [simp] internal_nat_trans_struct.resp_target
-
-@[ext]
-protected lemma internal_nat_trans_struct.ext {F G : 𝔻 ⟹ 𝔼} {α β : internal_nat_trans_struct F G}
-  (h : α.app = β.app) : α = β :=
-begin
-  cases α,
-  cases β,
-  congr',
-end
-
-lemma internal_nat_trans_struct_lift₁ {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans_struct F G) :
-  F.arr ≫ 𝔼.t = (𝔻.t ≫ α.app) ≫ 𝔼.s := by simp
-
-/--
 Defines a natural transformation between two internal functors, with the components
 of such an `α` given by `α.app` and naturality given by `α.naturality`.
 -/
-structure internal_nat_trans (F G : 𝔻 ⟹ 𝔼)
-extends internal_nat_trans_struct F G :=
-(naturality' : pullback.lift F.arr (𝔻.t ≫ app) (by simp) ≫ 𝔼.c =
-               pullback.lift (𝔻.s ≫ app) G.arr (by simp) ≫ 𝔼.c . obviously)
+structure internal_nat_trans (F G : 𝔻 ⟹ 𝔼) :=
+(app : 𝔻.Obj ⟶ 𝔼.Arr)
+(resp_source' : app ≫ 𝔼.s = F.obj . obviously)
+(resp_target' : app ≫ 𝔼.t = G.obj . obviously)
+(naturality' : pullback.lift F.arr (𝔻.t ≫ app) (by simp [resp_source']) ≫ 𝔼.c =
+               pullback.lift (𝔻.s ≫ app) G.arr (by simp [resp_target']) ≫ 𝔼.c . obviously)
 
 open internal_nat_trans
 
+restate_axiom internal_nat_trans.resp_source'
+restate_axiom internal_nat_trans.resp_target'
+attribute [simp] internal_nat_trans.resp_source
+attribute [simp] internal_nat_trans.resp_target
 restate_axiom internal_nat_trans.naturality'
 
 @[ext]
@@ -74,7 +53,6 @@ begin
   cases α,
   cases β,
   congr',
-  exact category_theory.internal_nat_trans_struct.ext h,
 end
 
 /--

--- a/src/category_theory/internal_natural_transformation.lean
+++ b/src/category_theory/internal_natural_transformation.lean
@@ -27,6 +27,9 @@ section
 
 variables {𝔻 𝔼 : internal_category 𝔸}
 
+/--
+The data of a natural transformation without naturality.
+-/
 structure internal_nat_trans_struct (F G : 𝔻 ⟹ 𝔼) :=
 (app : 𝔻.Obj ⟶ 𝔼.Arr)
 (resp_source' : app ≫ 𝔼.s = F.obj . obviously)
@@ -51,6 +54,10 @@ end
 lemma internal_nat_trans_struct_lift₁ {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans_struct F G) :
   F.arr ≫ 𝔼.t = (𝔻.t ≫ α.app) ≫ 𝔼.s := by simp
 
+/--
+Defines a natural transformation between two internal functors, with the components
+of such an `α` given by `α.app` and naturality given by `α.naturality`.
+-/
 structure internal_nat_trans (F G : 𝔻 ⟹ 𝔼)
 extends internal_nat_trans_struct F G :=
 (naturality' : pullback.lift F.arr (𝔻.t ≫ app) (by simp) ≫ 𝔼.c =
@@ -70,6 +77,11 @@ begin
   exact category_theory.internal_nat_trans_struct.ext h,
 end
 
+/--
+The vertical composition of `α : internal_nat_trans F G` and
+`β : internal_nat_trans G H`, with components
+`pullback.lift α.app β.app _ ≫ 𝔼.c`.
+-/
 def vcomp {F G H : 𝔻 ⟹ 𝔼}
   (α : internal_nat_trans F G) (β : internal_nat_trans G H) :
   internal_nat_trans F H :=
@@ -87,12 +99,17 @@ def vcomp {F G H : 𝔻 ⟹ 𝔼}
 
 namespace internal_nat_trans
 
+/--
+The identity natural transformation on an internal functor `F`.
+-/
 protected def id (F : 𝔻 ⟹ 𝔼) :
   internal_nat_trans F F :=
 { app := F.obj ≫ 𝔼.e }
 
 @[simp]
 protected lemma id_app' (F : 𝔻 ⟹ 𝔼) : (internal_nat_trans.id F).app = F.obj ≫ 𝔼.e := rfl
+
+instance (F : 𝔻 ⟹ 𝔼) : inhabited (internal_nat_trans F F) := ⟨internal_nat_trans.id F⟩
 
 end internal_nat_trans
 
@@ -109,7 +126,6 @@ begin
   simp,
 end
 
-@[simp]
 lemma vcomp_id_comp_app {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) :
   pullback.lift (internal_nat_trans.id F).app α.app (by simp) ≫ 𝔼.c = α.app :=
 begin
@@ -126,7 +142,6 @@ begin
   simp,
 end
 
-@[simp]
 lemma vcomp_comp_id_app {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) :
   pullback.lift α.app (internal_nat_trans.id G).app (by simp) ≫ 𝔼.c = α.app :=
 begin

--- a/src/category_theory/internal_natural_transformation.lean
+++ b/src/category_theory/internal_natural_transformation.lean
@@ -140,4 +140,3 @@ end
 end
 
 end category_theory
-#lint

--- a/src/category_theory/internal_natural_transformation.lean
+++ b/src/category_theory/internal_natural_transformation.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2023 Zach Murray. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Zach Murray.
+-/
+import category_theory.category.basic
+import category_theory.limits.shapes.pullbacks
+import category_theory.internal_category.basic
+import category_theory.internal_functor.basic
+open category_theory
+open category_theory.limits
+
+/-!
+# Internal Natural Transformations
+
+Defines natural transformations between two functors of internal categories.
+-/
+
+noncomputable theory
+
+namespace category_theory
+
+universes v u
+variables {𝔸 : Type u} [category.{v} 𝔸]
+
+section
+
+variables {𝔻 𝔼 : internal_category 𝔸}
+
+structure internal_nat_trans_struct (F G : 𝔻 ⟹ 𝔼) :=
+(app : 𝔻.Obj ⟶ 𝔼.Arr)
+(resp_source' : app ≫ 𝔼.s = F.obj . obviously)
+(resp_target' : app ≫ 𝔼.t = G.obj . obviously)
+
+open internal_nat_trans_struct
+
+restate_axiom internal_nat_trans_struct.resp_source'
+restate_axiom internal_nat_trans_struct.resp_target'
+attribute [simp] internal_nat_trans_struct.resp_source
+attribute [simp] internal_nat_trans_struct.resp_target
+
+@[ext]
+protected lemma internal_nat_trans_struct.ext {F G : 𝔻 ⟹ 𝔼} {α β : internal_nat_trans_struct F G}
+  (h : α.app = β.app) : α = β :=
+begin
+cases α,
+cases β,
+congr',
+end
+
+lemma internal_nat_trans_struct_lift₁ {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans_struct F G) :
+  F.arr ≫ 𝔼.t = (𝔻.t ≫ α.app) ≫ 𝔼.s := by simp
+
+structure internal_nat_trans (F G : 𝔻 ⟹ 𝔼)
+extends internal_nat_trans_struct F G :=
+(naturality' : pullback.lift F.arr (𝔻.t ≫ app) (by simp) ≫ 𝔼.c =
+               pullback.lift (𝔻.s ≫ app) G.arr (by simp) ≫ 𝔼.c . obviously)
+
+open internal_nat_trans
+
+restate_axiom internal_nat_trans.naturality'
+
+@[ext]
+protected lemma internal_nat_trans.ext {F G : 𝔻 ⟹ 𝔼} {α β : internal_nat_trans F G}
+  (h : α.app = β.app) : α = β :=
+begin
+cases α,
+cases β,
+congr',
+exact category_theory.internal_nat_trans_struct.ext h,
+end
+
+def vcomp {F G H : 𝔻 ⟹ 𝔼}
+  (α : internal_nat_trans F G) (β : internal_nat_trans G H) :
+  internal_nat_trans F H :=
+{
+  app := pullback.lift α.app β.app (by simp) ≫ 𝔼.c,
+  naturality' := by {
+    calc pullback.lift F.arr (𝔻.t ≫ pullback.lift α.app β.app (by simp) ≫ 𝔼.c) (by simp) ≫ 𝔼.c
+          = pullback.lift (pullback.lift F.arr (𝔻.t ≫ α.app) (by simp) ≫ 𝔼.c) (𝔻.t ≫ β.app) (by simp) ≫ 𝔼.c : by simp [pullback.lift_comp]
+      ... = pullback.lift (𝔻.s ≫ α.app) (pullback.lift (𝔻.s ≫ β.app) H.arr (by simp) ≫ 𝔼.c) (by simp) ≫ 𝔼.c : by simp [α.naturality, β.naturality]
+      ... = pullback.lift (𝔻.s ≫ pullback.lift α.app β.app (by simp) ≫ 𝔼.c) H.arr (by simp) ≫ 𝔼.c            : by {simp only [← category.assoc, ← pullback.lift_comp], rw pullback.lift_assoc}
+  }
+}
+
+namespace internal_nat_trans
+
+protected def id (F : 𝔻 ⟹ 𝔼) :
+  internal_nat_trans F F :=
+{
+  app := F.obj ≫ 𝔼.e,
+}
+
+@[simp]
+protected lemma id_app' (F : 𝔻 ⟹ 𝔼) : (internal_nat_trans.id F).app = F.obj ≫ 𝔼.e := rfl
+
+end internal_nat_trans
+
+lemma vcomp_app {F G H : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) (β : internal_nat_trans G H) :
+  (vcomp α β).app = pullback.lift α.app β.app (by simp) ≫ 𝔼.c := rfl
+
+
+@[simp]
+lemma vcomp_id_comp {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) :
+  vcomp (internal_nat_trans.id F) α = α :=
+begin
+ext,
+simp only [vcomp, internal_nat_trans.id, ← α.resp_source, category.assoc],
+simp,
+end
+
+@[simp]
+lemma vcomp_id_comp_app {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) :
+  pullback.lift (internal_nat_trans.id F).app α.app (by simp) ≫ 𝔼.c = α.app :=
+begin
+rw ← vcomp_app,
+simp,
+end
+
+@[simp]
+lemma vcomp_comp_id {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) :
+  vcomp α (internal_nat_trans.id G) = α :=
+begin
+ext,
+simp only [vcomp, internal_nat_trans.id, ← α.resp_target, category.assoc],
+simp,
+end
+
+@[simp]
+lemma vcomp_comp_id_app {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) :
+  pullback.lift α.app (internal_nat_trans.id G).app (by simp) ≫ 𝔼.c = α.app :=
+begin
+simp only [← vcomp_app],
+simp,
+end
+
+@[simp]
+lemma vcomp_assoc {F G H K : 𝔻 ⟹ 𝔼}
+  (α : internal_nat_trans F G) (β : internal_nat_trans G H) (η : internal_nat_trans H K) :
+  vcomp (vcomp α β) η = vcomp α (vcomp β η) :=
+begin
+ext,
+dunfold vcomp,
+simp,
+end
+
+end
+
+end category_theory

--- a/src/category_theory/internal_whiskering.lean
+++ b/src/category_theory/internal_whiskering.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Zach Murray. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Zach Murray.
+Authors: Zach Murray
 -/
 import category_theory.category.basic
 import category_theory.limits.shapes.pullbacks
@@ -18,17 +18,6 @@ open category_theory.limits
 
 Defines the left and right whiskerings of functors and natural transformations of internal
 categories.
-
-Given functors `F : 𝔻 ⟹ 𝔼` and `G,H : 𝔼 ⟹ 𝔽`, and a natural transformation
-`α : internal_nat_trans G H`,
-we define the natural transformation
-`internal_whisker_left F α : internal_nat_trans (F › G) (F › H)` to have components
-`F.obj ≫ α.app`.
-
-Similarly, given functors `F,G : 𝔻 ⟹ 𝔼` and `H : 𝔼 ⟹ 𝔽`, and a natural transformation
-`α : internal_nat_trans F G`, we define the natural transformation
-`internal_whisker_right α H : internal_nat_trans (F › H) (G › H)` to have components
-`α.app ≫ H.arr`.
 -/
 
 noncomputable theory
@@ -42,49 +31,63 @@ section
 
 variables {𝔻 𝔼 𝔽 : internal_category 𝔸}
 
-@[simps]
-def internal_whisker_left (F : 𝔻 ⟹ 𝔼) {G H : 𝔼 ⟹ 𝔽} (α : internal_nat_trans G H) :
+/--
+Given
+             G
+           ----->
+𝔻 -----> 𝔼  ↓ α  𝔽
+           ----->
+             H
+the components of
+`internal_whisker_left : internal_nat_trans (F › G) (F › H)`
+are `F.obj ≫ α.app`.
+-/
+@[simps] def internal_whisker_left (F : 𝔻 ⟹ 𝔼) {G H : 𝔼 ⟹ 𝔽} (α : internal_nat_trans G H) :
   internal_nat_trans (F › G) (F › H) :=
-{
-  app := F.obj ≫ α.app,
+{ app := F.obj ≫ α.app,
   naturality' := by {
     simp only [← category.assoc, F.resp_source, F.resp_target],
     simp only [category.assoc],
-    calc pullback.lift (F.arr ≫ G.arr) (F.arr ≫ (𝔼.t ≫ α.app)) (by simp *) ≫ 𝔽.c
-          = F.arr ≫ pullback.lift G.arr (𝔼.t ≫ α.app) (by simp *) ≫ 𝔽.c             : by simp [pullback.lift_comp]
-      ... = F.arr ≫ pullback.lift (𝔼.s ≫ α.app) H.arr (by simp *) ≫ 𝔽.c             : by simp [α.naturality]
-      ... = pullback.lift (F.arr ≫ (𝔼.s ≫ α.app)) (F.arr ≫ H.arr) (by simp *) ≫ 𝔽.c : by simp [pullback.lift_comp],
-  },
-}
+    simp [pullback.lift_comp, α.naturality] } }
 
-@[simps]
-def internal_whisker_right {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) (H : 𝔼 ⟹ 𝔽) :
+/--
+Given
+    F
+  ------>     H
+𝔻  ↓ α   𝔼 -----> 𝔽
+  ------>
+    G
+the components of
+`internal_whisker_right α H : internal_nat_trans (F › H) (G › H)`
+are `α.app ≫ H.arr`.
+-/
+@[simps] def internal_whisker_right {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) (H : 𝔼 ⟹ 𝔽) :
   internal_nat_trans (F › H) (G › H) :=
-{
-  app := α.app ≫ H.arr,
+{ app := α.app ≫ H.arr,
   resp_source' := by {
     simp only [category.assoc, ← H.resp_source],
     rw ← category.assoc,
-    obviously,
-  },
+    obviously },
   resp_target' := by {
     simp only [category.assoc, ← H.resp_target],
     rw ← category.assoc,
-    obviously,
-  },
+    obviously },
   naturality' := by {
     simp only [← category.assoc, internal_functor_comp.arr],
     have h : (F.arr ≫ H.arr) ≫ 𝔽.t = ((𝔻.t ≫ α.app) ≫ H.arr) ≫ 𝔽.s,
       by {simp only [category.assoc, symm H.resp_target, symm H.resp_source],
           simp only [← category.assoc], obviously},
     calc pullback.lift (F.arr ≫ H.arr) ((𝔻.t ≫ α.app) ≫ H.arr) h ≫ 𝔽.c
-          = (pullback.lift F.arr (𝔻.t ≫ α.app) (by simp) ≫ arr_x_arr H) ≫ 𝔽.c : by simp
-      ... = (pullback.lift F.arr (𝔻.t ≫ α.app) (by simp) ≫ 𝔼.c) ≫ H.arr : by {rw category.assoc, dunfold arr_x_arr, rw [← H.resp_comp, ← category.assoc]}
-      ... = pullback.lift (𝔻.s ≫ α.app) G.arr _ ≫ 𝔼.c ≫ H.arr           : by simp only [α.naturality, category.assoc]
-      ... = pullback.lift (𝔻.s ≫ α.app) G.arr _ ≫ arr_x_arr H ≫ 𝔽.c     : by {dunfold arr_x_arr, rw H.resp_comp}
-      ... = pullback.lift ((𝔻.s ≫ α.app) ≫ H.arr) (G.arr ≫ H.arr) _ ≫ 𝔽.c : by {rw ← category.assoc, simp [-category.assoc]},
-  },
-}
+        = (pullback.lift F.arr (𝔻.t ≫ α.app) (by simp) ≫ arr_x_arr H) ≫ 𝔽.c :
+      by simp
+    ... = (pullback.lift F.arr (𝔻.t ≫ α.app) (by simp) ≫ 𝔼.c) ≫ H.arr :
+      by {rw category.assoc, dunfold arr_x_arr, rw [← H.resp_comp, ← category.assoc]}
+    ... = pullback.lift (𝔻.s ≫ α.app) G.arr _ ≫ 𝔼.c ≫ H.arr           :
+      by simp only [α.naturality, category.assoc]
+    ... = pullback.lift (𝔻.s ≫ α.app) G.arr _ ≫ arr_x_arr H ≫ 𝔽.c     :
+      by {dunfold arr_x_arr, rw H.resp_comp}
+    ... = pullback.lift ((𝔻.s ≫ α.app) ≫ H.arr) (G.arr ≫ H.arr) _ ≫ 𝔽.c :
+      by {rw ← category.assoc, simp [-category.assoc]} } }
 
 end
 

--- a/src/category_theory/internal_whiskering.lean
+++ b/src/category_theory/internal_whiskering.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2023 Zach Murray. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Zach Murray.
+-/
+import category_theory.category.basic
+import category_theory.limits.shapes.pullbacks
+import category_theory.internal_category.basic
+import category_theory.internal_functor.basic
+import category_theory.internal_functor.category
+import category_theory.internal_natural_transformation
+import category_theory.isomorphism
+open category_theory
+open category_theory.limits
+
+/-!
+# Whiskering of Internal Functors and Internal Natural Transformations
+
+Defines the left and right whiskerings of functors and natural transformations of internal
+categories.
+
+Given functors `F : 𝔻 ⟹ 𝔼` and `G,H : 𝔼 ⟹ 𝔽`, and a natural transformation
+`α : internal_nat_trans G H`,
+we define the natural transformation
+`internal_whisker_left F α : internal_nat_trans (F › G) (F › H)` to have components
+`F.obj ≫ α.app`.
+
+Similarly, given functors `F,G : 𝔻 ⟹ 𝔼` and `H : 𝔼 ⟹ 𝔽`, and a natural transformation
+`α : internal_nat_trans F G`, we define the natural transformation
+`internal_whisker_right α H : internal_nat_trans (F › H) (G › H)` to have components
+`α.app ≫ H.arr`.
+-/
+
+noncomputable theory
+
+namespace category_theory
+
+universes v u
+variables {𝔸 : Type u} [category.{v} 𝔸]
+
+section
+
+variables {𝔻 𝔼 𝔽 : internal_category 𝔸}
+
+@[simps]
+def internal_whisker_left (F : 𝔻 ⟹ 𝔼) {G H : 𝔼 ⟹ 𝔽} (α : internal_nat_trans G H) :
+  internal_nat_trans (F › G) (F › H) :=
+{
+  app := F.obj ≫ α.app,
+  naturality' := by {
+    simp only [← category.assoc, F.resp_source, F.resp_target],
+    simp only [category.assoc],
+    calc pullback.lift (F.arr ≫ G.arr) (F.arr ≫ (𝔼.t ≫ α.app)) (by simp *) ≫ 𝔽.c
+          = F.arr ≫ pullback.lift G.arr (𝔼.t ≫ α.app) (by simp *) ≫ 𝔽.c             : by simp [pullback.lift_comp]
+      ... = F.arr ≫ pullback.lift (𝔼.s ≫ α.app) H.arr (by simp *) ≫ 𝔽.c             : by simp [α.naturality]
+      ... = pullback.lift (F.arr ≫ (𝔼.s ≫ α.app)) (F.arr ≫ H.arr) (by simp *) ≫ 𝔽.c : by simp [pullback.lift_comp],
+  },
+}
+
+@[simps]
+def internal_whisker_right {F G : 𝔻 ⟹ 𝔼} (α : internal_nat_trans F G) (H : 𝔼 ⟹ 𝔽) :
+  internal_nat_trans (F › H) (G › H) :=
+{
+  app := α.app ≫ H.arr,
+  resp_source' := by {
+    simp only [category.assoc, ← H.resp_source],
+    rw ← category.assoc,
+    obviously,
+  },
+  resp_target' := by {
+    simp only [category.assoc, ← H.resp_target],
+    rw ← category.assoc,
+    obviously,
+  },
+  naturality' := by {
+    simp only [← category.assoc, internal_functor_comp.arr],
+    have h : (F.arr ≫ H.arr) ≫ 𝔽.t = ((𝔻.t ≫ α.app) ≫ H.arr) ≫ 𝔽.s,
+      by {simp only [category.assoc, symm H.resp_target, symm H.resp_source],
+          simp only [← category.assoc], obviously},
+    calc pullback.lift (F.arr ≫ H.arr) ((𝔻.t ≫ α.app) ≫ H.arr) h ≫ 𝔽.c
+          = (pullback.lift F.arr (𝔻.t ≫ α.app) (by simp) ≫ arr_x_arr H) ≫ 𝔽.c : by simp
+      ... = (pullback.lift F.arr (𝔻.t ≫ α.app) (by simp) ≫ 𝔼.c) ≫ H.arr : by {rw category.assoc, dunfold arr_x_arr, rw [← H.resp_comp, ← category.assoc]}
+      ... = pullback.lift (𝔻.s ≫ α.app) G.arr _ ≫ 𝔼.c ≫ H.arr           : by simp only [α.naturality, category.assoc]
+      ... = pullback.lift (𝔻.s ≫ α.app) G.arr _ ≫ arr_x_arr H ≫ 𝔽.c     : by {dunfold arr_x_arr, rw H.resp_comp}
+      ... = pullback.lift ((𝔻.s ≫ α.app) ≫ H.arr) (G.arr ≫ H.arr) _ ≫ 𝔽.c : by {rw ← category.assoc, simp [-category.assoc]},
+  },
+}
+
+end
+
+end category_theory

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -988,6 +988,41 @@ def pullback_is_pullback {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [has_pullback f
 pullback_cone.is_limit.mk _ (λ s, pullback.lift s.fst s.snd s.condition)
   (by simp) (by simp) (by tidy)
 
+/-- A helper function for the uniqueness of the arrow given by the universal property. -/
+def pullback.lift_unique {C : Type u} [category.{v} C] {W X Y Z : C}
+      {f : X ⟶ Z} {g : Y ⟶ Z} [has_pullback f g]
+      (h : W ⟶ X) (k : W ⟶ Y) (w : h ≫ f = k ≫ g) :
+      Π (r : W ⟶ pullback f g), h = r ≫ pullback.fst → k = r ≫ pullback.snd →
+      r = pullback.lift h k w :=
+begin
+intros r hyp₁ hyp₂,
+exact is_limit.uniq (limit.is_limit (cospan f g)) (pullback_cone.mk h k w) r
+(by {
+      intro j,
+      cases j,
+
+      simp,
+      rw [← category.assoc, ← hyp₁],
+
+      cases j,
+      simp,
+      rw ← hyp₁,
+      simp,
+      rw ← hyp₂,
+})
+end
+
+lemma pullback.lift_comp {C : Type u} [category.{v} C] {X Y Z W U : C}
+  {f : X ⟶ Z} {g : Y ⟶ Z} [has_pullback f g]
+  (h : W ⟶ X) (k : W ⟶ Y) (t : U ⟶ W) (h₁ : h ≫ f = k ≫ g) :
+  pullback.lift (t ≫ h) (t ≫ k) (by simp *) = t ≫ pullback.lift h k h₁ :=
+begin
+symmetry,
+apply pullback.lift_unique,
+repeat {simp},
+end
+
+
 /-- The pullback of a monomorphism is a monomorphism -/
 instance pullback.fst_of_mono {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [has_pullback f g]
   [mono g] : mono (pullback.fst : pullback f g ⟶ X) :=


### PR DESCRIPTION
This is the internal category stuff that I made under the supervision of Dorette Pronk and Martin Szyld to use for double categories. I'm working on getting it accepted by the CI for the time being. In particular, CI wants an instance for an internal category. Is there any preferred instance by the mathlib community? I was thinking that making an instance that takes a small category and builds a category internal to Set would be good. If anyone has any suggestions (about anything, not just the instance), I'd love to hear them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
