### PR TITLE
[Merged by Bors] - refactor(combinatorics/simple_graph/density): Generalize to arbitrary ordered fields

### DIFF
--- a/src/combinatorics/simple_graph/density.lean
+++ b/src/combinatorics/simple_graph/density.lean
@@ -24,14 +24,14 @@ Between two finsets of vertices,
 open finset
 open_locale big_operators
 
-variables {ι κ α β : Type*}
+variables {𝕜 ι κ α β : Type*}
 
 /-! ### Density of a relation -/
 
 namespace rel
 section asymmetric
-variables (r : α → β → Prop) [Π a, decidable_pred (r a)] {s s₁ s₂ : finset α} {t t₁ t₂ : finset β}
-  {a : α} {b : β} {δ : ℚ}
+variables [linear_ordered_field 𝕜] (r : α → β → Prop) [Π a, decidable_pred (r a)]
+  {s s₁ s₂ : finset α} {t t₁ t₂ : finset β} {a : α} {b : β} {δ : 𝕜}
 
 /-- Finset of edges of a relation between two finsets of vertices. -/
 def interedges (s : finset α) (t : finset β) : finset (α × β) := (s ×ˢ t).filter $ λ e, r e.1 e.2
@@ -188,32 +188,36 @@ end
 lemma abs_edge_density_sub_edge_density_le_two_mul_sub_sq (hs : s₂ ⊆ s₁) (ht : t₂ ⊆ t₁)
   (hδ₀ : 0 ≤ δ) (hδ₁ : δ < 1) (hs₂ : (1 - δ) * s₁.card ≤ s₂.card)
   (ht₂ : (1 - δ) * t₁.card ≤ t₂.card) :
-  |edge_density r s₂ t₂ - edge_density r s₁ t₁| ≤ 2*δ - δ^2 :=
+  |(edge_density r s₂ t₂ : 𝕜) - edge_density r s₁ t₁| ≤ 2*δ - δ^2 :=
 begin
   have hδ' : 0 ≤ 2 * δ - δ ^ 2,
   { rw [sub_nonneg, sq],
     exact mul_le_mul_of_nonneg_right (hδ₁.le.trans (by norm_num)) hδ₀ },
   rw ←sub_pos at hδ₁,
-  simp only [edge_density],
   obtain rfl | hs₂' := s₂.eq_empty_or_nonempty,
   { rw [finset.card_empty, nat.cast_zero] at hs₂,
-    simpa [(nonpos_of_mul_nonpos_right hs₂ hδ₁).antisymm (nat.cast_nonneg _)] using hδ' },
+    simpa [edge_density, (nonpos_of_mul_nonpos_right hs₂ hδ₁).antisymm (nat.cast_nonneg _)]
+      using hδ' },
   obtain rfl | ht₂' := t₂.eq_empty_or_nonempty,
   { rw [finset.card_empty, nat.cast_zero] at ht₂,
-    simpa [(nonpos_of_mul_nonpos_right ht₂ hδ₁).antisymm (nat.cast_nonneg _)] using hδ' },
+    simpa [edge_density, (nonpos_of_mul_nonpos_right ht₂ hδ₁).antisymm (nat.cast_nonneg _)]
+      using hδ' },
   rw [show 2 * δ - δ ^ 2 = 1 - (1 - δ) * (1 - δ), by ring],
-  refine (abs_edge_density_sub_edge_density_le_one_sub_mul r hs ht hs₂' ht₂').trans _,
-  apply sub_le_sub_left (mul_le_mul ((le_div_iff _).2 hs₂) ((le_div_iff _).2 ht₂) hδ₁.le _),
-  { exact_mod_cast (hs₂'.mono hs).card_pos },
-  { exact_mod_cast (ht₂'.mono ht).card_pos },
-  { positivity }
+  norm_cast,
+  refine (rat.cast_le.2 $
+    abs_edge_density_sub_edge_density_le_one_sub_mul r hs ht hs₂' ht₂').trans _,
+  push_cast,
+  have := hs₂'.mono hs,
+  have := ht₂'.mono ht,
+  refine sub_le_sub_left (mul_le_mul ((le_div_iff _).2 hs₂) ((le_div_iff _).2 ht₂) hδ₁.le _) _;
+  positivity,
 end
 
 /-- If `s₂ ⊆ s₁`, `t₂ ⊆ t₁` and they take up all but a `δ`-proportion, then the difference in edge
 densities is at most `2 * δ`. -/
 lemma abs_edge_density_sub_edge_density_le_two_mul (hs : s₂ ⊆ s₁) (ht : t₂ ⊆ t₁) (hδ : 0 ≤ δ)
   (hscard : (1 - δ) * s₁.card ≤ s₂.card) (htcard : (1 - δ) * t₁.card ≤ t₂.card) :
-  |edge_density r s₂ t₂ - edge_density r s₁ t₁| ≤ 2 * δ :=
+  |(edge_density r s₂ t₂ : 𝕜) - edge_density r s₁ t₁| ≤ 2 * δ :=
 begin
   cases lt_or_le δ 1,
   { exact (abs_edge_density_sub_edge_density_le_two_mul_sub_sq r hs ht hδ h hscard htcard).trans
@@ -324,7 +328,7 @@ lemma edge_density_add_edge_density_compl (hs : s.nonempty) (ht : t.nonempty) (h
 begin
   rw [edge_density_def, edge_density_def, div_add_div_same, div_eq_one_iff_eq],
   { exact_mod_cast card_interedges_add_card_interedges_compl _ h },
-  { exact_mod_cast (mul_pos hs.card_pos ht.card_pos).ne' }
+  { positivity }
 end
 
 end decidable_eq


### PR DESCRIPTION
I originally thought making graph densities `ℚ`-valued would work best, but I now need it to be a real and it turns out to be more pain than anything.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
