### PR TITLE
[Merged by Bors] - chore(data/finset/sym): fix a typo

### DIFF
--- a/src/data/finset/sym.lean
+++ b/src/data/finset/sym.lean
@@ -141,9 +141,9 @@ end
 @[simp] lemma sym_nonempty : (s.sym n).nonempty ↔ n = 0 ∨ s.nonempty :=
 by simp_rw [nonempty_iff_ne_empty, ne.def, sym_eq_empty, not_and_distrib, not_ne_iff]
 
-alias sym2_nonempty ↔ _ nonempty.sym2
+alias sym_nonempty ↔ _ nonempty.sym
 
-attribute [protected] nonempty.sym2
+attribute [protected] nonempty.sym
 
 @[simp] lemma sym_univ [fintype α] (n : ℕ) : (univ : finset α).sym n = univ :=
 eq_univ_iff_forall.2 $ λ s, mem_sym_iff.2 $ λ a _, mem_univ _


### PR DESCRIPTION
During the port of this file to mathlib4 (see https://github.com/leanprover-community/mathlib4/pull/2168#), it was noticed that the same alias was declared twice. Looking at the code, it is clear that the second declaration is a typo that it is fixed in this PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
