### PR TITLE
[Merged by Bors] - chore(data/{multiset,finset}/pi): generalize from `Type` to `Sort`

### DIFF
--- a/src/data/finset/pi.lean
+++ b/src/data/finset/pi.lean
@@ -25,18 +25,18 @@ satisfied. -/
 def pi.empty (β : α → Sort*) (a : α) (h : a ∈ (∅ : finset α)) : β a :=
 multiset.pi.empty β a h
 
-variables {δ : α → Type*} [decidable_eq α]
+variables {β : α → Type*} {δ : α → Sort*} [decidable_eq α]
 
 /-- Given a finset `s` of `α` and for all `a : α` a finset `t a` of `δ a`, then one can define the
 finset `s.pi t` of all functions defined on elements of `s` taking values in `t a` for `a ∈ s`.
 Note that the elements of `s.pi t` are only partially defined, on `s`. -/
-def pi (s : finset α) (t : Πa, finset (δ a)) : finset (Πa∈s, δ a) :=
+def pi (s : finset α) (t : Πa, finset (β a)) : finset (Πa∈s, β a) :=
 ⟨s.1.pi (λ a, (t a).1), s.nodup.pi $ λ a _, (t a).nodup⟩
 
-@[simp] lemma pi_val (s : finset α) (t : Πa, finset (δ a)) :
+@[simp] lemma pi_val (s : finset α) (t : Πa, finset (β a)) :
   (s.pi t).1 = s.1.pi (λ a, (t a).1) := rfl
 
-@[simp] lemma mem_pi {s : finset α} {t : Πa, finset (δ a)} {f : Πa∈s, δ a} :
+@[simp] lemma mem_pi {s : finset α} {t : Πa, finset (β a)} {f : Πa∈s, β a} :
   f ∈ s.pi t ↔ (∀a (h : a ∈ s), f a h ∈ t a) :=
 mem_pi _ _ _
 
@@ -68,11 +68,11 @@ assume e₁ e₂ eq,
   { rw [eq] },
   this
 
-@[simp] lemma pi_empty {t : Πa:α, finset (δ a)} :
-  pi (∅ : finset α) t = singleton (pi.empty δ) := rfl
+@[simp] lemma pi_empty {t : Πa:α, finset (β a)} :
+  pi (∅ : finset α) t = singleton (pi.empty β) := rfl
 
-@[simp] lemma pi_insert [∀a, decidable_eq (δ a)]
-  {s : finset α} {t : Πa:α, finset (δ a)} {a : α} (ha : a ∉ s) :
+@[simp] lemma pi_insert [∀a, decidable_eq (β a)]
+  {s : finset α} {t : Πa:α, finset (β a)} {a : α} (ha : a ∉ s) :
   pi (insert a s) t = (t a).bUnion (λb, (pi s t).image (pi.cons s a b)) :=
 begin
   apply eq_of_veq,
@@ -83,7 +83,8 @@ begin
       λ f a' h', multiset.pi.cons s.1 a b f a' (h ▸ h')))) _ (insert_val_of_not_mem ha),
   subst s', rw pi_cons,
   congr, funext b,
-  exact ((pi s t).nodup.map $ multiset.pi_cons_injective ha).dedup.symm,
+  refine ((pi s t).nodup.map _).dedup.symm,
+  exact multiset.pi_cons_injective ha,
 end
 
 lemma pi_singletons {β : Type*} (s : finset α) (f : α → β) :
@@ -102,7 +103,7 @@ lemma pi_const_singleton {β : Type*} (s : finset α) (i : β) :
   s.pi (λ _, ({i} : finset β)) = {λ _ _, i} :=
 pi_singletons s (λ _, i)
 
-lemma pi_subset {s : finset α} (t₁ t₂ : Πa, finset (δ a)) (h : ∀ a ∈ s, t₁ a ⊆ t₂ a) :
+lemma pi_subset {s : finset α} (t₁ t₂ : Πa, finset (β a)) (h : ∀ a ∈ s, t₁ a ⊆ t₂ a) :
   s.pi t₁ ⊆ s.pi t₂ :=
 λ g hg, mem_pi.2 $ λ a ha, h a ha (mem_pi.mp hg a ha)
 

--- a/src/data/multiset/pi.lean
+++ b/src/data/multiset/pi.lean
@@ -20,9 +20,9 @@ open function
 
 /-- Given `δ : α → Type*`, `pi.empty δ` is the trivial dependent function out of the empty
 multiset. -/
-def pi.empty (δ : α → Type*) : (Πa∈(0:multiset α), δ a) .
+def pi.empty (δ : α → Sort*) : (Πa∈(0:multiset α), δ a) .
 
-variables [decidable_eq α] {δ : α → Type*}
+variables [decidable_eq α] {β : α → Type*} {δ : α → Sort*}
 
 /-- Given `δ : α → Type*`, a multiset `m` and a term `a`, as well as a term `b : δ a` and a
 function `f` such that `f a' : δ a'` for all `a'` in `m`, `pi.cons m a b f` is a function `g` such
@@ -51,8 +51,8 @@ begin
 end
 
 /-- `pi m t` constructs the Cartesian product over `t` indexed by `m`. -/
-def pi (m : multiset α) (t : Πa, multiset (δ a)) : multiset (Πa∈m, δ a) :=
-m.rec_on {pi.empty δ} (λa m (p : multiset (Πa∈m, δ a)), (t a).bind $ λb, p.map $ pi.cons m a b)
+def pi (m : multiset α) (t : Πa, multiset (β a)) : multiset (Πa∈m, β a) :=
+m.rec_on {pi.empty β} (λa m (p : multiset (Πa∈m, β a)), (t a).bind $ λb, p.map $ pi.cons m a b)
 begin
   intros a a' m n,
   by_cases eq : a = a',
@@ -67,9 +67,9 @@ begin
     exact pi.cons_swap eq }
 end
 
-@[simp] lemma pi_zero (t : Πa, multiset (δ a)) : pi 0 t = {pi.empty δ} := rfl
+@[simp] lemma pi_zero (t : Πa, multiset (β a)) : pi 0 t = {pi.empty β} := rfl
 
-@[simp] lemma pi_cons (m : multiset α) (t : Πa, multiset (δ a)) (a : α) :
+@[simp] lemma pi_cons (m : multiset α) (t : Πa, multiset (β a)) (a : α) :
   pi (a ::ₘ m) t = ((t a).bind $ λb, (pi m t).map $ pi.cons m a b) :=
 rec_on_cons a m
 
@@ -82,11 +82,11 @@ calc f₁ a' h' = pi.cons s a b f₁ a' this : by rw [pi.cons_ne this ne.symm]
   ... = pi.cons s a b f₂ a' this : by rw [eq]
   ... = f₂ a' h' : by rw [pi.cons_ne this ne.symm]
 
-lemma card_pi (m : multiset α) (t : Πa, multiset (δ a)) :
+lemma card_pi (m : multiset α) (t : Πa, multiset (β a)) :
   card (pi m t) = prod (m.map $ λa, card (t a)) :=
 multiset.induction_on m (by simp) (by simp [mul_comm] {contextual := tt})
 
-protected lemma nodup.pi {s : multiset α} {t : Π a, multiset (δ a)} :
+protected lemma nodup.pi {s : multiset α} {t : Π a, multiset (β a)} :
   nodup s → (∀a∈s, nodup (t a)) → nodup (pi s t) :=
 multiset.induction_on s (assume _ _, nodup_singleton _)
 begin
@@ -112,12 +112,12 @@ begin
   { rw [pi.cons_ne _ h] }
 end
 
-lemma mem_pi (m : multiset α) (t : Πa, multiset (δ a)) :
-  ∀f:Πa∈m, δ a, (f ∈ pi m t) ↔ (∀a (h : a ∈ m), f a h ∈ t a) :=
+lemma mem_pi (m : multiset α) (t : Πa, multiset (β a)) :
+  ∀f:Πa∈m, β a, (f ∈ pi m t) ↔ (∀a (h : a ∈ m), f a h ∈ t a) :=
 begin
   intro f,
   induction m using multiset.induction_on with a m ih,
-  { simpa using show f = pi.empty δ, by funext a ha; exact ha.elim },
+  { simpa using show f = pi.empty β, by funext a ha; exact ha.elim },
   simp_rw [pi_cons, mem_bind, mem_map, ih],
   split,
   { rintro ⟨b, hb, f', hf', rfl⟩ a' ha',


### PR DESCRIPTION
Everything in this file about `multiset.pi.cons` generalizes to `Sort`.
The parts of the file which don't generalize now use `β` instead.

This is motivated by #18417, though I do not know if supporting `Sort` is actually important there.

Forward-ported as https://github.com/leanprover-community/mathlib4/pull/2220

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
