### PR TITLE
[Merged by Bors] - feat(logic/equiv/fin): `div`/`mod` as an equivalence on `nat`/`int`

### DIFF
--- a/src/data/int/order/basic.lean
+++ b/src/data/int/order/basic.lean
@@ -346,6 +346,7 @@ begin
   rw [sub_add_cancel, ← add_mod_mod, sub_add_cancel, mod_mod]
 end
 
+/-- See also `int.div_mod_equiv` for a similar statement as an `equiv`. -/
 protected theorem div_mod_unique {a b r q : ℤ} (h : 0 < b) :
   a / b = q ∧ a % b = r ↔ r + b * q = a ∧ 0 ≤ r ∧ r < b :=
 begin

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -543,6 +543,7 @@ by { rw mul_comm, exact mod_add_div _ _ }
 lemma div_add_mod' (m k : ℕ) : (m / k) * k + m % k = m :=
 by { rw mul_comm, exact div_add_mod _ _ }
 
+/-- See also `nat.div_mod_equiv` for a similar statement as an `equiv`. -/
 protected theorem div_mod_unique {n k m d : ℕ} (h : 0 < k) :
   n / k = d ∧ n % k = m ↔ m + k * d = n ∧ m < k :=
 ⟨λ ⟨e₁, e₂⟩, e₁ ▸ e₂ ▸ ⟨mod_add_div _ _, mod_lt _ h⟩,

--- a/src/logic/equiv/fin.lean
+++ b/src/logic/equiv/fin.lean
@@ -427,7 +427,8 @@ def fin_prod_fin_equiv : fin m × fin n ≃ fin (m * n) :=
 
 /-- The equivalence between `a` and `(a / n, a % n)` for nonzero `n`.
 
-This is like `fin_prod_fin_equiv.symm` but with `m` infinite. -/
+This is like `fin_prod_fin_equiv.symm` but with `m` infinite.
+See `nat.div_mod_unique` for a similar propositional statement. -/
 @[simps]
 def nat.div_mod_equiv (n : ℕ) [ne_zero n] : ℕ ≃ ℕ × fin n :=
 { to_fun := λ a, (a / n, fin.of_nat' a),
@@ -439,10 +440,14 @@ def nat.div_mod_equiv (n : ℕ) [ne_zero n] : ℕ ≃ ℕ × fin n :=
     rw [add_comm, nat.add_mul_div_right _ _ (ne_zero.pos n), nat.div_eq_of_lt p.2.is_lt, zero_add],
   end }
 
-/-- The equivalence between `a` and `(a / n, a % n)` for nonzero `n`. -/
+/-- The equivalence between `a` and `(a / n, a % n)` for nonzero `n`.
+
+See `int.div_mod_unique` for a similar propositional statement. -/
 @[simps]
 def int.div_mod_equiv (n : ℕ) [ne_zero n] : ℤ ≃ ℤ × fin n :=
 { to_fun := λ a, (a / n, a.nat_mod n),
+  -- TODO: could cast to int directly if we import `data.zmod.defs`, though there are few lemmas
+  -- about that coercion.
   inv_fun := λ p, p.1 * n + (p.2 : ℕ),
   left_inv := λ a, by simp_rw [fin.coe_of_nat_eq_mod, int.coe_nat_mod, int.nat_mod,
     int.to_nat_of_nonneg (int.mod_nonneg _ $ ne_zero.ne n), int.mod_mod, int.div_add_mod'],

--- a/src/logic/equiv/fin.lean
+++ b/src/logic/equiv/fin.lean
@@ -431,8 +431,8 @@ This is like `fin_prod_fin_equiv.symm` but with `m` infinite.
 See `nat.div_mod_unique` for a similar propositional statement. -/
 @[simps]
 def nat.div_mod_equiv (n : ℕ) [ne_zero n] : ℕ ≃ ℕ × fin n :=
-{ to_fun := λ a, (a / n, fin.of_nat' a),
-  inv_fun := λ p, p.1 * n + p.2,  -- TODO: is there a canonical order of `*` and `+` here?
+{ to_fun := λ a, (a / n, ↑a),
+  inv_fun := λ p, p.1 * n + ↑p.2,  -- TODO: is there a canonical order of `*` and `+` here?
   left_inv := λ a, nat.div_add_mod' _ _,
   right_inv := λ p, begin
     refine prod.ext _ (fin.ext $ nat.mul_add_mod_of_lt p.2.is_lt),
@@ -445,14 +445,14 @@ def nat.div_mod_equiv (n : ℕ) [ne_zero n] : ℕ ≃ ℕ × fin n :=
 See `int.div_mod_unique` for a similar propositional statement. -/
 @[simps]
 def int.div_mod_equiv (n : ℕ) [ne_zero n] : ℤ ≃ ℤ × fin n :=
-{ to_fun := λ a, (a / n, a.nat_mod n),
-  -- TODO: could cast to int directly if we import `data.zmod.defs`, though there are few lemmas
+{ -- TODO: could cast from int directly if we import `data.zmod.defs`, though there are few lemmas
   -- about that coercion.
-  inv_fun := λ p, p.1 * n + (p.2 : ℕ),
-  left_inv := λ a, by simp_rw [fin.coe_of_nat_eq_mod, int.coe_nat_mod, int.nat_mod,
+  to_fun := λ a, (a / n, ↑(a.nat_mod n)),
+  inv_fun := λ p, p.1 * n + ↑p.2,
+  left_inv := λ a, by simp_rw [coe_coe, fin.coe_of_nat_eq_mod, int.coe_nat_mod, int.nat_mod,
     int.to_nat_of_nonneg (int.mod_nonneg _ $ ne_zero.ne n), int.mod_mod, int.div_add_mod'],
   right_inv := λ ⟨q, r, hrn⟩, begin
-    simp only [fin.coe_mk, prod.mk.inj_iff, fin.ext_iff],
+    simp only [fin.coe_mk, prod.mk.inj_iff, fin.ext_iff, coe_coe],
     obtain ⟨h1, h2⟩ := ⟨int.coe_nat_nonneg r, int.coe_nat_lt.2 hrn⟩,
     rw [add_comm, int.add_mul_div_right _ _ (ne_zero.ne n), int.div_eq_zero_of_lt h1 h2,
         int.nat_mod, int.add_mul_mod_self, int.mod_eq_of_lt h1 h2, int.to_nat_coe_nat],

--- a/src/logic/equiv/fin.lean
+++ b/src/logic/equiv/fin.lean
@@ -425,7 +425,7 @@ def fin_prod_fin_equiv : fin m × fin n ≃ fin (m * n) :=
         ... = y.1 : nat.mod_eq_of_lt y.2),
   right_inv := λ x, fin.eq_of_veq $ nat.mod_add_div _ _ }
 
-/-- The equivalence between `a` and `(a / n, a % n)` for nonzero `n`.
+/-- The equivalence induced by `a ↦ (a / n, a % n)` for nonzero `n`.
 
 This is like `fin_prod_fin_equiv.symm` but with `m` infinite.
 See `nat.div_mod_unique` for a similar propositional statement. -/
@@ -440,7 +440,7 @@ def nat.div_mod_equiv (n : ℕ) [ne_zero n] : ℕ ≃ ℕ × fin n :=
     rw [add_comm, nat.add_mul_div_right _ _ (ne_zero.pos n), nat.div_eq_of_lt p.2.is_lt, zero_add],
   end }
 
-/-- The equivalence between `a` and `(a / n, a % n)` for nonzero `n`.
+/-- The equivalence induced by `a ↦ (a / n, a % n)` for nonzero `n`.
 
 See `int.div_mod_unique` for a similar propositional statement. -/
 @[simps]

--- a/src/logic/equiv/fin.lean
+++ b/src/logic/equiv/fin.lean
@@ -442,37 +442,16 @@ def nat.div_mod_equiv (n : ℕ) [ne_zero n] : ℕ ≃ ℕ × fin n :=
 /-- The equivalence between `a` and `(a / n, a % n)` for nonzero `n`. -/
 @[simps]
 def int.div_mod_equiv (n : ℕ) [ne_zero n] : ℤ ≃ ℤ × fin n :=
-{ to_fun := λ a, (a / n, (a.nat_mod n)),
+{ to_fun := λ a, (a / n, a.nat_mod n),
   inv_fun := λ p, p.1 * n + (p.2 : ℕ),
-  left_inv := λ a, begin
-    dsimp only,
-    convert int.div_add_mod' _ (n : ℤ),
-    rw fin.coe_coe_of_lt ,
-    { rw [int.nat_mod, int.to_nat_of_nonneg],
-      refine int.mod_nonneg _ (nat.cast_ne_zero.mpr $ ne_zero.ne n), },
-    rw ←int.coe_nat_lt,
-    { rw [int.nat_mod,
-        int.to_nat_of_nonneg (int.mod_nonneg _ (nat.cast_ne_zero.mpr $ ne_zero.ne n))],
-      refine int.mod_lt_of_pos _ _,
-      rw [←int.coe_nat_zero, int.coe_nat_lt],
-      exact ne_zero.pos n, },
-  end,
-  right_inv := λ ⟨q, ⟨r, hrn⟩⟩, begin
-    -- TODO: either we're missing some important lemmas here, or they're not available in this file.
-    dsimp [←fin.of_nat'_eq_coe, fin.of_nat'],
-    have hn : (n : ℤ) ≠ 0 := (nat.cast_ne_zero.mpr $ ne_zero.ne n),
-    congr,
-    { rw [int.add_div_of_dvd_left (dvd_mul_left _ _), int.mul_div_cancel _ hn,
-        int.div_eq_zero_of_lt (int.coe_nat_nonneg r) (int.coe_nat_lt.mpr hrn), add_zero] },
-    { apply int.coe_nat_inj,
-      rw [int.nat_mod, nat.mod_eq_of_lt,
-        int.to_nat_of_nonneg (int.mod_nonneg _ (nat.cast_ne_zero.mpr $ ne_zero.ne n)), add_comm,
-        int.add_mul_mod_self, int.mod_eq_of_lt  (int.coe_nat_nonneg r) (int.coe_nat_lt.mpr hrn)],
-      rw ←int.coe_nat_lt,
-      rw [int.to_nat_of_nonneg (int.mod_nonneg _ (nat.cast_ne_zero.mpr $ ne_zero.ne n))],
-      refine int.mod_lt_of_pos _ _,
-      rw [←int.coe_nat_zero, int.coe_nat_lt],
-      exact ne_zero.pos n, }
+  left_inv := λ a, by simp_rw [fin.coe_of_nat_eq_mod, int.coe_nat_mod, int.nat_mod,
+    int.to_nat_of_nonneg (int.mod_nonneg _ $ ne_zero.ne n), int.mod_mod, int.div_add_mod'],
+  right_inv := λ ⟨q, r, hrn⟩, begin
+    simp only [fin.coe_mk, prod.mk.inj_iff, fin.ext_iff],
+    obtain ⟨h1, h2⟩ := ⟨int.coe_nat_nonneg r, int.coe_nat_lt.2 hrn⟩,
+    rw [add_comm, int.add_mul_div_right _ _ (ne_zero.ne n), int.div_eq_zero_of_lt h1 h2,
+        int.nat_mod, int.add_mul_mod_self, int.mod_eq_of_lt h1 h2, int.to_nat_coe_nat],
+    exact ⟨zero_add q, fin.coe_coe_of_lt hrn⟩,
   end }
 
 /-- Promote a `fin n` into a larger `fin m`, as a subtype where the underlying


### PR DESCRIPTION
The motivation here is to be able to use this to change a sum/product/supr/infi/tsum/etc to be indexed by a product, such that every `n`th term can be collected into an inner / outer sum. We already have the API in most places for `equiv`s and `prod`s to do this, all that's missing is the equivalences in this PR.

Note that we use `[ne_zero n]` instead of `hn : n ≠ 0` as this is required by `fin.of_nat'` for the coercion.


[Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/division.20and.20remainder.20as.20an.20equivalence/near/325359453)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

~~I found the `int` version really annoying to prove; either I can't find the lemmas i need, or they're not available in the file I decide to define this in.~~ Resolved, thanks @alreadydone!

Will forward-port at https://github.com/leanprover-community/mathlib4/pull/2106