### PR TITLE
[Merged by Bors] - refactor(topology/discrete_quotient): review API

### DIFF
--- a/src/topology/category/Profinite/as_limit.lean
+++ b/src/topology/category/Profinite/as_limit.lean
@@ -40,7 +40,7 @@ variables (X : Profinite.{u})
 
 /-- The functor `discrete_quotient X ⥤ Fintype` whose limit is isomorphic to `X`. -/
 def fintype_diagram : discrete_quotient X ⥤ Fintype :=
-{ obj := λ S, Fintype.of S,
+{ obj := λ S, by haveI := fintype.of_finite S; exact Fintype.of S,
   map := λ S T f, discrete_quotient.of_le f.le }
 
 /-- An abbreviation for `X.fintype_diagram ⋙ Fintype_to_Profinite`. -/
@@ -56,9 +56,8 @@ instance is_iso_as_limit_cone_lift :
   is_iso ((limit_cone_is_limit X.diagram).lift X.as_limit_cone) :=
 is_iso_of_bijective _
 begin
-  refine ⟨λ a b, _, λ a, _⟩,
-  { intro h,
-    refine discrete_quotient.eq_of_proj_eq (λ S, _),
+  refine ⟨λ a b h, _, λ a, _⟩,
+  { refine discrete_quotient.eq_of_forall_proj_eq (λ S, _),
     apply_fun (λ f : (limit_cone X.diagram).X, f.val S) at h,
     exact h },
   { obtain ⟨b, hb⟩ := discrete_quotient.exists_of_compat

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -678,6 +678,10 @@ eq_of_subset_of_subset
     (set.mem_of_mem_of_subset mem_connected_component
       (is_connected_connected_component.subset_connected_component h)))
 
+theorem connected_component_eq_iff_mem {x y : α} :
+  connected_component x = connected_component y ↔ x ∈ connected_component y :=
+⟨λ h, h ▸ mem_connected_component, λ h, (connected_component_eq h).symm⟩
+
 lemma connected_component_in_eq {x y : α} {F : set α} (h : y ∈ connected_component_in F x) :
   connected_component_in F x = connected_component_in F y :=
 begin
@@ -1168,6 +1172,14 @@ begin
                 λ ⟨V, ⟨hV, hxV, _⟩, hVU⟩, mem_nhds_iff.mpr ⟨V, hVU, hV, hxV⟩⟩⟩ }
 end
 
+/-- A space with discrete topology is a locally connected space. -/
+@[priority 100]
+instance discrete_topology.to_locally_connected_space (α) [topological_space α]
+  [discrete_topology α] : locally_connected_space α :=
+locally_connected_space_iff_open_connected_subsets.2 $ λ x _U hU,
+  ⟨{x}, singleton_subset_iff.2 $ mem_of_mem_nhds hU, is_open_discrete _, mem_singleton _,
+    is_connected_singleton⟩
+
 lemma connected_component_in_mem_nhds [locally_connected_space α] {F : set α} {x : α}
   (h : F ∈ 𝓝 x) :
   connected_component_in F x ∈ 𝓝 x :=
@@ -1353,6 +1365,10 @@ begin
   exact mem_connected_component
 end
 
+@[simp] theorem connected_component_eq_singleton [totally_disconnected_space α] (x : α) :
+  connected_component x = {x} :=
+totally_disconnected_space_iff_connected_component_singleton.1 ‹_› x
+
 /-- The image of a connected component in a totally disconnected space is a singleton. -/
 @[simp] lemma continuous.image_connected_component_eq_singleton {β : Type*} [topological_space β]
   [totally_disconnected_space β] {f : α → β} (h : continuous f) (a : α) :
@@ -1463,7 +1479,7 @@ not_congr coe_eq_coe
 
 lemma coe_eq_coe' {x y : α} :
   (x : connected_components α) = y ↔ x ∈ connected_component y :=
-coe_eq_coe.trans ⟨λ h, h ▸ mem_connected_component, λ h, (connected_component_eq h).symm⟩
+coe_eq_coe.trans connected_component_eq_iff_mem
 
 instance [inhabited α] : inhabited (connected_components α) := ⟨↑(default : α)⟩
 

--- a/src/topology/discrete_quotient.lean
+++ b/src/topology/discrete_quotient.lean
@@ -26,22 +26,31 @@ quotients as setoids whose equivalence classes are clopen.
   endowed with a `fintype` instance.
 
 ## Order structure
+
 The type `discrete_quotient X` is endowed with an instance of a `semilattice_inf` with `order_top`.
 The partial ordering `A ≤ B` mathematically means that `B.proj` factors through `A.proj`.
 The top element `⊤` is the trivial quotient, meaning that every element of `X` is collapsed
 to a point. Given `h : A ≤ B`, the map `A → B` is `discrete_quotient.of_le h`.
-Whenever `X` is discrete, the type `discrete_quotient X` is also endowed with an instance of a
-`semilattice_inf` with `order_bot`, where the bot element `⊥` is `X` itself.
 
-Given `f : X → Y` and `h : continuous f`, we define a predicate `le_comap h A B` for
-`A : discrete_quotient X` and `B : discrete_quotient Y`, asserting that `f` descends to `A → B`.
-If `cond : le_comap h A B`, the function `A → B` is obtained by `discrete_quotient.map cond`.
+Whenever `X` is a locally connected space, the type `discrete_quotient X` is also endowed with an
+instance of a `order_bot`, where the bot element `⊥` is given by the `connectedComponentSetoid`,
+i.e., `x ~ y` means that `x` and `y` belong to the same connected component. In particular, if `X`
+is a discrete topological space, then `x ~ y` is equivalent (propositionally, not definitionally) to
+`x = y`.
+
+Given `f : C(X, Y)`, we define a predicate `discrete_quotient.le_comap f A B` for `A :
+discrete_quotient X` and `B : discrete_quotient Y`, asserting that `f` descends to `A → B`.  If
+`cond : discrete_quotient.le_comap h A B`, the function `A → B` is obtained by
+`discrete_quotient.map f cond`.
 
 ## Theorems
+
 The two main results proved in this file are:
-1. `discrete_quotient.eq_of_proj_eq` which states that when `X` is compact, t2 and totally
-  disconnected, any two elements of `X` agree if their projections in `Q` agree for all
+
+1. `discrete_quotient.eq_of_forall_proj_eq` which states that when `X` is compact, T₂, and totally
+  disconnected, any two elements of `X` are equal if their projections in `Q` agree for all
   `Q : discrete_quotient X`.
+
 2. `discrete_quotient.exists_of_compat` which states that when `X` is compact, then any
   system of elements of `Q` as `Q : discrete_quotient X` varies, which is compatible with
   respect to `discrete_quotient.of_le`, must arise from some element of `X`.
@@ -51,49 +60,34 @@ The constructions in this file will be used to show that any profinite space is 
 of finite discrete spaces.
 -/
 
-variables (X : Type*) [topological_space X]
+open set function
+variables {α X Y Z : Type*} [topological_space X] [topological_space Y]
+  [topological_space Z]
 
 /-- The type of discrete quotients of a topological space. -/
 @[ext]
-structure discrete_quotient :=
-(rel : X → X → Prop)
-(equiv : equivalence rel)
-(clopen : ∀ x, is_clopen (set_of (rel x)))
+structure discrete_quotient (X : Type*) [topological_space X]  extends setoid X :=
+(is_open_set_of_rel : ∀ x, is_open (set_of (to_setoid.rel x)))
 
 namespace discrete_quotient
 
-variables {X} (S : discrete_quotient X)
+variables (S : discrete_quotient X)
 
 /-- Construct a discrete quotient from a clopen set. -/
 def of_clopen {A : set X} (h : is_clopen A) : discrete_quotient X :=
-{ rel := λ x y, x ∈ A ∧ y ∈ A ∨ x ∉ A ∧ y ∉ A,
-  equiv := ⟨by tauto!, by tauto!, by tauto!⟩,
-  clopen := begin
-    intros x,
-    by_cases hx : x ∈ A,
-    { apply is_clopen.union,
-      { convert h,
-        ext,
-        exact ⟨λ i, i.2, λ i, ⟨hx,i⟩⟩ },
-      { convert is_clopen_empty,
-        tidy } },
-    { apply is_clopen.union,
-      { convert is_clopen_empty,
-        tidy },
-      { convert is_clopen.compl h,
-        ext,
-        exact ⟨λ i, i.2, λ i, ⟨hx, i⟩⟩ } },
-  end }
+{ to_setoid := ⟨λ x y, x ∈ A ↔ y ∈ A, λ _, iff.rfl, λ _ _, iff.symm, λ _ _ _, iff.trans⟩,
+  is_open_set_of_rel := λ x,
+    by by_cases hx : x ∈ A; simp [setoid.rel, hx, h.1, h.2, ← compl_set_of] }
 
-lemma refl : ∀ x : X, S.rel x x := S.equiv.1
-lemma symm : ∀ x y : X, S.rel x y → S.rel y x := S.equiv.2.1
-lemma trans : ∀ x y z : X, S.rel x y → S.rel y z → S.rel x z := S.equiv.2.2
+lemma refl : ∀ x, S.rel x x := S.refl'
+lemma symm {x y : X} : S.rel x y → S.rel y x := S.symm'
+lemma trans {x y z} : S.rel x y → S.rel y z → S.rel x z := S.trans'
 
 /-- The setoid whose quotient yields the discrete quotient. -/
-def setoid : setoid X := ⟨S.rel, S.equiv⟩
+add_decl_doc to_setoid
 
 instance : has_coe_to_sort (discrete_quotient X) Type* :=
-⟨λ S, quotient S.setoid⟩
+⟨λ S, quotient S.to_setoid⟩
 
 instance : topological_space S := quotient.topological_space
 
@@ -101,12 +95,7 @@ instance : topological_space S := quotient.topological_space
 def proj : X → S := quotient.mk'
 
 lemma fiber_eq (x : X) : S.proj ⁻¹' {S.proj x} = set_of (S.rel x) :=
-begin
-  ext1 y,
-  simp only [set.mem_preimage, set.mem_singleton_iff, quotient.eq',
-    discrete_quotient.proj.equations._eqn_1, set.mem_set_of_eq],
-  exact ⟨λ h, S.symm _ _ h, λ h, S.symm _ _ h⟩,
-end
+set.ext $ λ y, eq_comm.trans quotient.eq'
 
 lemma proj_surjective : function.surjective S.proj := quotient.surjective_quotient_mk'
 lemma proj_quotient_map : quotient_map S.proj := quotient_map_quot_mk
@@ -114,247 +103,224 @@ lemma proj_continuous : continuous S.proj := S.proj_quotient_map.continuous
 
 instance : discrete_topology S :=
 singletons_open_iff_discrete.1 $ S.proj_surjective.forall.2 $ λ x,
-  by { rw [← S.proj_quotient_map.is_open_preimage, fiber_eq], exact (S.clopen _).1 }
+  by { rw [← S.proj_quotient_map.is_open_preimage, fiber_eq], exact S.is_open_set_of_rel _ }
 
 lemma proj_is_locally_constant : is_locally_constant S.proj :=
 (is_locally_constant.iff_continuous S.proj).2 S.proj_continuous
 
-lemma fiber_clopen (A : set S) : is_clopen (S.proj ⁻¹' A) :=
+lemma is_clopen_preimage (A : set S) : is_clopen (S.proj ⁻¹' A) :=
 (is_clopen_discrete A).preimage S.proj_continuous
 
-lemma fiber_open (A : set S) : is_open (S.proj ⁻¹' A) := (S.fiber_clopen A).1
-lemma fiber_closed (A : set S) : is_closed (S.proj ⁻¹' A) := (S.fiber_clopen A).2
+lemma is_open_preimage (A : set S) : is_open (S.proj ⁻¹' A) := (S.is_clopen_preimage A).1
+lemma is_closed_preimage (A : set S) : is_closed (S.proj ⁻¹' A) := (S.is_clopen_preimage A).2
 
-instance : partial_order (discrete_quotient X) :=
-{ le := λ A B, ∀ x y : X, A.rel x y → B.rel x y,
-  le_refl := λ a, by tauto,
-  le_trans := λ a b c h1 h2, by tauto,
-  le_antisymm := λ a b h1 h2, by { ext, tauto } }
+theorem is_clopen_set_of_rel (x : X) : is_clopen (set_of (S.rel x)) :=
+by { rw [← fiber_eq], apply is_clopen_preimage }
 
-instance : order_top (discrete_quotient X) :=
-{ top := ⟨λ a b, true, ⟨by tauto, by tauto, by tauto⟩, λ _, is_clopen_univ⟩,
-  le_top := λ a, by tauto }
+instance : has_inf (discrete_quotient X) :=
+⟨λ S₁ S₂, ⟨S₁.1 ⊓ S₂.1, λ x, (S₁.2 x).inter (S₂.2 x)⟩⟩
 
 instance : semilattice_inf (discrete_quotient X) :=
-{ inf := λ A B,
-  { rel := λ x y, A.rel x y ∧ B.rel x y,
-    equiv := ⟨λ a, ⟨A.refl _,B.refl _⟩, λ a b h, ⟨A.symm _ _ h.1, B.symm _ _ h.2⟩,
-      λ a b c h1 h2, ⟨A.trans _ _ _ h1.1 h2.1, B.trans _ _ _ h1.2 h2.2⟩⟩,
-    clopen := λ x, is_clopen.inter (A.clopen _) (B.clopen _) },
-  inf_le_left := λ a b, by tauto,
-  inf_le_right := λ a b, by tauto,
-  le_inf := λ a b c h1 h2, by tauto,
-  ..discrete_quotient.partial_order }
+injective.semilattice_inf to_setoid ext (λ _ _, rfl)
+
+instance : order_top (discrete_quotient X) :=
+{ top := ⟨⊤, λ _, is_open_univ⟩,
+  le_top := λ a, by tauto }
 
 instance : inhabited (discrete_quotient X) := ⟨⊤⟩
 
+instance inhabited_quotient [inhabited X] : inhabited S := ⟨S.proj default⟩
+instance [nonempty X] : nonempty S := nonempty.map S.proj ‹_›
+
 section comap
 
-variables {Y : Type*} [topological_space Y] {f : Y → X} (cont : continuous f)
+variables (g : C(Y, Z)) (f : C(X, Y))
 
 /-- Comap a discrete quotient along a continuous map. -/
-def comap : discrete_quotient Y :=
-{ rel := λ a b, S.rel (f a) (f b),
-  equiv := ⟨λ a, S.refl _, λ a b h, S.symm _ _ h, λ a b c h1 h2, S.trans _ _ _ h1 h2⟩,
-  clopen := λ y, ⟨is_open.preimage cont (S.clopen _).1, is_closed.preimage cont (S.clopen _).2⟩ }
+def comap (S : discrete_quotient Y) : discrete_quotient X :=
+{ to_setoid := setoid.comap f S.1,
+  is_open_set_of_rel := λ y, (S.2 _).preimage f.continuous }
 
 @[simp]
-lemma comap_id : S.comap (continuous_id : continuous (id : X → X)) = S := by { ext, refl }
+lemma comap_id : S.comap (continuous_map.id X) = S := by { ext, refl }
 
 @[simp]
-lemma comap_comp {Z : Type*} [topological_space Z] {g : Z → Y} (cont' : continuous g) :
-  S.comap (continuous.comp cont cont') = (S.comap cont).comap cont' := by { ext, refl }
+lemma comap_comp (S : discrete_quotient Z) : S.comap (g.comp f) = (S.comap g).comap f := rfl
 
-lemma comap_mono {A B : discrete_quotient X} (h : A ≤ B) : A.comap cont ≤ B.comap cont :=
+@[mono]
+lemma comap_mono {A B : discrete_quotient Y} (h : A ≤ B) : A.comap f ≤ B.comap f :=
 by tauto
 
 end comap
 
 section of_le
 
+variables {A B C : discrete_quotient X}
+
 /-- The map induced by a refinement of a discrete quotient. -/
-def of_le {A B : discrete_quotient X} (h : A ≤ B) : A → B :=
-λ a, quotient.lift_on' a (λ x, B.proj x) (λ a b i, quotient.sound' (h _ _ i))
+def of_le (h : A ≤ B) : A → B := quotient.map' (λ x, x) h
 
-@[simp]
-lemma of_le_refl {A : discrete_quotient X} : of_le (le_refl A) = id := by { ext ⟨⟩, refl }
+@[simp] lemma of_le_refl : of_le (le_refl A) = id := by { ext ⟨⟩, refl }
 
-lemma of_le_refl_apply {A : discrete_quotient X} (a : A) : of_le (le_refl A) a = a := by simp
+lemma of_le_refl_apply (a : A) : of_le (le_refl A) a = a := by simp
 
-@[simp]
-lemma of_le_comp {A B C : discrete_quotient X} (h1 : A ≤ B) (h2 : B ≤ C) :
-  of_le (le_trans h1 h2) = of_le h2 ∘ of_le h1 := by { ext ⟨⟩, refl }
+@[simp] lemma of_le_of_le (h₁ : A ≤ B) (h₂ : B ≤ C) (x : A) :
+  of_le h₂ (of_le h₁ x) = of_le (h₁.trans h₂) x := by { rcases x with ⟨⟩, refl }
 
-lemma of_le_comp_apply {A B C : discrete_quotient X} (h1 : A ≤ B) (h2 : B ≤ C) (a : A) :
-  of_le (le_trans h1 h2) a = of_le h2 (of_le h1 a) := by simp
+@[simp] lemma of_le_comp_of_le (h₁ : A ≤ B) (h₂ : B ≤ C) :
+  of_le h₂ ∘ of_le h₁ = of_le (le_trans h₁ h₂) :=
+funext $ of_le_of_le _ _
 
-lemma of_le_continuous {A B : discrete_quotient X} (h : A ≤ B) :
-  continuous (of_le h) := continuous_of_discrete_topology
+lemma of_le_continuous (h : A ≤ B) : continuous (of_le h) :=
+continuous_of_discrete_topology
 
-@[simp]
-lemma of_le_proj {A B : discrete_quotient X} (h : A ≤ B) :
-  of_le h ∘ A.proj = B.proj := by { ext, exact quotient.sound' (B.refl _) }
+@[simp] lemma of_le_proj (h : A ≤ B) (x : X) : of_le h (A.proj x) = B.proj x :=
+quotient.sound' (B.refl _)
 
-@[simp]
-lemma of_le_proj_apply {A B : discrete_quotient X} (h : A ≤ B) (x : X) :
-  of_le h (A.proj x) = B.proj x := by { change (of_le h ∘ A.proj) x = _, simp }
+@[simp] lemma of_le_comp_proj (h : A ≤ B) : of_le h ∘ A.proj = B.proj :=
+funext $ of_le_proj _
 
 end of_le
 
-/--
-When X is discrete, there is a `order_bot` instance on `discrete_quotient X`
+/-- When `X` is a locally connected space, there is an `order_bot` instance on
+`discrete_quotient X`. The bottom element is given by `connected_component_setoid X`
 -/
-instance [discrete_topology X] : order_bot (discrete_quotient X) :=
+instance [locally_connected_space X] : order_bot (discrete_quotient X) :=
 { bot :=
-  { rel := (=),
-    equiv := eq_equivalence,
-    clopen := λ x, is_clopen_discrete _ },
-  bot_le := by { rintro S a b (h : a = b), rw h, exact S.refl _ } }
+  { to_setoid := connected_component_setoid X,
+    is_open_set_of_rel := λ x,
+      begin
+        have : connected_component x = {y | (connected_component_setoid X).rel x y},
+        { ext y,
+          simpa only [connected_component_setoid, ← connected_component_eq_iff_mem] using eq_comm },
+        rw [← this],
+        exact is_open_connected_component
+      end },
+  bot_le := λ S x y (h : connected_component x = connected_component y),
+    (S.is_clopen_set_of_rel x).connected_component_subset (S.refl _) $ h.symm ▸ mem_connected_component }
 
-lemma proj_bot_injective [discrete_topology X] :
-  function.injective (⊥ : discrete_quotient X).proj := λ a b h, quotient.exact' h
+@[simp] theorem proj_bot_eq [locally_connected_space X] {x y : X} :
+  proj ⊥ x = proj ⊥ y ↔ connected_component x = connected_component y :=
+quotient.eq'
 
-lemma proj_bot_bijective [discrete_topology X] :
-  function.bijective (⊥ : discrete_quotient X).proj := ⟨proj_bot_injective, proj_surjective _⟩
+theorem proj_bot_inj [discrete_topology X] {x y : X} :
+  proj ⊥ x = proj ⊥ y ↔ x = y := by simp
+
+theorem proj_bot_injective [discrete_topology X] :
+  injective (⊥ : discrete_quotient X).proj := λ _ _, proj_bot_inj.1
+
+theorem proj_bot_bijective [discrete_topology X] :
+  bijective (⊥ : discrete_quotient X).proj :=
+⟨proj_bot_injective, proj_surjective _⟩
 
 section map
 
-variables {Y : Type*} [topological_space Y] {f : Y → X}
-  (cont : continuous f) (A : discrete_quotient Y) (B : discrete_quotient X)
+variables (f : C(X, Y)) (A A' : discrete_quotient X) (B B' : discrete_quotient Y)
 
-/--
-Given `cont : continuous f`, `le_comap cont A B` is defined as `A ≤ B.comap f`.
-Mathematically this means that `f` descends to a morphism `A → B`.
--/
-def le_comap : Prop := A ≤ B.comap cont
+/-- Given `f : C(X, Y)`, `le_comap cont A B` is defined as `A ≤ B.comap f`. Mathematically this
+means that `f` descends to a morphism `A → B`. -/
+def le_comap : Prop := A ≤ B.comap f
 
-variables {cont A B}
+theorem le_comap_id : le_comap (continuous_map.id X) A A := λ _ _, id
 
-lemma le_comap_id (A : discrete_quotient X) : le_comap continuous_id A A := by tauto
+variables {A A' B B'} {f} {g : C(Y, Z)} {C : discrete_quotient Z}
 
-lemma le_comap_comp {Z : Type*} [topological_space Z] {g : Z → Y} {cont' : continuous g}
-  {C : discrete_quotient Z} : le_comap cont' C A → le_comap cont A B →
-  le_comap (continuous.comp cont cont') C B := by tauto
+@[simp] theorem le_comap_id_iff : le_comap (continuous_map.id X) A A' ↔ A ≤ A' := iff.rfl
 
-lemma le_comap_trans {C : discrete_quotient X} :
-  le_comap cont A B → B ≤ C → le_comap cont A C := λ h1 h2, le_trans h1 $ comap_mono _ h2
+theorem le_comap.comp :
+  le_comap g B C → le_comap f A B → le_comap (g.comp f) A C := by tauto
+
+theorem le_comap.mono (h : le_comap f A B) (hA : A' ≤ A) (hB : B ≤ B') : le_comap f A' B' :=
+  hA.trans $ le_trans h $ comap_mono _ hB
 
 /-- Map a discrete quotient along a continuous map. -/
-def map (cond : le_comap cont A B) : A → B := quotient.map' f cond
+def map (f : C(X, Y)) (cond : le_comap f A B) : A → B := quotient.map' f cond
 
-lemma map_continuous (cond : le_comap cont A B) : continuous (map cond) :=
-continuous_of_discrete_topology
+theorem map_continuous (cond : le_comap f A B) : continuous (map f cond) :=
+  continuous_of_discrete_topology
 
-@[simp]
-lemma map_proj (cond : le_comap cont A B) : map cond ∘ A.proj = B.proj ∘ f := rfl
-
-@[simp]
-lemma map_proj_apply (cond : le_comap cont A B) (y : Y) : map cond (A.proj y) = B.proj (f y) := rfl
+@[simp] theorem map_comp_proj (cond : le_comap f A B) : map f cond ∘ A.proj = B.proj ∘ f := rfl
 
 @[simp]
-lemma map_id : map (le_comap_id A) = id := by { ext ⟨⟩, refl }
+theorem map_proj (cond : le_comap f A B) (x : X) : map f cond (A.proj x) = B.proj (f x) := rfl
 
-@[simp]
-lemma map_comp {Z : Type*} [topological_space Z] {g : Z → Y} {cont' : continuous g}
-  {C : discrete_quotient Z} (h1 : le_comap cont' C A) (h2 : le_comap cont A B) :
-  map (le_comap_comp h1 h2) = map h2 ∘ map h1 := by { ext ⟨⟩, refl }
+@[simp] theorem map_id : map _ (le_comap_id A) = id := by ext ⟨⟩; refl
 
-@[simp]
-lemma of_le_map {C : discrete_quotient X} (cond : le_comap cont A B) (h : B ≤ C) :
-   map (le_comap_trans cond h) = of_le h ∘ map cond := by { ext ⟨⟩, refl }
+@[simp] theorem map_comp (h1 : le_comap g B C) (h2 : le_comap f A B) :
+  map (g.comp f) (h1.comp h2) = map g h1 ∘ map f h2 :=
+by { ext ⟨⟩, refl }
 
-@[simp]
-lemma of_le_map_apply {C : discrete_quotient X} (cond : le_comap cont A B) (h : B ≤ C) (a : A) :
-  map (le_comap_trans cond h) a = of_le h (map cond a) := by { rcases a, refl }
+@[simp] theorem of_le_map (cond : le_comap f A B) (h : B ≤ B') (a : A) :
+  of_le h (map f cond a) = map f (cond.mono le_rfl h) a :=
+by { rcases a with ⟨⟩, refl }
 
-@[simp]
-lemma map_of_le {C : discrete_quotient Y} (cond : le_comap cont A B) (h : C ≤ A) :
-   map (le_trans h cond) = map cond ∘ of_le h := by { ext ⟨⟩, refl }
+@[simp] theorem of_le_comp_map (cond : le_comap f A B) (h : B ≤ B') :
+  of_le h ∘ map f cond = map f (cond.mono le_rfl h) :=
+funext $ of_le_map cond h
 
-@[simp]
-lemma map_of_le_apply {C : discrete_quotient Y} (cond : le_comap cont A B) (h : C ≤ A) (c : C) :
-  map (le_trans h cond) c = map cond (of_le h c) := by { rcases c, refl }
+@[simp] theorem map_of_le (cond : le_comap f A B) (h : A' ≤ A) (c : A') :
+  map f cond (of_le h c) = map f (cond.mono h le_rfl) c :=
+by { rcases c with ⟨⟩, refl }
+
+@[simp] theorem map_comp_of_le (cond : le_comap f A B) (h : A' ≤ A) :
+  map f cond ∘ of_le h =  map f (cond.mono h le_rfl) :=
+funext $ map_of_le cond h
 
 end map
 
-lemma eq_of_proj_eq [t2_space X] [compact_space X] [disc : totally_disconnected_space X]
-  {x y : X} : (∀ Q : discrete_quotient X, Q.proj x = Q.proj y) → x = y :=
+lemma eq_of_forall_proj_eq [t2_space X] [compact_space X] [disc : totally_disconnected_space X]
+  {x y : X} (h : ∀ Q : discrete_quotient X, Q.proj x = Q.proj y) : x = y :=
 begin
-  intro h,
-  change x ∈ ({y} : set X),
-  rw totally_disconnected_space_iff_connected_component_singleton at disc,
-  rw [← disc y, connected_component_eq_Inter_clopen],
-  rintros U ⟨⟨U, hU1, hU2⟩, rfl⟩,
-  replace h : _ ∨ _ := quotient.exact' (h (of_clopen hU1)),
-  tauto,
+  rw [← mem_singleton_iff, ← connected_component_eq_singleton, connected_component_eq_Inter_clopen,
+    mem_Inter],
+  rintro ⟨U, hU1, hU2⟩,
+  exact (quotient.exact' (h (of_clopen hU1))).mpr hU2
 end
 
-lemma fiber_le_of_le {A B : discrete_quotient X} (h : A ≤ B) (a : A) :
-  A.proj ⁻¹' {a} ≤ B.proj ⁻¹' {of_le h a} :=
+lemma fiber_subset_of_le {A B : discrete_quotient X} (h : A ≤ B) (a : A) :
+  A.proj ⁻¹' {a} ⊆ B.proj ⁻¹' {of_le h a} :=
 begin
-  induction a,
-  erw [fiber_eq, fiber_eq],
-  tidy,
+  rcases A.proj_surjective a with ⟨a, rfl⟩,
+  rw [fiber_eq, of_le_proj, fiber_eq],
+  exact λ _ h', h h'
 end
 
 lemma exists_of_compat [compact_space X] (Qs : Π (Q : discrete_quotient X), Q)
   (compat : ∀ (A B : discrete_quotient X) (h : A ≤ B), of_le h (Qs _) = Qs _) :
   ∃ x : X, ∀ Q : discrete_quotient X, Q.proj x = Qs _ :=
 begin
-  obtain ⟨x,hx⟩ := is_compact.nonempty_Inter_of_directed_nonempty_compact_closed
-    (λ (Q : discrete_quotient X), Q.proj ⁻¹' {Qs _}) (λ A B, _) (λ i, _)
-    (λ i,  (fiber_closed _ _).is_compact) (λ i, fiber_closed _ _),
+  obtain ⟨x,hx⟩ : (⋂ Q, proj Q ⁻¹' {Qs Q}).nonempty :=
+    is_compact.nonempty_Inter_of_directed_nonempty_compact_closed
+      (λ (Q : discrete_quotient X), Q.proj ⁻¹' {Qs _}) (directed_of_inf $ λ A B h, _)
+      (λ Q, (singleton_nonempty _).preimage Q.proj_surjective)
+      (λ i,  (is_closed_preimage _ _).is_compact) (λ i, is_closed_preimage _ _),
   { refine ⟨x, λ Q, _⟩,
     exact hx _ ⟨Q,rfl⟩ },
-  { refine ⟨A ⊓ B, λ a ha, _, λ a ha, _⟩,
-    { dsimp only,
-      erw ← compat (A ⊓ B) A inf_le_left,
-      exact fiber_le_of_le _ _ ha },
-    { dsimp only,
-      erw ← compat (A ⊓ B) B inf_le_right,
-      exact fiber_le_of_le _ _ ha } },
-  { obtain ⟨x,hx⟩ := i.proj_surjective (Qs i),
-    refine ⟨x,_⟩,
-    dsimp only,
-    rw [← hx, fiber_eq],
-    apply i.refl },
+  { rw [← compat _ _ h],
+    exact fiber_subset_of_le _ _ },
 end
 
-noncomputable instance [compact_space X] : fintype S :=
+instance [compact_space X] : finite S :=
 begin
-  have cond : is_compact (⊤ : set X) := is_compact_univ,
-  rw is_compact_iff_finite_subcover at cond,
-  have h := @cond S (λ s, S.proj ⁻¹' {s}) (λ s, fiber_open _ _)
-    (λ x hx, ⟨S.proj ⁻¹' {S.proj x}, ⟨S.proj x, rfl⟩, rfl⟩),
-  let T := classical.some h,
-  have hT := classical.some_spec h,
-  refine ⟨T,λ s, _⟩,
-  rcases S.proj_surjective s with ⟨x,rfl⟩,
-  rcases hT (by tauto : x ∈ ⊤) with ⟨j, ⟨j,rfl⟩, h1, ⟨hj, rfl⟩, h2⟩,
-  dsimp only at h2,
-  suffices : S.proj x = j, by rwa this,
-  rcases j with ⟨j⟩,
-  apply quotient.sound',
-  erw fiber_eq at h2,
-  exact S.symm _ _ h2
+  have : compact_space S := quotient.compact_space,
+  rwa [← is_compact_univ_iff, is_compact_iff_finite, finite_univ_iff] at this
 end
 
 end discrete_quotient
 
 namespace locally_constant
 
-variables {X} {α : Type*} (f : locally_constant X α)
+variables {X} (f : locally_constant X α)
 
 /-- Any locally constant function induces a discrete quotient. -/
 def discrete_quotient : discrete_quotient X :=
-{ rel := λ a b, f b = f a,
-  equiv := ⟨by tauto, by tauto, λ a b c h1 h2, by rw [h2, h1]⟩,
-  clopen := λ x, f.is_locally_constant.is_clopen_fiber _ }
+{ to_setoid := setoid.comap f ⊥,
+  is_open_set_of_rel := λ x, f.is_locally_constant _ }
 
 /-- The (locally constant) function from the discrete quotient associated to a locally constant
 function. -/
 def lift : locally_constant f.discrete_quotient α :=
-⟨λ a, quotient.lift_on' a f (λ a b h, h.symm), λ A, is_open_discrete _⟩
+⟨λ a, quotient.lift_on' a f (λ a b, id), λ A, is_open_discrete _⟩
 
 @[simp] lemma lift_comp_proj : f.lift ∘ f.discrete_quotient.proj = f := by { ext, refl }
 

--- a/src/topology/discrete_quotient.lean
+++ b/src/topology/discrete_quotient.lean
@@ -197,7 +197,8 @@ instance [locally_connected_space X] : order_bot (discrete_quotient X) :=
         exact is_open_connected_component
       end },
   bot_le := λ S x y (h : connected_component x = connected_component y),
-    (S.is_clopen_set_of_rel x).connected_component_subset (S.refl _) $ h.symm ▸ mem_connected_component }
+    (S.is_clopen_set_of_rel x).connected_component_subset (S.refl _) $
+      h.symm ▸ mem_connected_component }
 
 @[simp] theorem proj_bot_eq [locally_connected_space X] {x y : X} :
   proj ⊥ x = proj ⊥ y ↔ connected_component x = connected_component y :=


### PR DESCRIPTION
Backport various changes I made to the API while porting to Lean 4 in leanprover-community/mathlib4#2157.

* extend `setoid X`;
* require only that the fibers are open in the definition, prove that they are clopen;
* golf proofs, reuse lattice structure on `setoid`s;
* use bundled continuous maps for `comap`;
* swap LHS and RHS in some `simp` lemmas;
* generalize the `order_bot` instance from a discrete space to a locally connected space;
* prove that a discrete topological space is locally connected.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
