### PR TITLE
[Merged by Bors] - feat(algebra/continued_fractions/*): add some API lemmas

### DIFF
--- a/src/algebra/continued_fractions/computation/approximation_corollaries.lean
+++ b/src/algebra/continued_fractions/computation/approximation_corollaries.lean
@@ -66,6 +66,14 @@ lemma of_convergents_eq_convergents' :
   (of v).convergents = (of v).convergents' :=
 @continued_fraction.convergents_eq_convergents'  _ _ (continued_fraction.of v)
 
+/--
+The recurrence relation for the `convergents` of the continued fraction expansion
+of an element `v` of `K` in terms of the convergents of the inverse of its fractional part.
+-/
+lemma convergents_succ (n : ℕ):
+  (of v).convergents (n + 1) = ⌊v⌋ + 1 / (of (int.fract v)⁻¹).convergents n :=
+by rw [of_convergents_eq_convergents', convergents'_succ, of_convergents_eq_convergents']
+
 section convergence
 /-!
 ### Convergence

--- a/src/algebra/continued_fractions/computation/basic.lean
+++ b/src/algebra/continued_fractions/computation/basic.lean
@@ -31,8 +31,7 @@ For an example, refer to `int_fract_pair.stream`.
 - `generalized_continued_fraction.int_fract_pair.stream`: computes the stream of integer and
   fractional parts of a given value as described in the summary.
 - `generalized_continued_fraction.of`: computes the generalised continued fraction of a value `v`.
-  In fact, it computes a regular continued fraction that terminates if and only if `v` is rational
-  (those proofs will be added in a future commit).
+  In fact, it computes a regular continued fraction that terminates if and only if `v` is rational.
 
 ## Implementation Notes
 

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -50,6 +50,8 @@ Here we state some lemmas that give us inversion rules and recurrences for the c
 stream of integer and fractional parts of a value.
 -/
 
+lemma stream_zero (v : K) : int_fract_pair.stream v 0 = some (int_fract_pair.of v) := rfl
+
 variable {n : ℕ}
 
 lemma stream_eq_none_of_fr_eq_zero {ifp_n : int_fract_pair K}

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -310,6 +310,38 @@ fractional part of `v`.
 lemma of_s_tail : (of v).s.tail = (of (fract v)⁻¹).s :=
 seq.ext $ λ n, seq.nth_tail (of v).s n ▸ of_s_succ v n
 
+#where
+
+variables (K) (n)
+
+/--
+If `a` is an integer, then the `convergents'` of its continued fraction expansion
+are all equal to `a`.
+-/
+lemma convergents'_of_int (a : ℤ) : (of (a : K)).convergents' n = a :=
+begin
+  induction n with n ih,
+  { simp only [zeroth_convergent'_eq_h, of_h_eq_floor, floor_int_cast], },
+  { rw [convergents', of_h_eq_floor, floor_int_cast, add_right_eq_self],
+    exact convergents'_aux_succ_none ((of_s_of_int K a).symm ▸ seq.nth_nil 0) _, }
+end
+
+variables {K} (v)
+
+/--
+The recurrence relation for the `convergents'` of the continued fraction expansion
+of an element `v` of `K` in terms of the convergents of the inverse of its fractional part.
+-/
+lemma convergents'_succ :
+  (of v).convergents' (n + 1) = ⌊v⌋ + 1 / (of (fract v)⁻¹).convergents' n :=
+begin
+  cases eq_or_ne (fract v) 0 with h h,
+  { obtain ⟨a, rfl⟩ : ∃ a : ℤ, v = a := ⟨⌊v⌋, eq_of_sub_eq_zero h⟩,
+    rw [convergents'_of_int, fract_int_cast, inv_zero, ← cast_zero,
+        convergents'_of_int, cast_zero, div_zero, add_zero, floor_int_cast], },
+  { rw [convergents', of_h_eq_floor, add_right_inj, convergents'_aux_succ_some (of_s_head h)],
+    exact congr_arg ((/) 1) (by rw [convergents', of_h_eq_floor, add_right_inj, of_s_tail]), }
+end
 
 end values
 end sequence

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -310,8 +310,6 @@ fractional part of `v`.
 lemma of_s_tail : (of v).s.tail = (of (fract v)⁻¹).s :=
 seq.ext $ λ n, seq.nth_tail (of v).s n ▸ of_s_succ v n
 
-#where
-
 variables (K) (n)
 
 /--

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -85,6 +85,26 @@ lemma succ_nth_stream_eq_some_iff {ifp_succ_n : int_fract_pair K} :
       ∧ int_fract_pair.of ifp_n.fr⁻¹ = ifp_succ_n :=
 by simp [int_fract_pair.stream, ite_eq_iff]
 
+/--
+An easier to use version of one direction of
+`generalized_continued_fraction.int_fract_pair.succ_nth_stream_eq_some_iff`.
+-/
+lemma stream_succ_of_some {p : int_fract_pair K}
+  (h : int_fract_pair.stream v n = some p) (h' : p.fr ≠ 0) :
+  int_fract_pair.stream v (n + 1) = some (int_fract_pair.of (p.fr)⁻¹) :=
+succ_nth_stream_eq_some_iff.mpr ⟨p, h, h', rfl⟩
+
+/--
+The stream of `int_fract_pair`s of an integer stops after the first term.
+-/
+lemma stream_succ_of_int (a : ℤ) (n : ℕ) : int_fract_pair.stream (a : K) (n + 1) = none :=
+begin
+  induction n with n ih,
+  { refine int_fract_pair.stream_eq_none_of_fr_eq_zero (int_fract_pair.stream_zero (a : K)) _,
+    simp only [int_fract_pair.of, int.fract_int_cast], },
+  { exact int_fract_pair.succ_nth_stream_eq_none_iff.mpr (or.inl ih), }
+end
+
 lemma exists_succ_nth_stream_of_fr_zero {ifp_succ_n : int_fract_pair K}
   (stream_succ_nth_eq : int_fract_pair.stream v (n + 1) = some ifp_succ_n)
   (succ_nth_fr_eq_zero : ifp_succ_n.fr = 0) :
@@ -96,6 +116,28 @@ begin
     ⟨ifp_n, seq_nth_eq, nth_fr_ne_zero, rfl⟩,
   refine ⟨ifp_n, seq_nth_eq, _⟩,
   simpa only [int_fract_pair.of, int.fract, sub_eq_zero] using succ_nth_fr_eq_zero
+end
+
+/--
+A recurrence relation that expresses the `(n+1)`th term of the stream of `int_fract_pair`s
+of `v` for non-integer `v` in terms of the `n`th term of the stream associated to
+the inverse of the fractional part of `v`.
+-/
+lemma stream_succ  (h : int.fract v ≠ 0) (n : ℕ) :
+  int_fract_pair.stream v (n + 1) = int_fract_pair.stream (int.fract v)⁻¹ n :=
+begin
+  induction n with n ih,
+  { have H : (int_fract_pair.of v).fr = int.fract v := rfl,
+    rw [stream_zero, stream_succ_of_some (stream_zero v) (ne_of_eq_of_ne H h), H], },
+  { cases eq_or_ne (int_fract_pair.stream (int.fract v)⁻¹ n) none with hnone hsome,
+    { rw hnone at ih,
+      rw [succ_nth_stream_eq_none_iff.mpr (or.inl hnone),
+          succ_nth_stream_eq_none_iff.mpr (or.inl ih)], },
+    { obtain ⟨p, hp⟩ := option.ne_none_iff_exists'.mp hsome,
+      rw hp at ih,
+      cases eq_or_ne p.fr 0 with hz hnz,
+      { rw [stream_eq_none_of_fr_eq_zero hp hz, stream_eq_none_of_fr_eq_zero ih hz], },
+      { rw [stream_succ_of_some hp hnz, stream_succ_of_some ih hnz], } } }
 end
 
 end int_fract_pair

--- a/src/algebra/continued_fractions/convergents_equiv.lean
+++ b/src/algebra/continued_fractions/convergents_equiv.lean
@@ -18,6 +18,7 @@ direct evaluation (`convergents'`)) for `gcf`s on linear ordered fields. We foll
 [hardy2008introduction], Chapter 10. Here's a sketch:
 
 Let `c` be a continued fraction `[h; (a₀, b₀), (a₁, b₁), (a₂, b₂),...]`, visually:
+
                                 a₀
                 h + ---------------------------
                                   a₁

--- a/src/algebra/continued_fractions/translations.lean
+++ b/src/algebra/continued_fractions/translations.lean
@@ -119,5 +119,13 @@ lemma zeroth_convergent'_aux_eq_zero {s : seq $ pair K} : convergents'_aux s 0 =
 @[simp]
 lemma zeroth_convergent'_eq_h : g.convergents' 0 = g.h := by simp [convergents']
 
+lemma convergents'_aux_succ_none {s : seq (pair K)} (h : s.head = none) (n : ℕ) :
+  convergents'_aux s (n + 1) = 0 :=
+by rw [convergents'_aux, h, convergents'_aux._match_1]
+
+lemma convergents'_aux_succ_some {s : seq (pair K)} {p : pair K} (h : s.head = some p) (n : ℕ) :
+  convergents'_aux s (n + 1) = p.a / (p.b + convergents'_aux s.tail n) :=
+by rw [convergents'_aux, h, convergents'_aux._match_1]
+
 end with_division_ring
 end generalized_continued_fraction


### PR DESCRIPTION
This PR adds some API lemmas to the continued fractions files, leading to the recurrence
```lean
lemma convergents_succ (v : K) (n : ℕ) :
  (of v).convergents (n + 1) = ⌊v⌋ + 1 / (of (int.fract v)⁻¹).convergents n
```
for the convergents of the continued fraction expansion of an element v of a linearly ordered floor field K.
(Here `of` is `generalized_continued_fraction.of`.)

This recurrence will then be used (in a later PR) for a proof of a theorem due to Legendre, which says that when x is a real number and p/q is a fraction such that |x - p/q| < 1/(2*q^2), then p/q is a convergent of the continued fraction expansion of x.

See [this thread on Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Diophantine.20approximation/near/327440641).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
