### PR TITLE
[Merged by Bors] - fix(ring_theory/derivation): speed up a slow definition

### DIFF
--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -451,26 +451,25 @@ lemma derivation_to_square_zero_of_lift_apply (f : A →ₐ[R] B)
 
 /-- Given a tower of algebras `R → A → B`, and a square-zero `I : ideal B`, each `R`-derivation
 from `A` to `I` corresponds to a lift `A →ₐ[R] B` of the canonical map `A →ₐ[R] B ⧸ I`. -/
+@[simps]
 def lift_of_derivation_to_square_zero (f : derivation R A I) :
   A →ₐ[R] B :=
-{ map_one' := show (f 1 : B) + algebra_map A B 1 = 1,
-   by rw [map_one, f.map_one_eq_zero, submodule.coe_zero, zero_add],
+{ to_fun := λ x, f x + algebra_map A B x,
+  map_one' := by rw [map_one, f.map_one_eq_zero, submodule.coe_zero, zero_add],
   map_mul' := λ x y, begin
     have : (f x : B) * (f y) = 0,
     { rw [← ideal.mem_bot, ← hI, pow_two], convert (ideal.mul_mem_mul (f x).2 (f y).2) using 1 },
-    dsimp,
     simp only [map_mul, f.leibniz, add_mul, mul_add, submodule.coe_add,
       submodule.coe_smul_of_tower, algebra.smul_def, this],
     ring
   end,
-  commutes' := λ r, by { dsimp, simp [← is_scalar_tower.algebra_map_apply R A B r] },
+  commutes' := λ r,
+    by simp only [derivation.map_algebra_map, eq_self_iff_true, zero_add, submodule.coe_zero,
+      ←is_scalar_tower.algebra_map_apply R A B r],
   map_zero' := ((I.restrict_scalars R).subtype.comp f.to_linear_map +
     (is_scalar_tower.to_alg_hom R A B).to_linear_map).map_zero,
   ..((I.restrict_scalars R).subtype.comp f.to_linear_map +
-    (is_scalar_tower.to_alg_hom R A B).to_linear_map) }
-
-lemma lift_of_derivation_to_square_zero_apply (f : derivation R A I) (x : A) :
-  lift_of_derivation_to_square_zero I hI f x = f x + algebra_map A B x := rfl
+    (is_scalar_tower.to_alg_hom R A B).to_linear_map : A →ₗ[R] B) }
 
 @[simp] lemma lift_of_derivation_to_square_zero_mk_apply (d : derivation R A I) (x : A) :
     ideal.quotient.mk I (lift_of_derivation_to_square_zero I hI d x) = algebra_map A (B ⧸ I) x :=

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -451,7 +451,7 @@ lemma derivation_to_square_zero_of_lift_apply (f : A →ₐ[R] B)
 
 /-- Given a tower of algebras `R → A → B`, and a square-zero `I : ideal B`, each `R`-derivation
 from `A` to `I` corresponds to a lift `A →ₐ[R] B` of the canonical map `A →ₐ[R] B ⧸ I`. -/
-@[simps]
+@[simps {attrs := []}]
 def lift_of_derivation_to_square_zero (f : derivation R A I) :
   A →ₐ[R] B :=
 { to_fun := λ x, f x + algebra_map A B x,
@@ -472,7 +472,7 @@ def lift_of_derivation_to_square_zero (f : derivation R A I) :
     (is_scalar_tower.to_alg_hom R A B).to_linear_map : A →ₗ[R] B) }
 
 @[simp] lemma lift_of_derivation_to_square_zero_mk_apply (d : derivation R A I) (x : A) :
-    ideal.quotient.mk I (lift_of_derivation_to_square_zero I hI d x) = algebra_map A (B ⧸ I) x :=
+  ideal.quotient.mk I (lift_of_derivation_to_square_zero I hI d x) = algebra_map A (B ⧸ I) x :=
 by { rw [lift_of_derivation_to_square_zero_apply, map_add,
   ideal.quotient.eq_zero_iff_mem.mpr (d x).prop, zero_add], refl }
 


### PR DESCRIPTION
16s to 3s. I don't know which of the changes is responsible for the speedup, but they all seem sensible anyway.

With the explicit `to_fun` field, we may as well use `simps` to generate a lemma for us.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
