### PR TITLE
[Merged by Bors] - feat(group_theory/sylow): add inverse to card_eq_multiplicity

### DIFF
--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -606,21 +606,17 @@ end
 /-- A subgroup with cardinality `p ^ n` is a Sylow group
  where `n` is the multiplicity of `p` in the group order. -/
 def card_eq_multiplicity_to_sylow [fintype G] {p : ℕ} [hp : fact p.prime]
-  (H : subgroup G) [fintype H]
-  (card_eq: card H = p ^ (card G).factorization p) : sylow p G :=
+  (H : subgroup G) [fintype H] (card_eq: card H = p ^ (card G).factorization p) : sylow p G :=
 { to_subgroup := H,
   is_p_group' := is_p_group.of_card card_eq,
   is_maximal' := begin
     obtain ⟨P, hHP⟩ := (is_p_group.of_card card_eq).exists_le_sylow,
-    exact set_like.ext'
-      (set.eq_of_subset_of_card_le hHP
-        (P.card_eq_multiplicity.trans card_eq.symm).le).symm ▸ λ _, P.3,
+    exact set_like.ext' (set.eq_of_subset_of_card_le hHP
+      (P.card_eq_multiplicity.trans card_eq.symm).le).symm ▸ λ _, P.3,
   end }
 
-@[simp]
-lemma coe_card_eq_multiplicity_to_sylow [fintype G] {p : ℕ} [hp : fact p.prime]
-  (H : subgroup G) [fintype H]
-  (card_eq: card H = p ^ (card G).factorization p) :
+@[simp] lemma coe_card_eq_multiplicity_to_sylow [fintype G] {p : ℕ} [hp : fact p.prime]
+  (H : subgroup G) [fintype H] (card_eq: card H = p ^ (card G).factorization p) :
   ↑(card_eq_multiplicity_to_sylow H card_eq) = H := rfl
 
 lemma subsingleton_of_normal {p : ℕ} [fact p.prime] [finite (sylow p G)] (P : sylow p G)

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -605,8 +605,8 @@ end
 
 /-- A subgroup with cardinality `p ^ n` is a Sylow group
  where `n` is the multiplicity of `p` in the group order. -/
-def card_eq_multiplicity_to_sylow [fintype G] {p : ℕ} [hp : fact p.prime]
-  (H : subgroup G) [fintype H] (card_eq: card H = p ^ (card G).factorization p) : sylow p G :=
+def of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype H]
+  (card_eq: card H = p ^ (card G).factorization p) : sylow p G :=
 { to_subgroup := H,
   is_p_group' := is_p_group.of_card card_eq,
   is_maximal' := begin
@@ -615,9 +615,8 @@ def card_eq_multiplicity_to_sylow [fintype G] {p : ℕ} [hp : fact p.prime]
       (P.card_eq_multiplicity.trans card_eq.symm).le).symm ▸ λ _, P.3,
   end }
 
-@[simp] lemma coe_card_eq_multiplicity_to_sylow [fintype G] {p : ℕ} [hp : fact p.prime]
-  (H : subgroup G) [fintype H] (card_eq: card H = p ^ (card G).factorization p) :
-  ↑(card_eq_multiplicity_to_sylow H card_eq) = H := rfl
+@[simp] lemma coe_of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype H]
+  (card_eq: card H = p ^ (card G).factorization p) : ↑(of_card H card_eq) = H := rfl
 
 lemma subsingleton_of_normal {p : ℕ} [fact p.prime] [finite (sylow p G)] (P : sylow p G)
   (h : (P : subgroup G).normal) : subsingleton (sylow p G) :=

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -616,7 +616,7 @@ def of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype 
   end }
 
 @[simp, norm_cast] lemma coe_of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype H]
-  (card_eq: card H = p ^ (card G).factorization p) : ↑(of_card H card_eq) = H := rfl
+  (card_eq) : ↑(of_card H card_eq) = H := rfl
 
 lemma subsingleton_of_normal {p : ℕ} [fact p.prime] [finite (sylow p G)] (P : sylow p G)
   (h : (P : subgroup G).normal) : subsingleton (sylow p G) :=

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -615,8 +615,8 @@ def of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype 
       (P.card_eq_multiplicity.trans card_eq.symm).le).symm ▸ λ _, P.3,
   end }
 
-@[simp, norm_cast] lemma coe_of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype H]
-  (card_eq) : ↑(of_card H card_eq) = H := rfl
+@[simp, norm_cast] lemma coe_of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G)
+  [fintype H] (card_eq : card H = p ^ (card G).factorization p) : ↑(of_card H card_eq) = H := rfl
 
 lemma subsingleton_of_normal {p : ℕ} [fact p.prime] [finite (sylow p G)] (P : sylow p G)
   (h : (P : subgroup G).normal) : subsingleton (sylow p G) :=

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -603,6 +603,26 @@ begin
   exact P.1.card_subgroup_dvd_card,
 end
 
+/-- A subgroup with cardinality `p ^ n` is a Sylow group
+ where `n` is the multiplicity of `p` in the group order. -/
+def card_eq_multiplicity_to_sylow [fintype G] {p : ℕ} [hp : fact p.prime]
+  (H : subgroup G) [fintype H]
+  (card_eq: card H = p ^ (card G).factorization p) : sylow p G :=
+{ to_subgroup := H,
+  is_p_group' := is_p_group.of_card card_eq,
+  is_maximal' := begin
+    obtain ⟨P, hHP⟩ := (is_p_group.of_card card_eq).exists_le_sylow,
+    exact set_like.ext'
+      (set.eq_of_subset_of_card_le hHP
+        (P.card_eq_multiplicity.trans card_eq.symm).le).symm ▸ λ _, P.3,
+  end }
+
+@[simp]
+lemma coe_card_eq_multiplicity_to_sylow [fintype G] {p : ℕ} [hp : fact p.prime]
+  (H : subgroup G) [fintype H]
+  (card_eq: card H = p ^ (card G).factorization p) :
+  ↑(card_eq_multiplicity_to_sylow H card_eq) = H := rfl
+
 lemma subsingleton_of_normal {p : ℕ} [fact p.prime] [finite (sylow p G)] (P : sylow p G)
   (h : (P : subgroup G).normal) : subsingleton (sylow p G) :=
 begin

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -36,7 +36,7 @@ The Sylow theorems are the following results for every finite group `G` and ever
   there exists a subgroup of `G` of order `pⁿ`.
 * `is_p_group.exists_le_sylow`: A generalization of Sylow's first theorem:
   Every `p`-subgroup is contained in a Sylow `p`-subgroup.
-* `sylow.card_eq_multiplicity`: The cardinality of a Sylow group is `p ^ n`
+* `sylow.card_eq_multiplicity`: The cardinality of a Sylow subgroup is `p ^ n`
  where `n` is the multiplicity of `p` in the group order.
 * `sylow_conjugate`: A generalization of Sylow's second theorem:
   If the number of Sylow `p`-subgroups is finite, then all Sylow `p`-subgroups are conjugate.
@@ -592,7 +592,7 @@ begin
   rwa [h, card_bot] at key,
 end
 
-/-- The cardinality of a Sylow group is `p ^ n`
+/-- The cardinality of a Sylow subgroup is `p ^ n`
  where `n` is the multiplicity of `p` in the group order. -/
 lemma card_eq_multiplicity [fintype G] {p : ℕ} [hp : fact p.prime] (P : sylow p G) :
   card P = p ^ nat.factorization (card G) p :=
@@ -603,7 +603,7 @@ begin
   exact P.1.card_subgroup_dvd_card,
 end
 
-/-- A subgroup with cardinality `p ^ n` is a Sylow group
+/-- A subgroup with cardinality `p ^ n` is a Sylow subgroup
  where `n` is the multiplicity of `p` in the group order. -/
 def of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype H]
   (card_eq : card H = p ^ (card G).factorization p) : sylow p G :=
@@ -682,8 +682,8 @@ normalizer_eq_top.mp $ normalizer_condition_iff_only_full_group_self_normalizing
 
 open_locale big_operators
 
-/-- If all its sylow groups are normal, then a finite group is isomorphic to the direct product
-of these sylow groups.
+/-- If all its Sylow subgroups are normal, then a finite group is isomorphic to the direct product
+of these Sylow subgroups.
 -/
 noncomputable
 def direct_product_of_normal [fintype G]
@@ -692,7 +692,7 @@ def direct_product_of_normal [fintype G]
 begin
   set ps := (fintype.card G).factorization.support,
 
-  -- “The” sylow group for p
+  -- “The” Sylow subgroup for p
   let P : Π p, sylow p G := default,
 
   have hcomm : pairwise (λ (p₁ p₂ : ps), ∀ (x y : G), x ∈ P p₁ → y ∈ P p₂ → commute x y),
@@ -704,7 +704,7 @@ begin
     apply is_p_group.disjoint_of_ne p₁ p₂ hne' _ _ (P p₁).is_p_group' (P p₂).is_p_group', },
 
   refine mul_equiv.trans _ _,
-  -- There is only one sylow group for each p, so the inner product is trivial
+  -- There is only one Sylow subgroup for each p, so the inner product is trivial
   show (Π p : ps, Π P : sylow p G, P) ≃* (Π p : ps, P p),
   { -- here we need to help the elaborator with an explicit instantiation
     apply @mul_equiv.Pi_congr_right ps (λ p, (Π P : sylow p G, P)) (λ p, P p) _ _ ,

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -615,7 +615,7 @@ def of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype 
       (P.card_eq_multiplicity.trans card_eq.symm).le).symm ▸ λ _, P.3,
   end }
 
-@[simp] lemma coe_of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype H]
+@[simp, norm_cast] lemma coe_of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype H]
   (card_eq: card H = p ^ (card G).factorization p) : ↑(of_card H card_eq) = H := rfl
 
 lemma subsingleton_of_normal {p : ℕ} [fact p.prime] [finite (sylow p G)] (P : sylow p G)

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -606,7 +606,7 @@ end
 /-- A subgroup with cardinality `p ^ n` is a Sylow group
  where `n` is the multiplicity of `p` in the group order. -/
 def of_card [fintype G] {p : ℕ} [hp : fact p.prime] (H : subgroup G) [fintype H]
-  (card_eq: card H = p ^ (card G).factorization p) : sylow p G :=
+  (card_eq : card H = p ^ (card G).factorization p) : sylow p G :=
 { to_subgroup := H,
   is_p_group' := is_p_group.of_card card_eq,
   is_maximal' := begin


### PR DESCRIPTION
The lemma `card_eq_multiplicity` states that a Sylow group of a finite group has cardinality p^n, where n is
the multiplicity of p in the group order. This PR adds an inverse definition `card_eq_multiplicity_to_sylow`, promoting a subgroup of the right cardinality to a Sylow group, and a simplification lemma `coe_card_eq_multiplicity_to_sylow` for the coercion of the resulting Sylow group back to a subgroup. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
