### PR TITLE
[Merged by Bors] - fix(*): add missing `classical` tactics and `decidable` arguments

### DIFF
--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -230,16 +230,20 @@ noncomputable def sigma_curry : (⨁ (i : Σ i, _), δ i.1 i.2) →+ ⨁ i j, δ
 
 /--The natural map between `⨁ i (j : α i), δ i j` and `Π₀ (i : Σ i, α i), δ i.1 i.2`, inverse of
 `curry`.-/
-noncomputable def sigma_uncurry : (⨁ i j, δ i j) →+ ⨁ (i : Σ i, _), δ i.1 i.2 :=
+def sigma_uncurry [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)] :
+  (⨁ i j, δ i j) →+ ⨁ (i : Σ i, _), δ i.1 i.2 :=
 { to_fun := dfinsupp.sigma_uncurry,
   map_zero' := dfinsupp.sigma_uncurry_zero,
   map_add' := dfinsupp.sigma_uncurry_add }
 
-@[simp] lemma sigma_uncurry_apply (f : ⨁ i j, δ i j) (i : ι) (j : α i) :
+@[simp] lemma sigma_uncurry_apply [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)]
+  (f : ⨁ i j, δ i j) (i : ι) (j : α i) :
   sigma_uncurry f ⟨i, j⟩ = f i j := dfinsupp.sigma_uncurry_apply f i j
 
 /--The natural map between `⨁ (i : Σ i, α i), δ i.1 i.2` and `⨁ i (j : α i), δ i j`.-/
-noncomputable def sigma_curry_equiv : (⨁ (i : Σ i, _), δ i.1 i.2) ≃+ ⨁ i j, δ i j :=
+noncomputable def sigma_curry_equiv
+  [decidable_eq ι] [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)] :
+  (⨁ (i : Σ i, _), δ i.1 i.2) ≃+ ⨁ i j, δ i j :=
 { ..sigma_curry, ..dfinsupp.sigma_curry_equiv }
 
 end sigma

--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -242,7 +242,7 @@ def sigma_uncurry [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)] :
 
 /--The natural map between `⨁ (i : Σ i, α i), δ i.1 i.2` and `⨁ i (j : α i), δ i j`.-/
 noncomputable def sigma_curry_equiv
-  [decidable_eq ι] [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)] :
+  [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)] :
   (⨁ (i : Σ i, _), δ i.1 i.2) ≃+ ⨁ i j, δ i j :=
 { ..sigma_curry, ..dfinsupp.sigma_curry_equiv }
 

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -233,7 +233,7 @@ def sigma_luncurry [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)] :
 
 /--`curry_equiv` as a linear equiv.-/
 noncomputable def sigma_lcurry_equiv
-  [decidable_eq ι] [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)] :
+  [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)] :
   (⨁ (i : Σ i, _), δ i.1 i.2) ≃ₗ[R] ⨁ i j, δ i j :=
 { ..sigma_curry_equiv, ..sigma_lcurry R }
 

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -222,15 +222,19 @@ noncomputable def sigma_lcurry : (⨁ (i : Σ i, _), δ i.1 i.2) →ₗ[R] ⨁ i
   sigma_lcurry R f i j = f ⟨i, j⟩ := sigma_curry_apply f i j
 
 /--`uncurry` as a linear map.-/
-noncomputable def sigma_luncurry : (⨁ i j, δ i j) →ₗ[R] ⨁ (i : Σ i, _), δ i.1 i.2 :=
+def sigma_luncurry [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)] :
+  (⨁ i j, δ i j) →ₗ[R] ⨁ (i : Σ i, _), δ i.1 i.2 :=
 { map_smul' := dfinsupp.sigma_uncurry_smul,
   ..sigma_uncurry }
 
-@[simp] lemma sigma_luncurry_apply (f : ⨁ i j, δ i j) (i : ι) (j : α i) :
+@[simp] lemma sigma_luncurry_apply [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)]
+  (f : ⨁ i j, δ i j) (i : ι) (j : α i) :
   sigma_luncurry R f ⟨i, j⟩ = f i j := sigma_uncurry_apply f i j
 
 /--`curry_equiv` as a linear equiv.-/
-noncomputable def sigma_lcurry_equiv : (⨁ (i : Σ i, _), δ i.1 i.2) ≃ₗ[R] ⨁ i j, δ i j :=
+noncomputable def sigma_lcurry_equiv
+  [decidable_eq ι] [Π i, decidable_eq (α i)] [Π i j, decidable_eq (δ i j)] :
+  (⨁ (i : Σ i, _), δ i.1 i.2) ≃ₗ[R] ⨁ i j, δ i j :=
 { ..sigma_curry_equiv, ..sigma_lcurry R }
 
 end sigma

--- a/src/algebra/free_algebra.lean
+++ b/src/algebra/free_algebra.lean
@@ -344,9 +344,9 @@ map_eq_one_iff (algebra_map _ _) algebra_map_left_inverse.injective
 
 -- this proof is copied from the approach in `free_abelian_group.of_injective`
 lemma ι_injective [nontrivial R] : function.injective (ι R : X → free_algebra R X) :=
-λ x y hoxy, classical.by_contradiction $ assume hxy : x ≠ y,
+λ x y hoxy, classical.by_contradiction $ by classical; exact assume hxy : x ≠ y,
   let f : free_algebra R X →ₐ[R] R :=
-    lift R (λ z, by classical; exact if x = z then (1 : R) else 0) in
+    lift R (λ z, if x = z then (1 : R) else 0) in
   have hfx1 : f (ι R x) = 1, from (lift_ι_apply _ _).trans $ if_pos rfl,
   have hfy1 : f (ι R y) = 1, from hoxy ▸ hfx1,
   have hfy0 : f (ι R y) = 0, from (lift_ι_apply _ _).trans $ if_neg hxy,

--- a/src/algebra/module/pid.lean
+++ b/src/algebra/module/pid.lean
@@ -213,6 +213,7 @@ begin
     haveI := λ i, is_noetherian_submodule' (torsion_by R N $ p i ^ e i),
     exact λ i, torsion_by_prime_power_decomposition (hp i)
       ((is_torsion'_powers_iff $ p i).mpr $ λ x, ⟨e i, smul_torsion_by _ _⟩) },
+  classical,
   refine ⟨Σ i, fin (this i).some, infer_instance,
     λ ⟨i, j⟩, p i, λ ⟨i, j⟩, hp i, λ ⟨i, j⟩, (this i).some_spec.some j,
     ⟨(linear_equiv.of_bijective (direct_sum.coe_linear_map _) h).symm.trans $

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -330,7 +330,8 @@ end
 lemma mul_apply_antidiagonal [has_mul G] (f g : monoid_algebra k G) (x : G) (s : finset (G × G))
   (hs : ∀ {p : G × G}, p ∈ s ↔ p.1 * p.2 = x) :
   (f * g) x = ∑ p in s, (f p.1 * g p.2) :=
-let F : G × G → k := λ p, by classical; exact if p.1 * p.2 = x then f p.1 * g p.2 else 0 in
+by classical; exact
+let F : G × G → k := λ p, if p.1 * p.2 = x then f p.1 * g p.2 else 0 in
 calc (f * g) x = (∑ a₁ in f.support, ∑ a₂ in g.support, F (a₁, a₂)) :
   mul_apply f g x
 ... = ∑ p in f.support ×ˢ g.support, F p : finset.sum_product.symm
@@ -477,8 +478,8 @@ end⟩
 also commute with the algebra multiplication. -/
 instance smul_comm_class_self [smul_comm_class R k k] :
   smul_comm_class R (monoid_algebra k G) (monoid_algebra k G) :=
-⟨λ t a b,
-begin
+⟨λ t a b, begin
+  classical,
   ext m,
   simp only [mul_apply, finsupp.sum, finset.smul_sum, smul_ite, mul_smul_comm, sum_smul_index',
     implies_true_iff, eq_self_iff_true, coe_smul, ite_eq_right_iff, smul_eq_mul, pi.smul_apply,

--- a/src/algebraic_geometry/elliptic_curve/weierstrass.lean
+++ b/src/algebraic_geometry/elliptic_curve/weierstrass.lean
@@ -433,6 +433,8 @@ instance : is_scalar_tower R R[X] W.coordinate_ring := ideal.quotient.is_scalar_
 
 instance [subsingleton R] : subsingleton W.coordinate_ring := module.subsingleton R[X] _
 
+section
+open_locale classical
 /-- The basis $\{1, Y\}$ for the coordinate ring $R[W]$ over the polynomial ring $R[X]$.
 
 Given a Weierstrass curve `W`, write `W^.coordinate_ring.basis` for this basis. -/
@@ -440,11 +442,16 @@ protected noncomputable def basis : basis (fin 2) R[X] W.coordinate_ring :=
 (subsingleton_or_nontrivial R).by_cases (λ _, by exactI default) $ λ _, by exactI
   (basis.reindex (adjoin_root.power_basis' W.monic_polynomial).basis $
     fin_congr $ W.nat_degree_polynomial)
+end
 
 lemma basis_apply (n : fin 2) :
   W^.coordinate_ring.basis n = (adjoin_root.power_basis' W.monic_polynomial).gen ^ (n : ℕ) :=
-by { nontriviality R, simpa only [coordinate_ring.basis, or.by_cases, dif_neg (not_subsingleton R),
-                                  basis.reindex_apply, power_basis.basis_eq_pow] }
+begin
+  classical,
+  nontriviality R,
+  simpa only [coordinate_ring.basis, or.by_cases, dif_neg (not_subsingleton R),
+                                  basis.reindex_apply, power_basis.basis_eq_pow]
+end
 
 lemma basis_zero : W^.coordinate_ring.basis 0 = 1 := by simpa only [basis_apply] using pow_zero _
 

--- a/src/analysis/inner_product_space/orientation.lean
+++ b/src/analysis/inner_product_space/orientation.lean
@@ -213,7 +213,8 @@ lemma volume_form_robust (b : orthonormal_basis (fin n) ℝ E) (hb : b.to_basis.
   o.volume_form = b.to_basis.det :=
 begin
   unfreezingI { cases n },
-  { have : o = positive_orientation := hb.symm.trans b.to_basis.orientation_is_empty,
+  { classical,
+    have : o = positive_orientation := hb.symm.trans b.to_basis.orientation_is_empty,
     simp [volume_form, or.by_cases, dif_pos this] },
   { dsimp [volume_form],
     rw [same_orientation_iff_det_eq_det, hb],
@@ -227,7 +228,8 @@ lemma volume_form_robust_neg (b : orthonormal_basis (fin n) ℝ E)
   o.volume_form = - b.to_basis.det :=
 begin
   unfreezingI { cases n },
-  { have : positive_orientation ≠ o := by rwa b.to_basis.orientation_is_empty at hb,
+  { classical,
+    have : positive_orientation ≠ o := by rwa b.to_basis.orientation_is_empty at hb,
     simp [volume_form, or.by_cases, dif_neg this.symm] },
   let e : orthonormal_basis (fin n.succ) ℝ E := o.fin_orthonormal_basis n.succ_pos (fact.out _),
   dsimp [volume_form],
@@ -239,7 +241,7 @@ end
 @[simp] lemma volume_form_neg_orientation : (-o).volume_form = - o.volume_form :=
 begin
   unfreezingI { cases n },
-  { refine o.eq_or_eq_neg_of_is_empty.by_cases _ _; rintros rfl; simp [volume_form_zero_neg] },
+  { refine o.eq_or_eq_neg_of_is_empty.elim _ _; rintros rfl; simp [volume_form_zero_neg] },
   let e : orthonormal_basis (fin n.succ) ℝ E := o.fin_orthonormal_basis n.succ_pos (fact.out _),
   have h₁ : e.to_basis.orientation = o := o.fin_orthonormal_basis_orientation _ _,
   have h₂ : e.to_basis.orientation ≠ -o,
@@ -252,7 +254,7 @@ lemma volume_form_robust' (b : orthonormal_basis (fin n) ℝ E) (v : fin n → E
   |o.volume_form v| = |b.to_basis.det v| :=
 begin
   unfreezingI { cases n },
-  { refine o.eq_or_eq_neg_of_is_empty.by_cases _ _; rintros rfl; simp },
+  { refine o.eq_or_eq_neg_of_is_empty.elim _ _; rintros rfl; simp },
   { rw [o.volume_form_robust (b.adjust_to_orientation o) (b.orientation_adjust_to_orientation o),
       b.abs_det_adjust_to_orientation] },
 end
@@ -263,7 +265,7 @@ value by the product of the norms of the vectors `v i`. -/
 lemma abs_volume_form_apply_le (v : fin n → E) : |o.volume_form v| ≤ ∏ i : fin n, ‖v i‖ :=
 begin
   unfreezingI { cases n },
-  { refine o.eq_or_eq_neg_of_is_empty.by_cases _ _; rintros rfl; simp },
+  { refine o.eq_or_eq_neg_of_is_empty.elim _ _; rintros rfl; simp },
   haveI : finite_dimensional ℝ E := fact_finite_dimensional_of_finrank_eq_succ n,
   have : finrank ℝ E = fintype.card (fin n.succ) := by simpa using _i.out,
   let b : orthonormal_basis (fin n.succ) ℝ E := gram_schmidt_orthonormal_basis this v,
@@ -288,7 +290,7 @@ lemma abs_volume_form_apply_of_pairwise_orthogonal
   |o.volume_form v| = ∏ i : fin n, ‖v i‖ :=
 begin
   unfreezingI { cases n },
-  { refine o.eq_or_eq_neg_of_is_empty.by_cases _ _; rintros rfl; simp },
+  { refine o.eq_or_eq_neg_of_is_empty.elim _ _; rintros rfl; simp },
   haveI : finite_dimensional ℝ E := fact_finite_dimensional_of_finrank_eq_succ n,
   have hdim : finrank ℝ E = fintype.card (fin n.succ) := by simpa using _i.out,
   let b : orthonormal_basis (fin n.succ) ℝ E := gram_schmidt_orthonormal_basis hdim v,
@@ -320,7 +322,7 @@ lemma volume_form_map {F : Type*} [inner_product_space ℝ F] [fact (finrank ℝ
   (orientation.map (fin n) φ.to_linear_equiv o).volume_form x = o.volume_form (φ.symm ∘ x) :=
 begin
   unfreezingI { cases n },
-  { refine o.eq_or_eq_neg_of_is_empty.by_cases _ _; rintros rfl; simp },
+  { refine o.eq_or_eq_neg_of_is_empty.elim _ _; rintros rfl; simp },
   let e : orthonormal_basis (fin n.succ) ℝ E := o.fin_orthonormal_basis n.succ_pos (fact.out _),
   have he : e.to_basis.orientation = o :=
     (o.fin_orthonormal_basis_orientation n.succ_pos (fact.out _)),

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -296,6 +296,7 @@ basis.of_equiv_fun b.repr.to_linear_equiv
 begin
   change ⇑(basis.of_equiv_fun b.repr.to_linear_equiv) = b,
   ext j,
+  classical,
   rw basis.coe_of_equiv_fun,
   congr,
 end
@@ -402,7 +403,7 @@ protected lemma coe_mk (hon : orthonormal 𝕜 v) (hsp: ⊤ ≤ submodule.span �
 by classical; rw [orthonormal_basis.mk, _root_.basis.coe_to_orthonormal_basis, basis.coe_mk]
 
 /-- Any finite subset of a orthonormal family is an `orthonormal_basis` for its span. -/
-protected def span {v' : ι' → E} (h : orthonormal 𝕜 v') (s : finset ι') :
+protected def span [decidable_eq E] {v' : ι' → E} (h : orthonormal 𝕜 v') (s : finset ι') :
   orthonormal_basis s 𝕜 (span 𝕜 (s.image v' : set E)) :=
 let
   e₀' : basis s 𝕜 _ := basis.span (h.linear_independent.comp (coe : s → ι') subtype.coe_injective),
@@ -421,7 +422,8 @@ let
 in
 e₀.map φ.symm
 
-@[simp] protected lemma span_apply {v' : ι' → E} (h : orthonormal 𝕜 v') (s : finset ι') (i : s) :
+@[simp] protected lemma span_apply [decidable_eq E]
+  {v' : ι' → E} (h : orthonormal 𝕜 v') (s : finset ι') (i : s) :
   (orthonormal_basis.span h s i : E) = v' i :=
 by simp only [orthonormal_basis.span, basis.span_apply, linear_isometry_equiv.of_eq_symm,
               orthonormal_basis.map_apply, orthonormal_basis.coe_mk,

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -606,13 +606,16 @@ attribute [mono] edge_finset_mono edge_finset_strict_mono
 
 @[simp] lemma edge_finset_bot : (⊥ : simple_graph V).edge_finset = ∅ := by simp [edge_finset]
 
-@[simp] lemma edge_finset_sup : (G₁ ⊔ G₂).edge_finset = G₁.edge_finset ∪ G₂.edge_finset :=
+@[simp] lemma edge_finset_sup [decidable_eq V] :
+  (G₁ ⊔ G₂).edge_finset = G₁.edge_finset ∪ G₂.edge_finset :=
 by simp [edge_finset]
 
-@[simp] lemma edge_finset_inf : (G₁ ⊓ G₂).edge_finset = G₁.edge_finset ∩ G₂.edge_finset :=
+@[simp] lemma edge_finset_inf [decidable_eq V] :
+  (G₁ ⊓ G₂).edge_finset = G₁.edge_finset ∩ G₂.edge_finset :=
 by simp [edge_finset]
 
-@[simp] lemma edge_finset_sdiff : (G₁ \ G₂).edge_finset = G₁.edge_finset \ G₂.edge_finset :=
+@[simp] lemma edge_finset_sdiff [decidable_eq V] :
+  (G₁ \ G₂).edge_finset = G₁.edge_finset \ G₂.edge_finset :=
 by simp [edge_finset]
 
 lemma edge_finset_card : G.edge_finset.card = fintype.card G.edge_set := set.to_finset_card _

--- a/src/data/dfinsupp/basic.lean
+++ b/src/data/dfinsupp/basic.lean
@@ -1302,7 +1302,7 @@ end
 
 This is the dfinsupp version of `equiv.Pi_curry`. -/
 noncomputable def sigma_curry_equiv [Π i j, has_zero (δ i j)]
-  [decidable_eq ι] [Π i, decidable_eq (α i)] [Π i j (x : δ i j), decidable (x ≠ 0)] :
+  [Π i, decidable_eq (α i)] [Π i j (x : δ i j), decidable (x ≠ 0)] :
   (Π₀ (i : Σ i, _), δ i.1 i.2) ≃ Π₀ i j, δ i j :=
 { to_fun := sigma_curry,
   inv_fun := sigma_uncurry,

--- a/src/data/dfinsupp/basic.lean
+++ b/src/data/dfinsupp/basic.lean
@@ -1221,7 +1221,8 @@ begin
       sigma_curry_apply, smul_apply]
 end
 
-@[simp] lemma sigma_curry_single [Π i j, has_zero (δ i j)] (ij : Σ i, α i) (x : δ ij.1 ij.2) :
+@[simp] lemma sigma_curry_single [decidable_eq ι] [Π i, decidable_eq (α i)]
+  [Π i j, has_zero (δ i j)] (ij : Σ i, α i) (x : δ ij.1 ij.2) :
   @sigma_curry _ _ _ _ (single ij x) = single ij.1 (single ij.2 x : Π₀ j, δ ij.1 j) :=
 begin
   obtain ⟨i, j⟩ := ij,
@@ -1240,7 +1241,8 @@ end
 
 /--The natural map between `Π₀ i (j : α i), δ i j` and `Π₀ (i : Σ i, α i), δ i.1 i.2`, inverse of
 `curry`.-/
-noncomputable def sigma_uncurry [Π i j, has_zero (δ i j)] (f : Π₀ i j, δ i j) :
+def sigma_uncurry [Π i j, has_zero (δ i j)]
+  [Π i, decidable_eq (α i)] [Π i j (x : δ i j), decidable (x ≠ 0)] (f : Π₀ i j, δ i j) :
   Π₀ (i : Σ i, _), δ i.1 i.2 :=
 { to_fun := λ i, f i.1 i.2,
   support' := f.support'.map $ λ s,
@@ -1255,24 +1257,32 @@ noncomputable def sigma_uncurry [Π i j, has_zero (δ i j)] (f : Π₀ i j, δ i
         rw [hi, zero_apply] }
     end⟩ }
 
-@[simp] lemma sigma_uncurry_apply [Π i j, has_zero (δ i j)] (f : Π₀ i j, δ i j) (i : ι) (j : α i) :
+@[simp] lemma sigma_uncurry_apply [Π i j, has_zero (δ i j)]
+  [Π i, decidable_eq (α i)] [Π i j (x : δ i j), decidable (x ≠ 0)]
+  (f : Π₀ i j, δ i j) (i : ι) (j : α i) :
   sigma_uncurry f ⟨i, j⟩ = f i j :=
 rfl
 
-@[simp] lemma sigma_uncurry_zero [Π i j, has_zero (δ i j)] :
+@[simp] lemma sigma_uncurry_zero [Π i j, has_zero (δ i j)]
+  [Π i, decidable_eq (α i)] [Π i j (x : δ i j), decidable (x ≠ 0)]:
   sigma_uncurry (0 : Π₀ i j, δ i j) = 0 :=
 rfl
 
-@[simp] lemma sigma_uncurry_add [Π i j, add_zero_class (δ i j)] (f g : Π₀ i j, δ i j) :
+@[simp] lemma sigma_uncurry_add [Π i j, add_zero_class (δ i j)]
+  [Π i, decidable_eq (α i)] [Π i j (x : δ i j), decidable (x ≠ 0)]
+  (f g : Π₀ i j, δ i j) :
   sigma_uncurry (f + g) = sigma_uncurry f + sigma_uncurry g :=
 coe_fn_injective rfl
 
 @[simp] lemma sigma_uncurry_smul [monoid γ] [Π i j, add_monoid (δ i j)]
+  [Π i, decidable_eq (α i)] [Π i j (x : δ i j), decidable (x ≠ 0)]
   [Π i j, distrib_mul_action γ (δ i j)] (r : γ) (f : Π₀ i j, δ i j) :
   sigma_uncurry (r • f) = r • sigma_uncurry f :=
 coe_fn_injective rfl
 
-@[simp] lemma sigma_uncurry_single [Π i j, has_zero (δ i j)] (i) (j : α i) (x : δ i j) :
+@[simp] lemma sigma_uncurry_single [Π i j, has_zero (δ i j)]
+  [decidable_eq ι] [Π i, decidable_eq (α i)] [Π i j (x : δ i j), decidable (x ≠ 0)]
+  (i) (j : α i) (x : δ i j) :
   sigma_uncurry (single i (single j x : Π₀ (j : α i), δ i j)) = single ⟨i, j⟩ x:=
 begin
   ext ⟨i', j'⟩,
@@ -1291,7 +1301,8 @@ end
 /--The natural bijection between `Π₀ (i : Σ i, α i), δ i.1 i.2` and `Π₀ i (j : α i), δ i j`.
 
 This is the dfinsupp version of `equiv.Pi_curry`. -/
-noncomputable def sigma_curry_equiv [Π i j, has_zero (δ i j)] :
+noncomputable def sigma_curry_equiv [Π i j, has_zero (δ i j)]
+  [decidable_eq ι] [Π i, decidable_eq (α i)] [Π i j (x : δ i j), decidable (x ≠ 0)] :
   (Π₀ (i : Σ i, _), δ i.1 i.2) ≃ Π₀ i j, δ i j :=
 { to_fun := sigma_curry,
   inv_fun := sigma_uncurry,

--- a/src/data/finsupp/alist.lean
+++ b/src/data/finsupp/alist.lean
@@ -91,6 +91,7 @@ by { classical, simp [←alist.insert_empty] }
 @[simp] lemma _root_.finsupp.to_alist_lookup_finsupp (f : α →₀ M) : f.to_alist.lookup_finsupp = f :=
 begin
   ext,
+  classical,
   by_cases h : f a = 0,
   { suffices : f.to_alist.lookup a = none,
     { simp [h, this] },

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -901,7 +901,7 @@ prod_bij (λp _, p.val)
   (λ _, by classical; exact mem_subtype.1)
   (λ _ _, rfl)
   (λ _ _ _ _, subtype.eq)
-  (λ b hb, ⟨⟨b, hp b hb⟩, mem_subtype.2 hb, rfl⟩)
+  (λ b hb, ⟨⟨b, hp b hb⟩, by classical; exact mem_subtype.2 hb, rfl⟩)
 
 end zero
 

--- a/src/data/finsupp/defs.lean
+++ b/src/data/finsupp/defs.lean
@@ -245,8 +245,10 @@ lemma single_eq_pi_single [decidable_eq α] (a : α) (b : M) : ⇑(single a b) =
 single_eq_update a b
 
 @[simp] lemma single_zero (a : α) : (single a 0 : α →₀ M) = 0 :=
-coe_fn_injective $ by {
-  classical, simpa only [single_eq_update, coe_zero] using function.update_eq_self a (0 : α → M) }
+coe_fn_injective $ begin
+  classical,
+  simpa only [single_eq_update, coe_zero] using function.update_eq_self a (0 : α → M)
+end
 
 lemma single_of_single_apply (a a' : α) (b : M) :
   single a ((single a' b) a) = single a' (single a' b) a :=

--- a/src/data/finsupp/defs.lean
+++ b/src/data/finsupp/defs.lean
@@ -222,21 +222,21 @@ def single (a : α) (b : M) : α →₀ M :=
   end }
 
 lemma single_apply [decidable (a = a')] : single a b a' = if a = a' then b else 0 :=
-by { simp_rw [@eq_comm _ a a'], convert pi.single_apply _ _ _, }
+by { classical, simp_rw [@eq_comm _ a a'], convert pi.single_apply _ _ _, }
 
 lemma single_apply_left {f : α → β} (hf : function.injective f)
   (x z : α) (y : M) :
   single (f x) y (f z) = single x y z :=
-by simp only [single_apply, hf.eq_iff]
+by { classical, simp only [single_apply, hf.eq_iff] }
 
 lemma single_eq_indicator : ⇑(single a b) = set.indicator {a} (λ _, b) :=
-by { ext, simp [single_apply, set.indicator, @eq_comm _ a] }
+by { classical, ext, simp [single_apply, set.indicator, @eq_comm _ a] }
 
 @[simp] lemma single_eq_same : (single a b : α →₀ M) a = b :=
-pi.single_eq_same a b
+by { classical, exact pi.single_eq_same a b }
 
 @[simp] lemma single_eq_of_ne (h : a ≠ a') : (single a b : α →₀ M) a' = 0 :=
-pi.single_eq_of_ne' h _
+by { classical, exact pi.single_eq_of_ne' h _ }
 
 lemma single_eq_update [decidable_eq α] (a : α) (b : M) : ⇑(single a b) = function.update 0 a b :=
 by rw [single_eq_indicator, ← set.piecewise_eq_indicator, set.piecewise_singleton]
@@ -245,12 +245,13 @@ lemma single_eq_pi_single [decidable_eq α] (a : α) (b : M) : ⇑(single a b) =
 single_eq_update a b
 
 @[simp] lemma single_zero (a : α) : (single a 0 : α →₀ M) = 0 :=
-coe_fn_injective $ by simpa only [single_eq_update, coe_zero]
-  using function.update_eq_self a (0 : α → M)
+coe_fn_injective $ by {
+  classical, simpa only [single_eq_update, coe_zero] using function.update_eq_self a (0 : α → M) }
 
 lemma single_of_single_apply (a a' : α) (b : M) :
   single a ((single a' b) a) = single a' (single a' b) a :=
 begin
+  classical,
   rw [single_apply, single_apply],
   ext,
   split_ifs,
@@ -259,10 +260,10 @@ begin
 end
 
 lemma support_single_ne_zero (a : α) (hb : b ≠ 0) : (single a b).support = {a} :=
-if_neg hb
+by { classical, exact if_neg hb }
 
 lemma support_single_subset : (single a b).support ⊆ {a} :=
-show ite _ _ _ ⊆ _, by split_ifs; [exact empty_subset _, exact subset.refl _]
+by { classical, show ite _ _ _ ⊆ _, split_ifs; [exact empty_subset _, exact subset.refl _] }
 
 lemma single_apply_mem (x) : single a b x ∈ ({0, b} : set M) :=
 by rcases em (a = x) with (rfl|hx); [simp, simp [single_eq_of_ne hx]]
@@ -334,7 +335,7 @@ by rw [support_single_ne_zero _ hb, support_single_ne_zero _ hb', disjoint_singl
 by simp [ext_iff, single_eq_indicator]
 
 lemma single_swap (a₁ a₂ : α) (b : M) : single a₁ b a₂ = single a₂ b a₁ :=
-by simp only [single_apply]; ac_refl
+by { classical, simp only [single_apply], ac_refl }
 
 instance [nonempty α] [nontrivial M] : nontrivial (α →₀ M) :=
 begin

--- a/src/data/finsupp/to_dfinsupp.lean
+++ b/src/data/finsupp/to_dfinsupp.lean
@@ -257,6 +257,7 @@ begin
   suffices : finsupp.single (⟨i, a⟩ : Σ i, η i) n ⟨j, b⟩ = 0,
   { simp [split_apply, dif_neg h, this] },
   have H : (⟨i, a⟩ : Σ i, η i) ≠ ⟨j, b⟩ := by simp [h],
+  classical,
   rw [finsupp.single_apply, if_neg H]
 end
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -756,7 +756,7 @@ noncomputable def finset_equiv_set [fintype α] : finset α ≃ set α :=
 { to_fun := coe,
   inv_fun := by { classical, exact λ s, s.to_finset },
   left_inv := λ s, by convert finset.to_finset_coe s,
-  right_inv := λ s, s.coe_to_finset }
+  right_inv := λ s, by { classical, exact s.coe_to_finset } }
 
 @[simp] lemma finset_equiv_set_apply [fintype α] (s : finset α) : finset_equiv_set s = s := rfl
 

--- a/src/data/fintype/sum.lean
+++ b/src/data/fintype/sum.lean
@@ -39,7 +39,7 @@ def fintype_of_fintype_ne (a : α) (h : fintype {b // b ≠ a}) : fintype α :=
 fintype.of_bijective (sum.elim (coe : {b // b = a} → α) (coe : {b // b ≠ a} → α)) $
   by { classical, exact (equiv.sum_compl (= a)).bijective }
 
-lemma image_subtype_ne_univ_eq_image_erase [fintype α] (k : β) (b : α → β) :
+lemma image_subtype_ne_univ_eq_image_erase [fintype α] [decidable_eq β] (k : β) (b : α → β) :
   image (λ i : {a // b a ≠ k}, b ↑i) univ = (image b univ).erase k :=
 begin
   apply subset_antisymm,
@@ -53,7 +53,7 @@ begin
     exact ⟨⟨a, ne_of_mem_erase hi⟩, mem_univ _, rfl⟩ }
 end
 
-lemma image_subtype_univ_ssubset_image_univ [fintype α] (k : β) (b : α → β)
+lemma image_subtype_univ_ssubset_image_univ [fintype α] [decidable_eq β] (k : β) (b : α → β)
   (hk : k ∈ image b univ) (p : β → Prop) [decidable_pred p] (hp : ¬ p k) :
   image (λ i : {a // p (b a)}, b ↑i) univ ⊂ image b univ :=
 begin
@@ -72,7 +72,7 @@ end
 
 /-- Any injection from a finset `s` in a fintype `α` to a finset `t` of the same cardinality as `α`
 can be extended to a bijection between `α` and `t`. -/
-lemma finset.exists_equiv_extend_of_card_eq [fintype α] {t : finset β}
+lemma finset.exists_equiv_extend_of_card_eq [fintype α] [decidable_eq β] {t : finset β}
   (hαt : fintype.card α = t.card) {s : finset α} {f : α → β} (hfst : s.image f ⊆ t)
   (hfs : set.inj_on f s) :
   ∃ g : α ≃ t, ∀ i ∈ s, (g i : β) = f i :=

--- a/src/data/pi/lex.lean
+++ b/src/data/pi/lex.lean
@@ -173,8 +173,11 @@ end⟩
 
 lemma lex.no_max_order' [preorder ι] [Π i, has_lt (β i)] (i : ι) [no_max_order (β i)] :
   no_max_order (lex (Π i, β i)) :=
-⟨λ a, let ⟨b, hb⟩ := exists_gt (a i) in ⟨a.update i b, i,
-  λ j hj, (a.update_noteq hj.ne b).symm, by rwa a.update_same i b⟩⟩
+⟨λ a, begin
+  classical,
+  obtain ⟨b, hb⟩ := exists_gt (a i),
+  exact ⟨a.update i b, i, λ j hj, (a.update_noteq hj.ne b).symm, by rwa a.update_same i b⟩
+end⟩
 
 instance [linear_order ι] [is_well_order ι (<)] [nonempty ι] [Π i, partial_order (β i)]
   [Π i, no_max_order (β i)] :

--- a/src/group_theory/divisible.lean
+++ b/src/group_theory/divisible.lean
@@ -117,7 +117,7 @@ noncomputable def rootable_by_of_pow_left_surj
 rootable_by A α :=
 { root := λ a n, @dite _ (n = 0) (classical.dec _) (λ _, (1 : A)) (λ hn, (H hn a).some),
   root_zero := λ _, by classical; exact dif_pos rfl,
-  root_cancel := λ n a hn, by rw dif_neg hn; exact (H hn a).some_spec }
+  root_cancel := λ n a hn, by { classical, rw dif_neg hn, exact (H hn a).some_spec } }
 
 section pi
 

--- a/src/linear_algebra/free_module/ideal_quotient.lean
+++ b/src/linear_algebra/free_module/ideal_quotient.lean
@@ -96,5 +96,5 @@ let b := module.free.choose_basis ℤ S,
     a := I.smith_coeffs b hI,
     e := I.quotient_equiv_pi_zmod b hI
 in by haveI : ∀ i, ne_zero (a i).nat_abs :=
-    (λ i, ⟨int.nat_abs_ne_zero_of_ne_zero (ideal.smith_coeffs_ne_zero b I hI i)⟩);
+    (λ i, ⟨int.nat_abs_ne_zero_of_ne_zero (ideal.smith_coeffs_ne_zero b I hI i)⟩); classical;
   exact fintype.of_equiv (Π i, zmod (a i).nat_abs) e.symm

--- a/src/number_theory/legendre_symbol/mul_character.lean
+++ b/src/number_theory/legendre_symbol/mul_character.lean
@@ -104,6 +104,7 @@ def trivial : mul_char R R' :=
   map_nonunit' := by { intros a ha, simp only [ha, if_false], },
   map_one' := by simp only [is_unit_one, if_true],
   map_mul' := by { intros x y,
+                   classical,
                    simp only [is_unit.mul_iff, boole_mul],
                    split_ifs; tauto, } }
 
@@ -175,6 +176,7 @@ def of_unit_hom (f : Rˣ →* R'ˣ) : mul_char R R' :=
                    simp only [h1, dif_pos, units.coe_eq_one, map_one, is_unit_one], },
   map_mul' :=
   begin
+    classical,
     intros x y,
     by_cases hx : is_unit x,
     { simp only [hx, is_unit.mul_iff, true_and, dif_pos],
@@ -249,7 +251,7 @@ instance inhabited : inhabited (mul_char R R') := ⟨1⟩
 /-- Evaluation of the trivial character -/
 @[simp]
 lemma one_apply_coe (a : Rˣ) : (1 : mul_char R R') a = 1 :=
-dif_pos a.is_unit
+by { classical, exact dif_pos a.is_unit }
 
 /-- Multiplication of multiplicative characters. (This needs the target to be commutative.) -/
 def mul (χ χ' : mul_char R R') : mul_char R R' :=

--- a/src/order/interval.lean
+++ b/src/order/interval.lean
@@ -446,7 +446,8 @@ by classical; exact { Sup := λ S, if h : S ⊆ {⊥} then ⊥ else some
   end,
   ..interval.lattice, ..interval.bounded_order }
 
-@[simp, norm_cast] lemma coe_Inf (S : set (interval α)) : ↑(Inf S) = ⋂ s ∈ S, (s : set α) :=
+@[simp, norm_cast] lemma coe_Inf [@decidable_rel α (≤)] (S : set (interval α)) :
+  ↑(Inf S) = ⋂ s ∈ S, (s : set α) :=
 begin
   change coe (dite _ _ _) = _,
   split_ifs,
@@ -463,10 +464,11 @@ begin
     exact h (λ s ha t hb, (hx _ ha).1.trans (hx _ hb).2) }
 end
 
-@[simp, norm_cast] lemma coe_infi (f : ι → interval α) : ↑(⨅ i, f i) = ⋂ i, (f i : set α) :=
+@[simp, norm_cast] lemma coe_infi [@decidable_rel α (≤)] (f : ι → interval α) :
+  ↑(⨅ i, f i) = ⋂ i, (f i : set α) :=
 by simp [infi]
 
-@[simp, norm_cast] lemma coe_infi₂ (f : Π i, κ i → interval α) :
+@[simp, norm_cast] lemma coe_infi₂ [@decidable_rel α (≤)] (f : Π i, κ i → interval α) :
   ↑(⨅ i j, f i j) = ⋂ i j, (f i j : set α) :=
 by simp_rw [coe_infi]
 

--- a/src/order/max.lean
+++ b/src/order/max.lean
@@ -95,6 +95,7 @@ end⟩
 
 instance [nonempty ι] [Π i, preorder (π i)] [Π i, no_min_order (π i)] : no_min_order (Π i, π i) :=
 ⟨λ a, begin
+  classical,
   obtain ⟨b, hb⟩ := exists_lt (a $ classical.arbitrary _),
   exact ⟨_, update_lt_self_iff.2 hb⟩,
 end⟩

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -107,17 +107,21 @@ by { classical, exact rel_iso.of_surjective (rel_embedding.order_embedding_of_lt
 variable {s}
 
 @[simp]
-lemma coe_order_embedding_of_set : ⇑(order_embedding_of_set s) = coe ∘ subtype.of_nat s := rfl
+lemma coe_order_embedding_of_set [decidable_pred (∈ s)] :
+  ⇑(order_embedding_of_set s) = coe ∘ subtype.of_nat s := rfl
 
-lemma order_embedding_of_set_apply {n : ℕ} : order_embedding_of_set s n = subtype.of_nat s n := rfl
+lemma order_embedding_of_set_apply [decidable_pred (∈ s)] {n : ℕ} :
+  order_embedding_of_set s n = subtype.of_nat s n := rfl
 
 @[simp]
-lemma subtype.order_iso_of_nat_apply {n : ℕ} : subtype.order_iso_of_nat s n = subtype.of_nat s n :=
-by simp [subtype.order_iso_of_nat]
+lemma subtype.order_iso_of_nat_apply [decidable_pred (∈ s)] {n : ℕ} :
+  subtype.order_iso_of_nat s n = subtype.of_nat s n :=
+by { simp [subtype.order_iso_of_nat], congr }
 
 variable (s)
 
-lemma order_embedding_of_set_range : set.range (nat.order_embedding_of_set s) = s :=
+lemma order_embedding_of_set_range [decidable_pred (∈ s)] :
+  set.range (nat.order_embedding_of_set s) = s :=
 subtype.coe_comp_of_nat_range
 
 theorem exists_subseq_of_forall_mem_union {s t : set α} (e : ℕ → α) (he : ∀ n, e n ∈ s ∪ t) :

--- a/src/order/prop_instances.lean
+++ b/src/order/prop_instances.lean
@@ -59,6 +59,7 @@ lemma disjoint_iff [Π i, order_bot (α' i)] {f g : Π i, α' i} :
 begin
   split,
   { intros h i x hf hg,
+    classical,
     refine (update_le_iff.mp $
     -- this line doesn't work
       h (update_le_iff.mpr ⟨hf, λ _ _, _⟩) (update_le_iff.mpr ⟨hg, λ _ _, _⟩)).1,
@@ -85,5 +86,6 @@ codisjoint_iff_le_sup.trans $ forall_const _
 @[simp] lemma Prop.is_compl_iff {P Q : Prop} : is_compl P Q ↔ ¬(P ↔ Q) :=
 begin
   rw [is_compl_iff, Prop.disjoint_iff, Prop.codisjoint_iff, not_iff],
+  classical,
   tauto,
 end

--- a/src/ring_theory/bezout.lean
+++ b/src/ring_theory/bezout.lean
@@ -95,8 +95,8 @@ local attribute [instance] to_gcd_domain
 -- Note that the proof, despite being `infer_instance`, depends on the `local attribute [instance]`
 -- lemma above, and is thus necessary to be restated.
 @[priority 100]
-instance [is_domain R] [is_bezout R] [decidable_eq R] : is_integrally_closed R :=
-gcd_monoid.to_is_integrally_closed
+instance [is_domain R] [is_bezout R] : is_integrally_closed R :=
+by classical; exact gcd_monoid.to_is_integrally_closed
 
 lemma _root_.function.surjective.is_bezout {S : Type v} [comm_ring S] (f : R →+* S)
   (hf : function.surjective f) [is_bezout R] : is_bezout S :=

--- a/src/ring_theory/bezout.lean
+++ b/src/ring_theory/bezout.lean
@@ -95,7 +95,8 @@ local attribute [instance] to_gcd_domain
 -- Note that the proof, despite being `infer_instance`, depends on the `local attribute [instance]`
 -- lemma above, and is thus necessary to be restated.
 @[priority 100]
-instance [is_domain R] [is_bezout R] : is_integrally_closed R := infer_instance
+instance [is_domain R] [is_bezout R] [decidable_eq R] : is_integrally_closed R :=
+gcd_monoid.to_is_integrally_closed
 
 lemma _root_.function.surjective.is_bezout {S : Type v} [comm_ring S] (f : R →+* S)
   (hf : function.surjective f) [is_bezout R] : is_bezout S :=

--- a/src/ring_theory/discriminant.lean
+++ b/src/ring_theory/discriminant.lean
@@ -127,6 +127,7 @@ begin
   { simp [discr] },
   { have := span_eq_top_of_linear_independent_of_card_eq_finrank b.linear_independent
       (finrank_eq_card_basis b).symm,
+    classical,
     rw [discr_def, trace_matrix_def],
     simp_rw [← basis.mk_apply b.linear_independent this.ge],
     rw [← trace_matrix_def, trace_matrix_of_basis, ← bilin_form.nondegenerate_iff_det_ne_zero],

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -590,16 +590,17 @@ noncomputable instance : has_inv pgame :=
 
 noncomputable instance : has_div pgame := ⟨λ x y, x * y⁻¹⟩
 
-theorem inv_eq_of_equiv_zero {x : pgame} (h : x ≈ 0) : x⁻¹ = 0 := if_pos h
+theorem inv_eq_of_equiv_zero {x : pgame} (h : x ≈ 0) : x⁻¹ = 0 :=
+by { classical, exact if_pos h }
 
 @[simp] theorem inv_zero : (0 : pgame)⁻¹ = 0 :=
 inv_eq_of_equiv_zero (equiv_refl _)
 
 theorem inv_eq_of_pos {x : pgame} (h : 0 < x) : x⁻¹ = inv' x :=
-(if_neg h.lf.not_equiv').trans (if_pos h)
+by { classical, exact (if_neg h.lf.not_equiv').trans (if_pos h) }
 
 theorem inv_eq_of_lf_zero {x : pgame} (h : x ⧏ 0) : x⁻¹ = -inv' (-x) :=
-(if_neg h.not_equiv).trans (if_neg h.not_gt)
+by { classical, exact (if_neg h.not_equiv).trans (if_neg h.not_gt) }
 
 /-- `1⁻¹` has exactly the same moves as `1`. -/
 def inv_one : 1⁻¹ ≡r 1 :=

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -1790,38 +1790,6 @@ else do
   -- Turn on the `prop_decidable` instance. `9` is what we use in the `classical` locale
   tactic.set_basic_attribute `instance `classical.prop_decidable ff (some 9)
 
-/-- `finally tac finalizer` runs `tac` first, then runs `finalizer` even if
-`tac` fails. `finally tac finalizer` fails if either `tac` or `finalizer` fails. -/
-meta def finally {β} (tac : tactic α) (finalizer : tactic β) : tactic α :=
-λ s, match tac s with
-     | (result.success r s') := (finalizer >> pure r) s'
-     | (result.exception msg p s') := (finalizer >> result.exception msg p) s'
-     end
-
-/-- Execute a tactic that might modify the given attribute for hte given declaration and then
-restore the original attribute state. -/
-meta def with_local_attribute (c_name : name) (attr : name) {α : Type*} (tac : tactic α) :
-  tactic α :=
-do
-  old ← try_core (tactic.has_attribute attr c_name),
-  finally tac $ do
-    /- it might be more efficient to only change it back if it's different... -/
-    new ← try_core (tactic.has_attribute attr c_name),
-    when (new ≠ old) $ do
-      match old with
-      | none := tactic.unset_attribute attr c_name
-      | some (persistent, prio) := tactic.set_basic_attribute attr c_name persistent prio
-      end
-
-meta def mathlib_tactic_executor : interactive.executor tactic :=
-{ config_type := unit,
-  execute_with := λ _ block,
-    tactic.with_local_attribute `classical.prop_decidable `instance $
-    tactic.with_local_attribute `classical.decidable_eq_of_decidable `instance $
-    block }
-
-attribute [vm_override mathlib_tactic_executor] interactive.executor_tactic
-
 open expr
 
 /-- `mk_comp v e` checks whether `e` is a sequence of nested applications `f (g (h v))`, and if so,
@@ -2009,6 +1977,14 @@ open _root_.interactive _root_.interactive.types
 local postfix (name := parser.optional) `?`:9001 := optional
 local postfix (name := parser.many) *:9001 := many .
 "
+
+/-- `finally tac finalizer` runs `tac` first, then runs `finalizer` even if
+`tac` fails. `finally tac finalizer` fails if either `tac` or `finalizer` fails. -/
+meta def finally {β} (tac : tactic α) (finalizer : tactic β) : tactic α :=
+λ s, match tac s with
+     | (result.success r s') := (finalizer >> pure r) s'
+     | (result.exception msg p s') := (finalizer >> result.exception msg p) s'
+     end
 
 /--
 `on_exception handler tac` runs `tac` first, and then runs `handler` only if `tac` failed.


### PR DESCRIPTION
As discussed in [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60classical.60.20attribute.20leakage/near/282726128), the `classical` tactic is buggy in Mathlib3, and "leaks" into subsequent declarations.

This doesn't port well, as the bug is fixed in lean 4.

This PR installs a temporary hack to contain these leaks, fixes all of the correponding breakages, then reverts the hack.

The result is that the new `classical` tactics in the diff are not needed in Lean 3, but will be needed in Lean 4.

In a future PR, I will try committing the hack itself; but in the meantime, these files are very close to (if not beyond) the port, so the sooner they are fixed the better.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
