### PR TITLE
[Merged by Bors] - chore(topology/algebra/infinite_sum): correct argument explicitness

### DIFF
--- a/src/analysis/analytic/isolated_zeros.lean
+++ b/src/analysis/analytic/isolated_zeros.lean
@@ -58,7 +58,7 @@ begin
       from finset.sum_eq_zero (λ k hk, by simp [ha k (finset.mem_range.mp hk)]),
     have h2 : has_sum (λ m, z ^ (m + n) • a (m + n)) s,
       by simpa [h1] using (has_sum_nat_add_iff' n).mpr hs,
-    convert @has_sum.const_smul E ℕ 𝕜 _ _ _ _ _ _ _ (z⁻¹ ^ n) h2,
+    convert h2.const_smul (z⁻¹ ^ n),
     { field_simp [pow_add, smul_smul] },
     { simp only [inv_pow] } }
 end

--- a/src/analysis/analytic/isolated_zeros.lean
+++ b/src/analysis/analytic/isolated_zeros.lean
@@ -79,7 +79,7 @@ begin
   { have hxx : ∀ (n : ℕ), x⁻¹ * x ^ (n + 1) = x ^ n := λ n, by field_simp [h, pow_succ'],
     suffices : has_sum (λ n, x⁻¹ • x ^ (n + 1) • p.coeff (n + 1)) (x⁻¹ • (f (z₀ + x) - f z₀)),
     { simpa [dslope, slope, h, smul_smul, hxx] using this },
-    { simpa [hp0] using ((has_sum_nat_add_iff' 1).mpr hx).const_smul } }
+    { simpa [hp0] using ((has_sum_nat_add_iff' 1).mpr hx).const_smul x⁻¹ } }
 end
 
 lemma has_fpower_series_iterate_dslope_fslope (n : ℕ) (hp : has_fpower_series_at f p z₀) :

--- a/src/analysis/inner_product_space/l2_space.lean
+++ b/src/analysis/inner_product_space/l2_space.lean
@@ -186,7 +186,7 @@ protected def linear_isometry : lp G 2 →ₗᵢ[𝕜] E :=
   map_add' := λ f g, by simp only [tsum_add (hV.summable_of_lp f) (hV.summable_of_lp g),
     lp.coe_fn_add, pi.add_apply, linear_isometry.map_add],
   map_smul' := λ c f, by simpa only [linear_isometry.map_smul, pi.smul_apply, lp.coe_fn_smul]
-    using tsum_const_smul (hV.summable_of_lp f),
+    using tsum_const_smul c (hV.summable_of_lp f),
   norm_map' := λ f, begin
     classical, -- needed for lattice instance on `finset ι`, for `filter.at_top_ne_bot`
     have H : 0 < (2:ℝ≥0∞).to_real := by norm_num,

--- a/src/measure_theory/integral/circle_integral.lean
+++ b/src/measure_theory/integral/circle_integral.lean
@@ -532,7 +532,7 @@ begin
       using hf.norm.mul_continuous_on continuous_on_const },
   { refine eventually_of_forall (λ θ hθ, has_sum.const_smul _),
     simp only [smul_smul],
-    refine has_sum.smul_const _,
+    refine has_sum.smul_const _ _,
     have : ‖w / (circle_map c R θ - c)‖ < 1, by simpa [abs_of_pos hR] using hwR.2,
     convert (has_sum_geometric_of_norm_lt_1 this).mul_right _,
     simp [← sub_sub, ← mul_inv, sub_mul, div_mul_cancel _ (circle_map_ne_center hR.ne')] }

--- a/src/measure_theory/integral/circle_integral.lean
+++ b/src/measure_theory/integral/circle_integral.lean
@@ -547,7 +547,7 @@ lemma has_sum_cauchy_power_series_integral {f : ℂ → E} {c : ℂ} {R : ℝ} {
     ((2 * π * I : ℂ)⁻¹ • ∮ z in C(c, R), (z - (c + w))⁻¹ • f z) :=
 begin
   simp only [cauchy_power_series_apply],
-  exact (has_sum_two_pi_I_cauchy_power_series_integral hf hw).const_smul
+  exact (has_sum_two_pi_I_cauchy_power_series_integral hf hw).const_smul _
 end
 
 /-- For any circle integrable function `f`, the power series `cauchy_power_series f c R`, `R > 0`,

--- a/src/measure_theory/integral/circle_integral.lean
+++ b/src/measure_theory/integral/circle_integral.lean
@@ -530,7 +530,7 @@ begin
   { exact eventually_of_forall (λ _ _, (summable_geometric_of_lt_1 hwR.1 hwR.2).mul_left _) },
   { simpa only [tsum_mul_left, tsum_geometric_of_lt_1 hwR.1 hwR.2]
       using hf.norm.mul_continuous_on continuous_on_const },
-  { refine eventually_of_forall (λ θ hθ, has_sum.const_smul _),
+  { refine eventually_of_forall (λ θ hθ, has_sum.const_smul _ _),
     simp only [smul_smul],
     refine has_sum.smul_const _ _,
     have : ‖w / (circle_map c R θ - c)‖ < 1, by simpa [abs_of_pos hR] using hwR.2,

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -1061,7 +1061,7 @@ begin
   simp only [interval_integrable_iff, interval_integral_eq_integral_uIoc,
     ← ae_restrict_iff' measurable_set_uIoc] at *,
   exact (has_sum_integral_of_dominated_convergence bound hF_meas h_bound bound_summable
-    bound_integrable h_lim).const_smul
+    bound_integrable h_lim).const_smul _,
 end
 
 open topological_space

--- a/src/measure_theory/measure/vector_measure.lean
+++ b/src/measure_theory/measure/vector_measure.lean
@@ -256,7 +256,7 @@ def smul (r : R) (v : vector_measure α M) : vector_measure α M :=
 { measure_of' := r • v,
   empty' := by rw [pi.smul_apply, empty, smul_zero],
   not_measurable' := λ _ hi, by rw [pi.smul_apply, v.not_measurable hi, smul_zero],
-  m_Union' := λ _ hf₁ hf₂, has_sum.const_smul (v.m_Union hf₁ hf₂) }
+  m_Union' := λ _ hf₁ hf₂, has_sum.const_smul _ (v.m_Union hf₁ hf₂) }
 
 instance : has_smul R (vector_measure α M) := ⟨smul⟩
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -1084,10 +1084,10 @@ lemma has_sum.const_smul {a : α} (r : R) (hf : has_sum f a) : has_sum (λ z, r 
 hf.map (distrib_mul_action.to_add_monoid_hom α r) (continuous_const_smul r)
 
 lemma summable.const_smul (r : R) (hf : summable f) : summable (λ z, r • f z) :=
-hf.has_sum.const_smul.summable
+(hf.has_sum.const_smul r).summable
 
 lemma tsum_const_smul [t2_space α] (r : R) (hf : summable f) : ∑' z, r • f z = r • ∑' z, f z :=
-hf.has_sum.const_smul.tsum_eq
+(hf.has_sum.const_smul r).tsum_eq
 
 end const_smul
 
@@ -1102,10 +1102,10 @@ lemma has_sum.smul_const {r : R} (hf : has_sum f r) (a : α) : has_sum (λ z, f 
 hf.map ((smul_add_hom R α).flip a) (continuous_id.smul continuous_const)
 
 lemma summable.smul_const (hf : summable f) (a : α) : summable (λ z, f z • a) :=
-hf.has_sum.smul_const.summable
+(hf.has_sum.smul_const a).summable
 
 lemma tsum_smul_const [t2_space α] (hf : summable f) (a : α) : ∑' z, f z • a = (∑' z, f z) • a :=
-hf.has_sum.smul_const.tsum_eq
+(hf.has_sum.smul_const a).tsum_eq
 
 end smul_const
 

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -1080,13 +1080,13 @@ variables {R : Type*}
 [distrib_mul_action R α] [has_continuous_const_smul R α]
 {f : β → α}
 
-lemma has_sum.const_smul {a : α} {r : R} (hf : has_sum f a) : has_sum (λ z, r • f z) (r • a) :=
+lemma has_sum.const_smul {a : α} (r : R) (hf : has_sum f a) : has_sum (λ z, r • f z) (r • a) :=
 hf.map (distrib_mul_action.to_add_monoid_hom α r) (continuous_const_smul r)
 
-lemma summable.const_smul {r : R} (hf : summable f) : summable (λ z, r • f z) :=
+lemma summable.const_smul (r : R) (hf : summable f) : summable (λ z, r • f z) :=
 hf.has_sum.const_smul.summable
 
-lemma tsum_const_smul [t2_space α] {r : R} (hf : summable f) : ∑' z, r • f z = r • ∑' z, f z :=
+lemma tsum_const_smul [t2_space α] (r : R) (hf : summable f) : ∑' z, r • f z = r • ∑' z, f z :=
 hf.has_sum.const_smul.tsum_eq
 
 end const_smul
@@ -1098,13 +1098,13 @@ variables {R : Type*}
 [module R α] [has_continuous_smul R α]
 {f : β → R}
 
-lemma has_sum.smul_const {a : α} {r : R} (hf : has_sum f r) : has_sum (λ z, f z • a) (r • a) :=
+lemma has_sum.smul_const {r : R} (hf : has_sum f r) (a : α) : has_sum (λ z, f z • a) (r • a) :=
 hf.map ((smul_add_hom R α).flip a) (continuous_id.smul continuous_const)
 
-lemma summable.smul_const {a : α} (hf : summable f) : summable (λ z, f z • a) :=
+lemma summable.smul_const (hf : summable f) (a : α) : summable (λ z, f z • a) :=
 hf.has_sum.smul_const.summable
 
-lemma tsum_smul_const [t2_space α] {a : α} (hf : summable f) : ∑' z, f z • a = (∑' z, f z) • a :=
+lemma tsum_smul_const [t2_space α] (hf : summable f) (a : α) : ∑' z, f z • a = (∑' z, f z) • a :=
 hf.has_sum.smul_const.tsum_eq
 
 end smul_const


### PR DESCRIPTION
It is quite annoying to use the current `const_smul` and `smul_const`, because Lean often can't even infer the type of this implicit argument.

There was one existing place in mathlib where this became really painful (the `@` in the diff), and there are a couple more in one of my branches.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
