### PR TITLE
[Merged by Bors] - refactor(topology): move `pcontinuous` etc to a new file

### DIFF
--- a/src/combinatorics/hall/basic.lean
+++ b/src/combinatorics/hall/basic.lean
@@ -5,6 +5,7 @@ Authors: Alena Gusakov, Bhavik Mehta, Kyle Miller
 -/
 import combinatorics.hall.finite
 import topology.category.Top.limits
+import data.rel
 
 /-!
 # Hall's Marriage Theorem

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
 -/
 import order.filter.ultrafilter
-import order.filter.partial
 import algebra.support
 import order.filter.lift
 
@@ -817,22 +816,6 @@ theorem all_mem_nhds_filter (x : α) (f : set α → set β) (hf : ∀ s t, s �
   (∀ s ∈ 𝓝 x, f s ∈ l) ↔ (∀ s, is_open s → x ∈ s → f s ∈ l) :=
 all_mem_nhds _ _ (λ s t ssubt h, mem_of_superset h (hf s t ssubt))
 
-theorem rtendsto_nhds {r : rel β α} {l : filter β} {a : α} :
-  rtendsto r l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → r.core s ∈ l) :=
-all_mem_nhds_filter _ _ (λ s t, id) _
-
-theorem rtendsto'_nhds {r : rel β α} {l : filter β} {a : α} :
-  rtendsto' r l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → r.preimage s ∈ l) :=
-by { rw [rtendsto'_def], apply all_mem_nhds_filter, apply rel.preimage_mono }
-
-theorem ptendsto_nhds {f : β →. α} {l : filter β} {a : α} :
-  ptendsto f l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → f.core s ∈ l) :=
-rtendsto_nhds
-
-theorem ptendsto'_nhds {f : β →. α} {l : filter β} {a : α} :
-  ptendsto' f l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → f.preimage s ∈ l) :=
-rtendsto'_nhds
-
 theorem tendsto_nhds {f : β → α} {l : filter β} {a : α} :
   tendsto f l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → f ⁻¹' s ∈ l) :=
 all_mem_nhds_filter _ _ (λ s t h, preimage_mono h) _
@@ -1430,38 +1413,6 @@ lemma continuous.frontier_preimage_subset
   {f : α → β} (hf : continuous f) (t : set β) :
   frontier (f ⁻¹' t) ⊆ f ⁻¹' (frontier t) :=
 diff_subset_diff (hf.closure_preimage_subset t) (preimage_interior_subset_interior_preimage hf)
-
-/-! ### Continuity and partial functions -/
-
-/-- Continuity of a partial function -/
-def pcontinuous (f : α →. β) := ∀ s, is_open s → is_open (f.preimage s)
-
-lemma open_dom_of_pcontinuous {f : α →. β} (h : pcontinuous f) : is_open f.dom :=
-by rw [←pfun.preimage_univ]; exact h _ is_open_univ
-
-lemma pcontinuous_iff' {f : α →. β} :
-  pcontinuous f ↔ ∀ {x y} (h : y ∈ f x), ptendsto' f (𝓝 x) (𝓝 y) :=
-begin
-  split,
-  { intros h x y h',
-    simp only [ptendsto'_def, mem_nhds_iff],
-    rintros s ⟨t, tsubs, opent, yt⟩,
-    exact ⟨f.preimage t, pfun.preimage_mono _ tsubs, h _ opent, ⟨y, yt, h'⟩⟩ },
-  intros hf s os,
-  rw is_open_iff_nhds,
-  rintros x ⟨y, ys, fxy⟩ t,
-  rw [mem_principal],
-  assume h : f.preimage s ⊆ t,
-  change t ∈ 𝓝 x,
-  apply mem_of_superset _ h,
-  have h' : ∀ s ∈ 𝓝 y, f.preimage s ∈ 𝓝 x,
-  { intros s hs,
-     have : ptendsto' f (𝓝 x) (𝓝 y) := hf fxy,
-     rw ptendsto'_def at this,
-     exact this s hs },
-  show f.preimage s ∈ 𝓝 x,
-  apply h', rw mem_nhds_iff, exact ⟨s, set.subset.refl _, os, ys⟩
-end
 
 /-- If a continuous map `f` maps `s` to `t`, then it maps `closure s` to `closure t`. -/
 lemma set.maps_to.closure {s : set α} {t : set β} {f : α → β} (h : maps_to f s t)

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -615,10 +615,6 @@ ctsf.tendsto_nhds_within_image.le_comap
   comap f (𝓝[range f] y) = comap f (𝓝 y) :=
 comap_inf_principal_range
 
-theorem continuous_within_at_iff_ptendsto_res (f : α → β) {x : α} {s : set α} :
-  continuous_within_at f s x ↔ ptendsto (pfun.res f s) (𝓝 x) (𝓝 (f x)) :=
-tendsto_iff_ptendsto _ _ _ _
-
 lemma continuous_iff_continuous_on_univ {f : α → β} : continuous f ↔ continuous_on f univ :=
 by simp [continuous_iff_continuous_at, continuous_on, continuous_at, continuous_within_at,
          nhds_within_univ]

--- a/src/topology/partial.lean
+++ b/src/topology/partial.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
-import topology.basic
+import topology.continuous_on
 import order.filter.partial
 
 /-!
@@ -67,3 +67,7 @@ begin
   apply h', rw mem_nhds_iff, exact ⟨s, set.subset.refl _, os, ys⟩
 end
 
+
+theorem continuous_within_at_iff_ptendsto_res (f : α → β) {x : α} {s : set α} :
+  continuous_within_at f s x ↔ ptendsto (pfun.res f s) (𝓝 x) (𝓝 (f x)) :=
+tendsto_iff_ptendsto _ _ _ _

--- a/src/topology/partial.lean
+++ b/src/topology/partial.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2023 Jeremy Avigad. All rights reserved.
+Copyright (c) 2018 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/

--- a/src/topology/partial.lean
+++ b/src/topology/partial.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2023 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad
+-/
+import topology.basic
+import order.filter.partial
+
+/-!
+# Partial functions and topological spaces
+
+In this file we prove properties of `filter.ptendsto` etc in topological spaces.
+-/
+
+open filter
+open_locale topological_space
+
+variables {α β : Type*} [topological_space α]
+
+theorem rtendsto_nhds {r : rel β α} {l : filter β} {a : α} :
+  rtendsto r l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → r.core s ∈ l) :=
+all_mem_nhds_filter _ _ (λ s t, id) _
+
+theorem rtendsto'_nhds {r : rel β α} {l : filter β} {a : α} :
+  rtendsto' r l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → r.preimage s ∈ l) :=
+by { rw [rtendsto'_def], apply all_mem_nhds_filter, apply rel.preimage_mono }
+
+theorem ptendsto_nhds {f : β →. α} {l : filter β} {a : α} :
+  ptendsto f l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → f.core s ∈ l) :=
+rtendsto_nhds
+
+theorem ptendsto'_nhds {f : β →. α} {l : filter β} {a : α} :
+  ptendsto' f l (𝓝 a) ↔ (∀ s, is_open s → a ∈ s → f.preimage s ∈ l) :=
+rtendsto'_nhds
+
+/-! ### Continuity and partial functions -/
+
+variable [topological_space β]
+
+/-- Continuity of a partial function -/
+def pcontinuous (f : α →. β) := ∀ s, is_open s → is_open (f.preimage s)
+
+lemma open_dom_of_pcontinuous {f : α →. β} (h : pcontinuous f) : is_open f.dom :=
+by rw [←pfun.preimage_univ]; exact h _ is_open_univ
+
+lemma pcontinuous_iff' {f : α →. β} :
+  pcontinuous f ↔ ∀ {x y} (h : y ∈ f x), ptendsto' f (𝓝 x) (𝓝 y) :=
+begin
+  split,
+  { intros h x y h',
+    simp only [ptendsto'_def, mem_nhds_iff],
+    rintros s ⟨t, tsubs, opent, yt⟩,
+    exact ⟨f.preimage t, pfun.preimage_mono _ tsubs, h _ opent, ⟨y, yt, h'⟩⟩ },
+  intros hf s os,
+  rw is_open_iff_nhds,
+  rintros x ⟨y, ys, fxy⟩ t,
+  rw [mem_principal],
+  assume h : f.preimage s ⊆ t,
+  change t ∈ 𝓝 x,
+  apply mem_of_superset _ h,
+  have h' : ∀ s ∈ 𝓝 y, f.preimage s ∈ 𝓝 x,
+  { intros s hs,
+     have : ptendsto' f (𝓝 x) (𝓝 y) := hf fxy,
+     rw ptendsto'_def at this,
+     exact this s hs },
+  show f.preimage s ∈ 𝓝 x,
+  apply h', rw mem_nhds_iff, exact ⟨s, set.subset.refl _, os, ys⟩
+end
+

--- a/src/topology/partial.lean
+++ b/src/topology/partial.lean
@@ -9,7 +9,8 @@ import order.filter.partial
 /-!
 # Partial functions and topological spaces
 
-In this file we prove properties of `filter.ptendsto` etc in topological spaces.
+In this file we prove properties of `filter.ptendsto` etc in topological spaces. We also introduce
+`pcontinuous`, a version of `continuous` for partially defined functions.
 -/
 
 open filter
@@ -66,7 +67,6 @@ begin
   show f.preimage s ∈ 𝓝 x,
   apply h', rw mem_nhds_iff, exact ⟨s, set.subset.refl _, os, ys⟩
 end
-
 
 theorem continuous_within_at_iff_ptendsto_res (f : α → β) {x : α} {s : set α} :
   continuous_within_at f s x ↔ ptendsto (pfun.res f s) (𝓝 x) (𝓝 (f x)) :=


### PR DESCRIPTION
Move `pcontinuous` and lemmas about `ptendsto` to a new file. There are some issues with porting `data.pfun` to Lean 4, so this PR makes it possible to port topology without waiting for `pfun`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
