### PR TITLE
[Merged by Bors] - feat(ring_theory): lemmas on algebra norm

### DIFF
--- a/src/linear_algebra/free_module/basic.lean
+++ b/src/linear_algebra/free_module/basic.lean
@@ -68,7 +68,7 @@ variables [add_comm_monoid N] [module R N]
 
 /-- If `module.free R M` then `choose_basis_index R M` is the `ι` which indexes the basis
   `ι → M`. -/
-@[nolint has_nonempty_instance] def choose_basis_index := (exists_basis R M).some.1
+def choose_basis_index := (exists_basis R M).some.1
 
 /-- If `module.free R M` then `choose_basis : ι → M` is the basis.
 Here `ι = choose_basis_index R M`. -/
@@ -91,6 +91,9 @@ noncomputable def constr {S : Type z} [semiring S] [module S N] [smul_comm_class
 @[priority 100]
 instance no_zero_smul_divisors [no_zero_divisors R] : no_zero_smul_divisors R M :=
 let ⟨⟨_, b⟩⟩ := exists_basis R M in b.no_zero_smul_divisors
+
+instance [nontrivial M] : nonempty (module.free.choose_basis_index R M) :=
+(module.free.choose_basis R M).index_nonempty
 
 variables {R M N}
 

--- a/src/ring_theory/localization/norm.lean
+++ b/src/ring_theory/localization/norm.lean
@@ -38,6 +38,7 @@ lemma algebra.norm_localization [nontrivial R] [module.free R S] [module.finite 
   (a : S) (hM : algebra.algebra_map_submonoid S M ≤ S⁰) :
   algebra.norm Rₘ (algebra_map S Sₘ a) = algebra_map R Rₘ (algebra.norm R a) :=
 begin
+  nontriviality,
   let b := module.free.choose_basis R S,
   letI := classical.dec_eq (module.free.choose_basis_index R S),
   rw [algebra.norm_eq_matrix_det (b.localization_localization Rₘ M Sₘ hM),

--- a/src/ring_theory/localization/norm.lean
+++ b/src/ring_theory/localization/norm.lean
@@ -40,7 +40,9 @@ lemma algebra.norm_localization [module.free R S] [module.finite R S]
   (a : S) (hM : algebra.algebra_map_submonoid S M ≤ S⁰) :
   algebra.norm Rₘ (algebra_map S Sₘ a) = algebra_map R Rₘ (algebra.norm R a) :=
 begin
-  nontriviality,
+  casesI subsingleton_or_nontrivial R,
+  { haveI : subsingleton Rₘ := module.subsingleton R Rₘ,
+    simp },
   let b := module.free.choose_basis R S,
   letI := classical.dec_eq (module.free.choose_basis_index R S),
   rw [algebra.norm_eq_matrix_det (b.localization_localization Rₘ M Sₘ hM),

--- a/src/ring_theory/localization/norm.lean
+++ b/src/ring_theory/localization/norm.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2023 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+
+import ring_theory.localization.module
+import ring_theory.norm
+
+/-!
+
+# Field/algebra norm and localization
+
+This file contains results on the combination of `algebra.norm` and `is_localization`.
+
+## Main results
+
+ * `algebra.norm_localization`: let `S` be an extension of `R` and `Rₘ Sₘ` be localizations at `M`
+  of `R S` respectively. Then the norm of `a : Sₘ` over `Rₘ` is the norm of `a : S` over `R`.
+
+## Tags
+
+field norm, algebra norm, localization
+
+-/
+
+open_locale non_zero_divisors
+
+variables (R : Type*) {S : Type*} [comm_ring R] [comm_ring S] [algebra R S]
+variables {Rₘ Sₘ : Type*} [comm_ring Rₘ] [algebra R Rₘ] [comm_ring Sₘ] [algebra S Sₘ]
+variables {M : submonoid R}
+variables [is_localization M Rₘ] [is_localization (algebra.algebra_map_submonoid S M) Sₘ]
+variables [algebra Rₘ Sₘ] [algebra R Sₘ] [is_scalar_tower R Rₘ Sₘ] [is_scalar_tower R S Sₘ]
+
+/-- Let `S` be an extension of `R` and `Rₘ Sₘ` be localizations at `M` of `R S` respectively.
+Then the norm of `a : Sₘ` over `Rₘ` is the norm of `a : S` over `R`. -/
+lemma algebra.norm_localization [nontrivial R] [module.free R S] [module.finite R S]
+  (a : S) (hM : algebra.algebra_map_submonoid S M ≤ S⁰) :
+  algebra.norm Rₘ (algebra_map S Sₘ a) = algebra_map R Rₘ (algebra.norm R a) :=
+begin
+  let b := module.free.choose_basis R S,
+  letI := classical.dec_eq (module.free.choose_basis_index R S),
+  rw [algebra.norm_eq_matrix_det (b.localization_localization Rₘ M Sₘ hM),
+      algebra.norm_eq_matrix_det b, ring_hom.map_det],
+  congr,
+  ext i j,
+  simp only [matrix.map_apply, ring_hom.map_matrix_apply, algebra.left_mul_matrix_eq_repr_mul,
+      basis.localization_localization_apply, ← _root_.map_mul],
+  apply basis.localization_localization_repr_algebra_map
+end

--- a/src/ring_theory/localization/norm.lean
+++ b/src/ring_theory/localization/norm.lean
@@ -16,7 +16,8 @@ This file contains results on the combination of `algebra.norm` and `is_localiza
 ## Main results
 
  * `algebra.norm_localization`: let `S` be an extension of `R` and `Rₘ Sₘ` be localizations at `M`
-  of `R S` respectively. Then the norm of `a : Sₘ` over `Rₘ` is the norm of `a : S` over `R`.
+  of `R S` respectively. Then the norm of `a : Sₘ` over `Rₘ` is the norm of `a : S` over `R`
+  if `S` is free as `R`-module
 
 ## Tags
 
@@ -33,8 +34,9 @@ variables [is_localization M Rₘ] [is_localization (algebra.algebra_map_submono
 variables [algebra Rₘ Sₘ] [algebra R Sₘ] [is_scalar_tower R Rₘ Sₘ] [is_scalar_tower R S Sₘ]
 
 /-- Let `S` be an extension of `R` and `Rₘ Sₘ` be localizations at `M` of `R S` respectively.
-Then the norm of `a : Sₘ` over `Rₘ` is the norm of `a : S` over `R`. -/
-lemma algebra.norm_localization [nontrivial R] [module.free R S] [module.finite R S]
+Then the norm of `a : Sₘ` over `Rₘ` is the norm of `a : S` over `R` if `S` is free as `R`-module.
+-/
+lemma algebra.norm_localization [module.free R S] [module.finite R S]
   (a : S) (hM : algebra.algebra_map_submonoid S M ≤ S⁰) :
   algebra.norm Rₘ (algebra_map S Sₘ a) = algebra_map R Rₘ (algebra.norm R a) :=
 begin

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -130,9 +130,12 @@ end eq_prod_roots
 section eq_zero_iff
 variables [finite ι]
 
-@[simp] lemma norm_zero [nontrivial R] [nontrivial S] [module.free R S] [module.finite R S] :
+@[simp] lemma norm_zero [nontrivial S] [module.free R S] [module.finite R S] :
   norm R (0 : S) = 0 :=
-by rw [norm_apply, coe_lmul_eq_mul, map_zero, linear_map.det_zero' (module.free.choose_basis R S)]
+begin
+  nontriviality,
+  rw [norm_apply, coe_lmul_eq_mul, map_zero, linear_map.det_zero' (module.free.choose_basis R S)]
+end
 
 @[simp] lemma norm_eq_zero_iff [is_domain R] [is_domain S] [module.free R S] [module.finite R S]
   {x : S} :

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -130,42 +130,53 @@ end eq_prod_roots
 section eq_zero_iff
 variables [finite ι]
 
-lemma norm_eq_zero_iff_of_basis [is_domain R] [is_domain S] (b : basis ι R S) {x : S} :
-  algebra.norm R x = 0 ↔ x = 0 :=
+@[simp] lemma norm_zero [nontrivial R] [nontrivial S] [module.free R S] [module.finite R S] :
+  norm R (0 : S) = 0 :=
+by rw [norm_apply, coe_lmul_eq_mul, map_zero, linear_map.det_zero' (module.free.choose_basis R S)]
+
+@[simp] lemma norm_eq_zero_iff [is_domain R] [is_domain S] [module.free R S] [module.finite R S]
+  {x : S} :
+  norm R x = 0 ↔ x = 0 :=
 begin
-  casesI nonempty_fintype ι,
-  have hι : nonempty ι := b.index_nonempty,
-  letI := classical.dec_eq ι,
-  rw algebra.norm_eq_matrix_det b,
   split,
-  { rw ← matrix.exists_mul_vec_eq_zero_iff,
+  let b := module.free.choose_basis R S,
+  swap, { rintro rfl, exact norm_zero },
+  { letI := classical.dec_eq (module.free.choose_basis_index R S),
+    rw [norm_eq_matrix_det b,
+        ← matrix.exists_mul_vec_eq_zero_iff],
     rintros ⟨v, v_ne, hv⟩,
     rw [← b.equiv_fun.apply_symm_apply v, b.equiv_fun_symm_apply, b.equiv_fun_apply,
-        algebra.left_mul_matrix_mul_vec_repr] at hv,
+        left_mul_matrix_mul_vec_repr] at hv,
     refine (mul_eq_zero.mp (b.ext_elem $ λ i, _)).resolve_right (show ∑ i, v i • b i ≠ 0, from _),
     { simpa only [linear_equiv.map_zero, pi.zero_apply] using congr_fun hv i },
     { contrapose! v_ne with sum_eq,
       apply b.equiv_fun.symm.injective,
       rw [b.equiv_fun_symm_apply, sum_eq, linear_equiv.map_zero] } },
-  { rintro rfl,
-    rw [alg_hom.map_zero, matrix.det_zero hι] },
+end
+
+lemma norm_ne_zero_iff [is_domain R] [is_domain S] [module.free R S] [module.finite R S]
+  {x : S} :
+  norm R x ≠ 0 ↔ x ≠ 0 :=
+not_iff_not.mpr norm_eq_zero_iff
+
+/-- This is `algebra.norm_eq_zero_iff` composed with `algebra.norm_apply`. -/
+@[simp]
+lemma norm_eq_zero_iff' [is_domain R] [is_domain S] [module.free R S] [module.finite R S]
+  {x : S} :
+  linear_map.det (linear_map.mul R S x) = 0 ↔ x = 0 :=
+norm_eq_zero_iff
+
+lemma norm_eq_zero_iff_of_basis [is_domain R] [is_domain S] (b : basis ι R S) {x : S} :
+  algebra.norm R x = 0 ↔ x = 0 :=
+begin
+  haveI : module.free R S := module.free.of_basis b,
+  haveI : module.finite R S := module.finite.of_basis b,
+  exact norm_eq_zero_iff
 end
 
 lemma norm_ne_zero_iff_of_basis [is_domain R] [is_domain S] (b : basis ι R S) {x : S} :
   algebra.norm R x ≠ 0 ↔ x ≠ 0 :=
-not_iff_not.mpr (algebra.norm_eq_zero_iff_of_basis b)
-
-/-- See also `algebra.norm_eq_zero_iff'` if you already have rewritten with `algebra.norm_apply`. -/
-@[simp]
-lemma norm_eq_zero_iff {K L : Type*} [field K] [comm_ring L] [algebra K L] [is_domain L]
-  [finite_dimensional K L] {x : L} : algebra.norm K x = 0 ↔ x = 0 :=
-algebra.norm_eq_zero_iff_of_basis (basis.of_vector_space K L)
-
-/-- This is `algebra.norm_eq_zero_iff` composed with `algebra.norm_apply`. -/
-@[simp]
-lemma norm_eq_zero_iff' {K L : Type*} [field K] [comm_ring L] [algebra K L] [is_domain L]
-  [finite_dimensional K L] {x : L} : linear_map.det (linear_map.mul K L x) = 0 ↔ x = 0 :=
-algebra.norm_eq_zero_iff_of_basis (basis.of_vector_space K L)
+not_iff_not.mpr (norm_eq_zero_iff_of_basis b)
 
 end eq_zero_iff
 


### PR DESCRIPTION
This PR includes some results on the algebra norm needed for the ideal norm:

 * `algebra.norm R (0 : S) = 0` under weaker conditions on `R` and `S`
 * use `module.free` and `module.finite` instead of explicit bases in `algebra.norm_eq_zero_iff` / generalize from vector spaces over a field to free modules over a ring
 * the norm map between localizations is equal to the norm over the base fields



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
