### PR TITLE
feat(set_theory.cardinality.basic) : change def of nat_cast for cardinals.

### DIFF
--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -267,7 +267,7 @@ theorem lift_strict_mono : strict_mono lift :=
 theorem lift_monotone : monotone lift :=
 lift_strict_mono.monotone
 
-instance : has_zero cardinal.{u} := ⟨#pempty⟩
+instance : has_zero cardinal.{u} := ⟨lift #(fin 0)⟩
 
 instance : inhabited cardinal.{u} := ⟨0⟩
 
@@ -287,7 +287,7 @@ theorem mk_ne_zero_iff {α : Type u} : #α ≠ 0 ↔ nonempty α :=
 
 @[simp] lemma mk_ne_zero (α : Type u) [nonempty α] : #α ≠ 0 := mk_ne_zero_iff.2 ‹_›
 
-instance : has_one cardinal.{u} := ⟨#punit⟩
+instance : has_one cardinal.{u} := ⟨lift #(fin 1)⟩
 
 instance : nontrivial cardinal.{u} := ⟨⟨1, 0, mk_ne_zero _⟩⟩
 
@@ -307,7 +307,7 @@ instance : has_add cardinal.{u} := ⟨map₂ sum $ λ α β γ δ, equiv.sum_con
 
 theorem add_def (α β : Type u) : #α + #β = #(α ⊕ β) := rfl
 
-instance : has_nat_cast cardinal.{u} := ⟨nat.unary_cast⟩
+instance : has_nat_cast cardinal.{u} := ⟨λ n, lift #(fin n)⟩
 
 @[simp] lemma mk_sum (α : Type u) (β : Type v) :
   #(α ⊕ β) = lift.{v u} (#α) + lift.{u v} (#β) :=

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -267,14 +267,14 @@ theorem lift_strict_mono : strict_mono lift :=
 theorem lift_monotone : monotone lift :=
 lift_strict_mono.monotone
 
-instance : has_zero cardinal.{u} := ⟨lift #(fin 0)⟩
+instance : has_zero cardinal.{u} := ⟨#(ulift (fin 0))⟩
 
 instance : inhabited cardinal.{u} := ⟨0⟩
 
 lemma mk_eq_zero (α : Type u) [is_empty α] : #α = 0 :=
-(equiv.equiv_pempty α).cardinal_eq
+  (equiv.equiv_of_is_empty α _).cardinal_eq
 
-@[simp] theorem lift_zero : lift 0 = 0 := mk_congr (equiv.equiv_pempty _)
+@[simp] theorem lift_zero : lift 0 = 0 := mk_congr (equiv.equiv_of_is_empty _ _)
 
 @[simp] theorem lift_eq_zero {a : cardinal.{v}} : lift.{u} a = 0 ↔ a = 0 :=
 lift_injective.eq_iff' lift_zero
@@ -287,12 +287,12 @@ theorem mk_ne_zero_iff {α : Type u} : #α ≠ 0 ↔ nonempty α :=
 
 @[simp] lemma mk_ne_zero (α : Type u) [nonempty α] : #α ≠ 0 := mk_ne_zero_iff.2 ‹_›
 
-instance : has_one cardinal.{u} := ⟨lift #(fin 1)⟩
+instance : has_one cardinal.{u} := ⟨#(ulift (fin 1))⟩
 
 instance : nontrivial cardinal.{u} := ⟨⟨1, 0, mk_ne_zero _⟩⟩
 
 lemma mk_eq_one (α : Type u) [unique α] : #α = 1 :=
-(equiv.equiv_punit α).cardinal_eq
+(equiv.equiv_of_unique α _).cardinal_eq
 
 theorem le_one_iff_subsingleton {α : Type u} : #α ≤ 1 ↔ subsingleton α :=
 ⟨λ ⟨f⟩, ⟨λ a b, f.injective (subsingleton.elim _ _)⟩,

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -365,7 +365,8 @@ theorem power_add {a b c : cardinal} : a ^ (b + c) = a ^ b * a ^ c :=
 induction_on₃ a b c $ λ α β γ, mk_congr $ equiv.sum_arrow_equiv_prod_arrow β γ α
 
 instance : comm_semiring cardinal.{u} :=
-{ zero          := 0,
+{ nat_cast := coe,
+  zero          := 0,
   one           := 1,
   add           := (+),
   mul           := (*),

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -307,7 +307,7 @@ instance : has_add cardinal.{u} := ⟨map₂ sum $ λ α β γ δ, equiv.sum_con
 
 theorem add_def (α β : Type u) : #α + #β = #(α ⊕ β) := rfl
 
-instance : has_nat_cast cardinal.{u} := ⟨λ n, lift #(fin n)⟩
+instance : has_nat_cast cardinal.{u} := ⟨λ n, #(ulift (fin n))⟩
 
 @[simp] lemma mk_sum (α : Type u) (β : Type v) :
   #(α ⊕ β) = lift.{v u} (#α) + lift.{u v} (#β) :=


### PR DESCRIPTION
This is a test if changing the definition of `nat_cast` for `cardinal` would cause any problems. This would help porting this file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
