### PR TITLE
[Merged by Bors] - feat(set_theory/zfc/basic): define `hereditarily`

### DIFF
--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -873,9 +873,26 @@ x.rec_on (λ x h, p x ∧ ∀ y ∈ x, h y H)
 
 lemma hereditarily_iff {p : Set → Prop} {x : Set} :
   hereditarily p x ↔ p x ∧ ∀ y ∈ x, hereditarily p y :=
-iff_of_eq (x.rec_on_eq _)
+iff_of_eq $ x.rec_on_eq _
 
 alias hereditarily_iff ↔ hereditarily.def _
+
+lemma hereditarily.self {p : Set → Prop} {x : Set} (h : x.hereditarily p) :
+  p x :=
+h.def.1
+
+lemma hereditarily.mem {p : Set → Prop} {x y : Set} (h : x.hereditarily p) (hy : y ∈ x) :
+  y.hereditarily p :=
+h.def.2 _ hy
+
+lemma empty_of_hereditarily {p : Set → Prop} {x : Set} : hereditarily p x → p ∅ :=
+begin
+  apply x.induction_on,
+  intros y IH h,
+  rcases Set.eq_empty_or_nonempty y with (rfl|⟨a, ha⟩),
+  { exact h.def.1 },
+  { exact IH a ha (h.def.2 _ ha) }
+end
 
 end Set
 

--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -871,11 +871,11 @@ members of `x` are all `hereditarily p`. -/
 def hereditarily (p : Set → Prop) (x : Set) : Prop :=
 x.rec_on (λ x h, p x ∧ ∀ y ∈ x, h y H)
 
-lemma hereditarily_def {p : Set → Prop} {x : Set} :
+lemma hereditarily_iff {p : Set → Prop} {x : Set} :
   hereditarily p x ↔ p x ∧ ∀ y ∈ x, hereditarily p y :=
 iff_of_eq (x.rec_on_eq _)
 
-alias hereditarily_def ↔ hereditarily.def _
+alias hereditarily_iff ↔ hereditarily.def _
 
 end Set
 

--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -865,21 +865,25 @@ def hereditarily (p : Set → Prop) : Set → Prop
 | x := p x ∧ ∀ y ∈ x, hereditarily y
 using_well_founded { dec_tac := `[assumption] }
 
-lemma hereditarily_iff {p : Set → Prop} {x : Set} :
+section hereditarily
+
+variables {p : Set.{u} → Prop} {x y : Set.{u}}
+
+lemma hereditarily_iff :
   hereditarily p x ↔ p x ∧ ∀ y ∈ x, hereditarily p y :=
 by rw [← hereditarily]
 
 alias hereditarily_iff ↔ hereditarily.def _
 
-lemma hereditarily.self {p : Set → Prop} {x : Set} (h : x.hereditarily p) :
+lemma hereditarily.self (h : x.hereditarily p) :
   p x :=
 h.def.1
 
-lemma hereditarily.mem {p : Set → Prop} {x y : Set} (h : x.hereditarily p) (hy : y ∈ x) :
+lemma hereditarily.mem (h : x.hereditarily p) (hy : y ∈ x) :
   y.hereditarily p :=
 h.def.2 _ hy
 
-lemma hereditarily.empty {p : Set → Prop} {x : Set} : hereditarily p x → p ∅ :=
+lemma hereditarily.empty : hereditarily p x → p ∅ :=
 begin
   apply x.induction_on,
   intros y IH h,
@@ -887,6 +891,8 @@ begin
   { exact h.self },
   { exact IH a ha (h.mem ha) }
 end
+
+end hereditarily
 
 end Set
 

--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -727,6 +727,15 @@ quotient.induction_on y (λ v ⟨a, ha⟩, by { rw (@quotient.sound pSet _ _ _ h
 
 theorem mem_wf : @well_founded Set (∈) := ⟨λ x, induction_on x acc.intro⟩
 
+/-- Recursion on the `∈` relation. -/
+@[elab_as_eliminator]
+def rec_on {p : Set → Sort*} (x) (h : Π x, (Π y ∈ x, p y) → p x) : p x :=
+mem_wf.fix h x
+
+lemma rec_on_eq {p : Set → Sort*} (x : Set) (h : Π x, (Π y ∈ x, p y) → p x) :
+  x.rec_on h = h x (λ y _, y.rec_on h) :=
+mem_wf.fix_eq h x
+
 instance : has_well_founded Set := ⟨_, mem_wf⟩
 
 instance : is_asymm Set (∈) := mem_wf.is_asymm
@@ -856,6 +865,17 @@ theorem map_unique {f : Set.{u} → Set.{u}} [H : definable 1 f] {x z : Set.{u}}
   (t2 (f z) (image.mk _ _ zx)).symm ▸ (pair_mem_prod.1 (ss t1)).right,
 λ h, ⟨λ y yx, let ⟨z, zx, ze⟩ := mem_image.1 yx in ze ▸ pair_mem_prod.2 ⟨zx, h z zx⟩,
      λ z, map_unique⟩⟩
+
+/-- Given a predicate `p` on ZFC sets. `hereditarily p x` means that `x` has property `p` and the
+members of `x` are all `hereditarily p`. -/
+def hereditarily (p : Set → Prop) (x : Set) : Prop :=
+x.rec_on (λ x h, p x ∧ ∀ y ∈ x, h y H)
+
+lemma hereditarily_def {p : Set → Prop} {x : Set} :
+  hereditarily p x ↔ p x ∧ ∀ y ∈ x, hereditarily p y :=
+iff_of_eq (x.rec_on_eq _)
+
+alias hereditarily_def ↔ hereditarily.def _
 
 end Set
 

--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -875,13 +875,8 @@ by rw [← hereditarily]
 
 alias hereditarily_iff ↔ hereditarily.def _
 
-lemma hereditarily.self (h : x.hereditarily p) :
-  p x :=
-h.def.1
-
-lemma hereditarily.mem (h : x.hereditarily p) (hy : y ∈ x) :
-  y.hereditarily p :=
-h.def.2 _ hy
+lemma hereditarily.self (h : x.hereditarily p) : p x := h.def.1
+lemma hereditarily.mem (h : x.hereditarily p) (hy : y ∈ x) : y.hereditarily p := h.def.2 _ hy
 
 lemma hereditarily.empty : hereditarily p x → p ∅ :=
 begin

--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -44,6 +44,8 @@ Then the rest is usual set theory.
   function `x → y`. That is, each member of `x` is related by the ZFC set to exactly one member of
   `y`.
 * `Set.funs`: ZFC set of ZFC functions `x → y`.
+* `Set.hereditarily p x`: Predicate that every set in the transitive closure of `x` has property
+  `p`.
 * `Class.iota`: Definite description operator.
 
 ## Notes


### PR DESCRIPTION
We will define von Neumann ordinals as hereditarily transitive sets in #18329. Also there are [hereditarily finite sets](https://en.wikipedia.org/wiki/Hereditarily_finite_set) and [hereditarily countable sets](https://en.wikipedia.org/wiki/Hereditarily_countable_set) in set theory.

Co-authored-by: Violeta Hernández [vi.hdz.p@gmail.com](mailto:vi.hdz.p@gmail.com)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
