### PR TITLE
[Merged by Bors] - refactor(geometry/euclidean/angle/unoriented/basic): split out conformal map lemmas

### DIFF
--- a/src/analysis/calculus/conformal/normed_space.lean
+++ b/src/analysis/calculus/conformal/normed_space.lean
@@ -26,7 +26,7 @@ if it is real differentiable at that point and its differential `is_conformal_li
 In `analysis.calculus.conformal.inner_product`:
 * `conformal_at_iff`: an equivalent definition of the conformality of a map
 
-In `geometry.euclidean.basic`:
+In `geometry.euclidean.angle.unoriented.conformal`:
 * `conformal_at.preserves_angle`: if a map is conformal at `x`, then its differential
                                   preserves all angles at `x`
 

--- a/src/geometry/euclidean/angle/unoriented/basic.lean
+++ b/src/geometry/euclidean/angle/unoriented/basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers, Manuel Candales
 -/
-import analysis.calculus.conformal.normed_space
 import analysis.inner_product_space.basic
 import analysis.special_functions.trigonometric.inverse
 
@@ -17,6 +16,9 @@ This file defines unoriented angles in real inner product spaces.
 * `inner_product_geometry.angle` is the undirected angle between two vectors.
 
 -/
+
+assert_not_exists has_fderiv_at
+assert_not_exists conformal_at
 
 noncomputable theory
 open_locale big_operators
@@ -52,24 +54,6 @@ by rw [angle, angle, f.inner_map_map, f.norm_map, f.norm_map]
 @[simp, norm_cast] lemma _root_.submodule.angle_coe {s : submodule ℝ V} (x y : s) :
   angle (x : V) (y : V) = angle x y :=
 s.subtypeₗᵢ.angle_map x y
-
-lemma is_conformal_map.preserves_angle {E F : Type*}
-  [inner_product_space ℝ E] [inner_product_space ℝ F]
-  {f' : E →L[ℝ] F} (h : is_conformal_map f') (u v : E) :
-  angle (f' u) (f' v) = angle u v :=
-begin
-  obtain ⟨c, hc, li, rfl⟩ := h,
-  exact (angle_smul_smul hc _ _).trans (li.angle_map _ _)
-end
-
-/-- If a real differentiable map `f` is conformal at a point `x`,
-    then it preserves the angles at that point. -/
-lemma conformal_at.preserves_angle {E F : Type*}
-  [inner_product_space ℝ E] [inner_product_space ℝ F]
-  {f : E → F} {x : E} {f' : E →L[ℝ] F}
-  (h : has_fderiv_at f f' x) (H : conformal_at f x) (u v : E) :
-  angle (f' u) (f' v) = angle u v :=
-let ⟨f₁, h₁, c⟩ := H in h₁.unique h ▸ is_conformal_map.preserves_angle c u v
 
 /-- The cosine of the angle between two vectors. -/
 lemma cos_angle (x y : V) : real.cos (angle x y) = ⟪x, y⟫ / (‖x‖ * ‖y‖) :=

--- a/src/geometry/euclidean/angle/unoriented/conformal.lean
+++ b/src/geometry/euclidean/angle/unoriented/conformal.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2021 Yourong Zang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yourong Zang
+-/
+import analysis.calculus.conformal.normed_space
+import geometry.euclidean.angle.unoriented.basic
+
+/-!
+# Angles and conformal maps
+
+This file proves that conformal maps preserve angles.
+
+-/
+
+namespace inner_product_geometry
+
+variables {V : Type*} [inner_product_space ℝ V]
+
+lemma is_conformal_map.preserves_angle {E F : Type*}
+  [inner_product_space ℝ E] [inner_product_space ℝ F]
+  {f' : E →L[ℝ] F} (h : is_conformal_map f') (u v : E) :
+  angle (f' u) (f' v) = angle u v :=
+begin
+  obtain ⟨c, hc, li, rfl⟩ := h,
+  exact (angle_smul_smul hc _ _).trans (li.angle_map _ _)
+end
+
+/-- If a real differentiable map `f` is conformal at a point `x`,
+    then it preserves the angles at that point. -/
+lemma conformal_at.preserves_angle {E F : Type*}
+  [inner_product_space ℝ E] [inner_product_space ℝ F]
+  {f : E → F} {x : E} {f' : E →L[ℝ] F}
+  (h : has_fderiv_at f f' x) (H : conformal_at f x) (u v : E) :
+  angle (f' u) (f' v) = angle u v :=
+let ⟨f₁, h₁, c⟩ := H in h₁.unique h ▸ is_conformal_map.preserves_angle c u v
+
+end inner_product_geometry


### PR DESCRIPTION
Move two lemmas about conformal maps preserving angles to a separate `geometry.euclidean.angle.unoriented.conformal`, so eliminating the dependence of angles on calculus (and use `assert_not_exists` to declare that the basic file should not depend on calculus or conformal maps).  None of the other Euclidean geometry results depend on these two lemmas.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
