### PR TITLE
feat(number_theory/bernoulli_polynomials): prove `bernoulli_eval_one_neg`

### DIFF
--- a/src/data/polynomial/derivative.lean
+++ b/src/data/polynomial/derivative.lean
@@ -218,6 +218,20 @@ theorem eq_C_of_derivative_eq_zero [no_zero_smul_divisors ℕ R] {f : R[X]} (h :
   f = C (f.coeff 0) :=
 eq_C_of_nat_degree_eq_zero $ nat_degree_eq_zero_of_derivative_eq_zero h
 
+theorem eq_C_iff_eval_and_derivative_eq_zero [no_zero_smul_divisors ℕ R] {c : R} {f : R[X]} :
+f = C c ↔ (∃ r, f.eval r = c) ∧ f.derivative = 0 :=
+begin
+  split ; intro h,
+  { split,
+    use 0,
+    { rw [h, eval_C] },
+    { rw [h, derivative_C] }, },
+  { rcases h with ⟨⟨r, hr⟩, h⟩,
+    let this := eq_C_of_nat_degree_eq_zero (nat_degree_eq_zero_of_derivative_eq_zero h),
+    rw [this, eval_C] at hr,
+    rwa hr at this, }
+end
+
 @[simp] lemma derivative_mul {f g : R[X]} :
   derivative (f * g) = derivative f * g + f * derivative g :=
 calc derivative (f * g) = f.sum (λ n a, g.sum (λ m b, (n + m) • (C (a * b) * X ^ ((n + m) - 1)))) :

--- a/src/number_theory/bernoulli_polynomials.lean
+++ b/src/number_theory/bernoulli_polynomials.lean
@@ -31,10 +31,12 @@ Bernoulli polynomials are defined using `bernoulli`, the Bernoulli numbers.
   coefficients up to `n` is `(n + 1) * X^n`.
 - `polynomial.bernoulli_generating_function`: The Bernoulli polynomials act as generating functions
   for the exponential.
+- `bernoulli_eval_one_neg` : The Bernoulli polynomials are symmetric along $x = \frac{1}{2}$, given
+  by $B_n(1 - x) = (-1)^n B_n(x)$.
 
 ## TODO
-
-- `bernoulli_eval_one_neg` : $$ B_n(1 - x) = (-1)^n B_n(x) $$
+- `bernoulli_eval_nat_mul` : For integers $m > 0$, we have
+  $B_n(mx) = m^{n - 1} \sum_{k = 0}^{m - 1} B_n \left(x + \frac{k}{m}\right)$.
 
 -/
 
@@ -238,6 +240,39 @@ begin
   congr',
   apply congr_arg,
   rw [mul_assoc, div_eq_mul_inv, ← mul_inv],
+end
+
+theorem bernoulli_eval_one_neg {n : ℕ} {x : ℚ} :
+(bernoulli n).eval x = (-1) ^ n * (bernoulli n).eval (1 - x) :=
+begin
+  -- We prove a more general result that the difference of both sides is 0
+  let En := λ n, polynomial.C ((-1) ^ n) * (bernoulli n).comp (1 - (X : ℚ[X])) - bernoulli n,
+  suffices : En n = 0,
+  { have : eval x (En n) = 0,
+    { rw [this, eval_zero] },
+    rw [eval_sub, eval_mul, eval_C, sub_eq_zero, eval_comp, eval_sub, eval_one, eval_X] at this,
+    exact this.symm, },
+  -- We do so by induction
+  induction n with k hk ; dsimp only [En],
+  { rw [pow_zero, bernoulli_zero, C_1, one_mul, one_comp, sub_self] },
+  -- And proving En(0) = 0 and En'(x) = 0
+  { rw [← C_0, eq_C_iff_eval_and_derivative_eq_zero],
+    split,
+    { use 0,
+      rw [pow_succ, succ_eq_add_one, eval_sub, eval_mul, eval_comp, eval_C, eval_sub,
+          eval_one, eval_X, sub_zero, bernoulli_eval_zero, bernoulli_eval_one,
+          bernoulli'_eq_bernoulli, ← pow_succ, ← mul_assoc, ← mul_pow, mul_neg_one, neg_neg,
+          one_pow, one_mul, sub_self] },
+    { rw [pow_succ, succ_eq_add_one, derivative_sub, derivative_mul, derivative_C, zero_mul, 
+          zero_add, derivative_comp, derivative_sub, derivative_one, derivative_X, zero_sub,
+          derivative_bernoulli_add_one],
+      suffices : (↑k + 1) * (C ((-1) ^ k) * (bernoulli k).comp (1 - X) - bernoulli k) = 0,
+      { rw [mul_sub, ← mul_assoc] at this,
+        rwa [C_mul, C_neg, C_1, ← mul_assoc, mul_right_comm _ _ (-1 : ℚ[X]), mul_neg_one, neg_neg,
+            mul_comp, add_comp, one_comp, nat_cast_comp, ← mul_assoc, one_mul,
+            mul_comm _ (k + 1 : ℚ[X])], },
+      dsimp only [En] at hk,
+      rw [hk, mul_zero] } }
 end
 
 end polynomial


### PR DESCRIPTION
Prove that Bernoulli polynomials are symmetric along x = 1 / 2.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is my first PR, hope the quality is at least decent. I hope to also prove the multiplication formula for Bernoulli polynomials, which can be done via induction or EGF. I have included it as a TODO in the file.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
