### PR TITLE
[Merged by Bors] - chore(algebra/group/units): is_add_unit.decidable

### DIFF
--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -458,6 +458,7 @@ lemma coe_inv_mul (h : is_unit a) : ↑(h.unit)⁻¹ * a = 1 := units.mul_inv _
 by convert h.unit.mul_inv
 
 /-- `is_unit x` is decidable if we can decide if `x` comes from `Mˣ`. -/
+@[to_additive "`is_add_unit x` is decidable if we can decide if `x` comes from `add_units M"]
 instance (x : M) [h : decidable (∃ u : Mˣ, ↑u = x)] : decidable (is_unit x) := h
 
 @[to_additive] lemma mul_left_inj (h : is_unit a) : b * a = c * a ↔ b = c :=


### PR DESCRIPTION
Missing `to_additive`

I had actually added this to mathlib4 3 months ago in leanprover-community/mathlib4@cbc083419c0aeee4e99154f304f5f8ac66bce0d8 (leanprover-community/mathlib4#549), and never noticed it wasn't in mathlib3.

mathlib4 hash-update placeholder pr: https://github.com/leanprover-community/mathlib4/pull/2278

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
