### PR TITLE
chore(measure_theory/function): make some arguments implicit

### DIFF
--- a/src/measure_theory/function/conditional_expectation/basic.lean
+++ b/src/measure_theory/function/conditional_expectation/basic.lean
@@ -1395,7 +1395,7 @@ section condexp_ind_L1_fin
 as a function in L1. -/
 def condexp_ind_L1_fin (hm : m ≤ m0) [sigma_finite (μ.trim hm)] (hs : measurable_set s)
   (hμs : μ s ≠ ∞) (x : G) : α →₁[μ] G :=
-(integrable_condexp_ind_smul hm hs hμs x).to_L1 _
+(integrable_condexp_ind_smul hm hs hμs x).to_L1
 
 lemma condexp_ind_L1_fin_ae_eq_condexp_ind_smul (hm : m ≤ m0) [sigma_finite (μ.trim hm)]
   (hs : measurable_set s) (hμs : μ s ≠ ∞) (x : G) :
@@ -1823,7 +1823,7 @@ lemma condexp_L1_undef (hf : ¬ integrable f μ) : condexp_L1 hm μ f = 0 :=
 set_to_fun_undef (dominated_fin_meas_additive_condexp_ind F' hm μ) hf
 
 lemma condexp_L1_eq (hf : integrable f μ) :
-  condexp_L1 hm μ f = condexp_L1_clm hm μ (hf.to_L1 f) :=
+  condexp_L1 hm μ f = condexp_L1_clm hm μ hf.to_L1 :=
 set_to_fun_eq (dominated_fin_meas_additive_condexp_ind F' hm μ) hf
 
 @[simp] lemma condexp_L1_zero : condexp_L1 hm μ (0 : α → F') = 0 :=
@@ -1857,7 +1857,7 @@ lemma set_integral_condexp_L1 (hf : integrable f μ) (hs : measurable_set[m] s) 
   ∫ x in s, condexp_L1 hm μ f x ∂μ = ∫ x in s, f x ∂μ :=
 begin
   simp_rw condexp_L1_eq hf,
-  rw set_integral_condexp_L1_clm (hf.to_L1 f) hs,
+  rw set_integral_condexp_L1_clm hf.to_L1 hs,
   exact set_integral_congr_ae (hm s hs) ((hf.coe_fn_to_L1).mono (λ x hx hxs, hx)),
 end
 
@@ -1972,7 +1972,7 @@ begin
 end
 
 lemma condexp_ae_eq_condexp_L1_clm (hm : m ≤ m0) [sigma_finite (μ.trim hm)] (hf : integrable f μ) :
-  μ[f|m] =ᵐ[μ] condexp_L1_clm hm μ (hf.to_L1 f) :=
+  μ[f|m] =ᵐ[μ] condexp_L1_clm hm μ hf.to_L1 :=
 begin
   refine (condexp_ae_eq_condexp_L1 hm f).trans (eventually_of_forall (λ x, _)),
   rw condexp_L1_eq hf,

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -13,7 +13,7 @@ In the first part of this file, the predicate `integrable` is defined and basic 
 integrable functions are proved.
 
 Such a predicate is already available under the name `mem_ℒp 1`. We give a direct definition which
-is easier to use, and show that it is equivalent to `mem_ℒp 1`
+is easier to use, and show that it is equivalent to `mem_ℒp 1`.
 
 In the second part, we establish an API between `integrable` and the space `L¹` of equivalence
 classes of integrable functions, already defined as a special case of `L^p` spaces for `p = 1`.
@@ -88,7 +88,7 @@ lemma lintegral_nnnorm_add_right
   ∫⁻ a, ‖f a‖₊ + ‖g a‖₊ ∂μ = ∫⁻ a, ‖f a‖₊ ∂μ + ∫⁻ a, ‖g a‖₊ ∂μ :=
 lintegral_add_right' _ hg.ennnorm
 
-lemma lintegral_nnnorm_neg {f : α → β} :
+lemma lintegral_nnnorm_neg (f : α → β) :
   ∫⁻ a, ‖(-f) a‖₊ ∂μ = ∫⁻ a, ‖f a‖₊ ∂μ :=
 by simp only [pi.neg_apply, nnnorm_neg]
 
@@ -210,7 +210,7 @@ have eq : (λa, (nnnorm ‖f a‖ : ℝ≥0∞)) = λa, (‖f a‖₊ : ℝ≥0�
   by { funext, rw nnnorm_norm },
 by { rwa [has_finite_integral, eq] }
 
-lemma has_finite_integral_norm_iff (f : α → β) :
+lemma has_finite_integral_norm_iff {f : α → β} :
   has_finite_integral (λa, ‖f a‖) μ ↔ has_finite_integral f μ :=
 has_finite_integral_congr' $ eventually_of_forall $ λ x, norm_norm (f x)
 
@@ -386,7 +386,6 @@ end normed_space
 
 /-! ### The predicate `integrable` -/
 
--- variables [measurable_space β] [measurable_space γ] [measurable_space δ]
 
 /-- `integrable f μ` means that `f` is measurable and that the integral `∫⁻ a, ‖f a‖ ∂μ` is finite.
   `integrable f` means `integrable f volume`. -/
@@ -467,7 +466,7 @@ end
 lemma integrable.mono_measure {f : α → β} (h : integrable f ν) (hμ : μ ≤ ν) : integrable f μ :=
 ⟨h.ae_strongly_measurable.mono_measure hμ, h.has_finite_integral.mono_measure hμ⟩
 
-lemma integrable.of_measure_le_smul {μ' : measure α} (c : ℝ≥0∞) (hc : c ≠ ∞)
+lemma integrable.of_measure_le_smul {μ' : measure α} {c : ℝ≥0∞} (hc : c ≠ ∞)
   (hμ'_le : μ' ≤ c • μ) {f : α → β} (hf : integrable f μ) :
   integrable f μ' :=
 by { rw ← mem_ℒp_one_iff_integrable at hf ⊢, exact hf.of_measure_le_smul c hc hμ'_le, }
@@ -1169,57 +1168,57 @@ namespace integrable
 
 /-- Construct the equivalence class `[f]` of an integrable function `f`, as a member of the
 space `L1 β 1 μ`. -/
-def to_L1 (f : α → β) (hf : integrable f μ) : α →₁[μ] β :=
+def to_L1 {f : α → β} (hf : integrable f μ) : α →₁[μ] β :=
 (mem_ℒp_one_iff_integrable.2 hf).to_Lp f
 
-@[simp] lemma to_L1_coe_fn (f : α →₁[μ] β) (hf : integrable f μ) : hf.to_L1 f = f :=
+@[simp] lemma to_L1_coe_fn (f : α →₁[μ] β) (hf : integrable f μ) : hf.to_L1 = f :=
 by simp [integrable.to_L1]
 
-lemma coe_fn_to_L1 {f : α → β} (hf : integrable f μ) : hf.to_L1 f =ᵐ[μ] f :=
+lemma coe_fn_to_L1 {f : α → β} (hf : integrable f μ) : hf.to_L1 =ᵐ[μ] f :=
 ae_eq_fun.coe_fn_mk _ _
 
-@[simp] lemma to_L1_zero (h : integrable (0 : α → β) μ) : h.to_L1 0 = 0 := rfl
+@[simp] lemma to_L1_zero (h : integrable (0 : α → β) μ) : h.to_L1 = 0 := rfl
 
-@[simp] lemma to_L1_eq_mk (f : α → β) (hf : integrable f μ) :
-  (hf.to_L1 f : α →ₘ[μ] β) = ae_eq_fun.mk f hf.ae_strongly_measurable :=
+@[simp] lemma to_L1_eq_mk {f : α → β} (hf : integrable f μ) :
+  (hf.to_L1 : α →ₘ[μ] β) = ae_eq_fun.mk f hf.ae_strongly_measurable :=
 rfl
 
-@[simp] lemma to_L1_eq_to_L1_iff (f g : α → β) (hf : integrable f μ) (hg : integrable g μ) :
-  to_L1 f hf = to_L1 g hg ↔ f =ᵐ[μ] g :=
+@[simp] lemma to_L1_eq_to_L1_iff {f g : α → β} (hf : integrable f μ) (hg : integrable g μ) :
+  to_L1 hf = to_L1 hg ↔ f =ᵐ[μ] g :=
 mem_ℒp.to_Lp_eq_to_Lp_iff _ _
 
-lemma to_L1_add (f g : α → β) (hf : integrable f μ) (hg : integrable g μ) :
-  to_L1 (f + g) (hf.add hg) = to_L1 f hf + to_L1 g hg := rfl
+lemma to_L1_add {f g : α → β} (hf : integrable f μ) (hg : integrable g μ) :
+  to_L1 (hf.add hg) = to_L1 hf + to_L1 hg := rfl
 
-lemma to_L1_neg (f : α → β) (hf : integrable f μ) :
-  to_L1 (- f) (integrable.neg hf) = - to_L1 f hf := rfl
+lemma to_L1_neg {f : α → β} (hf : integrable f μ) :
+  to_L1 (integrable.neg hf) = - to_L1 hf := rfl
 
-lemma to_L1_sub (f g : α → β) (hf : integrable f μ) (hg : integrable g μ) :
-  to_L1 (f - g) (hf.sub hg) = to_L1 f hf - to_L1 g hg := rfl
+lemma to_L1_sub {f g : α → β} (hf : integrable f μ) (hg : integrable g μ) :
+  to_L1 (hf.sub hg) = to_L1 hf - to_L1 hg := rfl
 
-lemma norm_to_L1 (f : α → β) (hf : integrable f μ) :
-  ‖hf.to_L1 f‖ = ennreal.to_real (∫⁻ a, edist (f a) 0 ∂μ) :=
+lemma norm_to_L1 {f : α → β} (hf : integrable f μ) :
+  ‖hf.to_L1‖ = ennreal.to_real (∫⁻ a, edist (f a) 0 ∂μ) :=
 by { simp [to_L1, snorm, snorm'], simp [edist_eq_coe_nnnorm] }
 
-lemma norm_to_L1_eq_lintegral_norm (f : α → β) (hf : integrable f μ) :
-  ‖hf.to_L1 f‖ = ennreal.to_real (∫⁻ a, (ennreal.of_real ‖f a‖) ∂μ) :=
+lemma norm_to_L1_eq_lintegral_norm {f : α → β} (hf : integrable f μ) :
+  ‖hf.to_L1‖ = ennreal.to_real (∫⁻ a, (ennreal.of_real ‖f a‖) ∂μ) :=
 by { rw [norm_to_L1, lintegral_norm_eq_lintegral_edist] }
 
-@[simp] lemma edist_to_L1_to_L1 (f g : α → β) (hf : integrable f μ) (hg : integrable g μ) :
-  edist (hf.to_L1 f) (hg.to_L1 g) = ∫⁻ a, edist (f a) (g a) ∂μ :=
+@[simp] lemma edist_to_L1_to_L1 {f g : α → β} (hf : integrable f μ) (hg : integrable g μ) :
+  edist hf.to_L1 hg.to_L1 = ∫⁻ a, edist (f a) (g a) ∂μ :=
 by { simp [integrable.to_L1, snorm, snorm'], simp [edist_eq_coe_nnnorm_sub] }
 
-@[simp] lemma edist_to_L1_zero (f : α → β) (hf : integrable f μ) :
-  edist (hf.to_L1 f) 0 = ∫⁻ a, edist (f a) 0 ∂μ :=
+@[simp] lemma edist_to_L1_zero {f : α → β} (hf : integrable f μ) :
+  edist hf.to_L1 0 = ∫⁻ a, edist (f a) 0 ∂μ :=
 by { simp [integrable.to_L1, snorm, snorm'], simp [edist_eq_coe_nnnorm] }
 
 variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β]
 
-lemma to_L1_smul (f : α → β) (hf : integrable f μ) (k : 𝕜) :
-  to_L1 (λ a, k • f a) (hf.smul k) = k • to_L1 f hf := rfl
+lemma to_L1_smul {f : α → β} (hf : integrable f μ) (k : 𝕜) :
+  to_L1 (hf.smul k : integrable (λ a, k • f a) μ) = k • to_L1 hf := rfl
 
-lemma to_L1_smul' (f : α → β) (hf : integrable f μ) (k : 𝕜) :
-  to_L1 (k • f) (hf.smul k) = k • to_L1 f hf := rfl
+lemma to_L1_smul' {f : α → β} (hf : integrable f μ) (k : 𝕜) :
+  to_L1 (hf.smul k : integrable (k • f) μ) = k • to_L1 hf := rfl
 
 end integrable
 

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -1171,7 +1171,7 @@ space `L1 β 1 μ`. -/
 def to_L1 {f : α → β} (hf : integrable f μ) : α →₁[μ] β :=
 (mem_ℒp_one_iff_integrable.2 hf).to_Lp f
 
-@[simp] lemma to_L1_coe_fn (f : α →₁[μ] β) (hf : integrable f μ) : hf.to_L1 = f :=
+@[simp] lemma to_L1_coe_fn {f : α →₁[μ] β} (hf : integrable f μ) : hf.to_L1 = f :=
 by simp [integrable.to_L1]
 
 lemma coe_fn_to_L1 {f : α → β} (hf : integrable f μ) : hf.to_L1 =ᵐ[μ] f :=

--- a/src/measure_theory/function/simple_func_dense_lp.lean
+++ b/src/measure_theory/function/simple_func_dense_lp.lean
@@ -900,7 +900,7 @@ section integrable
 notation α ` →₁ₛ[`:25 μ `] ` E := @measure_theory.Lp.simple_func α E _ _ 1 μ
 
 lemma L1.simple_func.to_Lp_one_eq_to_L1 (f : α →ₛ E) (hf : integrable f μ) :
-  (Lp.simple_func.to_Lp f (mem_ℒp_one_iff_integrable.2 hf) : α →₁[μ] E) = hf.to_L1 f :=
+  (Lp.simple_func.to_Lp f (mem_ℒp_one_iff_integrable.2 hf) : α →₁[μ] E) = hf.to_L1 :=
 rfl
 
 protected lemma L1.simple_func.integrable (f : α →₁ₛ[μ] E) :

--- a/src/measure_theory/integral/bochner.lean
+++ b/src/measure_theory/integral/bochner.lean
@@ -719,7 +719,7 @@ open_locale classical
 
 /-- The Bochner integral -/
 @[irreducible] def integral {m : measurable_space α} (μ : measure α) (f : α → E) : E :=
-if hf : integrable f μ then L1.integral (hf.to_L1 f) else 0
+if hf : integrable f μ then L1.integral hf.to_L1 else 0
 
 end
 
@@ -738,7 +738,7 @@ open continuous_linear_map measure_theory.simple_func
 variables {f g : α → E} {m : measurable_space α} {μ : measure α}
 
 lemma integral_eq (f : α → E) (hf : integrable f μ) :
-  ∫ a, f a ∂μ = L1.integral (hf.to_L1 f) :=
+  ∫ a, f a ∂μ = L1.integral hf.to_L1 :=
 by { rw [integral], exact @dif_pos _ (id _) hf _ _ _ }
 
 lemma integral_eq_set_to_fun (f : α → E) :
@@ -838,7 +838,7 @@ begin
 end
 
 @[simp] lemma L1.integral_of_fun_eq_integral {f : α → E} (hf : integrable f μ) :
-  ∫ a, (hf.to_L1 f) a ∂μ = ∫ a, f a ∂μ :=
+  ∫ a, hf.to_L1 a ∂μ = ∫ a, f a ∂μ :=
 begin
   simp only [integral, L1.integral],
   exact set_to_fun_to_L1 (dominated_fin_meas_additive_weighted_smul μ) hf
@@ -855,7 +855,7 @@ lemma norm_integral_le_lintegral_norm (f : α → E) :
   ‖∫ a, f a ∂μ‖ ≤ ennreal.to_real (∫⁻ a, (ennreal.of_real ‖f a‖) ∂μ) :=
 begin
   by_cases hf : integrable f μ,
-  { rw [integral_eq f hf, ← integrable.norm_to_L1_eq_lintegral_norm f hf],
+  { rw [integral_eq f hf, ← integrable.norm_to_L1_eq_lintegral_norm hf],
     exact L1.norm_integral_le _ },
   { rw [integral_undef hf, norm_zero], exact to_real_nonneg }
 end
@@ -1014,7 +1014,7 @@ lemma integral_eq_lintegral_pos_part_sub_lintegral_neg_part {f : α → ℝ} (hf
   ∫ a, f a ∂μ =
   ennreal.to_real (∫⁻ a, (ennreal.of_real $ f a) ∂μ) -
   ennreal.to_real (∫⁻ a, (ennreal.of_real $ - f a) ∂μ) :=
-let f₁ := hf.to_L1 f in
+let f₁ := hf.to_L1 in
 -- Go to the `L¹` space
 have eq₁ : ennreal.to_real (∫⁻ a, (ennreal.of_real $ f a) ∂μ) = ‖Lp.pos_part f₁‖ :=
 begin
@@ -1190,7 +1190,7 @@ begin
 end
 
 lemma L1.norm_of_fun_eq_integral_norm {f : α → H} (hf : integrable f μ) :
-  ‖hf.to_L1 f‖ = ∫ a, ‖f a‖ ∂μ :=
+  ‖hf.to_L1‖ = ∫ a, ‖f a‖ ∂μ :=
 begin
   rw L1.norm_eq_integral_norm,
   refine integral_congr_ae _,

--- a/src/measure_theory/integral/set_to_l1.lean
+++ b/src/measure_theory/integral/set_to_l1.lean
@@ -1299,12 +1299,12 @@ variables (μ T)
 /-- Extend `T : set α → E →L[ℝ] F` to `(α → E) → F` (for integrable functions `α → E`). We set it to
 0 if the function is not integrable. -/
 def set_to_fun (hT : dominated_fin_meas_additive μ T C) (f : α → E) : F :=
-if hf : integrable f μ then L1.set_to_L1 hT (hf.to_L1 f) else 0
+if hf : integrable f μ then L1.set_to_L1 hT hf.to_L1 else 0
 
 variables {μ T}
 
 lemma set_to_fun_eq (hT : dominated_fin_meas_additive μ T C) (hf : integrable f μ) :
-  set_to_fun μ T hT f = L1.set_to_L1 hT (hf.to_L1 f) :=
+  set_to_fun μ T hT f = L1.set_to_L1 hT hf.to_L1 :=
 dif_pos hf
 
 lemma L1.set_to_fun_eq_set_to_L1 (hT : dominated_fin_meas_additive μ T C) (f : α →₁[μ] E) :
@@ -1465,7 +1465,7 @@ begin
   by_cases hfi : integrable f μ,
   { have hgi : integrable g μ := hfi.congr h,
     rw [set_to_fun_eq hT hfi, set_to_fun_eq hT hgi,
-      (integrable.to_L1_eq_to_L1_iff f g hfi hgi).2 h] },
+      (integrable.to_L1_eq_to_L1_iff hfi hgi).2 h] },
   { have hgi : ¬ integrable g μ, { rw integrable_congr h at hfi, exact hfi },
     rw [set_to_fun_undef hT hfi, set_to_fun_undef hT hgi] },
 end
@@ -1480,7 +1480,7 @@ lemma set_to_fun_measure_zero' (hT : dominated_fin_meas_additive μ T C)
 set_to_fun_zero_left' hT (λ s hs hμs, hT.eq_zero_of_measure_zero hs (h s hs hμs))
 
 lemma set_to_fun_to_L1 (hT : dominated_fin_meas_additive μ T C) (hf : integrable f μ) :
-  set_to_fun μ T hT (hf.to_L1 f) = set_to_fun μ T hT f :=
+  set_to_fun μ T hT hf.to_L1 = set_to_fun μ T hT f :=
 set_to_fun_congr_ae hT hf.coe_fn_to_L1
 
 lemma set_to_fun_indicator_const (hT : dominated_fin_meas_additive μ T C) {s : set α}
@@ -1565,8 +1565,8 @@ lemma tendsto_set_to_fun_of_L1 (hT : dominated_fin_meas_additive μ T C)
   tendsto (λ i, set_to_fun μ T hT (fs i)) l (𝓝 $ set_to_fun μ T hT f) :=
 begin
   classical,
-  let f_lp := hfi.to_L1 f,
-  let F_lp := λ i, if hFi : integrable (fs i) μ then hFi.to_L1 (fs i) else 0,
+  let f_lp := hfi.to_L1,
+  let F_lp := λ i, if hFi : integrable (fs i) μ then hFi.to_L1 else 0,
   have tendsto_L1 : tendsto F_lp l (𝓝 f_lp),
   { rw Lp.tendsto_Lp_iff_tendsto_ℒp',
     simp_rw [snorm_one_eq_lintegral_nnnorm, pi.sub_apply],
@@ -1613,13 +1613,13 @@ end
 lemma continuous_L1_to_L1
   {μ' : measure α} (c' : ℝ≥0∞) (hc' : c' ≠ ∞) (hμ'_le : μ' ≤ c' • μ) :
   continuous (λ f : α →₁[μ] G,
-    (integrable.of_measure_le_smul c' hc' hμ'_le (L1.integrable_coe_fn f)).to_L1 f) :=
+    (integrable.of_measure_le_smul hc' hμ'_le (L1.integrable_coe_fn f)).to_L1) :=
 begin
   by_cases hc'0 : c' = 0,
   { have hμ'0 : μ' = 0,
     { rw ← measure.nonpos_iff_eq_zero', refine hμ'_le.trans _, simp [hc'0], },
     have h_im_zero : (λ f : α →₁[μ] G,
-        (integrable.of_measure_le_smul c' hc' hμ'_le (L1.integrable_coe_fn f)).to_L1 f) = 0,
+        (integrable.of_measure_le_smul hc' hμ'_le (L1.integrable_coe_fn f)).to_L1) = 0,
       by { ext1 f, ext1, simp_rw hμ'0, simp only [ae_zero], },
     rw h_im_zero,
     exact continuous_zero, },
@@ -1629,8 +1629,8 @@ begin
   refine ⟨div_pos (half_pos hε_pos) (to_real_pos hc'0 hc'), _⟩,
   intros g hfg,
   rw Lp.dist_def at hfg ⊢,
-  let h_int := λ f' : α →₁[μ] G, (L1.integrable_coe_fn f').of_measure_le_smul c' hc' hμ'_le,
-  have : snorm (integrable.to_L1 g (h_int g) - integrable.to_L1 f (h_int f)) 1 μ'
+  let h_int := λ f' : α →₁[μ] G, (L1.integrable_coe_fn f').of_measure_le_smul hc' hμ'_le,
+  have : snorm (integrable.to_L1 (h_int g) - integrable.to_L1 (h_int f)) 1 μ'
       = snorm (g - f) 1 μ',
     from snorm_congr_ae ((integrable.coe_fn_to_L1 _).sub (integrable.coe_fn_to_L1 _)),
   rw this,
@@ -1662,7 +1662,7 @@ lemma set_to_fun_congr_measure_of_integrable {μ' : measure α} (c' : ℝ≥0∞
 begin
   /- integrability for `μ` implies integrability for `μ'`. -/
   have h_int : ∀ g : α → E, integrable g μ → integrable g μ',
-    from λ g hg, integrable.of_measure_le_smul c' hc' hμ'_le hg,
+    from λ g hg, integrable.of_measure_le_smul hc' hμ'_le hg,
   /- We use `integrable.induction` -/
   refine hfμ.induction _ _ _ _ _,
   { intros c s hs hμs,
@@ -1676,7 +1676,7 @@ begin
       set_to_fun_add hT' (h_int f₂ hf₂) (h_int g₂ hg₂), h_eq_f, h_eq_g], },
   { refine is_closed_eq (continuous_set_to_fun hT) _,
     have : (λ f : α →₁[μ] E, set_to_fun μ' T hT' f)
-      = (λ f : α →₁[μ] E, set_to_fun μ' T hT' ((h_int f (L1.integrable_coe_fn f)).to_L1 f)),
+      = (λ f : α →₁[μ] E, set_to_fun μ' T hT' (h_int f (L1.integrable_coe_fn f)).to_L1),
     { ext1 f, exact set_to_fun_congr_ae hT' (integrable.coe_fn_to_L1 _).symm, },
     rw this,
     exact (continuous_set_to_fun hT').comp (continuous_L1_to_L1 c' hc' hμ'_le), },
@@ -1694,7 +1694,7 @@ begin
   { exact set_to_fun_congr_measure_of_integrable c' hc' hμ'_le hT hT' f hf, },
   { /- if `f` is not integrable, both `set_to_fun` are 0. -/
     have h_int : ∀ g : α → E, ¬ integrable g μ → ¬ integrable g μ',
-      from λ g, mt (λ h, h.of_measure_le_smul _ hc hμ_le),
+      from λ g, mt (λ h, h.of_measure_le_smul hc hμ_le),
     simp_rw [set_to_fun_undef _ hf, set_to_fun_undef _ (h_int f hf)], },
 end
 
@@ -1757,11 +1757,11 @@ by { rw L1.set_to_fun_eq_set_to_L1, exact L1.norm_set_to_L1_le_mul_norm' hT f, }
 
 lemma norm_set_to_fun_le (hT : dominated_fin_meas_additive μ T C) (hf : integrable f μ)
   (hC : 0 ≤ C) :
-  ‖set_to_fun μ T hT f‖ ≤ C * ‖hf.to_L1 f‖ :=
+  ‖set_to_fun μ T hT f‖ ≤ C * ‖hf.to_L1‖ :=
 by { rw set_to_fun_eq hT hf, exact L1.norm_set_to_L1_le_mul_norm hT hC _, }
 
 lemma norm_set_to_fun_le' (hT : dominated_fin_meas_additive μ T C) (hf : integrable f μ) :
-  ‖set_to_fun μ T hT f‖ ≤ max C 0 * ‖hf.to_L1 f‖ :=
+  ‖set_to_fun μ T hT f‖ ≤ max C 0 * ‖hf.to_L1‖ :=
 by { rw set_to_fun_eq hT hf, exact L1.norm_set_to_L1_le_mul_norm' hT _, }
 
 /-- Lebesgue dominated convergence theorem provides sufficient conditions under which almost
@@ -1787,8 +1787,8 @@ begin
   ⟨f_measurable, has_finite_integral_of_dominated_convergence
     bound_integrable.has_finite_integral h_bound h_lim⟩,
   /- it suffices to prove the result for the corresponding L1 functions -/
-  suffices : tendsto (λ n, L1.set_to_L1 hT ((fs_int n).to_L1 (fs n))) at_top
-    (𝓝 (L1.set_to_L1 hT (f_int.to_L1 f))),
+  suffices : tendsto (λ n, L1.set_to_L1 hT (fs_int n).to_L1) at_top
+    (𝓝 (L1.set_to_L1 hT f_int.to_L1)),
   { convert this,
     { ext1 n, exact set_to_fun_eq hT (fs_int n), },
     { exact set_to_fun_eq hT f_int, }, },


### PR DESCRIPTION
The lemma `integrable.to_L1` and some of its cousins have an explicit argument which isn't needed since it can be inferred from others. This makes it implicit, and fixes all the fallout elswhere.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
