### PR TITLE
[Merged by Bors] - feat(algebra/order/floor): `0 < fract a ↔ a ≠ ⌊a⌋`

### DIFF
--- a/src/algebra/order/floor.lean
+++ b/src/algebra/order/floor.lean
@@ -593,6 +593,13 @@ end
 
 @[simp] lemma fract_nonneg (a : α) : 0 ≤ fract a := sub_nonneg.2 $ floor_le _
 
+/-- The fractional part of `a` is positive if and only if `a ≠ ⌊a⌋`. -/
+lemma fract_pos_iff {a : α} : 0 < fract a ↔ a ≠ ⌊a⌋ :=
+(fract_nonneg a).lt_iff_ne.trans $ iff.rfl.trans $ ne_comm.trans sub_ne_zero
+
+/-- If `a ≠ ⌊a⌋`, then the fractional part of `a` is positive. -/
+lemma fract_pos {a : α} (h : a ≠ ⌊a⌋) : 0 < fract a := fract_pos_iff.mpr h
+
 lemma fract_lt_one (a : α) : fract a < 1 := sub_lt_comm.1 $ sub_one_lt_floor _
 
 @[simp] lemma fract_zero : fract (0 : α) = 0 := by rw [fract, floor_zero, cast_zero, sub_self]

--- a/src/algebra/order/floor.lean
+++ b/src/algebra/order/floor.lean
@@ -595,7 +595,7 @@ end
 
 /-- The fractional part of `a` is positive if and only if `a ≠ ⌊a⌋`. -/
 lemma fract_pos : 0 < fract a ↔ a ≠ ⌊a⌋ :=
-(fract_nonneg a).lt_iff_ne.trans $ iff.rfl.trans $ ne_comm.trans sub_ne_zero
+(fract_nonneg a).lt_iff_ne.trans $ ne_comm.trans sub_ne_zero
 
 lemma fract_lt_one (a : α) : fract a < 1 := sub_lt_comm.1 $ sub_one_lt_floor _
 

--- a/src/algebra/order/floor.lean
+++ b/src/algebra/order/floor.lean
@@ -594,11 +594,8 @@ end
 @[simp] lemma fract_nonneg (a : α) : 0 ≤ fract a := sub_nonneg.2 $ floor_le _
 
 /-- The fractional part of `a` is positive if and only if `a ≠ ⌊a⌋`. -/
-lemma fract_pos_iff {a : α} : 0 < fract a ↔ a ≠ ⌊a⌋ :=
+lemma fract_pos : 0 < fract a ↔ a ≠ ⌊a⌋ :=
 (fract_nonneg a).lt_iff_ne.trans $ iff.rfl.trans $ ne_comm.trans sub_ne_zero
-
-/-- If `a ≠ ⌊a⌋`, then the fractional part of `a` is positive. -/
-lemma fract_pos {a : α} (h : a ≠ ⌊a⌋) : 0 < fract a := fract_pos_iff.mpr h
 
 lemma fract_lt_one (a : α) : fract a < 1 := sub_lt_comm.1 $ sub_one_lt_floor _
 


### PR DESCRIPTION
This PR adds a lemma on the fractional part:
```lean
lemma fract_pos : 0 < fract a ↔ a ≠ ⌊a⌋
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Match https://github.com/leanprover-community/mathlib4/pull/1921

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
