### PR TITLE
perf(algebraic_topology/dold_kan/normalized): Speedup `N₁_iso_normalized_Moore_complex_comp_to_karoubi`

### DIFF
--- a/src/algebraic_topology/dold_kan/normalized.lean
+++ b/src/algebraic_topology/dold_kan/normalized.lean
@@ -111,29 +111,37 @@ def split_mono_inclusion_of_Moore_complex_map (X : simplicial_object A) :
 
 variable (A)
 
+/-- Forward hom of `N₁_iso_normalized_Moore_complex_comp_to_karoubi`. -/
+private def iso_hom :
+  N₁ ⟶ (normalized_Moore_complex A ⋙ to_karoubi _) :=
+{ app := λ X,
+  { f := P_infty_to_normalized_Moore_complex X,
+    comm := by tidy } }
+
+/-- Backward hom of `N₁_iso_normalized_Moore_complex_comp_to_karoubi`. -/
+private def iso_inv :
+  (normalized_Moore_complex A ⋙ to_karoubi _) ⟶ N₁ :=
+{ app := λ X,
+  { f := inclusion_of_Moore_complex_map X,
+    comm := by tidy } }
+
 /-- When the category `A` is abelian,
 the functor `N₁ : simplicial_object A ⥤ karoubi (chain_complex A ℕ)` defined
 using `P_infty` identifies to the composition of the normalized Moore complex functor
 and the inclusion in the Karoubi envelope. -/
 def N₁_iso_normalized_Moore_complex_comp_to_karoubi :
   N₁ ≅ (normalized_Moore_complex A ⋙ to_karoubi _) :=
-{ hom :=
-  { app := λ X,
-    { f := P_infty_to_normalized_Moore_complex X,
-      comm := by tidy, }, },
-  inv :=
-  { app := λ X,
-    { f := inclusion_of_Moore_complex_map X,
-      comm := by tidy, }, },
+{ hom := iso_hom _,
+  inv := iso_inv _,
   hom_inv_id' := begin
     ext X : 3,
-    simp only [P_infty_to_normalized_Moore_complex_comp_inclusion_of_Moore_complex_map,
-      nat_trans.comp_app, karoubi.comp_f, N₁_obj_p, nat_trans.id_app, karoubi.id_eq],
+    simp only [P_infty_to_normalized_Moore_complex_comp_inclusion_of_Moore_complex_map, iso_inv,
+      nat_trans.comp_app, karoubi.comp_f, N₁_obj_p, nat_trans.id_app, karoubi.id_eq, iso_hom],
   end,
   inv_hom_id' := begin
     ext X : 3,
     simp only [← cancel_mono (inclusion_of_Moore_complex_map X),
-      nat_trans.comp_app, karoubi.comp_f, assoc, nat_trans.id_app, karoubi.id_eq,
+      nat_trans.comp_app, karoubi.comp_f, assoc, nat_trans.id_app, karoubi.id_eq, iso_hom, iso_inv,
       P_infty_to_normalized_Moore_complex_comp_inclusion_of_Moore_complex_map,
       inclusion_of_Moore_complex_map_comp_P_infty],
     dsimp only [functor.comp_obj, to_karoubi],


### PR DESCRIPTION
This makes the longest declaration take 12s instead of 20s on my machine.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
If you have any better, please do. This is not a terribly great speedup.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
