### PR TITLE
[Merged by Bors] - feat(data/quot): make `trunc` a `quotient`

### DIFF
--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -368,7 +368,7 @@ lemma nonempty_quotient_iff (s : setoid α) : nonempty (quotient s) ↔ nonempty
 theorem true_equivalence : @equivalence α (λ _ _, true) :=
 ⟨λ _, trivial, λ _ _ _, trivial, λ _ _ _ _ _, trivial⟩
 
-/-- Always-true relation as a `setoid`. -/
+/-- Always-true relation as a `setoid`. Note that in later files the preferred spelling is `⊤ : setoid α`. -/
 def true_setoid : setoid α :=
 ⟨_, true_equivalence⟩
 

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -368,6 +368,7 @@ lemma nonempty_quotient_iff (s : setoid α) : nonempty (quotient s) ↔ nonempty
 theorem true_equivalence : @equivalence α (λ _ _, true) :=
 ⟨λ _, trivial, λ _ _ _, trivial, λ _ _ _ _ _, trivial⟩
 
+/-- Always-true relation as a `setoid`. -/
 def true_setoid : setoid α :=
 ⟨_, true_equivalence⟩
 

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -365,15 +365,18 @@ lemma nonempty_quotient_iff (s : setoid α) : nonempty (quotient s) ↔ nonempty
 
 /-! ### Truncation -/
 
+theorem true_equivalence : @equivalence α (λ _ _, true) :=
+⟨λ _, trivial, λ _ _ _, trivial, λ _ _ _ _ _, trivial⟩
+
+def true_setoid : setoid α :=
+⟨_, true_equivalence⟩
+
 /-- `trunc α` is the quotient of `α` by the always-true relation. This
   is related to the propositional truncation in HoTT, and is similar
   in effect to `nonempty α`, but unlike `nonempty α`, `trunc α` is data,
   so the VM representation is the same as `α`, and so this can be used to
   maintain computability. -/
-def {u} trunc (α : Sort u) : Sort u := @quot α (λ _ _, true)
-
-theorem true_equivalence : @equivalence α (λ _ _, true) :=
-⟨λ _, trivial, λ _ _ _, trivial, λ _ _ _ _ _, trivial⟩
+def {u} trunc (α : Sort u) : Sort u := @quotient α true_setoid
 
 namespace trunc
 

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -368,7 +368,9 @@ lemma nonempty_quotient_iff (s : setoid α) : nonempty (quotient s) ↔ nonempty
 theorem true_equivalence : @equivalence α (λ _ _, true) :=
 ⟨λ _, trivial, λ _ _ _, trivial, λ _ _ _ _ _, trivial⟩
 
-/-- Always-true relation as a `setoid`. Note that in later files the preferred spelling is `⊤ : setoid α`. -/
+/-- Always-true relation as a `setoid`.
+
+Note that in later files the preferred spelling is `⊤ : setoid α`. -/
 def true_setoid : setoid α :=
 ⟨_, true_equivalence⟩
 


### PR DESCRIPTION
This allows us to use `quotient` lemmas for `trunc`.

mathlib4 PR: https://github.com/leanprover-community/mathlib4/pull/1924

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
