### PR TITLE
[Merged by Bors] - chore(100.yaml): Brouwer fix point

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -133,6 +133,9 @@
   author : Moritz Doll
 36:
   title  : Brouwer Fixed Point Theorem
+  author : Brendan Seamas Murphy
+  links  :
+    result: https://github.com/Shamrock-Frost/BrouwerFixedPoint/blob/master/src/brouwer_fixed_point.lean
 37:
   title  : The Solution of a Cubic
   author : Jeoff Lee


### PR DESCRIPTION
@Shamrock-Frost formalized Brouwer's fix point theorem a few months ago, and we never got around to adding this to the list of 100 theorems. This should be the 75th entry if I counted correctly :tada:



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
