### PR TITLE
[Merged by Bors] - chore(algebra/group_with_zero/units/lemmas): `div_div_cancel_left'`

### DIFF
--- a/src/algebra/group_with_zero/units/lemmas.lean
+++ b/src/algebra/group_with_zero/units/lemmas.lean
@@ -113,6 +113,8 @@ hb.is_unit.div_eq_div_iff hd.is_unit
 
 lemma div_div_cancel' (ha : a ≠ 0) : a / (a / b) = b := ha.is_unit.div_div_cancel
 
+lemma div_div_cancel_left' (ha : a ≠ 0) : a / b / a = b⁻¹ := ha.is_unit.div_div_cancel_left
+
 lemma div_helper (b : G₀) (h : a ≠ 0) : 1 / (a * b) * a = 1 / b :=
 by rw [div_mul_eq_mul_div, one_mul, div_mul_right _ h]
 

--- a/src/algebra/hom/units.lean
+++ b/src/algebra/hom/units.lean
@@ -318,9 +318,9 @@ by rw [←(hb.mul hd).mul_left_inj, ←mul_assoc, hb.div_mul_cancel, ←mul_asso
 @[to_additive] protected lemma div_div_cancel (h : is_unit a) : a / (a / b) = b :=
 by rw [div_div_eq_mul_div, h.mul_div_cancel_left]
 
-@[to_additive] protected lemma div_div_cancel_left (ha : is_unit a) :
+@[to_additive] protected lemma div_div_cancel_left (h : is_unit a) :
   a / b / a = b⁻¹ :=
-by rw [div_eq_mul_inv, div_eq_mul_inv, mul_right_comm, ha.mul_inv_cancel, one_mul]
+by rw [div_eq_mul_inv, div_eq_mul_inv, mul_right_comm, h.mul_inv_cancel, one_mul]
 
 end division_comm_monoid
 end is_unit

--- a/src/algebra/hom/units.lean
+++ b/src/algebra/hom/units.lean
@@ -318,5 +318,9 @@ by rw [←(hb.mul hd).mul_left_inj, ←mul_assoc, hb.div_mul_cancel, ←mul_asso
 @[to_additive] protected lemma div_div_cancel (h : is_unit a) : a / (a / b) = b :=
 by rw [div_div_eq_mul_div, h.mul_div_cancel_left]
 
+@[to_additive] protected lemma div_div_cancel_left (ha : is_unit a) :
+  a / b / a = b⁻¹ :=
+by rw [div_eq_mul_inv, div_eq_mul_inv, mul_right_comm, ha.mul_inv_cancel, one_mul]
+
 end division_comm_monoid
 end is_unit


### PR DESCRIPTION
This is the `group_with_zero` version of `div_div_cancel_left`.

Forward-ported in https://github.com/leanprover-community/mathlib4/pull/2191

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
