### PR TITLE
[Merged by Bors] - refactor(set_theory/ordinal/arithmetic): fix `rank` universes

### DIFF
--- a/src/order/extension/well.lean
+++ b/src/order/extension/well.lean
@@ -44,7 +44,7 @@ arbitrary well-order to serve as a tiebreak between two elements of same rank.
 noncomputable def well_order_extension : linear_order α :=
 let l : linear_order α := is_well_order.linear_order well_ordering_rel in by exactI
   @linear_order.lift' α (ordinal ×ₗ α) _
-    (λ a : α, (well_founded.rank.{u u} hwf a, a)) (λ _ _, congr_arg prod.snd)
+    (λ a : α, (well_founded.rank.{u} hwf a, a)) (λ _ _, congr_arg prod.snd)
 
 instance well_order_extension.is_well_founded_lt : is_well_founded α hwf.well_order_extension.lt :=
 ⟨inv_image.wf _ $ prod.lex_wf ordinal.well_founded_lt.wf well_ordering_rel.is_well_order.wf⟩

--- a/src/set_theory/ordinal/arithmetic.lean
+++ b/src/set_theory/ordinal/arithmetic.lean
@@ -54,10 +54,10 @@ open function cardinal set equiv order
 open_locale classical cardinal ordinal
 
 universes u v w
-variables {α : Type*} {β : Type*} {γ : Type*}
-  {r : α → α → Prop} {s : β → β → Prop} {t : γ → γ → Prop}
 
 namespace ordinal
+variables {α : Type*} {β : Type*} {γ : Type*}
+  {r : α → α → Prop} {s : β → β → Prop} {t : γ → γ → Prop}
 
 /-! ### Further properties of addition on ordinals -/
 
@@ -2332,17 +2332,18 @@ meta def positivity_opow : expr → tactic strictness
 
 end tactic
 
+variables {α : Type u} {r : α → α → Prop} {a b : α}
+
 namespace acc
-variables {a b : α}
 
 /-- The rank of an element `a` accessible under a relation `r` is defined inductively as the
 smallest ordinal greater than the ranks of all elements below it (i.e. elements `b` such that
 `r b a`). -/
-noncomputable def rank (h : acc r a) : ordinal :=
-acc.rec_on h $ λ a h ih, ordinal.sup $ λ b : {b // r b a}, order.succ $ ih b b.2
+noncomputable def rank (h : acc r a) : ordinal.{u} :=
+acc.rec_on h $ λ a h ih, ordinal.sup.{u u} $ λ b : {b // r b a}, order.succ $ ih b b.2
 
 lemma rank_eq (h : acc r a) :
-  h.rank = ordinal.sup (λ b : {b // r b a}, order.succ (h.inv b.2).rank) :=
+  h.rank = ordinal.sup.{u u} (λ b : {b // r b a}, order.succ (h.inv b.2).rank) :=
 by { change (acc.intro a $ λ _, h.inv).rank = _, refl }
 
 /-- if `r a b` then the rank of `a` is less than the rank of `b`. -/
@@ -2352,15 +2353,15 @@ lemma rank_lt_of_rel (hb : acc r b) (h : r a b) : (hb.inv h).rank < hb.rank :=
 end acc
 
 namespace well_founded
-variables (hwf : well_founded r) {a b : α}
+variables (hwf : well_founded r)
 include hwf
 
 /-- The rank of an element `a` under a well-founded relation `r` is defined inductively as the
 smallest ordinal greater than the ranks of all elements below it (i.e. elements `b` such that
 `r b a`). -/
-noncomputable def rank (a : α) : ordinal := (hwf.apply a).rank
+noncomputable def rank (a : α) : ordinal.{u} := (hwf.apply a).rank
 
-lemma rank_eq : hwf.rank a = ordinal.sup (λ b : {b // r b a}, order.succ $ hwf.rank b) :=
+lemma rank_eq : hwf.rank a = ordinal.sup.{u u} (λ b : {b // r b a}, order.succ $ hwf.rank b) :=
 by { rw [rank, acc.rank_eq], refl }
 
 lemma rank_lt_of_rel (h : r a b) : hwf.rank a < hwf.rank b := acc.rank_lt_of_rel _ h


### PR DESCRIPTION
The rank of an object in universe `u` should also be an ordinal in universe `u`, rather than universe `max u v` for some other `v`, as `ordinal.lift` can achieve this effect.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I had to do some weird variable management. Maybe it might be worth placing this elsewhere? The arithmetic file is already huge...

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
