### PR TITLE
[Merged by Bors] - feat(topology/algebra/infinite_sum): add tsum_finset_bUnion_disjoint

### DIFF
--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -327,6 +327,16 @@ begin
   exact ha.add hb
 end
 
+lemma has_sum_sum_disjoint {ι} (s : finset ι) {t : ι → set β} {a : ι → α}
+  (hs : (s : set ι).pairwise (disjoint on t))
+  (hf : ∀ i ∈ s, has_sum (f ∘ coe : t i → α) (a i)):
+  has_sum (f ∘ coe : (⋃ i ∈ s, t i) → α) (∑ i in s, a i) :=
+begin
+  simp_rw has_sum_subtype_iff_indicator at *,
+  rw set.indicator_finset_bUnion _ _ hs,
+  exact has_sum_sum hf,
+end
+
 lemma has_sum.add_is_compl {s t : set β} (hs : is_compl s t)
   (ha : has_sum (f ∘ coe : s → α) a) (hb : has_sum (f ∘ coe : t → α) b) :
   has_sum f (a + b) :=
@@ -732,6 +742,12 @@ lemma tsum_union_disjoint {s t : set β} (hd : disjoint s t)
   (hs : summable (f ∘ coe : s → α)) (ht : summable (f ∘ coe : t → α)) :
   (∑' x : s ∪ t, f x) = (∑' x : s, f x) + (∑' x : t, f x) :=
 (hs.has_sum.add_disjoint hd ht.has_sum).tsum_eq
+
+lemma tsum_finset_bUnion_disjoint {ι} {s : finset ι} {t : ι → set β}
+  (hd : (s : set ι).pairwise (disjoint on t))
+  (hf : ∀ i ∈ s, summable (f ∘ coe : t i → α)) :
+  (∑' x : (⋃ i ∈ s, t i), f x) = ∑ i in s, ∑' x : t i, f x :=
+(has_sum_sum_disjoint _ hd (λ i hi, (hf i hi).has_sum)).tsum_eq
 
 lemma tsum_even_add_odd {f : ℕ → α} (he : summable (λ k, f (2 * k)))
   (ho : summable (λ k, f (2 * k + 1))) :

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -329,7 +329,7 @@ end
 
 lemma has_sum_sum_disjoint {ι} (s : finset ι) {t : ι → set β} {a : ι → α}
   (hs : (s : set ι).pairwise (disjoint on t))
-  (hf : ∀ i ∈ s, has_sum (f ∘ coe : t i → α) (a i)):
+  (hf : ∀ i ∈ s, has_sum (f ∘ coe : t i → α) (a i)) :
   has_sum (f ∘ coe : (⋃ i ∈ s, t i) → α) (∑ i in s, a i) :=
 begin
   simp_rw has_sum_subtype_iff_indicator at *,


### PR DESCRIPTION
This is the n-ary version of `tsum_union_disjoint`, although unfortunately I realized that what I actually wanted was the n-ary version of `has_sum.add_is_compl` which is harder to state!

Either way, this lemma seems worth having.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
