### PR TITLE
[Merged by Bors] - feat(analysis/complex/basic): lemmas about tsum

### DIFF
--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -324,60 +324,11 @@ by rw [eq_re_of_real_le hz, is_R_or_C.norm_of_real, real.norm_of_nonneg (complex
 
 end complex_order
 
-section tsum
-variables {α : Type*}
-
-@[simp] lemma has_sum_conj {f : α → ℂ} {x : ℂ} :
-  has_sum (λ x, conj (f x)) x ↔ has_sum f (conj x) :=
-conj_cle.has_sum
-
-lemma has_sum_conj' {f : α → ℂ} {x : ℂ} : has_sum (λ x, conj (f x)) (conj x) ↔ has_sum f x :=
-conj_cle.has_sum'
-
-@[simp] lemma summable_conj {f : α → ℂ} : summable (λ x, conj (f x)) ↔ summable f :=
-conj_cle.summable
-
-lemma conj_tsum (f : α → ℂ) : conj (∑' a, f a) = ∑' a, conj (f a) :=
-conj_cle.map_tsum
-
-@[simp, norm_cast] lemma has_sum_of_real {f : α → ℝ} {x : ℝ} :
-  has_sum (λ x, (f x : ℂ)) x ↔ has_sum f x :=
-⟨re_clm.has_sum, of_real_clm.has_sum⟩
-
-@[simp, norm_cast] lemma summable_of_real {f : α → ℝ} : summable (λ x, (f x : ℂ)) ↔ summable f :=
-⟨re_clm.summable, of_real_clm.summable⟩
-
-@[norm_cast] lemma of_real_tsum (f : α → ℝ) : (↑(∑' a, f a) : ℂ) = ∑' a, f a :=
-begin
-  by_cases h : summable f,
-  { exact continuous_linear_map.map_tsum of_real_clm h },
-  { rw [tsum_eq_zero_of_not_summable h, tsum_eq_zero_of_not_summable (summable_of_real.not.mpr h),
-      of_real_zero] }
-end
-
-lemma has_sum_iff (f : α → ℂ) (c : ℂ) :
-  has_sum f c ↔ has_sum (λ x, (f x).re) c.re ∧ has_sum (λ x, (f x).im) c.im :=
-begin
-  -- For some reason, `continuous_linear_map.has_sum` is orders of magnitude faster than
-  -- `has_sum.mapL` here:
-  refine ⟨λ h, ⟨re_clm.has_sum h, im_clm.has_sum h⟩, _⟩,
-  rintro ⟨h₁, h₂⟩,
-  convert (h₁.prod_mk h₂).mapL equiv_real_prod_clm.symm.to_continuous_linear_map,
-  { ext x; refl },
-  { cases c, refl }
-end
-
-lemma re_tsum {f : α → ℂ} (h : summable f) : (∑' a, f a).re = ∑' a, (f a).re :=
-re_clm.map_tsum h
-
-lemma im_tsum {f : α → ℂ} (h : summable f) : (∑' a, f a).im = ∑' a, (f a).im :=
-im_clm.map_tsum h
-
-end tsum
-
 end complex
 
 namespace is_R_or_C
+
+open_locale complex_conjugate
 
 local notation `reC` := @is_R_or_C.re ℂ _
 local notation `imC` := @is_R_or_C.im ℂ _
@@ -393,10 +344,97 @@ by simp [is_R_or_C.norm_sq, complex.norm_sq]
 @[simp] lemma abs_to_complex {x : ℂ} : absC x = complex.abs x :=
 by simp [is_R_or_C.abs, complex.abs]
 
-lemma re_tsum {α} {f : α → ℂ} (h : summable f) : re (∑' a, f a) = ∑' a, re (f a) :=
+section tsum
+variables {α : Type*} (𝕜 : Type*) [is_R_or_C 𝕜]
+
+@[simp] lemma has_sum_conj {f : α → 𝕜} {x : 𝕜} :
+  has_sum (λ x, conj (f x)) x ↔ has_sum f (conj x) :=
+conj_cle.has_sum
+
+lemma has_sum_conj' {f : α → 𝕜} {x : 𝕜} : has_sum (λ x, conj (f x)) (conj x) ↔ has_sum f x :=
+conj_cle.has_sum'
+
+@[simp] lemma summable_conj {f : α → 𝕜} : summable (λ x, conj (f x)) ↔ summable f :=
+conj_cle.summable
+
+lemma conj_tsum (f : α → 𝕜) : conj (∑' a, f a) = ∑' a, conj (f a) :=
+conj_cle.map_tsum
+
+@[simp, norm_cast] lemma has_sum_of_real {f : α → ℝ} {x : ℝ} :
+  has_sum (λ x, (f x : 𝕜)) x ↔ has_sum f x :=
+⟨λ h, by simpa only [is_R_or_C.re_clm_apply, is_R_or_C.of_real_re] using re_clm.has_sum h,
+  of_real_clm.has_sum⟩
+
+@[simp, norm_cast] lemma summable_of_real {f : α → ℝ} : summable (λ x, (f x : 𝕜)) ↔ summable f :=
+⟨λ h, by simpa only [is_R_or_C.re_clm_apply, is_R_or_C.of_real_re] using re_clm.summable h,
+  of_real_clm.summable⟩
+
+@[norm_cast] lemma of_real_tsum (f : α → ℝ) : (↑(∑' a, f a) : 𝕜) = ∑' a, f a :=
+begin
+  by_cases h : summable f,
+  { exact continuous_linear_map.map_tsum of_real_clm h },
+  { rw [tsum_eq_zero_of_not_summable h,
+    tsum_eq_zero_of_not_summable ((summable_of_real _).not.mpr h), of_real_zero] }
+end
+
+lemma has_sum_re {f : α → 𝕜} {x : 𝕜} (h : has_sum f x) : has_sum (λ x, re (f x)) (re x) :=
+re_clm.has_sum h
+
+lemma has_sum_im {f : α → 𝕜} {x : 𝕜} (h : has_sum f x) : has_sum (λ x, im (f x)) (im x) :=
+im_clm.has_sum h
+
+lemma re_tsum {f : α → 𝕜} (h : summable f) : re (∑' a, f a) = ∑' a, re (f a) :=
 re_clm.map_tsum h
 
-lemma im_tsum {α} {f : α → ℂ} (h : summable f) : im (∑' a, f a) = ∑' a, im (f a) :=
+lemma im_tsum {f : α → 𝕜} (h : summable f) : im (∑' a, f a) = ∑' a, im (f a) :=
 im_clm.map_tsum h
 
+variables {𝕜}
+
+lemma has_sum_iff (f : α → 𝕜) (c : 𝕜) :
+  has_sum f c ↔ has_sum (λ x, re (f x)) (re c) ∧ has_sum (λ x, im (f x)) (im c) :=
+begin
+  refine ⟨λ h, ⟨has_sum_re _ h, has_sum_im _ h⟩, _⟩,
+  rintro ⟨h₁, h₂⟩,
+  rw ←is_R_or_C.re_add_im c,
+  convert ((has_sum_of_real 𝕜).mpr h₁).add (((has_sum_of_real 𝕜).mpr h₂).mul_right I),
+  simp_rw is_R_or_C.re_add_im,
+end
+
+end tsum
+
 end is_R_or_C
+
+namespace complex
+/-!
+We have to repeat the lemmas about `is_R_or_C.re` and `is_R_or_C.im` as they are not syntactic
+matches for `complex.re` and `complex.im`. We do not have this problem with `of_real` and `conj`.
+Note that in Lean 4 we will need to be careful with our definition of the `of_real` coercion to
+ensure a syntactic match.
+-/
+section tsum
+variables {α : Type*}
+
+open_locale complex_conjugate
+
+-- For some reason, `continuous_linear_map.has_sum` is orders of magnitude faster than
+-- `has_sum.mapL` here:
+lemma has_sum_re {f : α → ℂ} {x : ℂ} (h : has_sum f x) : has_sum (λ x, (f x).re) x.re :=
+is_R_or_C.has_sum_re _ h
+
+lemma has_sum_im {f : α → ℂ} {x : ℂ} (h : has_sum f x) : has_sum (λ x, (f x).im) x.im :=
+is_R_or_C.has_sum_im _ h
+
+lemma re_tsum {f : α → ℂ} (h : summable f) : (∑' a, f a).re = ∑' a, (f a).re :=
+is_R_or_C.re_tsum _ h
+
+lemma im_tsum {f : α → ℂ} (h : summable f) : (∑' a, f a).im = ∑' a, (f a).im :=
+is_R_or_C.im_tsum _ h
+
+lemma has_sum_iff (f : α → ℂ) (c : ℂ) :
+  has_sum f c ↔ has_sum (λ x, (f x).re) c.re ∧ has_sum (λ x, (f x).im) c.im :=
+is_R_or_C.has_sum_iff _ _
+
+end tsum
+
+end complex

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -355,12 +355,12 @@ lemma has_sum_conj' {f : α → 𝕜} {x : 𝕜} : has_sum (λ x, conj (f x)) (c
 conj_cle.has_sum'
 
 @[simp] lemma summable_conj {f : α → 𝕜} : summable (λ x, conj (f x)) ↔ summable f :=
-conj_cle.summable
+summable_star_iff
 
 variables {𝕜}
 
 lemma conj_tsum (f : α → 𝕜) : conj (∑' a, f a) = ∑' a, conj (f a) :=
-conj_cle.map_tsum
+tsum_star
 
 variables (𝕜)
 

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -445,8 +445,6 @@ is_R_or_C.summable_of_real _
 @[norm_cast] lemma of_real_tsum (f : α → ℝ) : (↑(∑' a, f a) : ℂ) = ∑' a, f a :=
 is_R_or_C.of_real_tsum _ _
 
--- For some reason, `continuous_linear_map.has_sum` is orders of magnitude faster than
--- `has_sum.mapL` here:
 lemma has_sum_re {f : α → ℂ} {x : ℂ} (h : has_sum f x) : has_sum (λ x, (f x).re) x.re :=
 is_R_or_C.has_sum_re _ h
 

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -357,8 +357,12 @@ conj_cle.has_sum'
 @[simp] lemma summable_conj {f : α → 𝕜} : summable (λ x, conj (f x)) ↔ summable f :=
 conj_cle.summable
 
+variables {𝕜}
+
 lemma conj_tsum (f : α → 𝕜) : conj (∑' a, f a) = ∑' a, conj (f a) :=
 conj_cle.map_tsum
+
+variables (𝕜)
 
 @[simp, norm_cast] lemma has_sum_of_real {f : α → ℝ} {x : ℝ} :
   has_sum (λ x, (f x : 𝕜)) x ↔ has_sum f x :=
@@ -408,14 +412,38 @@ end is_R_or_C
 namespace complex
 /-!
 We have to repeat the lemmas about `is_R_or_C.re` and `is_R_or_C.im` as they are not syntactic
-matches for `complex.re` and `complex.im`. We do not have this problem with `of_real` and `conj`.
-Note that in Lean 4 we will need to be careful with our definition of the `of_real` coercion to
-ensure a syntactic match.
+matches for `complex.re` and `complex.im`.
+
+We do not have this problem with `of_real` and `conj`, although we repeat them anyway for
+discoverability and to avoid the need to unify `𝕜`.
 -/
 section tsum
 variables {α : Type*}
 
 open_locale complex_conjugate
+
+@[simp] lemma has_sum_conj {f : α → ℂ} {x : ℂ} :
+  has_sum (λ x, conj (f x)) x ↔ has_sum f (conj x) :=
+is_R_or_C.has_sum_conj _
+
+lemma has_sum_conj' {f : α → ℂ} {x : ℂ} : has_sum (λ x, conj (f x)) (conj x) ↔ has_sum f x :=
+is_R_or_C.has_sum_conj' _
+
+@[simp] lemma summable_conj {f : α → ℂ} : summable (λ x, conj (f x)) ↔ summable f :=
+is_R_or_C.summable_conj _
+
+lemma conj_tsum (f : α → ℂ) : conj (∑' a, f a) = ∑' a, conj (f a) :=
+is_R_or_C.conj_tsum _
+
+@[simp, norm_cast] lemma has_sum_of_real {f : α → ℝ} {x : ℝ} :
+  has_sum (λ x, (f x : ℂ)) x ↔ has_sum f x :=
+is_R_or_C.has_sum_of_real _
+
+@[simp, norm_cast] lemma summable_of_real {f : α → ℝ} : summable (λ x, (f x : ℂ)) ↔ summable f :=
+is_R_or_C.summable_of_real _
+
+@[norm_cast] lemma of_real_tsum (f : α → ℝ) : (↑(∑' a, f a) : ℂ) = ∑' a, f a :=
+is_R_or_C.of_real_tsum _ _
 
 -- For some reason, `continuous_linear_map.has_sum` is orders of magnitude faster than
 -- `has_sum.mapL` here:

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -324,7 +324,38 @@ by rw [eq_re_of_real_le hz, is_R_or_C.norm_of_real, real.norm_of_nonneg (complex
 
 end complex_order
 
-lemma has_sum_iff {α} (f : α → ℂ) (c : ℂ) :
+section tsum
+variables {α : Type*}
+
+@[simp] lemma has_sum_conj {f : α → ℂ} {x : ℂ} :
+  has_sum (λ x, conj (f x)) x ↔ has_sum f (conj x) :=
+conj_cle.has_sum
+
+lemma has_sum_conj' {f : α → ℂ} {x : ℂ} : has_sum (λ x, conj (f x)) (conj x) ↔ has_sum f x :=
+conj_cle.has_sum'
+
+@[simp] lemma summable_conj {f : α → ℂ} : summable (λ x, conj (f x)) ↔ summable f :=
+conj_cle.summable
+
+lemma conj_tsum (f : α → ℂ) : conj (∑' a, f a) = ∑' a, conj (f a) :=
+conj_cle.map_tsum
+
+@[simp, norm_cast] lemma has_sum_of_real {f : α → ℝ} {x : ℝ} :
+  has_sum (λ x, (f x : ℂ)) x ↔ has_sum f x :=
+⟨re_clm.has_sum, of_real_clm.has_sum⟩
+
+@[simp, norm_cast] lemma summable_of_real {f : α → ℝ} : summable (λ x, (f x : ℂ)) ↔ summable f :=
+⟨re_clm.summable, of_real_clm.summable⟩
+
+@[norm_cast] lemma of_real_tsum (f : α → ℝ) : (↑(∑' a, f a) : ℂ) = ∑' a, f a :=
+begin
+  by_cases h : summable f,
+  { exact continuous_linear_map.map_tsum of_real_clm h },
+  { rw [tsum_eq_zero_of_not_summable h, tsum_eq_zero_of_not_summable (summable_of_real.not.mpr h),
+      of_real_zero] }
+end
+
+lemma has_sum_iff (f : α → ℂ) (c : ℂ) :
   has_sum f c ↔ has_sum (λ x, (f x).re) c.re ∧ has_sum (λ x, (f x).im) c.im :=
 begin
   -- For some reason, `continuous_linear_map.has_sum` is orders of magnitude faster than
@@ -335,6 +366,14 @@ begin
   { ext x; refl },
   { cases c, refl }
 end
+
+lemma re_tsum {f : α → ℂ} (h : summable f) : (∑' a, f a).re = ∑' a, (f a).re :=
+re_clm.map_tsum h
+
+lemma im_tsum {f : α → ℂ} (h : summable f) : (∑' a, f a).im = ∑' a, (f a).im :=
+im_clm.map_tsum h
+
+end tsum
 
 end complex
 
@@ -353,5 +392,11 @@ local notation `norm_sqC` := @is_R_or_C.norm_sq ℂ _
 by simp [is_R_or_C.norm_sq, complex.norm_sq]
 @[simp] lemma abs_to_complex {x : ℂ} : absC x = complex.abs x :=
 by simp [is_R_or_C.abs, complex.abs]
+
+lemma re_tsum {α} {f : α → ℂ} (h : summable f) : re (∑' a, f a) = ∑' a, re (f a) :=
+re_clm.map_tsum h
+
+lemma im_tsum {α} {f : α → ℂ} (h : summable f) : im (∑' a, f a) = ∑' a, im (f a) :=
+im_clm.map_tsum h
 
 end is_R_or_C


### PR DESCRIPTION
This adds lemmas about the four "basis" complex operations: `re`, `im`, `of_real` (coercion), and `conj`.

These all follow trivially from the API for continuous linear morphisms, but using those results directly gives syntacticly different terms that don't work in rewrites. Similarly, the conj lemmas follow trivially from the results about `star`, but `conj` (aka `star_ring_end`) is not a syntactic match for `star`.

This proves all the results for `is_R_or_C` (including a more general version of `has_sum_iff`), then copies across the results to `complex` for convenience.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
