### PR TITLE
[Merged by Bors] - chore(algebra/algebra/basic): missing lemmas about the `↑` spelling of `algebra_map`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -169,19 +169,37 @@ attribute [to_additive] coe_prod
 end comm_semiring_comm_semiring
 
 section field_nontrivial
-
 variables {R A : Type*} [field R] [comm_semiring A] [nontrivial A] [algebra R A]
 
 @[norm_cast, simp] lemma coe_inj {a b : R} : (↑a : A) = ↑b ↔ a = b :=
-⟨λ h, (algebra_map R A).injective h, by rintro rfl; refl⟩
+(algebra_map R A).injective.eq_iff
 
 @[norm_cast, simp] lemma lift_map_eq_zero_iff (a : R) : (↑a : A) = 0 ↔ a = 0 :=
-begin
-  rw (show (0 : A) = ↑(0 : R), from (map_zero (algebra_map R A)).symm),
-  norm_cast,
-end
+map_eq_zero_iff _ (algebra_map R A).injective
 
 end field_nontrivial
+
+section semifield_semidivision_ring
+variables {R : Type*} (A : Type*) [semifield R] [division_semiring A] [algebra R A]
+
+@[norm_cast, simp] lemma coe_inv (r : R) : ↑(r⁻¹) = ((↑r)⁻¹ : A) :=
+map_inv₀ (algebra_map R A) r
+
+@[norm_cast, simp] lemma coe_div (r s : R) : ↑(r / s) = (↑r / ↑s : A) :=
+map_div₀ (algebra_map R A) r s
+
+@[norm_cast, simp] lemma coe_zpow (r : R) (z : ℤ) : ↑(r ^ z) = (↑r ^ z : A) :=
+map_zpow₀ (algebra_map R A) r z
+
+end semifield_semidivision_ring
+
+section field_division_ring
+variables (R A : Type*) [field R] [division_ring A] [algebra R A]
+
+@[norm_cast] lemma coe_rat_cast (q : ℚ) : ↑(q : R) = (q : A) :=
+map_rat_cast (algebra_map R A) q
+
+end field_division_ring
 
 end algebra_map
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -182,13 +182,13 @@ end field_nontrivial
 section semifield_semidivision_ring
 variables {R : Type*} (A : Type*) [semifield R] [division_semiring A] [algebra R A]
 
-@[norm_cast, simp] lemma coe_inv (r : R) : ↑(r⁻¹) = ((↑r)⁻¹ : A) :=
+@[norm_cast] lemma coe_inv (r : R) : ↑(r⁻¹) = ((↑r)⁻¹ : A) :=
 map_inv₀ (algebra_map R A) r
 
-@[norm_cast, simp] lemma coe_div (r s : R) : ↑(r / s) = (↑r / ↑s : A) :=
+@[norm_cast] lemma coe_div (r s : R) : ↑(r / s) = (↑r / ↑s : A) :=
 map_div₀ (algebra_map R A) r s
 
-@[norm_cast, simp] lemma coe_zpow (r : R) (z : ℤ) : ↑(r ^ z) = (↑r ^ z : A) :=
+@[norm_cast] lemma coe_zpow (r : R) (z : ℤ) : ↑(r ^ z) = (↑r ^ z : A) :=
 map_zpow₀ (algebra_map R A) r z
 
 end semifield_semidivision_ring


### PR DESCRIPTION
This only really scratches the surface; in general we can't afford to have two different spellings here as it forces us to duplicate every result about `ring_hom`. A previously refactor (#17048) made these lemmas unecessary, but it was reverted to aid with the port. Since these lemmas are needed in mathlib3 PRs, lets have them anyway.

For consistency with the existing `algebra_map.coe_mul` etc, these are not `simp` lemmas.
Making them `simp` lemmas makes a bunch of downstream `simp` lemmas redundant; so perhaps worth exploring in a future PR.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
