### PR TITLE
chore(*): Improve simp confluence on `foo_equiv.symm`

### DIFF
--- a/src/algebra/module/equiv.lean
+++ b/src/algebra/module/equiv.lean
@@ -169,15 +169,12 @@ variables {module_M : module R M} {module_S_M₂ : module S M₂} {σ : R →+* 
 variables {re₁ : ring_hom_inv_pair σ σ'} {re₂ : ring_hom_inv_pair σ' σ}
 variables (e e' : M ≃ₛₗ[σ] M₂)
 
-lemma to_linear_map_eq_coe : e.to_linear_map = (e : M →ₛₗ[σ] M₂) := rfl
-
-@[simp, norm_cast] theorem coe_coe : ⇑(e : M →ₛₗ[σ] M₂) = e := rfl
-
-@[simp] lemma coe_to_equiv : ⇑e.to_equiv = e := rfl
-
-@[simp] lemma coe_to_linear_map : ⇑e.to_linear_map = e := rfl
+@[simp] lemma to_linear_map_eq_coe : e.to_linear_map = (e : M →ₛₗ[σ] M₂) := rfl
+@[simp] lemma to_equiv_eq_coe : e.to_equiv = (e : M ≃ M₂) := rfl
 
 @[simp] lemma to_fun_eq_coe : e.to_fun = e := rfl
+@[simp, norm_cast] lemma coe_to_equiv : ⇑(e : M ≃ M₂) = e := rfl
+@[simp, norm_cast] lemma coe_to_linear_map : ⇑(e : M →ₛₗ[σ] M₂) = e := rfl
 
 section
 variables {e e'}
@@ -225,7 +222,13 @@ include σ'
 @[simp] lemma inv_fun_eq_symm : e.inv_fun = e.symm := rfl
 omit σ'
 
-@[simp] lemma coe_to_equiv_symm : ⇑e.to_equiv.symm = e.symm := rfl
+@[simp, norm_cast] lemma coe_to_equiv_symm : (e.symm : M₂ ≃ M) = (e : M ≃ M₂).symm := rfl
+
+@[simp, norm_cast]
+lemma coe_to_add_equiv_symm : (e.symm : M₂ ≃+ M) = (e : M ≃+ M₂).symm := rfl
+
+@[simp] lemma coe_to_equiv_symm_apply (x : M₂) : (e : M ≃ M₂).symm x = e.symm x := rfl
+@[simp] lemma coe_to_add_equiv_symm_apply (x : M₂) : (e : M ≃+ M₂).symm x = e.symm x := rfl
 
 variables {module_M₁ : module R₁ M₁} {module_M₂ : module R₂ M₂} {module_M₃ : module R₃ M₃}
 variables {module_N₁ : module R₁ N₁} {module_N₂ : module R₁ N₂}

--- a/src/algebra/ring/equiv.lean
+++ b/src/algebra/ring/equiv.lean
@@ -119,11 +119,15 @@ instance : ring_equiv_class (R ≃+* S) R S :=
 
 instance : has_coe_to_fun (R ≃+* S) (λ _, R → S) := ⟨ring_equiv.to_fun⟩
 
-@[simp] lemma to_equiv_eq_coe (f : R ≃+* S) : f.to_equiv = f := rfl
-
 @[simp] lemma to_fun_eq_coe (f : R ≃+* S) : f.to_fun = f := rfl
 
-@[simp] lemma coe_to_equiv (f : R ≃+* S) : ⇑(f : R ≃ S) = f := rfl
+@[simp] lemma to_equiv_eq_coe (f : R ≃+* S) : f.to_equiv = f := rfl
+@[simp] lemma to_add_equiv_eq_coe (f : R ≃+* S) : f.to_add_equiv = f := rfl
+@[simp] lemma to_mul_equiv_eq_coe (f : R ≃+* S) : f.to_mul_equiv = f := rfl
+
+@[simp, norm_cast] lemma coe_to_equiv (f : R ≃+* S) : ⇑(f : R ≃ S) = f := rfl
+@[simp, norm_cast] lemma coe_to_add_equiv (f : R ≃+* S) : ⇑(f : R ≃+ S) = f := rfl
+@[simp, norm_cast] lemma coe_to_mul_equiv (f : R ≃+* S) : ⇑(f : R ≃* S) = f := rfl
 
 /-- A ring isomorphism preserves multiplication. -/
 protected lemma map_mul (e : R ≃+* S) (x y : R) : e (x * y) = e x * e y := map_mul e x y
@@ -146,14 +150,6 @@ protected lemma congr_arg {f : R ≃+* S} {x x' : R} : x = x' → f x = f x' := 
 protected lemma congr_fun {f g : R ≃+* S} (h : f = g) (x : R) : f x = g x := fun_like.congr_fun h x
 
 protected lemma ext_iff {f g : R ≃+* S} : f = g ↔ ∀ x, f x = g x := fun_like.ext_iff
-
-@[simp] lemma to_add_equiv_eq_coe (f : R ≃+* S) : f.to_add_equiv = ↑f := rfl
-
-@[simp] lemma to_mul_equiv_eq_coe (f : R ≃+* S) : f.to_mul_equiv = ↑f := rfl
-
-@[simp, norm_cast] lemma coe_to_mul_equiv (f : R ≃+* S) : ⇑(f : R ≃* S) = f := rfl
-
-@[simp, norm_cast] lemma coe_to_add_equiv (f : R ≃+* S) : ⇑(f : R ≃+ S) = f := rfl
 
 /-- The `ring_equiv` between two semirings with a unique element. -/
 def ring_equiv_of_unique {M N}
@@ -194,8 +190,20 @@ initialize_simps_projections ring_equiv (to_fun → apply, inv_fun → symm_appl
 
 @[simp] lemma symm_symm (e : R ≃+* S) : e.symm.symm = e := ext $ λ x, rfl
 
-@[simp]
+@[simp, norm_cast]
 lemma coe_to_equiv_symm (e : R ≃+* S) : (e.symm : S ≃ R) = (e : R ≃ S).symm := rfl
+
+@[simp, norm_cast]
+lemma coe_to_add_equiv_symm (e : R ≃+* S) : (e.symm : S ≃+ R) = (e : R ≃+ S).symm := rfl
+
+@[simp, norm_cast]
+lemma coe_to_mul_equiv_symm (e : R ≃+* S) : (e.symm : S ≃* R) = (e : R ≃* S).symm := rfl
+
+@[simp] lemma coe_to_equiv_symm_apply (f : R ≃+* S) (x : S) : (f : R ≃ S).symm x = f.symm x := rfl
+@[simp] lemma coe_to_add_equiv_symm_apply (f : R ≃+* S) (x : S) : (f : R ≃+ S).symm x = f.symm x :=
+rfl
+@[simp] lemma coe_to_mul_equiv_symm_apply (f : R ≃+* S) (x : S) : (f : R ≃* S).symm x = f.symm x :=
+rfl
 
 lemma symm_bijective : function.bijective (ring_equiv.symm : (R ≃+* S) → (S ≃+* R)) :=
 equiv.bijective ⟨ring_equiv.symm, ring_equiv.symm, symm_symm, symm_symm⟩

--- a/src/order/rel_iso/basic.lean
+++ b/src/order/rel_iso/basic.lean
@@ -469,6 +469,13 @@ theorem ext_iff {f g : r ≃r s} : f = g ↔ ∀ x, f x = g x := fun_like.ext_if
 @[symm] protected def symm (f : r ≃r s) : s ≃r r :=
 ⟨f.to_equiv.symm, λ a b, by erw [← f.map_rel_iff, f.1.apply_symm_apply, f.1.apply_symm_apply]⟩
 
+@[simp] lemma inv_fun_eq_symm (f : r ≃r s) : f.inv_fun = f.symm := rfl
+
+@[simp] lemma symm_symm (e : r ≃r s) : e.symm.symm = e := ext $ λ x, rfl
+
+@[simp] lemma to_equiv_symm (f : r ≃r s) : f.symm.to_equiv = f.to_equiv.symm := rfl
+@[simp] lemma to_equiv_symm_apply (f : r ≃r s) (x : β) : f.to_equiv.symm x = f.symm x := rfl
+
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
   because it is a composition of multiple projections. -/
 def simps.apply (h : r ≃r s) : α → β := h


### PR DESCRIPTION
Uniformise API around symmetric of algebraic equivalences/isomorphisms.

Kinds of lemmas:
* `to_weaker_eq_coe`: Transform a projection extension into . I only add those for the existing coercions. I don't want to introduce new coercions here.
* `coe_to_weaker_equiv_symm`: Commute `foo_equiv.symm` and the coercion from `foo_equiv` to `weaker_equiv`.
* `coe_to_weaker_equiv_symm_apply`: Turn `e.to_weaker_equiv.symm x` into `e.symm x`. This is a completely new kind of lemmas (the other two existed for some equivs, but not others). This is crucial for simp normal form as without it `e.symm.to_weaker_equiv x` could either get simplified to `e.symm x` directly, or to `e.to_weaker_equiv.symm x` and get stuck.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
This is not done! I already took care of a few equivs, but many are left. I hope the existing ones provide enough guidance for the pattern to be reproduced, as I won't have much time in the coming week.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
