### PR TITLE
[Merged by Bors] - chore(data/set/semiring): add an `idem_semiring` instance

### DIFF
--- a/src/data/set/semiring.lean
+++ b/src/data/set/semiring.lean
@@ -104,9 +104,9 @@ variables [has_one α]
 
 instance : has_one (set_semiring α) := { one := set.up 1 }
 
-lemma one_def : (0 : set_semiring α) = set.up ∅ := rfl
+lemma one_def : (1 : set_semiring α) = set.up 1 := rfl
 
-@[simp] lemma down_one : (0 : set_semiring α).down = ∅ := rfl
+@[simp] lemma down_one : (1 : set_semiring α).down = 1 := rfl
 
 @[simp] lemma _root_.set.up_one : (1 : set α).up = 1 := rfl
 

--- a/src/data/set/semiring.lean
+++ b/src/data/set/semiring.lean
@@ -52,6 +52,18 @@ instance : add_comm_monoid (set_semiring α) :=
   add_zero := union_empty,
   add_comm := union_comm }
 
+lemma zero_def : (0 : set_semiring α) = set.up ∅ := rfl
+
+@[simp] lemma down_zero : (0 : set_semiring α).down = ∅ := rfl
+
+@[simp] lemma _root_.set.up_empty: (∅ : set α).up = 0 := rfl
+
+lemma add_def (s t : set_semiring α) : s + t = (s.down ∪ t.down).up := rfl
+
+@[simp] lemma down_add (s t : set_semiring α) : (s + t).down = s.down ∪ t.down := rfl
+
+@[simp] lemma _root_.set.up_union (s t : set α) : (s ∪ t).up = s.up + t.up := rfl
+
 /- Since addition on `set_semiring` is commutative (it is set union), there is no need
 to also have the instance `covariant_class (set_semiring α) (set_semiring α) (swap (+)) (≤)`. -/
 instance covariant_class_add : covariant_class (set_semiring α) (set_semiring α) (+) (≤) :=
@@ -61,12 +73,18 @@ section has_mul
 variables [has_mul α]
 
 instance : non_unital_non_assoc_semiring (set_semiring α) :=
-{ mul := λ s t, (image2 (*) s.down t.down).up,
+{ mul := λ s t, (s.down * t.down).up,
   zero_mul := λ s, empty_mul,
   mul_zero := λ s, mul_empty,
   left_distrib := λ _ _ _, mul_union,
   right_distrib := λ _ _ _, union_mul,
   ..set_semiring.add_comm_monoid }
+
+lemma mul_def (s t : set_semiring α) : s * t = (s.down * t.down).up := rfl
+
+@[simp] lemma down_mul (s t : set_semiring α) : (s + t).down = s.down ∪ t.down := rfl
+
+@[simp] lemma _root_.set.up_mul (s t : set α) : (s * t).up = s.up * t.up := rfl
 
 instance : no_zero_divisors (set_semiring α) :=
 ⟨λ a b ab, a.eq_empty_or_nonempty.imp_right $ λ ha, b.eq_empty_or_nonempty.resolve_right $
@@ -80,6 +98,19 @@ instance covariant_class_mul_right :
 ⟨λ a b c, mul_subset_mul_right⟩
 
 end has_mul
+
+section has_one
+variables [has_one α]
+
+instance : has_one (set_semiring α) := { one := set.up 1 }
+
+lemma one_def : (0 : set_semiring α) = set.up ∅ := rfl
+
+@[simp] lemma down_one : (0 : set_semiring α).down = ∅ := rfl
+
+@[simp] lemma _root_.set.up_one : (1 : set α).up = 1 := rfl
+
+end has_one
 
 instance [mul_one_class α] : non_assoc_semiring (set_semiring α) :=
 { one := 1,

--- a/src/data/set/semiring.lean
+++ b/src/data/set/semiring.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import data.set.pointwise.smul
+import algebra.order.kleene
 
 /-!
 # Sets as a semiring under union
@@ -88,18 +89,21 @@ instance [mul_one_class α] : non_assoc_semiring (set_semiring α) :=
 instance [semigroup α] : non_unital_semiring (set_semiring α) :=
 { ..set_semiring.non_unital_non_assoc_semiring, ..set.semigroup }
 
-instance [monoid α] : semiring (set_semiring α) :=
-{ ..set_semiring.non_assoc_semiring, ..set_semiring.non_unital_semiring }
+instance [monoid α] : idem_semiring (set_semiring α) :=
+{ ..set_semiring.non_assoc_semiring, ..set_semiring.non_unital_semiring,
+  ..set.complete_boolean_algebra }
 
 instance [comm_semigroup α] : non_unital_comm_semiring (set_semiring α) :=
 { ..set_semiring.non_unital_semiring, ..set.comm_semigroup }
+
+instance [comm_monoid α] : idem_comm_semiring (set_semiring α) :=
+{ ..set_semiring.idem_semiring, ..set.comm_monoid }
 
 instance [comm_monoid α] : canonically_ordered_comm_semiring (set_semiring α) :=
 { add_le_add_left := λ a b, add_le_add_left,
   exists_add_of_le := λ a b ab, ⟨b, (union_eq_right_iff_subset.2 ab).symm⟩,
   le_self_add := subset_union_left,
-  ..set_semiring.semiring, ..set.comm_monoid, ..set_semiring.partial_order _,
-  ..set_semiring.order_bot _, ..set_semiring.no_zero_divisors }
+  ..set_semiring.idem_semiring, ..set.comm_monoid, ..set_semiring.no_zero_divisors }
 
 /-- The image of a set under a multiplicative homomorphism is a ring homomorphism
 with respect to the pointwise operations on sets. -/

--- a/src/data/set/semiring.lean
+++ b/src/data/set/semiring.lean
@@ -56,7 +56,7 @@ lemma zero_def : (0 : set_semiring α) = set.up ∅ := rfl
 
 @[simp] lemma down_zero : (0 : set_semiring α).down = ∅ := rfl
 
-@[simp] lemma _root_.set.up_empty: (∅ : set α).up = 0 := rfl
+@[simp] lemma _root_.set.up_empty : (∅ : set α).up = 0 := rfl
 
 lemma add_def (s t : set_semiring α) : s + t = (s.down ∪ t.down).up := rfl
 

--- a/src/data/set/semiring.lean
+++ b/src/data/set/semiring.lean
@@ -3,8 +3,8 @@ Copyright (c) 2020 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import data.set.pointwise.smul
 import algebra.order.kleene
+import data.set.pointwise.smul
 
 /-!
 # Sets as a semiring under union

--- a/src/data/set/semiring.lean
+++ b/src/data/set/semiring.lean
@@ -73,7 +73,8 @@ section has_mul
 variables [has_mul α]
 
 instance : non_unital_non_assoc_semiring (set_semiring α) :=
-{ mul := λ s t, (s.down * t.down).up,
+{ -- reducibility linter complains if we use `(s.down * t.down).up`
+  mul := λ s t, (image2 (*) s.down t.down).up,
   zero_mul := λ s, empty_mul,
   mul_zero := λ s, mul_empty,
   left_distrib := λ _ _ _, mul_union,


### PR DESCRIPTION
This typeclass is reasonably new, so some obvious instances are missing.

Also adds some basic API lemmas that were missing about the casting functions `set.up` and `set_semiring.down`.

forward-ported as https://github.com/leanprover-community/mathlib4/pull/2518

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #18400 (which fixes name conflicts caused by adding this import)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](http://gitpod.io/from-referrer/)
