### PR TITLE
[Merged by Bors] - feat(set_theory/zfc/basic): induction principle for sets

### DIFF
--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -1007,13 +1007,11 @@ by { ext, simp }
 
 /-- An induction principle for sets. If every subset of a class is a member, then the class is
   universal. -/
-theorem eq_univ_of_forall_subset_imp_mem {A : Class}
-  (H : ∀ x : Set.{u}, (x : Class.{u}) ⊆ A → A x) : A = univ :=
+theorem eq_univ_of_powerset_subset {A : Class} (H : powerset A ⊆ A) : A = univ :=
 eq_univ_of_forall begin
-  by_contra',
-  cases this with a ha,
-  exact well_founded.min_mem Set.mem_wf _ ⟨a, ha⟩ (H _ $ λ x hx, not_not.1 $
-    λ hB, well_founded.not_lt_min Set.mem_wf _ ⟨a, ha⟩ hB $ (mem_hom_right _ _).1 hx)
+  by_contra' h,
+  exact well_founded.min_mem Set.mem_wf _ h (H $ λ x hx, not_not.1 $
+    λ hB, well_founded.not_lt_min Set.mem_wf _ h hB $ (mem_hom_right _ _).1 hx)
 end
 
 /-- The definite description operator, which is `{x}` if `{y | A y} = {x}` and `∅` otherwise. -/

--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -1007,11 +1007,11 @@ by { ext, simp }
 
 /-- An induction principle for sets. If every subset of a class is a member, then the class is
   universal. -/
-theorem eq_univ_of_powerset_subset {A : Class} (H : powerset A ⊆ A) : A = univ :=
+theorem eq_univ_of_powerset_subset {A : Class} (hA : powerset A ⊆ A) : A = univ :=
 eq_univ_of_forall begin
-  by_contra' h,
-  exact well_founded.min_mem Set.mem_wf _ h (H $ λ x hx, not_not.1 $
-    λ hB, well_founded.not_lt_min Set.mem_wf _ h hB $ (mem_hom_right _ _).1 hx)
+  by_contra' hnA,
+  exact well_founded.min_mem Set.mem_wf _ hnA (hA $ λ x hx, not_not.1 $
+    λ hB, well_founded.not_lt_min Set.mem_wf _ hnA hB $ (mem_hom_right _ _).1 hx)
 end
 
 /-- The definite description operator, which is `{x}` if `{y | A y} = {x}` and `∅` otherwise. -/

--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -895,7 +895,7 @@ exists_congr $ λ x, and_true _
 
 @[simp] theorem mem_univ_hom (x : Set.{u}) : univ.{u} x := trivial
 
-theorem eq_univ_iff_forall {A : Class.{u}} : A = univ ↔ (∀ x : Set, A x) := set.eq_univ_iff_forall
+theorem eq_univ_iff_forall {A : Class.{u}} : A = univ ↔ ∀ x : Set, A x := set.eq_univ_iff_forall
 theorem eq_univ_of_forall {A : Class.{u}} : (∀ x : Set, A x) → A = univ := set.eq_univ_of_forall
 
 theorem mem_wf : @well_founded Class.{u} (∈) :=

--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -895,6 +895,9 @@ exists_congr $ λ x, and_true _
 
 @[simp] theorem mem_univ_hom (x : Set.{u}) : univ.{u} x := trivial
 
+theorem eq_univ_iff_forall {A : Class.{u}} : A = univ ↔ (∀ x : Set, A x) := set.eq_univ_iff_forall
+theorem eq_univ_of_forall {A : Class.{u}} : (∀ x : Set, A x) → A = univ := set.eq_univ_of_forall
+
 theorem mem_wf : @well_founded Class.{u} (∈) :=
 ⟨begin
   have H : ∀ x : Set.{u}, @acc Class.{u} (∈) ↑x,
@@ -1001,6 +1004,17 @@ end
 
 @[simp] theorem sUnion_empty : ⋃₀ (∅ : Class.{u}) = (∅ : Class.{u}) :=
 by { ext, simp }
+
+/-- An induction principle for sets. If every subset of a class is a member, then the class is
+  universal. -/
+theorem eq_univ_of_forall_subset_imp_mem {A : Class}
+  (H : ∀ x : Set.{u}, (x : Class.{u}) ⊆ A → A x) : A = univ :=
+eq_univ_of_forall begin
+  by_contra',
+  cases this with a ha,
+  exact well_founded.min_mem Set.mem_wf _ ⟨a, ha⟩ (H _ $ λ x hx, not_not.1 $
+    λ hB, well_founded.not_lt_min Set.mem_wf _ ⟨a, ha⟩ hB $ (mem_hom_right _ _).1 hx)
+end
 
 /-- The definite description operator, which is `{x}` if `{y | A y} = {x}` and `∅` otherwise. -/
 def iota (A : Class) : Class := ⋃₀ {x | ∀ y, A y ↔ y = x}


### PR DESCRIPTION
If every subset of a class is a member, the class is universal. This will help us establish that the von Neumann hierarchy exhausts sets later on.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
