### PR TITLE
[Merged by Bors] - fix(data/set_like): unbundled subclasses of `out_param` classes should not repeat the parents' `out_param`

### DIFF
--- a/src/algebra/module/submodule/basic.lean
+++ b/src/algebra/module/submodule/basic.lean
@@ -32,8 +32,11 @@ variables {G : Type u''} {S : Type u'} {R : Type u} {M : Type v} {ι : Type w}
 
 set_option old_structure_cmd true
 
-/-- `submodule_class S R M` says `S` is a type of submodules `s ≤ M`. -/
-class submodule_class (S : Type*) (R M : out_param $ Type*) [add_zero_class M]
+/-- `submodule_class S R M` says `S` is a type of submodules `s ≤ M`.
+
+Note that only `R` is marked as `out_param` since `M` is already supplied by the `set_like` class.
+-/
+class submodule_class (S : Type*) (R : out_param $ Type*) (M : Type*) [add_zero_class M]
   [has_smul R M] [set_like S M] [add_submonoid_class S M] extends smul_mem_class S R M
 
 /-- A submodule of a module is one which is closed under vector operations.

--- a/src/algebra/monoid_algebra/grading.lean
+++ b/src/algebra/monoid_algebra/grading.lean
@@ -177,7 +177,8 @@ graded_algebra.of_alg_hom _
   (decompose_aux f)
   (begin
     ext : 2,
-    dsimp,
+    simp only [alg_hom.coe_to_monoid_hom, function.comp_app, alg_hom.coe_comp,
+        function.comp.left_id, alg_hom.coe_id, add_monoid_algebra.of_apply, monoid_hom.coe_comp],
     rw [decompose_aux_single, direct_sum.coe_alg_hom_of, subtype.coe_mk],
   end)
   (λ i x, by rw [decompose_aux_coe f x])

--- a/src/algebra/monoid_algebra/grading.lean
+++ b/src/algebra/monoid_algebra/grading.lean
@@ -191,7 +191,7 @@ by apply_instance
     (direct_sum.decompose (grade_by R f)) := rfl
 
 @[simp] lemma grades_by.decompose_single (m : M) (r : R) :
-  direct_sum.decompose (grade_by R f) (finsupp.single m r) =
+  direct_sum.decompose (grade_by R f) (finsupp.single m r : add_monoid_algebra R M) =
     direct_sum.of (λ i : ι, grade_by R f i) (f m)
       ⟨finsupp.single m r, single_mem_grade_by _ _ _⟩ :=
 decompose_aux_single _ _ _
@@ -205,7 +205,7 @@ by apply_instance
 
 @[simp]
 lemma grade.decompose_single (i : ι) (r : R) :
-  direct_sum.decompose (grade R : ι → submodule _ _) (finsupp.single i r) =
+  direct_sum.decompose (grade R : ι → submodule _ _) (finsupp.single i r : add_monoid_algebra _ _) =
     direct_sum.of (λ i : ι, grade R i) i ⟨finsupp.single i r, single_mem_grade _ _⟩ :=
 decompose_aux_single _ _ _
 

--- a/src/data/set_like/basic.lean
+++ b/src/data/set_like/basic.lean
@@ -82,6 +82,15 @@ Note: if `set_like.coe` is a projection, implementers should create a simp lemma
 @[simp] lemma mem_carrier {p : my_subobject X} : x ∈ p.carrier ↔ x ∈ (p : set X) := iff.rfl
 ```
 to normalize terms.
+
+If you declare an unbundled subclass of `set_like`, for example:
+```
+class mul_mem_class (S : Type*) (M : Type*) [has_mul M] [set_like S M] where
+  ...
+```
+Then you should *not* repeat the `out_param` declaration, `set_like` will supply the value instead.
+This ensures in Lean 4 your subclass will not have issues with synthesis of the `[has_mul M]`
+parameter starting before the value of `M` is known.
 -/
 @[protect_proj]
 class set_like (A : Type*) (B : out_param $ Type*) :=

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -65,7 +65,7 @@ universes u v w
 variables {K : Type u} {L : Type v} {M : Type w} [field K] [field L] [field M]
 
 /-- `subfield_class S K` states `S` is a type of subsets `s ⊆ K` closed under field operations. -/
-class subfield_class (S : Type*) (K : out_param $ Type*) [field K] [set_like S K]
+class subfield_class (S K : Type*) [field K] [set_like S K]
   extends subring_class S K, inv_mem_class S K : Prop
 
 namespace subfield_class

--- a/src/group_theory/group_action/sub_mul_action.lean
+++ b/src/group_theory/group_action/sub_mul_action.lean
@@ -36,13 +36,23 @@ variables {S : Type u'} {T : Type u''} {R : Type u} {M : Type v}
 set_option old_structure_cmd true
 
 /-- `smul_mem_class S R M` says `S` is a type of subsets `s ≤ M` that are closed under the
-scalar action of `R` on `M`. -/
-class smul_mem_class (S : Type*) (R M : out_param $ Type*) [has_smul R M] [set_like S M] :=
+scalar action of `R` on `M`.
+
+Note that only `R` is marked as an `out_param` here, since `M` is supplied by the `set_like`
+class instead.
+-/
+class smul_mem_class (S : Type*) (R : out_param $ Type*) (M : Type*) [has_smul R M]
+  [set_like S M] :=
 (smul_mem : ∀ {s : S} (r : R) {m : M}, m ∈ s → r • m ∈ s)
 
 /-- `vadd_mem_class S R M` says `S` is a type of subsets `s ≤ M` that are closed under the
-additive action of `R` on `M`. -/
-class vadd_mem_class (S : Type*) (R M : out_param $ Type*) [has_vadd R M] [set_like S M] :=
+additive action of `R` on `M`.
+
+Note that only `R` is marked as an `out_param` here, since `M` is supplied by the `set_like`
+class instead.
+-/
+class vadd_mem_class (S : Type*) (R : out_param $ Type*) (M : Type*) [has_vadd R M]
+  [set_like S M] :=
 (vadd_mem : ∀ {s : S} (r : R) {m : M}, m ∈ s → r +ᵥ m ∈ s)
 
 attribute [to_additive] smul_mem_class

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -63,13 +63,13 @@ variables [mul_one_class M] {s : set M}
 variables [add_zero_class A] {t : set A}
 
 /-- `one_mem_class S M` says `S` is a type of subsets `s ≤ M`, such that `1 ∈ s` for all `s`. -/
-class one_mem_class (S : Type*) (M : out_param $ Type*) [has_one M] [set_like S M] : Prop :=
+class one_mem_class (S M : Type*) [has_one M] [set_like S M] : Prop :=
 (one_mem : ∀ (s : S), (1 : M) ∈ s)
 
 export one_mem_class (one_mem)
 
 /-- `zero_mem_class S M` says `S` is a type of subsets `s ≤ M`, such that `0 ∈ s` for all `s`. -/
-class zero_mem_class (S : Type*) (M : out_param $ Type*) [has_zero M] [set_like S M] : Prop :=
+class zero_mem_class (S M : Type*) [has_zero M] [set_like S M] : Prop :=
 (zero_mem : ∀ (s : S), (0 : M) ∈ s)
 
 export zero_mem_class (zero_mem)
@@ -92,7 +92,7 @@ add_decl_doc submonoid.to_subsemigroup
 
 /-- `submonoid_class S M` says `S` is a type of subsets `s ≤ M` that contain `1`
 and are closed under `(*)` -/
-class submonoid_class (S : Type*) (M : out_param $ Type*) [mul_one_class M] [set_like S M]
+class submonoid_class (S M : Type*) [mul_one_class M] [set_like S M]
   extends mul_mem_class S M, one_mem_class S M : Prop
 
 section
@@ -113,7 +113,7 @@ add_decl_doc add_submonoid.to_add_subsemigroup
 
 /-- `add_submonoid_class S M` says `S` is a type of subsets `s ≤ M` that contain `0`
 and are closed under `(+)` -/
-class add_submonoid_class (S : Type*) (M : out_param $ Type*) [add_zero_class M] [set_like S M]
+class add_submonoid_class (S M : Type*) [add_zero_class M] [set_like S M]
   extends add_mem_class S M, zero_mem_class S M : Prop
 
 attribute [to_additive] submonoid submonoid_class

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -441,7 +441,7 @@ begin
     work_on_goal 1 { intros, apply closure_induction hb,
       work_on_goal 1 { intros, exact subset_closure ⟨_, _, ‹_›, ‹_›, rfl⟩ } },
     all_goals { intros, simp only [mul_zero, zero_mul, zero_mem,
-        left_distrib, right_distrib, mul_smul_comm, smul_mul_assoc],
+        left_distrib, right_distrib, mul_smul_comm, smul_mul_assoc];
       solve_by_elim [add_mem _ _, zero_mem _]
         { max_depth := 4, discharger := tactic.interactive.apply_instance } } },
   { rw closure_le, rintros _ ⟨a, b, ha, hb, rfl⟩,

--- a/src/group_theory/subsemigroup/basic.lean
+++ b/src/group_theory/subsemigroup/basic.lean
@@ -57,13 +57,13 @@ variables [has_mul M] {s : set M}
 variables [has_add A] {t : set A}
 
 /-- `mul_mem_class S M` says `S` is a type of subsets `s ≤ M` that are closed under `(*)` -/
-class mul_mem_class (S : Type*) (M : out_param $ Type*) [has_mul M] [set_like S M] : Prop :=
+class mul_mem_class (S M : Type*) [has_mul M] [set_like S M] : Prop :=
 (mul_mem : ∀ {s : S} {a b : M}, a ∈ s → b ∈ s → a * b ∈ s)
 
 export mul_mem_class (mul_mem)
 
 /-- `add_mem_class S M` says `S` is a type of subsets `s ≤ M` that are closed under `(+)` -/
-class add_mem_class (S : Type*) (M : out_param $ Type*) [has_add M] [set_like S M] : Prop :=
+class add_mem_class (S M : Type*) [has_add M] [set_like S M] : Prop :=
 (add_mem : ∀ {s : S} {a b : M}, a ∈ s → b ∈ s → a + b ∈ s)
 
 export add_mem_class (add_mem)

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -90,7 +90,7 @@ theorem coe_fn_coe_trans
 
 /-- Non-dependent version of `coe_fn_coe_trans`, helps `rw` figure out the argument. -/
 theorem coe_fn_coe_trans'
-  {α β γ} {δ : out_param $ _} [has_coe α β] [has_coe_t_aux β γ] [has_coe_to_fun γ (λ _, δ)]
+  {α β γ} {δ : _} [has_coe α β] [has_coe_t_aux β γ] [has_coe_to_fun γ (λ _, δ)]
   (x : α) : @coe_fn α _ _ x = @coe_fn β _ _ x := rfl
 
 @[simp] theorem coe_fn_coe_base
@@ -99,7 +99,7 @@ theorem coe_fn_coe_trans'
 
 /-- Non-dependent version of `coe_fn_coe_base`, helps `rw` figure out the argument. -/
 theorem coe_fn_coe_base'
-  {α β} {γ : out_param $ _} [has_coe α β] [has_coe_to_fun β (λ _, γ)]
+  {α β} {γ : _} [has_coe α β] [has_coe_to_fun β (λ _, γ)]
   (x : α) : @coe_fn α _ _ x = @coe_fn β _ _ x := rfl
 
 -- This instance should have low priority, to ensure we follow the chain

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -685,8 +685,8 @@ begin
     refine ⟨kaehler_differential.one_smul_sub_smul_one_mem_ideal R x, _⟩,
     apply submodule.subset_span,
     exact ⟨x, kaehler_differential.D_linear_map_apply R S x⟩ },
-  { exact ⟨zero_mem _, zero_mem _⟩ },
-  { rintros x y ⟨hx₁, hx₂⟩ ⟨hy₁, hy₂⟩, exact ⟨add_mem hx₁ hy₁, add_mem hx₂ hy₂⟩ },
+  { exact ⟨zero_mem _, submodule.zero_mem _⟩ },
+  { rintros x y ⟨hx₁, hx₂⟩ ⟨hy₁, hy₂⟩, exact ⟨add_mem hx₁ hy₁, submodule.add_mem _ hx₂ hy₂⟩ },
   { rintros r x ⟨hx₁, hx₂⟩, exact ⟨((kaehler_differential.ideal R S).restrict_scalars S).smul_mem
       r hx₁, submodule.smul_mem _ r hx₂⟩ }
 end

--- a/src/ring_theory/non_unital_subsemiring/basic.lean
+++ b/src/ring_theory/non_unital_subsemiring/basic.lean
@@ -28,12 +28,12 @@ variables {R : Type u} {S : Type v} {T : Type w} [non_unital_non_assoc_semiring 
 
 /-- `non_unital_subsemiring_class S R` states that `S` is a type of subsets `s ⊆ R` that
 are both an additive submonoid and also a multiplicative subsemigroup. -/
-class non_unital_subsemiring_class (S : Type*) (R : out_param $ Type u)
+class non_unital_subsemiring_class (S : Type*) (R : Type u)
   [non_unital_non_assoc_semiring R] [set_like S R] extends add_submonoid_class S R :=
 (mul_mem : ∀ {s : S} {a b : R}, a ∈ s → b ∈ s → a * b ∈ s)
 
 @[priority 100] -- See note [lower instance priority]
-instance non_unital_subsemiring_class.mul_mem_class (S : Type*) (R : out_param $ Type u)
+instance non_unital_subsemiring_class.mul_mem_class (S : Type*) (R : Type u)
   [non_unital_non_assoc_semiring R] [set_like S R] [h : non_unital_subsemiring_class S R] :
   mul_mem_class S R :=
 { .. h }

--- a/src/ring_theory/subring/basic.lean
+++ b/src/ring_theory/subring/basic.lean
@@ -71,11 +71,11 @@ section subring_class
 
 /-- `subring_class S R` states that `S` is a type of subsets `s ⊆ R` that
 are both a multiplicative submonoid and an additive subgroup. -/
-class subring_class (S : Type*) (R : out_param $ Type u) [ring R] [set_like S R]
+class subring_class (S : Type*) (R : Type u) [ring R] [set_like S R]
   extends subsemiring_class S R, neg_mem_class S R : Prop
 
 @[priority 100] -- See note [lower instance priority]
-instance subring_class.add_subgroup_class (S : Type*) (R : out_param $ Type u) [set_like S R]
+instance subring_class.add_subgroup_class (S : Type*) (R : Type u) [set_like S R]
   [ring R] [h : subring_class S R] : add_subgroup_class S R :=
 { .. h }
 

--- a/src/ring_theory/subsemiring/basic.lean
+++ b/src/ring_theory/subsemiring/basic.lean
@@ -29,7 +29,7 @@ section add_submonoid_with_one_class
 
 /-- `add_submonoid_with_one_class S R` says `S` is a type of subsets `s ≤ R` that contain `0`, `1`,
 and are closed under `(+)` -/
-class add_submonoid_with_one_class (S : Type*) (R : out_param $ Type*)
+class add_submonoid_with_one_class (S : Type*) (R : Type*)
   [add_monoid_with_one R] [set_like S R]
   extends add_submonoid_class S R, one_mem_class S R : Prop
 
@@ -55,11 +55,11 @@ section subsemiring_class
 
 /-- `subsemiring_class S R` states that `S` is a type of subsets `s ⊆ R` that
 are both a multiplicative and an additive submonoid. -/
-class subsemiring_class (S : Type*) (R : out_param $ Type u) [non_assoc_semiring R] [set_like S R]
+class subsemiring_class (S : Type*) (R : Type u) [non_assoc_semiring R] [set_like S R]
   extends submonoid_class S R, add_submonoid_class S R : Prop
 
 @[priority 100] -- See note [lower instance priority]
-instance subsemiring_class.add_submonoid_with_one_class (S : Type*) (R : out_param $ Type u)
+instance subsemiring_class.add_submonoid_with_one_class (S : Type*) (R : Type u)
   [non_assoc_semiring R] [set_like S R] [h : subsemiring_class S R] :
   add_submonoid_with_one_class S R :=
 { .. h }


### PR DESCRIPTION
This PR is a backport for a mathlib4 fix for a large amount of issues encountered in the port of `group_theory.subgroup.basic`, leanprover-community/mathlib4#1797. Subobject classes such as `mul_mem_class` and `submonoid_class` take a `set_like` parameter, and we were used to just copy over the `M : out_param Type` declaration from `set_like`. Since Lean 3 synthesizes from left to right, we'd fill in the `out_param` from `set_like`, then the `has_mul M` instance would be available for synthesis and we'd be in business. In Lean 4 however, we will often go from right to left, so that `MulMemClass ?M S [?inst : Mul ?M]` is handled first, which can't be solved before finding a `Mul ?M` instance on the metavariable `?M`, causing search through all `Mul` instances.

The solution is: whenever a class is declared that takes another class as parameter (i.e. unbundled inheritance), the `out_param`s of the parent class should be unmarked and become in-params in the child class. Then Lean will try to find the parent class instance first, fill in the `out_param`s and we'll be able to synthesize the child class instance without problems.

One consequence is that sometimes we have to give slightly more type ascription when talking about membership and the types don't quite align: if `M` and `M'` are semireducibly defeq, then before `zero_mem_class S M` would work to prove `(0 : M') ∈ (s : S)`, since the `out_param` became a metavariable, was filled in, and then checked (up to semireducibility apparently) for equality. Now `M` is checked to equal `M'` before applying the instance, with instance-reducible transparency. I don't think this is a huge issue since it feels Lean 4 is stricter about these kinds of equalities anyway.

Mathlib4 pair: leanprover-community/mathlib4#1832

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
