### PR TITLE
[Merged by Bors] - feat(probability/probability_mass_function): construct a `pmf` from a probability measure

### DIFF
--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1852,6 +1852,16 @@ end
   sum (λ a, μ {a} • dirac a) = μ :=
 by simpa using (map_eq_sum μ id measurable_id).symm
 
+/-- Given that `α` is a countable, measurable space with all singleton sets measurable,
+write the measure of a set `s` as the sum of the measure of `{x}` for all `x ∈ s`. -/
+lemma apply_eq_tsum_indicator_apply_singleton [countable α] [measurable_singleton_class α]
+  (μ : measure α) (s : set α) (hs : measurable_set s) :
+  μ s = ∑' (x : α), s.indicator (λ x, μ {x}) x :=
+calc μ s = measure.sum (λ a, μ {a} • measure.dirac a) s : by rw μ.sum_smul_dirac
+  ... = ∑' (x : α), s.indicator (λ x, μ {x}) x :
+    by simp only [measure.sum_apply _ hs, measure.smul_apply, smul_eq_mul, measure.dirac_apply,
+      set.indicator_apply, mul_ite, pi.one_apply, mul_one, mul_zero]
+
 omit m0
 end sum
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1854,13 +1854,13 @@ by simpa using (map_eq_sum μ id measurable_id).symm
 
 /-- Given that `α` is a countable, measurable space with all singleton sets measurable,
 write the measure of a set `s` as the sum of the measure of `{x}` for all `x ∈ s`. -/
-lemma apply_eq_tsum_indicator_apply_singleton [countable α] [measurable_singleton_class α]
+lemma tsum_indicator_apply_singleton [countable α] [measurable_singleton_class α]
   (μ : measure α) (s : set α) (hs : measurable_set s) :
-  μ s = ∑' (x : α), s.indicator (λ x, μ {x}) x :=
-calc μ s = measure.sum (λ a, μ {a} • measure.dirac a) s : by rw μ.sum_smul_dirac
-  ... = ∑' (x : α), s.indicator (λ x, μ {x}) x :
+  ∑' (x : α), s.indicator (λ x, μ {x}) x = μ s :=
+calc ∑' (x : α), s.indicator (λ x, μ {x}) x = measure.sum (λ a, μ {a} • measure.dirac a) s :
     by simp only [measure.sum_apply _ hs, measure.smul_apply, smul_eq_mul, measure.dirac_apply,
       set.indicator_apply, mul_ite, pi.one_apply, mul_one, mul_zero]
+  ... = μ s : by rw μ.sum_smul_dirac
 
 omit m0
 end sum

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -113,10 +113,6 @@ begin
     (le_smul_caratheodory _ _)).trans (le_of_eq hy),
 end
 
-lemma measurable_set_to_outer_measure (s : set α) :
-  measurable_set[p.to_outer_measure.caratheodory] s :=
-p.to_outer_measure_caratheodory.symm ▸ measurable_space.measurable_set_top
-
 @[simp]
 lemma to_outer_measure_apply_finset (s : finset α) : p.to_outer_measure s = ∑ x in s, p x :=
 begin
@@ -258,7 +254,7 @@ is the measure of the singleton set under the original measure. -/
 def to_pmf [countable α] [measurable_space α] [measurable_singleton_class α]
   (μ : measure α) [h : is_probability_measure μ] : pmf α :=
 ⟨λ x, μ ({x} : set α), ennreal.summable.has_sum_iff.2 (trans (symm $
-(apply_eq_tsum_indicator_apply_singleton μ set.univ measurable_set.univ).trans
+(tsum_indicator_apply_singleton μ set.univ measurable_set.univ).symm.trans
   (tsum_congr (λ x, congr_fun (set.indicator_univ _) x))) (h.measure_univ))⟩
 
 variables [countable α] [measurable_space α] [measurable_singleton_class α]
@@ -268,7 +264,7 @@ lemma to_pmf_apply (x : α) : μ.to_pmf x = μ {x} := rfl
 
 @[simp] lemma to_pmf_to_measure : μ.to_pmf.to_measure = μ :=
 measure.ext (λ s hs, by simpa only [μ.to_pmf.to_measure_apply s hs,
-  μ.apply_eq_tsum_indicator_apply_singleton s hs])
+  ← μ.tsum_indicator_apply_singleton s hs])
 
 end measure
 

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -304,6 +304,6 @@ pmf.ext (λ x, by rw [← p.to_measure_apply_singleton x (measurable_set_singlet
 
 lemma to_measure_eq_iff_to_pmf_eq (μ : measure α) [hμ : is_probability_measure μ] :
   p.to_measure = μ ↔ p = μ.to_pmf :=
-by rw [← to_measure_inj, measure.to_pmf_to_measure, eq_comm]
+by rw [← to_measure_inj, measure.to_pmf_to_measure]
 
 end pmf

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -302,8 +302,12 @@ variables [countable α] [measurable_space α] [measurable_singleton_class α]
 pmf.ext (λ x, by rw [← p.to_measure_apply_singleton x (measurable_set_singleton x),
   p.to_measure.to_pmf_apply])
 
-lemma to_measure_eq_iff_to_pmf_eq (μ : measure α) [hμ : is_probability_measure μ] :
+lemma to_measure_eq_iff_eq_to_pmf (μ : measure α) [is_probability_measure μ] :
   p.to_measure = μ ↔ p = μ.to_pmf :=
+by rw [← to_measure_inj, measure.to_pmf_to_measure]
+
+lemma to_pmf_eq_iff_to_measure_eq (μ : measure α) [is_probability_measure μ] :
+  μ.to_pmf = p ↔ μ = p.to_measure :=
 by rw [← to_measure_inj, measure.to_pmf_to_measure]
 
 end pmf

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -274,8 +274,9 @@ we can convert any probability measure into a `pmf`, where the mass of a point
 is the measure of the singleton set under the original measure. -/
 def to_pmf [countable α] [measurable_space α] [measurable_singleton_class α]
   (μ : measure α) [h : is_probability_measure μ] : pmf α :=
-⟨λ x, μ ({x} : set α), ennreal.summable.has_sum_iff.2 (trans (symm $ by rw
-  [apply_eq_tsum_indicator_apply_singleton μ set.univ measurable_set.univ, set.indicator_univ]) (h.measure_univ))⟩
+⟨λ x, μ ({x} : set α), ennreal.summable.has_sum_iff.2 (trans (symm $
+(apply_eq_tsum_indicator_apply_singleton μ set.univ measurable_set.univ).trans
+  (tsum_congr (λ x, congr_fun (set.indicator_univ _) x))) (h.measure_univ))⟩
 
 variables [countable α] [measurable_space α] [measurable_singleton_class α]
   (μ : measure α) [is_probability_measure μ]

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -20,9 +20,9 @@ by assigning each set the sum of the probabilities of each of its elements.
 Under this outer measure, every set is Carathéodory-measurable,
 so we can further extend this to a `measure` on `α`, see `pmf.to_measure`.
 `pmf.to_measure.is_probability_measure` shows this associated measure is a probability measure.
-Conversely, given a probability measure `μ` on a countable, measurable space,
-`μ.to_pmf` constructs a `pmf` on `α`, assigning the probability mass of a point `x`
-to bet the measure of the singleton set `{x}`.
+Conversely, given a probability measure `μ` on a measurable space `α` with all singleton sets
+measurable, `μ.to_pmf` constructs a `pmf` on `α`, setting the probability mass of a point `x`
+to be the measure of the singleton set `{x}`.
 
 ## Tags
 

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -132,14 +132,6 @@ begin
   { exact ite_eq_left_iff.2 (λ ha', false.elim $ ha' rfl) }
 end
 
-lemma to_outer_measure_apply_Union {s : ℕ → set α} (h : pairwise (disjoint on s)) :
-  p.to_outer_measure (⋃ n, s n) = ∑' n, p.to_outer_measure (s n) :=
-outer_measure.Union_eq_of_caratheodory _ (λ n, measurable_set_to_outer_measure _ (s n)) h
-
-lemma to_outer_measure_apply_union (h : disjoint s t) :
-  p.to_outer_measure (s ∪ t) = p.to_outer_measure s + p.to_outer_measure t :=
-by simp only [to_outer_measure_apply, set.indicator_union_of_disjoint h, ennreal.tsum_add]
-
 lemma to_outer_measure_apply_eq_zero_iff : p.to_outer_measure s = 0 ↔ disjoint p.support s :=
 begin
   rw [to_outer_measure_apply, ennreal.tsum_eq_zero],
@@ -204,15 +196,6 @@ lemma to_measure_apply (hs : measurable_set s) : p.to_measure s = ∑' x, s.indi
 lemma to_measure_apply_singleton (a : α) (h : measurable_set ({a} : set α)) :
   p.to_measure {a} = p a :=
 by simp [to_measure_apply_eq_to_outer_measure_apply _ _ h, to_outer_measure_apply_singleton]
-
-lemma to_measure_apply_Union {s : ℕ → set α} (hs : ∀ n, measurable_set (s n))
-  (h : pairwise (disjoint on s)) : p.to_measure (⋃ n, s n) = ∑' n, p.to_measure (s n) :=
-p.to_measure.m_Union hs h
-
-lemma to_measure_apply_union (hs : measurable_set s) (ht : measurable_set t)
-  (h : disjoint s t) : p.to_measure (s ∪ t) = p.to_measure s + p.to_measure t :=
-by simp only [to_measure_apply_eq_to_outer_measure_apply, hs, ht, hs.union ht,
-  to_outer_measure_apply_union _ _ _ h]
 
 lemma to_measure_apply_eq_zero_iff (hs : measurable_set s) :
   p.to_measure s = 0 ↔ disjoint p.support s :=
@@ -301,10 +284,18 @@ instance to_measure.is_probability_measure [measurable_space α] (p : pmf α) :
 ⟨by simpa only [measurable_set.univ, to_measure_apply_eq_to_outer_measure_apply,
   set.indicator_univ, to_outer_measure_apply, ennreal.coe_eq_one] using tsum_coe p⟩
 
-variables [countable α] [measurable_space α] [measurable_singleton_class α] (p : pmf α)
+variables [countable α] [measurable_space α] [measurable_singleton_class α]
+  (p : pmf α) (μ : measure α) [is_probability_measure μ]
 
 lemma to_measure_to_pmf : p.to_measure.to_pmf = p :=
 pmf.ext (λ x, by rw [← p.to_measure_apply_singleton x (measurable_set_singleton x),
   p.to_measure.to_pmf_apply])
+
+lemma to_measure_eq_iff_to_pmf_eq (μ : measure α) [hμ : is_probability_measure μ]:
+  p.to_measure = μ ↔ μ.to_pmf = p :=
+begin
+  refine ⟨λ h, trans _ p.to_measure_to_pmf, λ h, trans (congr_arg _ h.symm) μ.to_pmf_to_measure⟩,
+  unfreezingI {induction h, refl}
+end
 
 end pmf

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -305,13 +305,29 @@ end
 /-- Given that `α` is a measurable space such that all singleton sets are measurable,
 we can convert any probability measure into a `pmf`, where the mass of a point
 is the measure of the singleton set under the original measure. -/
-lemma is_probability_measure.to_pmf [countable α] [measurable_space α]
+def to_pmf [countable α] [measurable_space α]
   [measurable_singleton_class α] (μ : measure α) [h : is_probability_measure μ] : pmf α :=
-⟨λ x, μ {x}, ennreal.summable.has_sum_iff.2 begin
-  refine trans (symm _) (h.measure_univ),
-  rw [apply_eq_tsum_indicator_apply_singleton],
-  simp only [set.indicator_univ],
-end⟩
+⟨λ x, μ ({x} : set α), ennreal.summable.has_sum_iff.2 (trans (symm $ by rw
+  [apply_eq_tsum_indicator_apply_singleton μ set.univ, set.indicator_univ]) (h.measure_univ))⟩
+
+variables [countable α] [measurable_space α]
+  [measurable_singleton_class α] (μ : measure α) [is_probability_measure μ]
+
+lemma to_pmf_apply (x : α) : to_pmf μ x = μ {x} := rfl
+
+lemma to_pmf_to_outer_measure_apply (s : set α) : (to_pmf μ).to_outer_measure s = μ s :=
+begin
+  rw [apply_eq_tsum_indicator_apply_singleton, to_outer_measure_apply],
+  refine tsum_congr (λ x, _),
+  simp only [set.indicator_apply, to_pmf_apply],
+end
+
+lemma to_pmf_to_measure_apply (s : set α) (hs : measurable_set s) :
+  (to_pmf μ).to_measure s = μ s :=
+begin
+  rw [to_measure_apply_eq_to_outer_measure_apply _ s hs,
+    to_pmf_to_outer_measure_apply],
+end
 
 end to_pmf
 

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -132,8 +132,8 @@ lemma to_outer_measure_injective : (to_outer_measure : pmf α → outer_measure 
 λ p q h, pmf.ext (λ x, (p.to_outer_measure_apply_singleton x).symm.trans
   ((congr_fun (congr_arg _ h) _).trans $ q.to_outer_measure_apply_singleton x))
 
-lemma to_outer_measure_inj {p q : pmf α} : p.to_outer_measure = q.to_outer_measure ↔ p = q :=
-to_outer_measure_injective.eq_iff
+@[simp] lemma to_outer_measure_inj {p q : pmf α} :
+  p.to_outer_measure = q.to_outer_measure ↔ p = q := to_outer_measure_injective.eq_iff
 
 lemma to_outer_measure_apply_eq_zero_iff : p.to_outer_measure s = 0 ↔ disjoint p.support s :=
 begin
@@ -234,7 +234,7 @@ lemma to_measure_injective : (to_measure : pmf α → measure α).injective :=
   ((congr_fun (congr_arg _ h) _).trans $ q.to_measure_apply_singleton x $
     measurable_set_singleton x))
 
-lemma to_measure_inj {p q : pmf α} : p.to_measure = q.to_measure ↔ p = q :=
+@[simp] lemma to_measure_inj {p q : pmf α} : p.to_measure = q.to_measure ↔ p = q :=
 to_measure_injective.eq_iff
 
 @[simp]
@@ -302,8 +302,8 @@ variables [countable α] [measurable_space α] [measurable_singleton_class α]
 pmf.ext (λ x, by rw [← p.to_measure_apply_singleton x (measurable_set_singleton x),
   p.to_measure.to_pmf_apply])
 
-lemma to_measure_eq_iff_to_pmf_eq (μ : measure α) [hμ : is_probability_measure μ]:
-  p.to_measure = μ ↔ μ.to_pmf = p :=
+lemma to_measure_eq_iff_to_pmf_eq (μ : measure α) [hμ : is_probability_measure μ] :
+  p.to_measure = μ ↔ p = μ.to_pmf :=
 by rw [← to_measure_inj, measure.to_pmf_to_measure, eq_comm]
 
 end pmf

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -128,6 +128,13 @@ begin
   { exact ite_eq_left_iff.2 (λ ha', false.elim $ ha' rfl) }
 end
 
+lemma to_outer_measure_injective : (to_outer_measure : pmf α → outer_measure α).injective :=
+λ p q h, pmf.ext (λ x, (p.to_outer_measure_apply_singleton x).symm.trans
+  ((congr_fun (congr_arg _ h) _).trans $ q.to_outer_measure_apply_singleton x))
+
+lemma to_outer_measure_inj {p q : pmf α} : p.to_outer_measure = q.to_outer_measure ↔ p = q :=
+to_outer_measure_injective.eq_iff
+
 lemma to_outer_measure_apply_eq_zero_iff : p.to_outer_measure s = 0 ↔ disjoint p.support s :=
 begin
   rw [to_outer_measure_apply, ennreal.tsum_eq_zero],
@@ -222,6 +229,14 @@ section measurable_singleton_class
 
 variables [measurable_singleton_class α]
 
+lemma to_measure_injective : (to_measure : pmf α → measure α).injective :=
+λ p q h, pmf.ext (λ x, (p.to_measure_apply_singleton x $ measurable_set_singleton x).symm.trans
+  ((congr_fun (congr_arg _ h) _).trans $ q.to_measure_apply_singleton x $
+    measurable_set_singleton x))
+
+lemma to_measure_inj {p q : pmf α} : p.to_measure = q.to_measure ↔ p = q :=
+to_measure_injective.eq_iff
+
 @[simp]
 lemma to_measure_apply_finset (s : finset α) : p.to_measure s = ∑ x in s, p x :=
 (p.to_measure_apply_eq_to_outer_measure_apply s s.measurable_set).trans
@@ -283,15 +298,12 @@ instance to_measure.is_probability_measure [measurable_space α] (p : pmf α) :
 variables [countable α] [measurable_space α] [measurable_singleton_class α]
   (p : pmf α) (μ : measure α) [is_probability_measure μ]
 
-lemma to_measure_to_pmf : p.to_measure.to_pmf = p :=
+@[simp] lemma to_measure_to_pmf : p.to_measure.to_pmf = p :=
 pmf.ext (λ x, by rw [← p.to_measure_apply_singleton x (measurable_set_singleton x),
   p.to_measure.to_pmf_apply])
 
 lemma to_measure_eq_iff_to_pmf_eq (μ : measure α) [hμ : is_probability_measure μ]:
   p.to_measure = μ ↔ μ.to_pmf = p :=
-begin
-  refine ⟨λ h, trans _ p.to_measure_to_pmf, λ h, trans (congr_arg _ h.symm) μ.to_pmf_to_measure⟩,
-  unfreezingI {induction h, refl}
-end
+by rw [← to_measure_inj, measure.to_pmf_to_measure, eq_comm]
 
 end pmf

--- a/src/probability/probability_mass_function/monad.lean
+++ b/src/probability/probability_mass_function/monad.lean
@@ -21,6 +21,7 @@ so that the second argument only needs to be defined on the support of the first
 noncomputable theory
 variables {α β γ : Type*}
 open_locale classical big_operators nnreal ennreal
+open measure_theory
 
 namespace pmf
 
@@ -54,10 +55,20 @@ begin
     exact ite_eq_right_iff.2 (λ hb, ite_eq_right_iff.2 (λ h, (ha $ h ▸ hb).elim)) }
 end
 
+variable [measurable_space α]
+
 /-- The measure of a set under `pure a` is `1` for sets containing `a` and `0` otherwise -/
-@[simp] lemma to_measure_pure_apply [measurable_space α] (hs : measurable_set s) :
+@[simp] lemma to_measure_pure_apply (hs : measurable_set s) :
   (pure a).to_measure s = if a ∈ s then 1 else 0 :=
 (to_measure_apply_eq_to_outer_measure_apply (pure a) s hs).trans (to_outer_measure_pure_apply a s)
+
+lemma to_measure_pure : (pure a).to_measure = measure.dirac a :=
+measure.ext (λ s hs, by simpa only [to_measure_pure_apply a s hs, measure.dirac_apply' a hs])
+
+@[simp] lemma to_pmf_dirac [countable α] [h : measurable_singleton_class α] :
+  (measure.dirac a).to_pmf = pure a :=
+pmf.ext (λ x, by simp only [pi.one_apply, measure.to_pmf_apply, set.indicator_apply, @eq_comm α x,
+  measure.dirac_apply' a (measurable_set_singleton x), set.mem_singleton_iff, pmf.pure_apply])
 
 end measure
 

--- a/src/probability/probability_mass_function/monad.lean
+++ b/src/probability/probability_mass_function/monad.lean
@@ -67,7 +67,7 @@ measure.ext (λ s hs, by simpa only [to_measure_pure_apply a s hs, measure.dirac
 
 @[simp] lemma to_pmf_dirac [countable α] [h : measurable_singleton_class α] :
   (measure.dirac a).to_pmf = pure a :=
-by rw [← to_measure_eq_iff_to_pmf_eq, to_measure_pure]
+by rw [to_pmf_eq_iff_to_measure_eq, to_measure_pure]
 
 end measure
 

--- a/src/probability/probability_mass_function/monad.lean
+++ b/src/probability/probability_mass_function/monad.lean
@@ -67,8 +67,7 @@ measure.ext (λ s hs, by simpa only [to_measure_pure_apply a s hs, measure.dirac
 
 @[simp] lemma to_pmf_dirac [countable α] [h : measurable_singleton_class α] :
   (measure.dirac a).to_pmf = pure a :=
-pmf.ext (λ x, by simp only [pi.one_apply, measure.to_pmf_apply, set.indicator_apply, @eq_comm α x,
-  measure.dirac_apply' a (measurable_set_singleton x), set.mem_singleton_iff, pmf.pure_apply])
+by rw [← to_measure_eq_iff_to_pmf_eq, to_measure_pure]
 
 end measure
 


### PR DESCRIPTION
Given a measurable space `α` with a `measurable_singleton_class` instance, this PR defines a function `measure.to_pmf` that converts a probability measure `μ` to a `pmf`, by defining the mass of a point `x`
to be the measure of the singleton set `{x}` under `μ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
