### PR TITLE
[Merged by Bors] - feat(data/real/pi): refactor Wallis formula for pi

### DIFF
--- a/src/analysis/special_functions/stirling.lean
+++ b/src/analysis/special_functions/stirling.lean
@@ -20,16 +20,15 @@ The proof follows: <https://proofwiki.org/wiki/Stirling%27s_Formula>.
 
 We proceed in two parts.
 
-### Part 1
-We consider the fraction sequence $a_n$ of fractions $\frac{n!}{\sqrt{2n}(\frac{n}{e})^n}$ and
-prove that this sequence converges against a real, positive number $a$. For this the two main
+**Part 1**: We consider the sequence $a_n$ of fractions $\frac{n!}{\sqrt{2n}(\frac{n}{e})^n}$
+and prove that this sequence converges to a real, positive number $a$. For this the two main
 ingredients are
  - taking the logarithm of the sequence and
- - use the series expansion of $\log(1 + x)$.
+ - using the series expansion of $\log(1 + x)$.
 
-### Part 2
-We use the fact that the series defined in part 1 converges againt a real number $a$ and prove that
-$a = \sqrt{\pi}$. Here the main ingredient is the convergence of the Wallis product.
+**Part 2**: We use the fact that the series defined in part 1 converges againt a real number $a$
+and prove that $a = \sqrt{\pi}$. Here the main ingredient is the convergence of Wallis' product
+formula for `π`.
 -/
 
 open_locale topological_space real big_operators nat
@@ -202,26 +201,6 @@ end
  https://proofwiki.org/wiki/Stirling%27s_Formula#Part_2
 -/
 
-/-- For `n : ℕ`, define `w n` as `2^(4*n) * n!^4 / ((2*n)!^2 * (2*n + 1))` -/
-noncomputable def w (n : ℕ) : ℝ :=
-(2 ^ (4 * n) * n! ^ 4) / ((2 * n)!^ 2 * (2 * n + 1))
-
-/-- The sequence `w n` converges to `π/2` -/
-lemma tendsto_w_at_top: tendsto (λ (n : ℕ), w n) at_top (𝓝 (π/2)) :=
-begin
-  convert tendsto_prod_pi_div_two,
-  funext n,
-  induction n with n ih,
-  { rw [w, prod_range_zero, cast_zero, mul_zero, pow_zero, one_mul, mul_zero, factorial_zero,
-        cast_one, one_pow, one_pow, one_mul, mul_zero, zero_add, div_one] },
-  rw [w, prod_range_succ, ←ih, w, _root_.div_mul_div_comm, _root_.div_mul_div_comm],
-  refine (div_eq_div_iff _ _).mpr _,
-  any_goals { exact ne_of_gt (by positivity) },
-  simp_rw [nat.mul_succ, factorial_succ, pow_succ],
-  push_cast,
-  ring_nf,
-end
-
 /-- The sequence `n / (2 * n + 1)` tends to `1/2` -/
 lemma tendsto_self_div_two_mul_self_add_one :
   tendsto (λ (n : ℕ), (n : ℝ) / (2 * n + 1)) at_top (𝓝 (1 / 2)) :=
@@ -229,16 +208,16 @@ begin
   conv { congr, skip, skip, rw [one_div, ←add_zero (2 : ℝ)] },
   refine (((tendsto_const_div_at_top_nhds_0_nat 1).const_add (2 : ℝ)).inv₀
     ((add_zero (2 : ℝ)).symm ▸ two_ne_zero)).congr' (eventually_at_top.mpr ⟨1, λ n hn, _⟩),
-  rw [add_div' (1 : ℝ) (2 : ℝ) (n : ℝ) (cast_ne_zero.mpr (one_le_iff_ne_zero.mp hn)), inv_div],
+  rw [add_div' (1 : ℝ) 2 n (cast_ne_zero.mpr (one_le_iff_ne_zero.mp hn)), inv_div],
 end
 
-
 /-- For any `n ≠ 0`, we have the identity
-`(stirling_seq n)^4/(stirling_seq (2*n))^2 * (n / (2 * n + 1)) = w n`. -/
+`(stirling_seq n)^4 / (stirling_seq (2*n))^2 * (n / (2 * n + 1)) = W n`, where `W n` is the
+`n`-th partial product of Wallis' formula for `π / 2`. -/
 lemma stirling_seq_pow_four_div_stirling_seq_pow_two_eq (n : ℕ) (hn : n ≠ 0) :
-  ((stirling_seq n) ^ 4 / (stirling_seq (2 * n)) ^ 2) * (n / (2 * n + 1)) = w n :=
+  ((stirling_seq n) ^ 4 / (stirling_seq (2 * n)) ^ 2) * (n / (2 * n + 1)) = wallis.W n :=
 begin
-  rw [bit0_eq_two_mul, stirling_seq, pow_mul, stirling_seq, w],
+  rw [bit0_eq_two_mul, stirling_seq, pow_mul, stirling_seq, wallis.W_eq_factorial_ratio],
   simp_rw [div_pow, mul_pow],
   rw [sq_sqrt, sq_sqrt],
   any_goals { positivity },
@@ -253,10 +232,10 @@ end
 
 /--
 Suppose the sequence `stirling_seq` (defined above) has the limit `a ≠ 0`.
-Then the sequence `w` has limit `a^2/2`
+Then the Wallis sequence `W n` has limit `a^2 / 2`.
 -/
 lemma second_wallis_limit (a : ℝ) (hane : a ≠ 0) (ha : tendsto stirling_seq at_top (𝓝 a)) :
-  tendsto w at_top (𝓝 (a ^ 2 / 2)):=
+  tendsto wallis.W at_top (𝓝 (a ^ 2 / 2)):=
 begin
   refine tendsto.congr' (eventually_at_top.mpr ⟨1, λ n hn,
     stirling_seq_pow_four_div_stirling_seq_pow_two_eq n (one_le_iff_ne_zero.mp hn)⟩) _,
@@ -272,9 +251,9 @@ end
 theorem tendsto_stirling_seq_sqrt_pi : tendsto (λ (n : ℕ), stirling_seq n) at_top (𝓝 (sqrt π)) :=
 begin
   obtain ⟨a, hapos, halimit⟩ := stirling_seq_has_pos_limit_a,
-  have hπ : π / 2 = a ^ 2 / 2 := tendsto_nhds_unique tendsto_w_at_top
-    (second_wallis_limit a (ne_of_gt hapos) halimit),
-  rwa [(div_left_inj' (show (2 : ℝ) ≠ 0, from two_ne_zero)).mp hπ, sqrt_sq hapos.le],
+  have hπ : π / 2 = a ^ 2 / 2 := tendsto_nhds_unique wallis.tendsto_W_nhds_pi_div_two
+    (second_wallis_limit a hapos.ne' halimit),
+  rwa [(div_left_inj' (two_ne_zero' ℝ)).mp hπ, sqrt_sq hapos.le],
 end
 
 end stirling

--- a/src/data/real/pi/wallis.lean
+++ b/src/data/real/pi/wallis.lean
@@ -5,70 +5,228 @@ Authors: Hanting Zhang
 -/
 import analysis.special_functions.integrals
 
-/-! ### The Wallis Product for Pi -/
+/-! # The Wallis formula for Pi
+
+This file establishes the Wallis product for `π` (`real.tendsto_prod_pi_div_two`). Our proof is
+largely about analyzing the behaviour of the sequence `∫ x in 0..π, sin x ^ n` as `n → ∞`.
+See: https://en.wikipedia.org/wiki/Wallis_product
+
+The proof can be broken down into two pieces. The first step (carried out in
+`analysis.special_functions.integrals`) is to use repeated integration by parts to obtain an
+explicit formula for this integra, which is rational if `n` is odd and a rational multiple of `π`
+if `n` is even.
+
+The second step, carried out here, is to estimate the ratio
+`∫ (x : ℝ) in 0..π, sin x ^ (2 * k + 1) / ∫ (x : ℝ) in 0..π, sin x ^ (2 * k)` and prove that
+it converges to one using the squeeze theorem. The final product for `π` is obtained after some
+algebraic manipulation. -/
+
+open_locale real topological_space big_operators nat
+open filter finset interval_integral
 
 namespace real
 
-open_locale real topological_space big_operators
-open filter finset interval_integral
+namespace wallis
 
-lemma integral_sin_pow_div_tendsto_one :
-  tendsto (λ k, (∫ x in 0..π, sin x ^ (2 * k + 1)) / ∫ x in 0..π, sin x ^ (2 * k)) at_top (𝓝 1) :=
+/-- The product of the first `k` terms in Wallis' formula for `π`. -/
+noncomputable def W (k : ℕ) : ℝ :=
+  ∏ i in range k, (2 * i + 2) / (2 * i + 1) * ((2 * i + 2) / (2 * i + 3))
+
+lemma W_succ (k : ℕ) :
+  W (k + 1) = W k * ((2 * k + 2) / (2 * k + 1) * ((2 * k + 2) / (2 * k + 3))) :=
+prod_range_succ _ _
+
+lemma W_pos (k : ℕ) : 0 < W k :=
 begin
-  have h₃ : ∀ n, (∫ x in 0..π, sin x ^ (2 * n + 1)) / ∫ x in 0..π, sin x ^ (2 * n) ≤ 1 :=
-    λ n, (div_le_one (integral_sin_pow_pos _)).mpr (integral_sin_pow_succ_le _),
-  have h₄ :
-    ∀ n, (∫ x in 0..π, sin x ^ (2 * n + 1)) / ∫ x in 0..π, sin x ^ (2 * n) ≥ 2 * n / (2 * n + 1),
-  { rintro ⟨n⟩,
-    { have : 0 ≤ (1 + 1) / π, exact div_nonneg (by norm_num) pi_pos.le,
-      simp [this] },
-    calc (∫ x in 0..π, sin x ^ (2 * n.succ + 1)) / ∫ x in 0..π, sin x ^ (2 * n.succ) ≥
-      (∫ x in 0..π, sin x ^ (2 * n.succ + 1)) / ∫ x in 0..π, sin x ^ (2 * n + 1) :
-      by { refine div_le_div (integral_sin_pow_pos _).le le_rfl (integral_sin_pow_pos _) _,
-        convert integral_sin_pow_succ_le (2 * n + 1) using 1 }
-    ... = 2 * ↑(n.succ) / (2 * ↑(n.succ) + 1) :
-      by { rw div_eq_iff (integral_sin_pow_pos (2 * n + 1)).ne',
-           convert integral_sin_pow (2 * n + 1), simp with field_simps, norm_cast } },
-  refine tendsto_of_tendsto_of_tendsto_of_le_of_le _ _ (λ n, (h₄ n).le) (λ n, (h₃ n)),
-  { refine metric.tendsto_at_top.mpr (λ ε hε, ⟨⌈1 / ε⌉₊, λ n hn, _⟩),
-    have h : (2:ℝ) * n / (2 * n + 1) - 1 = -1 / (2 * n + 1),
-    { conv_lhs { congr, skip, rw ← @div_self _ _ ((2:ℝ) * n + 1) (by { norm_cast, linarith }), },
-      rw [← sub_div, ← sub_sub, sub_self, zero_sub] },
-    have hpos : (0:ℝ) < 2 * n + 1, { norm_cast, norm_num },
-    rw [dist_eq, h, abs_div, abs_neg, abs_one, abs_of_pos hpos, one_div_lt hpos hε],
-    calc 1 / ε ≤ ⌈1 / ε⌉₊ : nat.le_ceil _
-          ... ≤ n : by exact_mod_cast hn.le
-          ... < 2 * n + 1 : by { norm_cast, linarith } },
-  { exact tendsto_const_nhds },
+  induction k with k hk,
+  { unfold W, simp },
+  { rw W_succ,
+    refine mul_pos hk (mul_pos (div_pos _ _) (div_pos _ _)),
+    all_goals { linarith [(nat.cast_nonneg k : 0 ≤ (k:ℝ))] } }
 end
 
-/-- This theorem establishes the Wallis Product for `π`. Our proof is largely about analyzing
-  the behavior of the ratio of the integral of `sin x ^ n` as `n → ∞`.
-  See: https://en.wikipedia.org/wiki/Wallis_product
-
-  The proof can be broken down into two pieces.
-  (Pieces involving general properties of the integral of `sin x ^n` can be found
-  in `analysis.special_functions.integrals`.) First, we use integration by parts to obtain a
-  recursive formula for `∫ x in 0..π, sin x ^ (n + 2)` in terms of `∫ x in 0..π, sin x ^ n`.
-  From this we can obtain closed form products of `∫ x in 0..π, sin x ^ (2 * n)` and
-  `∫ x in 0..π, sin x ^ (2 * n + 1)` via induction. Next, we study the behavior of the ratio
-  `∫ (x : ℝ) in 0..π, sin x ^ (2 * k + 1)) / ∫ (x : ℝ) in 0..π, sin x ^ (2 * k)` and prove that
-  it converges to one using the squeeze theorem. The final product for `π` is obtained after some
-  algebraic manipulation. -/
-theorem tendsto_prod_pi_div_two :
-  tendsto (λ k, ∏ i in range k,
-    (((2:ℝ) * i + 2) / (2 * i + 1)) * ((2 * i + 2) / (2 * i + 3))) at_top (𝓝 (π/2)) :=
+lemma W_eq_factorial_ratio (n : ℕ) :
+  W n = (2 ^ (4 * n) * n! ^ 4) / ((2 * n)!^ 2 * (2 * n + 1)) :=
 begin
-  suffices h : tendsto (λ k, (π / 2)⁻¹ * ∏ i in range k,
-    (2 * i + 2) / (2 * i + 1) * ((2 * i + 2) / (2 * i + 3))) at_top (𝓝 1),
-  { convert h.const_mul (π / 2),
-    { simp_rw mul_inv_cancel_left₀ (show π / 2 ≠ 0, by norm_num [pi_ne_zero]) },
-    { rw mul_one } },
-  convert integral_sin_pow_div_tendsto_one,
-  funext,
+  induction n with n IH,
+  { simp only [W, prod_range_zero, nat.factorial_zero, mul_zero, pow_zero, algebra_map.coe_one,
+      one_pow, mul_one, algebra_map.coe_zero, zero_add, div_self, ne.def, one_ne_zero,
+      not_false_iff] },
+  { unfold W at ⊢ IH,
+    rw [prod_range_succ, IH, _root_.div_mul_div_comm, _root_.div_mul_div_comm],
+    refine (div_eq_div_iff _ _).mpr _,
+    any_goals { exact ne_of_gt (by positivity) },
+    simp_rw [nat.mul_succ, nat.factorial_succ, pow_succ],
+    push_cast,
+    ring_nf }
+end
+
+lemma W_eq_integral_sin_pow_div_integral_sin_pow (k : ℕ) :
+  (π/2)⁻¹ * W k = (∫ (x : ℝ) in 0..π, sin x ^ (2 * k + 1)) / ∫ (x : ℝ) in 0..π, sin x ^ (2 * k) :=
+begin
   rw [integral_sin_pow_even, integral_sin_pow_odd, mul_div_mul_comm, ←prod_div_distrib, inv_div],
-  congr' with i,
-  rw [div_div_div_comm, div_div_eq_mul_div, mul_div_assoc],
+  simp_rw [div_div_div_comm, div_div_eq_mul_div, mul_div_assoc],
+  refl,
 end
+
+lemma W_le (k : ℕ) : W k ≤ π / 2 :=
+begin
+  rw [←div_le_one pi_div_two_pos, div_eq_inv_mul],
+  rw [W_eq_integral_sin_pow_div_integral_sin_pow, div_le_one (integral_sin_pow_pos _)],
+  apply integral_sin_pow_succ_le,
+end
+
+lemma W_ge (k : ℕ) : ((2:ℝ) * k + 1) / (2 * k + 2) * (π / 2) ≤ W k :=
+begin
+  rw [←le_div_iff pi_div_two_pos, div_eq_inv_mul (W k) _],
+  rw [W_eq_integral_sin_pow_div_integral_sin_pow, le_div_iff (integral_sin_pow_pos _)],
+  convert integral_sin_pow_succ_le (2 * k + 1),
+  rw [integral_sin_pow (2 * k)],
+  simp only [sin_zero, zero_pow', ne.def, nat.succ_ne_zero, not_false_iff, zero_mul, sin_pi,
+    tsub_zero, nat.cast_mul, nat.cast_bit0, algebra_map.coe_one, zero_div, zero_add],
+end
+
+lemma tendsto_W_nhds_pi_div_two : tendsto W at_top (𝓝 $ π / 2) :=
+begin
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le _ tendsto_const_nhds W_ge W_le,
+  have : 𝓝 (π / 2) = 𝓝 ((1 - 0) * (π / 2)) := by rw [sub_zero, one_mul], rw this,
+  refine tendsto.mul _ tendsto_const_nhds,
+  have h : ∀ (n:ℕ), ((2:ℝ) * n + 1) / (2 * n + 2) = 1 - 1 / (2 * n + 2),
+  { intro n,
+    rw [sub_div' _ _ _ (ne_of_gt (add_pos_of_nonneg_of_pos
+      (mul_nonneg ((two_pos : 0 < (2:ℝ)).le) (nat.cast_nonneg _)) two_pos)), one_mul],
+    congr' 1, ring },
+  simp_rw h,
+  refine (tendsto_const_nhds.div_at_top _).const_sub _,
+  refine tendsto.at_top_add _ tendsto_const_nhds,
+  exact tendsto_coe_nat_at_top_at_top.const_mul_at_top two_pos,
+end
+
+lemma W_eq_mul_sq (k : ℕ) :
+  W k = (2 * k + 1) * (∏ i in range k, ((2:ℝ) * i + 2) / (2 * i + 3)) ^ 2 :=
+begin
+  induction k with k hk,
+  { simp [W], },
+  { unfold W at *,
+    rw [prod_range_succ, prod_range_succ, hk],
+    suffices : ∀ (α : ℝ),
+      (2 * ↑k + 1) * α ^ 2 * ((2 * ↑k + 2) / (2 * ↑k + 1) * ((2 * ↑k + 2) / (2 * ↑k + 3))) =
+      (2 * ↑(k.succ) + 1) * (α * ((2 * ↑k + 2) / (2 * ↑k + 3))) ^ 2,
+    { rw this },
+    intro α,
+    have a : (2 * ↑k + 1 : ℝ) ≠ 0 := by positivity,
+    have b : (2 * ↑k + 3 : ℝ) ≠ 0 := by positivity,
+    field_simp, ring }
+end
+
+lemma integral_sin_pow_odd_sq_eq (k : ℕ) :
+  (∫ x in 0..π, sin x ^ (2 * k + 1)) ^ 2 = 4 * W k / (2 * k + 1) :=
+begin
+  rw integral_sin_pow_odd,
+  have B := W_eq_mul_sq k,
+  rw [mul_comm (2 * (k:ℝ) + 1) _, ←div_eq_iff] at B,
+  rw [mul_pow, ←B],
+  ring,
+  linarith [(nat.cast_nonneg k : 0 ≤ (k:ℝ))],
+end
+
+lemma integral_sin_pow_even_sq_eq (k : ℕ) :
+  (∫ x in 0..π, sin x ^ (2 * k)) ^ 2 = π ^ 2 / (2 * k + 1) / W k :=
+begin
+  induction k with k hk,
+  { dsimp only [W],
+    simp },
+  { have np : 0 < 2 * (k:ℝ) + 1 := by linarith [(nat.cast_nonneg k : 0 ≤ (k:ℝ))],
+    rw [nat.succ_eq_add_one, mul_add 2 k 1, mul_one, integral_sin_pow, sin_zero, sin_pi,
+      zero_pow (nat.add_pos_right _ zero_lt_one), zero_mul, zero_mul, sub_zero, zero_div, zero_add,
+      mul_pow, hk, W_succ, nat.cast_add_one, nat.cast_mul, mul_add, mul_one,
+      add_assoc (2 * (k:ℝ)) 2 1, (by ring : (2:ℝ) + 1 = 3), sq],
+    have np2 : 2 * (k:ℝ) + 2 ≠ 0 := by linarith,
+    have np3 : 2 * (k:ℝ) + 3 ≠ 0 := by linarith,
+    field_simp [np.ne', (W_pos k).ne'],
+    ring }
+end
+
+end wallis
 
 end real
+
+open real real.wallis
+
+section integral_sin_pow_bounds
+/-! ## Bounds for integrals of `sin x ^ n`
+
+Explicit `O(1/√n)` bounds for `∫ x in 0..π, sin x ^ n`, as a by-product of the proof of Wallis'
+formula for `π`. -/
+
+lemma integral_sin_pow_odd_le (n : ℕ) :
+  ∫ x in 0..π, sin x ^ (2 * n + 1) ≤ sqrt (2 * π / (2 * n + 1)) :=
+begin
+  have np : 0 < 2 * (n:ℝ) + 1 := by linarith [(nat.cast_nonneg n : 0 ≤ (n:ℝ))],
+  rw [le_sqrt (integral_sin_pow_pos _).le (div_pos two_pi_pos np).le, integral_sin_pow_odd_sq_eq],
+  apply div_le_div_of_le np.le,
+  rw ←le_div_iff' (by linarith : 0 < (4:ℝ)),
+  convert W_le n using 1,
+  ring,
+end
+
+lemma integral_sin_pow_even_le (n : ℕ) :
+  ∫ x in 0..π, sin x ^ (2 * n) ≤ sqrt (2 * π * (2 * n + 2) / (2 * n + 1) ^ 2) :=
+begin
+  have np : 0 < 2 * (n:ℝ) + 1 := by linarith [(nat.cast_nonneg n : 0 ≤ (n:ℝ))],
+  have np' : 0 < 2 * (n:ℝ) + 2 := by linarith,
+  rw le_sqrt (integral_sin_pow_pos _).le,
+  swap, { refine div_nonneg _ (sq_nonneg _), exact mul_nonneg (two_pi_pos).le np'.le },
+  rw [integral_sin_pow_even_sq_eq, div_le_iff (W_pos n), ←div_le_iff'],
+  swap, { refine div_pos _ (sq_pos_of_pos np), exact mul_pos two_pi_pos np' },
+  convert W_ge n,
+  field_simp [np.ne', np'.ne', pi_pos.ne'],
+  ring,
+end
+
+lemma integral_sin_pow_le {n : ℕ} (hn : n ≠ 0) : ∫ x in 0..π, sin x ^ n ≤ sqrt (2 * π / n) :=
+begin
+  -- this is a slightly weaker bound than `integral_sin_pow_even_le` for even `n`, but uniform in
+  -- its statement
+  obtain ⟨k, hk⟩ := nat.even_or_odd' n,
+  rcases hk with rfl | rfl,
+  { refine le_trans (integral_sin_pow_even_le k) _,
+    apply sqrt_le_sqrt,
+    rw [div_le_div_iff, mul_assoc, mul_le_mul_left two_pi_pos],
+    rotate, { positivity }, { positivity },
+    have : (2 * (k:ℝ) + 2) * ((2 * k : ℕ) : ℝ) = (2 * k + 1) ^ 2 - 1,
+    { push_cast, ring, },
+    rw [this, sub_le_self_iff],
+    exact zero_le_one },
+  { convert integral_sin_pow_odd_le k using 3,
+    rw [nat.cast_add, nat.cast_mul, nat.cast_two, nat.cast_one] },
+end
+
+lemma integral_sin_pow_ge (n : ℕ) : sqrt (2 * π / (n + 1)) ≤ ∫ x in 0..π, sin x ^ n :=
+begin
+  refine sqrt_le_iff.mpr ⟨(integral_sin_pow_pos _).le, _⟩,
+  obtain ⟨k, hk⟩ := nat.even_or_odd' n,
+  have np : 0 < 2 * (k:ℝ) + 1 := by positivity,
+  have np' : 2 * (k:ℝ) + 2 ≠ 0 := by positivity,
+  rcases hk with rfl | rfl,
+  { rw [integral_sin_pow_even_sq_eq, le_div_iff (W_pos _), nat.cast_mul, nat.cast_two,
+      ←le_div_iff' (div_pos two_pi_pos np)],
+    convert W_le k using 1,
+    field_simp [np.ne', np', pi_pos.ne'],
+    ring },
+  { rw [nat.cast_add, nat.cast_mul, nat.cast_two, nat.cast_one,
+      (by ring : (2:ℝ) * k + 1 + 1 = 2 * k + 2), integral_sin_pow_odd_sq_eq, le_div_iff np,
+      ←div_le_iff' (by positivity : 0 < (4:ℝ))],
+    convert W_ge k,
+    field_simp [np.ne', np'],
+    ring },
+end
+
+end integral_sin_pow_bounds
+
+/-- Wallis' product formula for `π / 2`. -/
+theorem real.tendsto_prod_pi_div_two :
+  tendsto
+  (λ k, ∏ i in range k, (((2:ℝ) * i + 2) / (2 * i + 1)) * ((2 * i + 2) / (2 * i + 3)))
+  at_top (𝓝 (π/2)) :=
+tendsto_W_nhds_pi_div_two

--- a/src/data/real/pi/wallis.lean
+++ b/src/data/real/pi/wallis.lean
@@ -28,7 +28,7 @@ algebraic manipulation.
 * `real.wallis.W_le` and `real.wallis.le_W`: upper and lower bounds for `W n`.
 * `real.wallis.integral_sin_pow_odd_sq_eq` and `real.wallis.integral_sin_pow_even_sq_eq`: formulas
   for `(∫ x in 0..π, sin x ^ n) ^ 2` in terms of `W`.
-* `integral_sin_pow_le` and `integral_sin_pow_ge`: bounds for `∫ x in 0..π, sin x ^ n`.
+* `integral_sin_pow_le` and `le_integral_sin_pow`: bounds for `∫ x in 0..π, sin x ^ n`.
 * `real.tendsto_prod_pi_div_two`: the Wallis product formula.
  -/
 

--- a/src/data/real/pi/wallis.lean
+++ b/src/data/real/pi/wallis.lean
@@ -13,13 +13,24 @@ See: https://en.wikipedia.org/wiki/Wallis_product
 
 The proof can be broken down into two pieces. The first step (carried out in
 `analysis.special_functions.integrals`) is to use repeated integration by parts to obtain an
-explicit formula for this integra, which is rational if `n` is odd and a rational multiple of `π`
+explicit formula for this integral, which is rational if `n` is odd and a rational multiple of `π`
 if `n` is even.
 
 The second step, carried out here, is to estimate the ratio
 `∫ (x : ℝ) in 0..π, sin x ^ (2 * k + 1) / ∫ (x : ℝ) in 0..π, sin x ^ (2 * k)` and prove that
 it converges to one using the squeeze theorem. The final product for `π` is obtained after some
-algebraic manipulation. -/
+algebraic manipulation.
+
+## Main statements
+
+* `real.wallis.W`: the product of the first `k` terms in Wallis' formula for `π`.
+* `real.wallis.W_eq_integral_sin_pow_div_integral_sin_pow`: express `W n` as a ratio of integrals.
+* `real.wallis.W_le` and `real.wallis.le_W`: upper and lower bounds for `W n`.
+* `real.wallis.integral_sin_pow_odd_sq_eq` and `real.wallis.integral_sin_pow_even_sq_eq`: formulas
+  for `(∫ x in 0..π, sin x ^ n) ^ 2` in terms of `W`.
+* `integral_sin_pow_le` and `integral_sin_pow_ge`: bounds for `∫ x in 0..π, sin x ^ n`.
+* `real.tendsto_prod_pi_div_two`: the Wallis product formula.
+ -/
 
 open_locale real topological_space big_operators nat
 open filter finset interval_integral
@@ -30,7 +41,7 @@ namespace wallis
 
 /-- The product of the first `k` terms in Wallis' formula for `π`. -/
 noncomputable def W (k : ℕ) : ℝ :=
-  ∏ i in range k, (2 * i + 2) / (2 * i + 1) * ((2 * i + 2) / (2 * i + 3))
+∏ i in range k, (2 * i + 2) / (2 * i + 1) * ((2 * i + 2) / (2 * i + 3))
 
 lemma W_succ (k : ℕ) :
   W (k + 1) = W k * ((2 * k + 2) / (2 * k + 1) * ((2 * k + 2) / (2 * k + 3))) :=
@@ -41,8 +52,8 @@ begin
   induction k with k hk,
   { unfold W, simp },
   { rw W_succ,
-    refine mul_pos hk (mul_pos (div_pos _ _) (div_pos _ _)),
-    all_goals { linarith [(nat.cast_nonneg k : 0 ≤ (k:ℝ))] } }
+    refine mul_pos hk (mul_pos (div_pos _ _) (div_pos _ _));
+    positivity }
 end
 
 lemma W_eq_factorial_ratio (n : ℕ) :
@@ -76,7 +87,7 @@ begin
   apply integral_sin_pow_succ_le,
 end
 
-lemma W_ge (k : ℕ) : ((2:ℝ) * k + 1) / (2 * k + 2) * (π / 2) ≤ W k :=
+lemma le_W (k : ℕ) : ((2:ℝ) * k + 1) / (2 * k + 2) * (π / 2) ≤ W k :=
 begin
   rw [←le_div_iff pi_div_two_pos, div_eq_inv_mul (W k) _],
   rw [W_eq_integral_sin_pow_div_integral_sin_pow, le_div_iff (integral_sin_pow_pos _)],
@@ -88,8 +99,8 @@ end
 
 lemma tendsto_W_nhds_pi_div_two : tendsto W at_top (𝓝 $ π / 2) :=
 begin
-  refine tendsto_of_tendsto_of_tendsto_of_le_of_le _ tendsto_const_nhds W_ge W_le,
-  have : 𝓝 (π / 2) = 𝓝 ((1 - 0) * (π / 2)) := by rw [sub_zero, one_mul], rw this,
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le _ tendsto_const_nhds le_W W_le,
+  have : 𝓝 (π / 2) = 𝓝 ((1 - 0) * (π / 2)), by rw [sub_zero, one_mul], rw this,
   refine tendsto.mul _ tendsto_const_nhds,
   have h : ∀ (n:ℕ), ((2:ℝ) * n + 1) / (2 * n + 2) = 1 - 1 / (2 * n + 2),
   { intro n,
@@ -109,13 +120,13 @@ begin
   { simp [W], },
   { unfold W at *,
     rw [prod_range_succ, prod_range_succ, hk],
-    suffices : ∀ (α : ℝ),
-      (2 * ↑k + 1) * α ^ 2 * ((2 * ↑k + 2) / (2 * ↑k + 1) * ((2 * ↑k + 2) / (2 * ↑k + 3))) =
-      (2 * ↑(k.succ) + 1) * (α * ((2 * ↑k + 2) / (2 * ↑k + 3))) ^ 2,
+    suffices : ∀ (x : ℝ),
+      (2 * ↑k + 1) * x ^ 2 * ((2 * ↑k + 2) / (2 * ↑k + 1) * ((2 * ↑k + 2) / (2 * ↑k + 3))) =
+      (2 * ↑(k.succ) + 1) * (x * ((2 * ↑k + 2) / (2 * ↑k + 3))) ^ 2,
     { rw this },
-    intro α,
-    have a : (2 * ↑k + 1 : ℝ) ≠ 0 := by positivity,
-    have b : (2 * ↑k + 3 : ℝ) ≠ 0 := by positivity,
+    intro x,
+    have a : (2 * ↑k + 1 : ℝ) ≠ 0, by positivity,
+    have b : (2 * ↑k + 3 : ℝ) ≠ 0, by positivity,
     field_simp, ring }
 end
 
@@ -125,9 +136,9 @@ begin
   rw integral_sin_pow_odd,
   have B := W_eq_mul_sq k,
   rw [mul_comm (2 * (k:ℝ) + 1) _, ←div_eq_iff] at B,
-  rw [mul_pow, ←B],
-  ring,
-  linarith [(nat.cast_nonneg k : 0 ≤ (k:ℝ))],
+  { rw [mul_pow, ←B],
+    ring },
+  { positivity },
 end
 
 lemma integral_sin_pow_even_sq_eq (k : ℕ) :
@@ -136,13 +147,13 @@ begin
   induction k with k hk,
   { dsimp only [W],
     simp },
-  { have np : 0 < 2 * (k:ℝ) + 1 := by linarith [(nat.cast_nonneg k : 0 ≤ (k:ℝ))],
+  { have np : 0 < 2 * (k:ℝ) + 1, by positivity,
     rw [nat.succ_eq_add_one, mul_add 2 k 1, mul_one, integral_sin_pow, sin_zero, sin_pi,
       zero_pow (nat.add_pos_right _ zero_lt_one), zero_mul, zero_mul, sub_zero, zero_div, zero_add,
       mul_pow, hk, W_succ, nat.cast_add_one, nat.cast_mul, mul_add, mul_one,
       add_assoc (2 * (k:ℝ)) 2 1, (by ring : (2:ℝ) + 1 = 3), sq],
-    have np2 : 2 * (k:ℝ) + 2 ≠ 0 := by linarith,
-    have np3 : 2 * (k:ℝ) + 3 ≠ 0 := by linarith,
+    have np2 : 2 * (k:ℝ) + 2 ≠ 0, by positivity,
+    have np3 : 2 * (k:ℝ) + 3 ≠ 0, by positivity,
     field_simp [np.ne', (W_pos k).ne'],
     ring }
 end
@@ -162,10 +173,10 @@ formula for `π`. -/
 lemma integral_sin_pow_odd_le (n : ℕ) :
   ∫ x in 0..π, sin x ^ (2 * n + 1) ≤ sqrt (2 * π / (2 * n + 1)) :=
 begin
-  have np : 0 < 2 * (n:ℝ) + 1 := by linarith [(nat.cast_nonneg n : 0 ≤ (n:ℝ))],
+  have np : 0 < 2 * (n:ℝ) + 1, by positivity,
   rw [le_sqrt (integral_sin_pow_pos _).le (div_pos two_pi_pos np).le, integral_sin_pow_odd_sq_eq],
   apply div_le_div_of_le np.le,
-  rw ←le_div_iff' (by linarith : 0 < (4:ℝ)),
+  rw ←le_div_iff' (by norm_num : 0 < (4:ℝ)),
   convert W_le n using 1,
   ring,
 end
@@ -173,13 +184,13 @@ end
 lemma integral_sin_pow_even_le (n : ℕ) :
   ∫ x in 0..π, sin x ^ (2 * n) ≤ sqrt (2 * π * (2 * n + 2) / (2 * n + 1) ^ 2) :=
 begin
-  have np : 0 < 2 * (n:ℝ) + 1 := by linarith [(nat.cast_nonneg n : 0 ≤ (n:ℝ))],
-  have np' : 0 < 2 * (n:ℝ) + 2 := by linarith,
+  have np : 0 < 2 * (n:ℝ) + 1, by positivity,
+  have np' : 0 < 2 * (n:ℝ) + 2, by positivity,
   rw le_sqrt (integral_sin_pow_pos _).le,
   swap, { refine div_nonneg _ (sq_nonneg _), exact mul_nonneg (two_pi_pos).le np'.le },
   rw [integral_sin_pow_even_sq_eq, div_le_iff (W_pos n), ←div_le_iff'],
   swap, { refine div_pos _ (sq_pos_of_pos np), exact mul_pos two_pi_pos np' },
-  convert W_ge n,
+  convert le_W n,
   field_simp [np.ne', np'.ne', pi_pos.ne'],
   ring,
 end
@@ -202,12 +213,12 @@ begin
     rw [nat.cast_add, nat.cast_mul, nat.cast_two, nat.cast_one] },
 end
 
-lemma integral_sin_pow_ge (n : ℕ) : sqrt (2 * π / (n + 1)) ≤ ∫ x in 0..π, sin x ^ n :=
+lemma le_integral_sin_pow (n : ℕ) : sqrt (2 * π / (n + 1)) ≤ ∫ x in 0..π, sin x ^ n :=
 begin
   refine sqrt_le_iff.mpr ⟨(integral_sin_pow_pos _).le, _⟩,
   obtain ⟨k, hk⟩ := nat.even_or_odd' n,
-  have np : 0 < 2 * (k:ℝ) + 1 := by positivity,
-  have np' : 2 * (k:ℝ) + 2 ≠ 0 := by positivity,
+  have np : 0 < 2 * (k:ℝ) + 1, by positivity,
+  have np' : 2 * (k:ℝ) + 2 ≠ 0, by positivity,
   rcases hk with rfl | rfl,
   { rw [integral_sin_pow_even_sq_eq, le_div_iff (W_pos _), nat.cast_mul, nat.cast_two,
       ←le_div_iff' (div_pos two_pi_pos np)],
@@ -217,7 +228,7 @@ begin
   { rw [nat.cast_add, nat.cast_mul, nat.cast_two, nat.cast_one,
       (by ring : (2:ℝ) * k + 1 + 1 = 2 * k + 2), integral_sin_pow_odd_sq_eq, le_div_iff np,
       ←div_le_iff' (by positivity : 0 < (4:ℝ))],
-    convert W_ge k,
+    convert le_W k,
     field_simp [np.ne', np'],
     ring },
 end


### PR DESCRIPTION
This is preparation for adding Euler's sine product (whose proof is a generalisation of the proof of Wallis' formula)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
