### PR TITLE
chore(algebra/big_operators/pi): fix some to_additive names

### DIFF
--- a/src/algebra/big_operators/pi.lean
+++ b/src/algebra/big_operators/pi.lean
@@ -47,7 +47,7 @@ lemma fintype.prod_apply {α : Type*} {β : α → Type*} {γ : Type*} [fintype 
   [∀a, comm_monoid (β a)] (a : α) (g : γ → Πa, β a) : (∏ c, g c) a = ∏ c, g c a :=
 finset.prod_apply a finset.univ g
 
-@[to_additive prod_mk_sum]
+@[to_additive]
 lemma prod_mk_prod {α β γ : Type*} [comm_monoid α] [comm_monoid β] (s : finset γ)
   (f : γ → α) (g : γ → β) : (∏ x in s, f x, ∏ x in s, g x) = ∏ x in s, (f x, g x) :=
 by haveI := classical.dec_eq γ; exact
@@ -95,16 +95,12 @@ ring_hom.coe_add_monoid_hom_injective $
 
 end ring_hom
 
-namespace prod
-
 variables {α β γ : Type*} [comm_monoid α] [comm_monoid β] {s : finset γ} {f : γ → α × β}
 
-@[to_additive]
-lemma fst_prod : (∏ c in s, f c).1 = ∏ c in s, (f c).1 :=
+@[to_additive sum.fst_sum]
+lemma prod.fst_prod : (∏ c in s, f c).1 = ∏ c in s, (f c).1 :=
 (monoid_hom.fst α β).map_prod f s
 
-@[to_additive]
-lemma snd_prod  : (∏ c in s, f c).2 = ∏ c in s, (f c).2 :=
+@[to_additive sum.snd_sum]
+lemma prod.snd_prod  : (∏ c in s, f c).2 = ∏ c in s, (f c).2 :=
 (monoid_hom.snd α β).map_prod f s
-
-end prod

--- a/src/algebra/big_operators/pi.lean
+++ b/src/algebra/big_operators/pi.lean
@@ -95,12 +95,16 @@ ring_hom.coe_add_monoid_hom_injective $
 
 end ring_hom
 
+namespace prod
+
 variables {α β γ : Type*} [comm_monoid α] [comm_monoid β] {s : finset γ} {f : γ → α × β}
 
-@[to_additive sum.fst_sum]
-lemma prod.fst_prod : (∏ c in s, f c).1 = ∏ c in s, (f c).1 :=
+@[to_additive]
+lemma fst_prod : (∏ c in s, f c).1 = ∏ c in s, (f c).1 :=
 (monoid_hom.fst α β).map_prod f s
 
-@[to_additive sum.snd_sum]
-lemma prod.snd_prod  : (∏ c in s, f c).2 = ∏ c in s, (f c).2 :=
+@[to_additive]
+lemma snd_prod  : (∏ c in s, f c).2 = ∏ c in s, (f c).2 :=
 (monoid_hom.snd α β).map_prod f s
+
+end prod

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -747,7 +747,7 @@ variables [add_comm_monoid α] [topological_space α] [add_comm_monoid γ] [topo
 lemma has_sum.prod_mk {f : β → α} {g : β → γ} {a : α} {b : γ}
   (hf : has_sum f a) (hg : has_sum g b) :
   has_sum (λ x, (⟨f x, g x⟩ : α × γ)) ⟨a, b⟩ :=
-by simp [has_sum, ← prod_mk_sum, filter.tendsto.prod_mk_nhds hf hg]
+by simp [has_sum, ← sum_mk_sum, filter.tendsto.prod_mk_nhds hf hg]
 
 end prod
 


### PR DESCRIPTION
This PR gives explicit correct `to_additive` names to two lemmas 
```lean
@[to_additive sum.fst_sum]
lemma prod.fst_prod : (∏ c in s, f c).1 = ∏ c in s, (f c).1 :=

@[to_additive sum.snd_sum]
lemma prod.snd_prod  : (∏ c in s, f c).2 = ∏ c in s, (f c).2 :=
```

Also, it is needed to trigger an update of the `to_additive` name of `prod_mk_prod` that is for the moment `prod_mk_sum` (see https://leanprover-community.github.io/mathlib_docs/algebra/big_operators/pi.html#prod_mk_sum). No changed is needed here since `to_additive` now generates the correct name `sum_mk_sum` for this lemma

This changes are needed for names in [mathlib4#1687](https://github.com/leanprover-community/mathlib4/pull/1687) to be consistent with names in `mathlib3`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
