### PR TITLE
[Merged by Bors] - docs(algebra/module/equiv): correct a misleading comment

### DIFF
--- a/src/algebra/module/equiv.lean
+++ b/src/algebra/module/equiv.lean
@@ -240,7 +240,8 @@ variables (e₁₂ : M₁ ≃ₛₗ[σ₁₂] M₂) (e₂₃ : M₂ ≃ₛₗ[σ
 
 include σ₃₁
 /-- Linear equivalences are transitive. -/
--- Note: The linter thinks the `ring_hom_comp_triple` argument is doubled -- it is not.
+-- Note: the `ring_hom_comp_triple σ₃₂ σ₂₁ σ₃₁` is unused, but is convenient to carry around
+-- implicitly for lemmas like `linear_equiv.self_trans_symm`.
 @[trans, nolint unused_arguments]
 def trans : M₁ ≃ₛₗ[σ₁₃] M₃ :=
 { .. e₂₃.to_linear_map.comp e₁₂.to_linear_map,


### PR DESCRIPTION
The linter is saying that the argument is unused because the argument is unused. The comment claiming that it doesn't appear and the linter is just confused is false.

We could remove the argument, but the extra generality it would provide is illusory, and it would likely just be inconvenient.

This is forward-ported in https://github.com/leanprover-community/mathlib4/pull/2347, though we will need to update the SHA again after this PR is merged.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
