### PR TITLE
feat(order/rel_iso/basic): add `rel_covering`, main defs only

### DIFF
--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -587,9 +587,9 @@ lemma iso_eq_iso_refl {x : simplex_category} (e : x ≅ x) :
 begin
   have h : (finset.univ : finset (fin (x.len+1))).card = x.len+1 := finset.card_fin (x.len+1),
   have eq₁ := finset.order_emb_of_fin_unique' h
-    (λ i, finset.mem_univ ((order_iso_of_iso e) i)),
+    (λ i, finset.mem_univ ((order_iso_of_iso e).to_order_embedding i)),
   have eq₂ := finset.order_emb_of_fin_unique' h
-    (λ i, finset.mem_univ ((order_iso_of_iso (iso.refl x)) i)),
+    (λ i, finset.mem_univ ((order_iso_of_iso (iso.refl x)).to_order_embedding i)),
   ext1, ext1,
   convert congr_arg (λ φ, (order_embedding.to_order_hom φ)) (eq₁.trans eq₂.symm),
   ext1, ext1 i,

--- a/src/order/antichain.lean
+++ b/src/order/antichain.lean
@@ -111,11 +111,11 @@ lemma preimage_rel_embedding {t : set β} (ht : is_antichain r' t) (φ : r ↪r 
 λ a ha a' ha' hne hle, ht ha ha' (λ h, hne (φ.injective h)) (φ.map_rel_iff.mpr hle)
 
 lemma image_rel_iso (hs : is_antichain r s) (φ : r ≃r r') : is_antichain r' (φ '' s) :=
-hs.image_rel_embedding φ
+hs.image_rel_embedding φ.to_rel_embedding
 
 lemma preimage_rel_iso {t : set β} (hs : is_antichain r' t) (φ : r ≃r r') :
   is_antichain r (φ ⁻¹' t) :=
-hs.preimage_rel_embedding φ
+hs.preimage_rel_embedding φ.to_rel_embedding
 
 lemma image_rel_embedding_iff {φ : r ↪r r'} : is_antichain r' (φ '' s) ↔ is_antichain r s :=
 ⟨λ h, (φ.injective.preimage_image s).subst (h.preimage_rel_embedding φ),
@@ -138,15 +138,15 @@ image_rel_embedding_iff
 
 lemma image_iso [has_le α] [has_le β] (hs : is_antichain (≤) s) (φ : α ≃o β) :
   is_antichain (≤) (φ '' s) :=
-image_rel_embedding hs _
+image_rel_iso hs _
 
 lemma image_iso_iff [has_le α] [has_le β] {φ : α ≃o β} :
   is_antichain (≤) (φ '' s) ↔ is_antichain (≤) s :=
-image_rel_embedding_iff
+image_rel_iso_iff
 
 lemma preimage_iso [has_le α] [has_le β] {t : set β} (ht : is_antichain (≤) t) (φ : α ≃o β) :
   is_antichain (≤) (φ ⁻¹' t) :=
-preimage_rel_embedding ht _
+preimage_rel_iso ht _
 
 lemma preimage_iso_iff [has_le α] [has_le β] {t : set β} {φ : α ≃o β} :
   is_antichain (≤) (φ ⁻¹' t) ↔ is_antichain (≤) t :=

--- a/src/order/rel_iso/basic.lean
+++ b/src/order/rel_iso/basic.lean
@@ -20,6 +20,8 @@ isomorphisms.
 
 * `rel_hom`: Relation homomorphism. A `rel_hom r s` is a function `f : α → β` such that
   `r a b → s (f a) (f b)`.
+* `rel_covering`: Relation covering. A `rel_covering r s` is a surjective function `f : α → β` such
+  that `r a b ↔ s (f a) (f b)`.
 * `rel_embedding`: Relation embedding. A `rel_embedding r s` is an embedding `f : α ↪ β` such that
   `r a b ↔ s (f a) (f b)`.
 * `rel_iso`: Relation isomorphism. A `rel_iso r s` is an equivalence `f : α ≃ β` such that
@@ -140,7 +142,7 @@ end rel_hom
 
 -- TODO: Do we need bundled surjective function?
 /-- A relation covering with respect to a given pair of relations `r` and `s`
-is an surjective function `f : α → β` such that `r a b ↔ s (f a) (f b)`. -/
+is a surjective function `f : α → β` such that `r a b ↔ s (f a) (f b)`. -/
 @[nolint has_nonempty_instance]
 structure rel_covering {α β : Type*} (r : α → α → Prop) (s : β → β → Prop) :=
 (to_fun : α → β)


### PR DESCRIPTION
`rel_covering` is the dual concept of `rel_embedding`. It preserves and reflects `is_irrefl` `is_asymm` `acc` `well_founded` between relations. An important example is `quotient.mk` between the relation and the `quotient.lift₂` of the relation.

See #18128 for more details.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
