### PR TITLE
[Merged by Bors] - fix(*/finsupp/*): add missing decidable arguments in lemma statements

### DIFF
--- a/src/algebra/big_operators/finsupp.lean
+++ b/src/algebra/big_operators/finsupp.lean
@@ -19,7 +19,7 @@ This file contains theorems relevant to big operators in finitely supported func
 noncomputable theory
 
 open finset function
-open_locale classical big_operators
+open_locale big_operators
 
 variables {α ι γ A B C : Type*} [add_comm_monoid A] [add_comm_monoid B] [add_comm_monoid C]
 variables {t : ι → A → C} (h0 : ∀ i, t i 0 = 0) (h1 : ∀ i x y, t i (x + y) = t i x + t i y)
@@ -86,7 +86,11 @@ by { dsimp [finsupp.prod], rw f.support.prod_ite_eq, }
 @[simp] lemma sum_ite_self_eq
   [decidable_eq α] {N : Type*} [add_comm_monoid N] (f : α →₀ N) (a : α) :
   f.sum (λ x v, ite (a = x) v 0) = f a :=
-by { convert f.sum_ite_eq a (λ x, id), simp [ite_eq_right_iff.2 eq.symm] }
+begin
+  classical,
+  convert f.sum_ite_eq a (λ x, id),
+  simp [ite_eq_right_iff.2 eq.symm]
+end
 
 /-- A restatement of `prod_ite_eq` with the equality test reversed. -/
 @[simp, to_additive "A restatement of `sum_ite_eq` with the equality test reversed."]
@@ -97,7 +101,11 @@ by { dsimp [finsupp.prod], rw f.support.prod_ite_eq', }
 @[simp] lemma sum_ite_self_eq'
   [decidable_eq α] {N : Type*} [add_comm_monoid N] (f : α →₀ N) (a : α) :
   f.sum (λ x v, ite (x = a) v 0) = f a :=
-by { convert f.sum_ite_eq' a (λ x, id), simp [ite_eq_right_iff.2 eq.symm] }
+begin
+  classical,
+  convert f.sum_ite_eq' a (λ x, id),
+  simp [ite_eq_right_iff.2 eq.symm]
+end
 
 @[simp] lemma prod_pow [fintype α] (f : α →₀ ℕ) (g : α → N) :
   f.prod (λ a b, g a ^ b) = ∏ a, g a ^ (f a) :=
@@ -121,6 +129,7 @@ single element `y ∈ f.support` to the sum over `erase y f`. "-/]
 lemma mul_prod_erase (f : α →₀ M) (y : α) (g : α → M → N) (hyf : y ∈ f.support) :
   g y (f y) * (erase y f).prod g = f.prod g :=
 begin
+  classical,
   rw [finsupp.prod, finsupp.prod, ←finset.mul_prod_erase _ _ hyf, finsupp.support_erase,
     finset.prod_congr rfl],
   intros h hx,
@@ -288,7 +297,7 @@ This is a more general version of `finsupp.prod_add_index'`; the latter has simp
 @[to_additive "Taking the product under `h` is an additive homomorphism of finsupps,
 if `h` is an additive homomorphism on the support.
 This is a more general version of `finsupp.sum_add_index'`; the latter has simpler hypotheses."]
-lemma prod_add_index [add_zero_class M] [comm_monoid N] {f g : α →₀ M}
+lemma prod_add_index [decidable_eq α] [add_zero_class M] [comm_monoid N] {f g : α →₀ M}
   {h : α → M → N} (h_zero : ∀ a ∈ f.support ∪ g.support, h a 0 = 1)
   (h_add : ∀ (a ∈ f.support ∪ g.support) b₁ b₂, h a (b₁ + b₂) = h a b₁ * h a b₂) :
   (f + g).prod h = f.prod h * g.prod h :=
@@ -309,7 +318,7 @@ This is a more specific version of `finsupp.sum_add_index` with simpler hypothes
 lemma prod_add_index' [add_zero_class M] [comm_monoid N] {f g : α →₀ M}
   {h : α → M → N} (h_zero : ∀a, h a 0 = 1) (h_add : ∀a b₁ b₂, h a (b₁ + b₂) = h a b₁ * h a b₂) :
   (f + g).prod h = f.prod h * g.prod h :=
-prod_add_index (λ a ha, h_zero a) (λ a ha, h_add a)
+by classical; exact prod_add_index (λ a ha, h_zero a) (λ a ha, h_add a)
 
 @[simp]
 lemma sum_hom_add_index [add_zero_class M] [add_comm_monoid N] {f g : α →₀ M} (h : α → M →+ N) :
@@ -401,8 +410,8 @@ lemma prod_finset_sum_index [add_comm_monoid M] [comm_monoid N]
   {s : finset ι} {g : ι → α →₀ M}
   {h : α → M → N} (h_zero : ∀a, h a 0 = 1) (h_add : ∀a b₁ b₂, h a (b₁ + b₂) = h a b₁ * h a b₂) :
   ∏ i in s, (g i).prod h = (∑ i in s, g i).prod h :=
-finset.induction_on s rfl $ λ a s has ih,
-by rw [prod_insert has, ih, sum_insert has, prod_add_index' h_zero h_add]
+finset.cons_induction_on s rfl $ λ a s has ih,
+by rw [prod_cons, ih, sum_cons, prod_add_index' h_zero h_add]
 
 @[to_additive]
 lemma prod_sum_index
@@ -420,10 +429,12 @@ lemma multiset_sum_sum_index
 multiset.induction_on f rfl $ assume a s ih,
 by rw [multiset.sum_cons, multiset.map_cons, multiset.sum_cons, sum_add_index' h₀ h₁, ih]
 
-lemma support_sum_eq_bUnion {α : Type*} {ι : Type*} {M : Type*} [add_comm_monoid M]
+lemma support_sum_eq_bUnion {α : Type*} {ι : Type*} {M : Type*} [decidable_eq α]
+  [add_comm_monoid M]
   {g : ι → α →₀ M} (s : finset ι) (h : ∀ i₁ i₂, i₁ ≠ i₂ → disjoint (g i₁).support (g i₂).support) :
   (∑ i in s, g i).support = s.bUnion (λ i, (g i).support) :=
 begin
+  classical,
   apply finset.induction_on s,
   { simp },
   { intros i s hi,
@@ -455,14 +466,18 @@ have ∀ {f1 f2 : α →₀ M}, disjoint f1.support f2.support →
   ∏ x in f1.support, g x (f1 x + f2 x) = f1.prod g :=
   λ f1 f2 hd, finset.prod_congr rfl (λ x hx,
     by simp only [not_mem_support_iff.mp (disjoint_left.mp hd hx), add_zero]),
-by simp_rw [← this hd, ← this hd.symm,
-  add_comm (f2 _), finsupp.prod, support_add_eq hd, prod_union hd, add_apply]
+begin
+  classical,
+  simp_rw [← this hd, ← this hd.symm,
+    add_comm (f2 _), finsupp.prod, support_add_eq hd, prod_union hd, add_apply]
+end
 
 lemma prod_dvd_prod_of_subset_of_dvd [add_comm_monoid M] [comm_monoid N]
   {f1 f2 : α →₀ M} {g1 g2 : α → M → N} (h1 : f1.support ⊆ f2.support)
   (h2 : ∀ (a : α), a ∈ f1.support → g1 a (f1 a) ∣ g2 a (f2 a)) :
   f1.prod g1 ∣ f2.prod g2 :=
 begin
+  classical,
   simp only [finsupp.prod, finsupp.prod_mul],
   rw [←sdiff_union_of_subset h1, prod_union sdiff_disjoint],
   apply dvd_mul_of_dvd_right,

--- a/src/algebra/category/Module/adjunctions.lean
+++ b/src/algebra/category/Module/adjunctions.lean
@@ -196,14 +196,14 @@ instance : preadditive (Free R C) :=
 { hom_group := λ X Y, finsupp.add_comm_group,
   add_comp' := λ X Y Z f f' g, begin
     dsimp,
-    rw [finsupp.sum_add_index];
+    rw [finsupp.sum_add_index'];
     { simp [add_mul], }
   end,
   comp_add' := λ X Y Z f g g', begin
     dsimp,
     rw ← finsupp.sum_add,
     congr, ext r h,
-    rw [finsupp.sum_add_index];
+    rw [finsupp.sum_add_index'];
     { simp [mul_add], },
   end, }
 
@@ -257,7 +257,7 @@ def lift (F : C ⥤ D) : Free R C ⥤ D :=
     { simp only [limits.zero_comp, sum_zero_index] },
     { intros f₁ f₂ w₁ w₂,
       rw add_comp,
-      rw [finsupp.sum_add_index, finsupp.sum_add_index],
+      rw [finsupp.sum_add_index', finsupp.sum_add_index'],
       { simp only [w₁, w₂, add_comp] },
       { intros, rw zero_smul },
       { intros, simp only [add_smul], },
@@ -268,7 +268,7 @@ def lift (F : C ⥤ D) : Free R C ⥤ D :=
       { simp only [limits.comp_zero, sum_zero_index] },
       { intros f₁ f₂ w₁ w₂,
         rw comp_add,
-        rw [finsupp.sum_add_index, finsupp.sum_add_index],
+        rw [finsupp.sum_add_index', finsupp.sum_add_index'],
         { simp only [w₁, w₂, comp_add], },
         { intros, rw zero_smul },
         { intros, simp only [add_smul], },
@@ -287,7 +287,7 @@ by simp
 instance lift_additive (F : C ⥤ D) : (lift R F).additive :=
 { map_add' := λ X Y f g, begin
     dsimp,
-    rw finsupp.sum_add_index; simp [add_smul]
+    rw finsupp.sum_add_index'; simp [add_smul]
   end, }
 
 instance lift_linear (F : C ⥤ D) : (lift R F).linear R :=

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -109,11 +109,13 @@ instance : non_unital_non_assoc_semiring (monoid_algebra k G) :=
 { zero          := 0,
   mul           := (*),
   add           := (+),
-  left_distrib  := assume f g h, by simp only [mul_def, sum_add_index, mul_add, mul_zero,
-    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_add],
-  right_distrib := assume f g h, by simp only [mul_def, sum_add_index, add_mul, zero_mul,
-    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_zero,
-    sum_add],
+  left_distrib  := assume f g h, by haveI := classical.dec_eq G;
+    simp only [mul_def, sum_add_index, mul_add, mul_zero,
+      single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_add],
+  right_distrib := assume f g h, by haveI := classical.dec_eq G;
+    simp only [mul_def, sum_add_index, add_mul, zero_mul,
+      single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_zero,
+      sum_add],
   zero_mul  := assume f, by simp only [mul_def, sum_zero_index],
   mul_zero  := assume f, by simp only [mul_def, sum_zero_index, sum_zero],
   .. finsupp.add_comm_monoid }
@@ -924,11 +926,13 @@ instance : non_unital_non_assoc_semiring (add_monoid_algebra k G) :=
 { zero          := 0,
   mul           := (*),
   add           := (+),
-  left_distrib  := assume f g h, by simp only [mul_def, sum_add_index, mul_add, mul_zero,
-    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_add],
-  right_distrib := assume f g h, by simp only [mul_def, sum_add_index, add_mul, mul_zero, zero_mul,
-    single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_zero,
-    sum_add],
+  left_distrib  := assume f g h, by haveI := classical.dec_eq G;
+    simp only [mul_def, sum_add_index, mul_add, mul_zero,
+      single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_add],
+  right_distrib := assume f g h, by haveI := classical.dec_eq G;
+    simp only [mul_def, sum_add_index, add_mul, mul_zero, zero_mul,
+      single_zero, single_add, eq_self_iff_true, forall_true_iff, forall_3_true_iff, sum_zero,
+      sum_add],
   zero_mul  := assume f, by simp only [mul_def, sum_zero_index],
   mul_zero  := assume f, by simp only [mul_def, sum_zero_index, sum_zero],
   nsmul     := λ n f, n • f,

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -827,8 +827,9 @@ lemma prod_option_index [add_comm_monoid M] [comm_monoid N]
   (h_add : ∀ o m₁ m₂, b o (m₁ + m₂) = b o m₁ * b o m₂) :
   f.prod b = b none (f none) * f.some.prod (λ a, b (option.some a)) :=
 begin
+  classical,
   apply induction_linear f,
-  { simp [h_zero], },
+  { simp [some_zero, h_zero], },
   { intros f₁ f₂ h₁ h₂,
     rw [finsupp.prod_add_index, h₁, h₂, some_add, finsupp.prod_add_index],
     simp only [h_add, pi.add_apply, finsupp.coe_add],
@@ -1147,10 +1148,18 @@ f.sum $ λa g, g.sum $ λb c, single (a, b) c
 /-- `finsupp_prod_equiv` defines the `equiv` between `((α × β) →₀ M)` and `(α →₀ (β →₀ M))` given by
 currying and uncurrying. -/
 def finsupp_prod_equiv : ((α × β) →₀ M) ≃ (α →₀ (β →₀ M)) :=
-by refine ⟨finsupp.curry, finsupp.uncurry, λ f, _, λ f, _⟩; simp only [
-  finsupp.curry, finsupp.uncurry, sum_sum_index, sum_zero_index, sum_add_index,
-  sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff,
-  forall_3_true_iff, prod.mk.eta, (single_sum _ _ _).symm, sum_single]
+{ to_fun := finsupp.curry,
+  inv_fun := finsupp.uncurry,
+  left_inv := λ f, begin
+    rw [finsupp.uncurry, sum_curry_index],
+    { simp_rw [prod.mk.eta, sum_single], },
+    { intros, apply single_zero },
+    { intros, apply single_add }
+  end,
+  right_inv := λ f, by simp only [
+    finsupp.curry, finsupp.uncurry, sum_sum_index, sum_zero_index, sum_add_index,
+    sum_single_index, single_zero, single_add, eq_self_iff_true, forall_true_iff,
+    forall_3_true_iff, prod.mk.eta, (single_sum _ _ _).symm, sum_single] }
 
 lemma filter_curry (f : α × β →₀ M) (p : α → Prop) :
   (f.filter (λa:α×β, p a.1)).curry = f.curry.filter p :=

--- a/src/data/finsupp/indicator.lean
+++ b/src/data/finsupp/indicator.lean
@@ -18,7 +18,6 @@ This file defines `finsupp.indicator` to help create finsupps from finsets.
 noncomputable theory
 
 open finset function
-open_locale classical
 
 variables {ι α : Type*}
 
@@ -27,20 +26,26 @@ variables [has_zero α] {s : finset ι} (f : Π i ∈ s, α) {i : ι}
 
 /-- Create an element of `ι →₀ α` from a finset `s` and a function `f` defined on this finset. -/
 def indicator (s : finset ι) (f : Π i ∈ s, α) : ι →₀ α :=
-{ to_fun := λ i, if H : i ∈ s then f i H else 0,
-  support := (s.attach.filter $ λ i : s, f i.1 i.2 ≠ 0).map $ embedding.subtype _,
+{ to_fun := λ i, by haveI := classical.dec_eq ι; exact
+    if H : i ∈ s then f i H else 0,
+  support := by haveI := classical.dec_eq α; exact
+    (s.attach.filter $ λ i : s, f i.1 i.2 ≠ 0).map (embedding.subtype _),
   mem_support_to_fun := λ i, begin
+    letI := classical.dec_eq α,
     rw [mem_map, dite_ne_right_iff],
     exact ⟨λ ⟨⟨j, hj⟩, hf, rfl⟩, ⟨hj, (mem_filter.1 hf).2⟩,
       λ ⟨hi, hf⟩, ⟨⟨i, hi⟩, mem_filter.2 $ ⟨mem_attach _ _, hf⟩, rfl⟩⟩,
   end }
 
-lemma indicator_of_mem (hi : i ∈ s) (f : Π i ∈ s, α) : indicator s f i = f i hi := dif_pos hi
-lemma indicator_of_not_mem (hi : i ∉ s) (f : Π i ∈ s, α) : indicator s f i = 0 := dif_neg hi
+lemma indicator_of_mem (hi : i ∈ s) (f : Π i ∈ s, α) : indicator s f i = f i hi :=
+@dif_pos _ (id _) hi _ _ _
+lemma indicator_of_not_mem (hi : i ∉ s) (f : Π i ∈ s, α) : indicator s f i = 0 :=
+@dif_neg _ (id _) hi _ _ _
 
 variables (s i)
 
-@[simp] lemma indicator_apply : indicator s f i = if hi : i ∈ s then f i hi else 0 := rfl
+@[simp] lemma indicator_apply [decidable_eq ι] :
+  indicator s f i = if hi : i ∈ s then f i hi else 0 := by convert rfl
 
 lemma indicator_injective : injective (λ f : Π i ∈ s, α, indicator s f) :=
 begin

--- a/src/data/finsupp/interval.lean
+++ b/src/data/finsupp/interval.lean
@@ -53,7 +53,7 @@ variables [has_zero α] [partial_order α] [locally_finite_order α] {f g : ι �
 /-- Pointwise `finset.Icc` bundled as a `finsupp`. -/
 @[simps to_fun] def range_Icc (f g : ι →₀ α) : ι →₀ finset α :=
 { to_fun := λ i, Icc (f i) (g i),
-  support := f.support ∪ g.support,
+  support := by haveI := classical.dec_eq ι; exact f.support ∪ g.support,
   mem_support_to_fun := λ i, begin
     rw [mem_union, ←not_iff_not, not_or_distrib, not_mem_support_iff, not_mem_support_iff,
       not_ne_iff],
@@ -72,6 +72,7 @@ section partial_order
 variables [partial_order α] [has_zero α] [locally_finite_order α] (f g : ι →₀ α)
 
 instance : locally_finite_order (ι →₀ α) :=
+by haveI := classical.dec_eq ι; haveI := classical.dec_eq α; exact
 locally_finite_order.of_Icc (ι →₀ α)
   (λ f g, (f.support ∪ g.support).finsupp $ f.range_Icc g)
   (λ f g x, begin
@@ -108,8 +109,11 @@ variables [canonically_ordered_add_monoid α] [locally_finite_order α]
 variables (f : ι →₀ α)
 
 lemma card_Iic : (Iic f).card = ∏ i in f.support, (Iic (f i)).card :=
-by simp_rw [Iic_eq_Icc, card_Icc, finsupp.bot_eq_zero, support_zero, empty_union, zero_apply,
-  bot_eq_zero]
+begin
+  classical,
+  simp_rw [Iic_eq_Icc, card_Icc, finsupp.bot_eq_zero, support_zero, empty_union, zero_apply,
+    bot_eq_zero]
+end
 
 lemma card_Iio : (Iio f).card = ∏ i in f.support, (Iic (f i)).card - 1 :=
 by rw [card_Iio_eq_card_Iic_sub_one, card_Iic]

--- a/src/data/finsupp/order.lean
+++ b/src/data/finsupp/order.lean
@@ -19,7 +19,7 @@ This file lifts order structures on `α` to `ι →₀ α`.
 -/
 
 noncomputable theory
-open_locale classical big_operators
+open_locale big_operators
 
 open finset
 
@@ -116,7 +116,8 @@ by simp [ext_iff, forall_and_distrib]
 
 lemma le_iff' (f g : ι →₀ α) {s : finset ι} (hf : f.support ⊆ s) : f ≤ g ↔ ∀ i ∈ s, f i ≤ g i :=
 ⟨λ h s hs, h s,
-λ h s, if H : s ∈ f.support then h s (hf H) else (not_mem_support_iff.1 H).symm ▸ zero_le (g s)⟩
+λ h s, by classical; exact
+  if H : s ∈ f.support then h s (hf H) else (not_mem_support_iff.1 H).symm ▸ zero_le (g s)⟩
 
 lemma le_iff (f g : ι →₀ α) : f ≤ g ↔ ∀ i ∈ f.support, f i ≤ g i := le_iff' f g $ subset.refl _
 
@@ -156,7 +157,8 @@ lemma support_tsub {f1 f2 : ι →₀ α} : (f1 - f2).support ⊆ f1.support :=
 by simp only [subset_iff, tsub_eq_zero_iff_le, mem_support_iff, ne.def, coe_tsub, pi.sub_apply,
     not_imp_not, zero_le, implies_true_iff] {contextual := tt}
 
-lemma subset_support_tsub {f1 f2 : ι →₀ α} : f1.support \ f2.support ⊆ (f1 - f2).support :=
+lemma subset_support_tsub [decidable_eq ι] {f1 f2 : ι →₀ α} :
+  f1.support \ f2.support ⊆ (f1 - f2).support :=
 by simp [subset_iff] {contextual := tt}
 
 end canonically_ordered_add_monoid
@@ -183,6 +185,7 @@ end
 
 lemma disjoint_iff {f g : ι →₀ α} : disjoint f g ↔ disjoint f.support g.support :=
 begin
+  classical,
   rw [disjoint_iff, disjoint_iff, finsupp.bot_eq_zero, ← finsupp.support_eq_empty,
     finsupp.support_inf],
   refl,

--- a/src/data/finsupp/to_dfinsupp.lean
+++ b/src/data/finsupp/to_dfinsupp.lean
@@ -235,7 +235,8 @@ lemma sigma_finsupp_equiv_dfinsupp_symm_apply [has_zero N] (f : Π₀ i, (η i �
 
 @[simp]
 lemma sigma_finsupp_equiv_dfinsupp_support
-  [decidable_eq ι] [has_zero N] [Π (i : ι) (x : η i →₀ N), decidable (x ≠ 0)] (f : (Σ i, η i) →₀ N) :
+  [decidable_eq ι] [has_zero N] [Π (i : ι) (x : η i →₀ N), decidable (x ≠ 0)]
+  (f : (Σ i, η i) →₀ N) :
   (sigma_finsupp_equiv_dfinsupp f).support = finsupp.split_support f :=
 begin
   ext,

--- a/src/data/finsupp/to_dfinsupp.lean
+++ b/src/data/finsupp/to_dfinsupp.lean
@@ -198,7 +198,6 @@ section sigma
 /-- ### Stronger versions of `finsupp.split` -/
 
 noncomputable theory
-open_locale
 
 variables {η : ι → Type*} {N : Type*} [semiring R]
 

--- a/src/data/finsupp/to_dfinsupp.lean
+++ b/src/data/finsupp/to_dfinsupp.lean
@@ -198,7 +198,7 @@ section sigma
 /-- ### Stronger versions of `finsupp.split` -/
 
 noncomputable theory
-open_locale classical
+open_locale
 
 variables {η : ι → Type*} {N : Type*} [semiring R]
 
@@ -209,10 +209,12 @@ def sigma_finsupp_equiv_dfinsupp [has_zero N] : ((Σ i, η i) →₀ N) ≃ (Π�
 { to_fun := λ f, ⟨split f, trunc.mk ⟨(split_support f : finset ι).val, λ i,
     begin
       rw [← finset.mem_def, mem_split_support_iff_nonzero],
-      exact (decidable.em _).symm
+      exact (em _).symm
     end⟩⟩,
   inv_fun := λ f,
   begin
+    haveI := classical.dec_eq ι,
+    haveI := λ i, classical.dec_eq (η i →₀ N),
     refine on_finset (finset.sigma f.support (λ j, (f j).support)) (λ ji, f ji.1 ji.2)
       (λ g hg, finset.mem_sigma.mpr ⟨_, mem_support_iff.mpr hg⟩),
     simp only [ne.def, dfinsupp.mem_support_to_fun],
@@ -232,7 +234,8 @@ lemma sigma_finsupp_equiv_dfinsupp_symm_apply [has_zero N] (f : Π₀ i, (η i �
   (sigma_finsupp_equiv_dfinsupp.symm f : (Σ i, η i) →₀ N) s = f s.1 s.2 := rfl
 
 @[simp]
-lemma sigma_finsupp_equiv_dfinsupp_support [has_zero N] (f : (Σ i, η i) →₀ N) :
+lemma sigma_finsupp_equiv_dfinsupp_support
+  [decidable_eq ι] [has_zero N] [Π (i : ι) (x : η i →₀ N), decidable (x ≠ 0)] (f : (Σ i, η i) →₀ N) :
   (sigma_finsupp_equiv_dfinsupp f).support = finsupp.split_support f :=
 begin
   ext,
@@ -240,7 +243,8 @@ begin
   exact (finsupp.mem_split_support_iff_nonzero _ _).symm,
 end
 
-@[simp] lemma sigma_finsupp_equiv_dfinsupp_single [has_zero N] (a : Σ i, η i) (n : N) :
+@[simp] lemma sigma_finsupp_equiv_dfinsupp_single [decidable_eq ι] [has_zero N]
+  (a : Σ i, η i) (n : N) :
   sigma_finsupp_equiv_dfinsupp (finsupp.single a n)
     = @dfinsupp.single _ (λ i, η i →₀ N) _ _ a.1 (finsupp.single a.2 n) :=
 begin
@@ -248,6 +252,7 @@ begin
   ext j b,
   by_cases h : i = j,
   { subst h,
+    classical,
     simp [split_apply, finsupp.single_apply] },
   suffices : finsupp.single (⟨i, a⟩ : Σ i, η i) n ⟨j, b⟩ = 0,
   { simp [split_apply, dif_neg h, this] },

--- a/src/data/mv_polynomial/derivation.lean
+++ b/src/data/mv_polynomial/derivation.lean
@@ -110,7 +110,7 @@ def mk_derivation (f : σ → A) : derivation R (mv_polynomial σ R) A :=
   leibniz' := (leibniz_iff_X (mk_derivationₗ R f) (mk_derivationₗ_C _ 1)).2 $ λ s i,
     begin
       simp only [mk_derivationₗ_monomial, X, monomial_mul, one_smul, one_mul],
-      rw [finsupp.sum_add_index];
+      rw [finsupp.sum_add_index'];
         [skip, by simp, by { intros, simp only [nat.cast_add, (monomial _).map_add, add_smul] }],
       rw [finsupp.sum_single_index, finsupp.sum_single_index]; [skip, by simp, by simp],
       rw [tsub_self, add_tsub_cancel_right, nat.cast_one, ← C_apply, C_1, one_smul,

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -257,7 +257,7 @@ begin
     simp },
   { exact ⟨0, λ i, I.zero_mem, finsupp.sum_zero_index⟩ },
   { rintros x y ⟨ax, hax, rfl⟩ ⟨ay, hay, rfl⟩,
-    refine ⟨ax + ay, λ i, I.add_mem (hax i) (hay i), finsupp.sum_add_index _ _⟩;
+    refine ⟨ax + ay, λ i, I.add_mem (hax i) (hay i), finsupp.sum_add_index' _ _⟩;
       intros; simp only [zero_smul, add_smul] },
   { rintros c x ⟨a, ha, rfl⟩,
     refine ⟨c • a, λ i, I.mul_mem_left c (ha i), _⟩,


### PR DESCRIPTION
I missed these files in #18241


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
