### PR TITLE
[Merged by Bors] - feat(ring_theory/localization): localization of a basis, again

### DIFF
--- a/src/ring_theory/localization/basic.lean
+++ b/src/ring_theory/localization/basic.lean
@@ -1190,15 +1190,11 @@ R  →  S
 Rₘ → Sₘ
 ```
 -/
-lemma is_localization.algebra_map_apply_eq_map_map_submonoid (x) :
-  algebra_map Rₘ Sₘ x = map Sₘ (algebra_map R S)
-    (show _ ≤ (algebra.algebra_map_submonoid S M).comap _, from M.le_comap_map)
-    x :=
-begin
-  obtain ⟨y, m, rfl⟩ := is_localization.mk'_surjective M x,
-  rw [is_localization.algebra_map_mk' M S Rₘ Sₘ, is_localization.map_mk'],
-  refl
-end
+lemma is_localization.algebra_map_eq_map_map_submonoid :
+  algebra_map Rₘ Sₘ = map Sₘ (algebra_map R S)
+    (show _ ≤ (algebra.algebra_map_submonoid S M).comap _, from M.le_comap_map) :=
+eq.symm $ is_localization.map_unique _ (algebra_map Rₘ Sₘ) (λ x,
+  by rw [← is_scalar_tower.algebra_map_apply R S Sₘ, ← is_scalar_tower.algebra_map_apply R Rₘ Sₘ])
 
 /-- If the square below commutes, the bottom map is uniquely specified:
 ```
@@ -1207,10 +1203,11 @@ R  →  S
 Rₘ → Sₘ
 ```
 -/
-lemma is_localization.algebra_map_eq_map_map_submonoid :
-  algebra_map Rₘ Sₘ = map Sₘ (algebra_map R S)
-    (show _ ≤ (algebra.algebra_map_submonoid S M).comap _, from M.le_comap_map) :=
-ring_hom.ext (is_localization.algebra_map_apply_eq_map_map_submonoid _ _ _ _)
+lemma is_localization.algebra_map_apply_eq_map_map_submonoid (x) :
+  algebra_map Rₘ Sₘ x = map Sₘ (algebra_map R S)
+    (show _ ≤ (algebra.algebra_map_submonoid S M).comap _, from M.le_comap_map)
+    x :=
+fun_like.congr_fun (is_localization.algebra_map_eq_map_map_submonoid _ _ _ _) x
 
 variables {R}
 

--- a/src/ring_theory/localization/basic.lean
+++ b/src/ring_theory/localization/basic.lean
@@ -1169,8 +1169,6 @@ begin
   exact is_localization.map_units Sₘ ⟨algebra_map R S y, algebra.mem_algebra_map_submonoid_of_mem y⟩
 end
 
-variables (M)
-
 @[simp] lemma is_localization.algebra_map_mk' (x : R) (y : M) :
   algebra_map Rₘ Sₘ (is_localization.mk' Rₘ x y) =
     is_localization.mk' Sₘ (algebra_map R S x) ⟨algebra_map R S y,
@@ -1182,6 +1180,8 @@ begin
       mul_comm, is_localization.mul_mk'_eq_mk'_of_mul],
   exact congr_arg (algebra_map Rₘ Sₘ) (is_localization.mk'_mul_cancel_left x y)
 end
+
+variables (M)
 
 /-- If the square below commutes, the bottom map is uniquely specified:
 ```

--- a/src/ring_theory/localization/basic.lean
+++ b/src/ring_theory/localization/basic.lean
@@ -1215,13 +1215,7 @@ lemma is_localization.lift_algebra_map_eq_algebra_map :
   @is_localization.lift R _ M Rₘ _ _ Sₘ _ _ (algebra_map R Sₘ)
     (is_localization.map_units_map_submonoid S Sₘ) =
     algebra_map Rₘ Sₘ :=
-begin
-  ext x,
-  obtain ⟨x, y, rfl⟩ := is_localization.mk'_surjective M x,
-  rw [is_localization.lift_mk'_spec, is_scalar_tower.algebra_map_apply R Rₘ Sₘ,
-      is_scalar_tower.algebra_map_apply R Rₘ Sₘ, ← _root_.map_mul (algebra_map Rₘ Sₘ),
-      is_localization.mul_mk'_eq_mk'_of_mul, is_localization.mk'_mul_cancel_left]
-end
+is_localization.lift_unique _ (λ x, (is_scalar_tower.algebra_map_apply _ _ _ _).symm)
 
 end
 

--- a/src/ring_theory/localization/module.lean
+++ b/src/ring_theory/localization/module.lean
@@ -16,8 +16,8 @@ This file contains some results about vector spaces over the field of fractions 
 
  * `linear_independent.localization`: `b` is linear independent over a localization of `R`
    if it is linear independent over `R` itself
- * `basis.localization`: promote an `R`-basis `b` to an `Rₛ`-basis,
-   where `Rₛ` is a localization of `R`
+ * `basis.localization_localization`: promote an `R`-basis `b` of `A` to an `Rₛ`-basis of `Aₛ`,
+   where `Rₛ` and `Aₛ` are localizations of `R` and `A` at `s` respectively
  * `linear_independent.iff_fraction_ring`: `b` is linear independent over `R` iff it is
    linear independent over `Frac(R)`
 -/
@@ -53,21 +53,6 @@ begin
   simp [hi, hg']
 end
 end add_comm_monoid
-
-section add_comm_group
-variables {M : Type*} [add_comm_group M] [module R M] [module Rₛ M] [is_scalar_tower R Rₛ M]
-
-/-- Promote a basis for `M` over `R` to a basis for `M` over the localization `Rₛ`.
-
-See `basis.localization_localization` for a similar result localizing both `R` and `A`,
-an `R`-algebra.
--/
-noncomputable def basis.localization {ι : Type*} (b : basis ι R M) : basis ι Rₛ M :=
-basis.mk (b.linear_independent.localization Rₛ S) $
-by { rw [← eq_top_iff, ← @submodule.restrict_scalars_eq_top_iff Rₛ R, eq_top_iff, ← b.span_eq],
-     apply submodule.span_le_restrict_scalars }
-
-end add_comm_group
 
 section localization_localization
 

--- a/src/ring_theory/localization/module.lean
+++ b/src/ring_theory/localization/module.lean
@@ -57,7 +57,11 @@ end add_comm_monoid
 section add_comm_group
 variables {M : Type*} [add_comm_group M] [module R M] [module Rₛ M] [is_scalar_tower R Rₛ M]
 
-/-- Promote a basis for `M` over `R` to a basis for `M` over the localization `Rₛ` -/
+/-- Promote a basis for `M` over `R` to a basis for `M` over the localization `Rₛ`.
+
+See `basis.localization_localization` for a similar result localizing both `R` and `A`,
+an `R`-algebra.
+-/
 noncomputable def basis.localization {ι : Type*} (b : basis ι R M) : basis ι Rₛ M :=
 basis.mk (b.linear_independent.localization Rₛ S) $
 by { rw [← eq_top_iff, ← @submodule.restrict_scalars_eq_top_iff Rₛ R, eq_top_iff, ← b.span_eq],

--- a/src/ring_theory/localization/module.lean
+++ b/src/ring_theory/localization/module.lean
@@ -97,7 +97,7 @@ begin
   obtain ⟨a, ⟨_, s, hs, rfl⟩, rfl⟩ := is_localization.mk'_surjective
     (algebra.algebra_map_submonoid A S) a',
   rw [is_localization.mk'_eq_mul_mk'_one, mul_comm, ← map_one (algebra_map R A)],
-  erw ← is_localization.algebra_map_mk' S A Rₛ Aₛ 1 ⟨s, hs⟩, -- `erw` needed to unify `⟨s, hs⟩`
+  erw ← is_localization.algebra_map_mk' A Rₛ Aₛ (1 : R) ⟨s, hs⟩, -- `erw` needed to unify `⟨s, hs⟩`
   rw ← algebra.smul_def,
   refine smul_mem _ _ (span_subset_span R _ _ _),
   rw [← algebra.coe_linear_map, ← linear_map.coe_restrict_scalars R, ← linear_map.map_span],


### PR DESCRIPTION
This PR replaces `basis.localization` with `basis.localization_localization`, which maps `basis ι R S` to `basis ι Rm Sm`, where `Rm` and `Sm` are the localizations of `R` and `S` at `m`. This differs from the existing `basis.localization` by localizing in two places at once, since localizing only the coefficients is probably not useful.

See also: #18150

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
