### PR TITLE
[Merged by Bors] - fix(algebra.group.ulift): fix to_additive name for cancel_comm_monoid

### DIFF
--- a/src/algebra/group/ulift.lean
+++ b/src/algebra/group/ulift.lean
@@ -155,7 +155,7 @@ instance cancel_monoid [cancel_monoid α] :
   cancel_monoid (ulift α) :=
 equiv.ulift.injective.cancel_monoid _ rfl (λ _ _, rfl) (λ _ _, rfl)
 
-@[to_additive add_cancel_monoid]
+@[to_additive add_cancel_comm_monoid]
 instance cancel_comm_monoid [cancel_comm_monoid α] :
   cancel_comm_monoid (ulift α) :=
 equiv.ulift.injective.cancel_comm_monoid _ rfl (λ _ _, rfl) (λ _ _, rfl)


### PR DESCRIPTION
This is a fix to match mathlib 4
https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Group/ULift.html#ULift.addCancelCommMonoid



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
