### PR TITLE
refactor(analysis/normed/group/basic): unbundle algebra from norm structure

### DIFF
--- a/src/algebra/module/pi.lean
+++ b/src/algebra/module/pi.lean
@@ -66,7 +66,7 @@ instance module (α) {r : semiring α} {m : ∀ i, add_comm_monoid $ f i}
 /- Extra instance to short-circuit type class resolution.
 For unknown reasons, this is necessary for certain inference problems. E.g., for this to succeed:
 ```lean
-example (β X : Type*) [normed_add_comm_group β] [normed_space ℝ β] : module ℝ (X → β) :=
+example (β X : Type*) [add_comm_group β] [normed_add_comm_group β] [normed_space ℝ β] : module ℝ (X → β) :=
 infer_instance
 ```
 See: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Typeclass.20resolution.20under.20binders/near/281296989

--- a/src/analysis/ODE/gronwall.lean
+++ b/src/analysis/ODE/gronwall.lean
@@ -27,8 +27,8 @@ Sec. 4.5][HubbardWest-ode], where `norm_le_gronwall_bound_of_norm_deriv_right_le
   of `K x` and `f x`.
 -/
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
-          {F : Type*} [normed_add_comm_group F] [normed_space ℝ F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+          {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F]
 
 open metric set asymptotics filter real
 open_locale classical topology nnreal

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -38,14 +38,14 @@ open_locale filter topology nnreal ennreal nat interval
 
 noncomputable theory
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
 
 /-- `Prop` structure holding the hypotheses of the Picard-Lindelöf theorem.
 
 The similarly named `picard_lindelof` structure is part of the internal API for convenience, so as
 not to constantly invoke choice, but is not intended for public use. -/
 structure is_picard_lindelof
-  {E : Type*} [normed_add_comm_group E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E)
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E)
   (L : ℝ≥0) (R C : ℝ) : Prop :=
 (ht₀ : t₀ ∈ Icc t_min t_max)
 (hR : 0 ≤ R)
@@ -336,7 +336,7 @@ end
 
 end picard_lindelof
 
-lemma is_picard_lindelof.norm_le₀ {E : Type*} [normed_add_comm_group E]
+lemma is_picard_lindelof.norm_le₀ {E : Type*} [add_comm_group E] [normed_add_comm_group E]
   {v : ℝ → E → E} {t_min t₀ t_max : ℝ} {x₀ : E} {C R : ℝ} {L : ℝ≥0}
   (hpl : is_picard_lindelof v t_min t₀ t_max x₀ L R C) : ‖v t₀ x₀‖ ≤ C :=
 hpl.norm_le t₀ hpl.ht₀ x₀ $ mem_closed_ball_self hpl.hR

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -62,7 +62,7 @@ of using this structure.
 The similarly named `is_picard_lindelof` is a bundled `Prop` holding the long hypotheses of the
 Picard-Lindelöf theorem as named arguments. It is used as part of the public API.
 -/
-structure picard_lindelof (E : Type*) [normed_add_comm_group E] [normed_space ℝ E] :=
+structure picard_lindelof (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] :=
 (to_fun : ℝ → E → E)
 (t_min t_max : ℝ)
 (t₀ : Icc t_min t_max)

--- a/src/analysis/analytic/composition.lean
+++ b/src/analysis/analytic/composition.lean
@@ -290,10 +290,10 @@ end formal_multilinear_series
 end topological
 
 variables [nontrivially_normed_field 𝕜]
-  [normed_add_comm_group E] [normed_space 𝕜 E]
-  [normed_add_comm_group F] [normed_space 𝕜 F]
-  [normed_add_comm_group G] [normed_space 𝕜 G]
-  [normed_add_comm_group H] [normed_space 𝕜 H]
+  [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+  [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+  [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
+  [add_comm_group H] [normed_add_comm_group H] [normed_space 𝕜 H]
 
 namespace formal_multilinear_series
 

--- a/src/analysis/analytic/inverse.lean
+++ b/src/analysis/analytic/inverse.lean
@@ -32,8 +32,8 @@ open finset filter
 namespace formal_multilinear_series
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 
 /-! ### The left inverse of a formal multilinear series -/
 

--- a/src/analysis/analytic/isolated_zeros.lean
+++ b/src/analysis/analytic/isolated_zeros.lean
@@ -32,7 +32,7 @@ open filter function nat formal_multilinear_series emetric set
 open_locale topology big_operators
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] {s : E}
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {s : E}
   {p q : formal_multilinear_series 𝕜 𝕜 E} {f g : 𝕜 → E}
   {n : ℕ} {z z₀ : 𝕜} {y : fin n → 𝕜}
 

--- a/src/analysis/analytic/linear.lean
+++ b/src/analysis/analytic/linear.lean
@@ -13,9 +13,9 @@ the formal power series `f x = f a + f (x - a)`.
 -/
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
-{G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+{G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
 
 open_locale topology classical big_operators nnreal ennreal
 open set filter asymptotics

--- a/src/analysis/analytic/radius_liminf.lean
+++ b/src/analysis/analytic/radius_liminf.lean
@@ -14,8 +14,8 @@ $\liminf_{n\to\infty} \frac{1}{\sqrt[n]{‖p n‖}}$. This lemma can't go to `ba
 would create a circular dependency once we redefine `exp` using `formal_multilinear_series`.
 -/
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 
 open_locale topology classical big_operators nnreal ennreal
 open filter asymptotics

--- a/src/analysis/analytic/uniqueness.lean
+++ b/src/analysis/analytic/uniqueness.lean
@@ -15,8 +15,8 @@ in `analytic_on.eq_on_of_preconnected_of_eventually_eq`.
 -/
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 
 open set
 open_locale topology ennreal

--- a/src/analysis/asymptotics/asymptotic_equivalent.lean
+++ b/src/analysis/asymptotics/asymptotic_equivalent.lean
@@ -221,7 +221,8 @@ end normed_field
 
 section smul
 
-lemma is_equivalent.smul {α E 𝕜 : Type*} [normed_field 𝕜] [normed_add_comm_group E]
+lemma is_equivalent.smul
+  {α E 𝕜 : Type*} [normed_field 𝕜] [add_comm_group E] [normed_add_comm_group E]
   [normed_space 𝕜 E] {a b : α → 𝕜} {u v : α → E} {l : filter α} (hab : a ~[l] b) (huv : u ~[l] v) :
   (λ x, a x • u x) ~[l] (λ x, b x • v x) :=
 begin

--- a/src/analysis/asymptotics/asymptotic_equivalent.lean
+++ b/src/analysis/asymptotics/asymptotic_equivalent.lean
@@ -61,7 +61,7 @@ open_locale topology
 
 section normed_add_comm_group
 
-variables {α β : Type*} [normed_add_comm_group β]
+variables {α β : Type*} [add_comm_group β] [normed_add_comm_group β]
 
 /-- Two functions `u` and `v` are said to be asymptotically equivalent along a filter `l` when
     `u x - v x = o(v x)` as x converges along `l`. -/
@@ -314,7 +314,7 @@ end asymptotics
 open filter asymptotics
 open_locale asymptotics
 
-variables {α β : Type*} [normed_add_comm_group β]
+variables {α β : Type*} [add_comm_group β] [normed_add_comm_group β]
 
 lemma filter.eventually_eq.is_equivalent {u v : α → β} {l : filter α} (h : u =ᶠ[l] v) : u ~[l] v :=
 is_equivalent.congr_right (is_o_refl_left _ _) h

--- a/src/analysis/asymptotics/asymptotics.lean
+++ b/src/analysis/asymptotics/asymptotics.lean
@@ -55,6 +55,9 @@ variables {α : Type*} {β : Type*} {E : Type*} {F : Type*} {G : Type*}
   {R : Type*} {R' : Type*} {𝕜 : Type*} {𝕜' : Type*}
 
 variables [has_norm E] [has_norm F] [has_norm G]
+variables [add_comm_group E'] [add_comm_group F']
+  [add_comm_group G'] [add_comm_group E''] [add_comm_group F'']
+  [add_comm_group G'']
 variables [seminormed_add_comm_group E'] [seminormed_add_comm_group F']
   [seminormed_add_comm_group G'] [normed_add_comm_group E''] [normed_add_comm_group F'']
   [normed_add_comm_group G''] [semi_normed_ring R] [semi_normed_ring R']

--- a/src/analysis/asymptotics/asymptotics.lean
+++ b/src/analysis/asymptotics/asymptotics.lean
@@ -1529,7 +1529,7 @@ theorem is_O_of_div_tendsto_nhds {α : Type*} {l : filter α}
   f =O[l] g :=
 (is_O_iff_div_is_bounded_under hgf).2 $ H.norm.is_bounded_under_le
 
-lemma is_o.tendsto_zero_of_tendsto {α E 𝕜 : Type*} [normed_add_comm_group E] [normed_field 𝕜]
+lemma is_o.tendsto_zero_of_tendsto {α E 𝕜 : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_field 𝕜]
   {u : α → E} {v : α → 𝕜} {l : filter α} {y : 𝕜} (huv : u =o[l] v) (hv : tendsto v l (𝓝 y)) :
   tendsto u l (𝓝 0) :=
 begin

--- a/src/analysis/asymptotics/asymptotics.lean
+++ b/src/analysis/asymptotics/asymptotics.lean
@@ -516,7 +516,7 @@ variables {u v : α → ℝ}
 by simp only [is_O_with, norm_norm]
 
 @[simp] theorem is_O_with_abs_right : is_O_with c l f (λ x, |u x|) ↔ is_O_with c l f u :=
-@is_O_with_norm_right _ _ _ _ _ _ f u l
+@is_O_with_norm_right _ _ _ _ _ _ _ f u l
 
 alias is_O_with_norm_right ↔ is_O_with.of_norm_right is_O_with.norm_right
 alias is_O_with_abs_right ↔ is_O_with.of_abs_right is_O_with.abs_right
@@ -525,7 +525,7 @@ alias is_O_with_abs_right ↔ is_O_with.of_abs_right is_O_with.abs_right
 by { unfold is_O, exact exists_congr (λ _, is_O_with_norm_right) }
 
 @[simp] theorem is_O_abs_right : f =O[l] (λ x, |u x|) ↔ f =O[l] u :=
-@is_O_norm_right _ _ ℝ _ _ _ _ _
+@is_O_norm_right _ _ ℝ _ _ _ _ _ _
 
 alias is_O_norm_right ↔ is_O.of_norm_right is_O.norm_right
 alias is_O_abs_right ↔ is_O.of_abs_right is_O.abs_right
@@ -534,7 +534,7 @@ alias is_O_abs_right ↔ is_O.of_abs_right is_O.abs_right
 by { unfold is_o, exact forall₂_congr (λ _ _, is_O_with_norm_right) }
 
 @[simp] theorem is_o_abs_right : f =o[l] (λ x, |u x|) ↔ f =o[l] u :=
-@is_o_norm_right _ _ ℝ _ _ _ _ _
+@is_o_norm_right _ _ ℝ _ _ _ _ _ _
 
 alias is_o_norm_right ↔ is_o.of_norm_right is_o.norm_right
 alias is_o_abs_right ↔ is_o.of_abs_right is_o.abs_right
@@ -543,7 +543,7 @@ alias is_o_abs_right ↔ is_o.of_abs_right is_o.abs_right
 by simp only [is_O_with, norm_norm]
 
 @[simp] theorem is_O_with_abs_left : is_O_with c l (λ x, |u x|) g ↔ is_O_with c l u g :=
-@is_O_with_norm_left _ _ _ _ _ _ g u l
+@is_O_with_norm_left _ _ _ _ _ _ _ g u l
 
 alias is_O_with_norm_left ↔ is_O_with.of_norm_left is_O_with.norm_left
 alias is_O_with_abs_left ↔ is_O_with.of_abs_left is_O_with.abs_left
@@ -552,7 +552,7 @@ alias is_O_with_abs_left ↔ is_O_with.of_abs_left is_O_with.abs_left
 by { unfold is_O, exact exists_congr (λ _, is_O_with_norm_left) }
 
 @[simp] theorem is_O_abs_left : (λ x, |u x|) =O[l] g ↔ u =O[l] g :=
-@is_O_norm_left _ _ _ _ _ g u l
+@is_O_norm_left _ _ _ _ _ _ g u l
 
 alias is_O_norm_left ↔ is_O.of_norm_left is_O.norm_left
 alias is_O_abs_left ↔ is_O.of_abs_left is_O.abs_left
@@ -561,7 +561,7 @@ alias is_O_abs_left ↔ is_O.of_abs_left is_O.abs_left
 by { unfold is_o, exact forall₂_congr (λ _ _, is_O_with_norm_left) }
 
 @[simp] theorem is_o_abs_left : (λ x, |u x|) =o[l] g ↔ u =o[l] g :=
-@is_o_norm_left _ _ _ _ _ g u l
+@is_o_norm_left _ _ _ _ _ _ g u l
 
 alias is_o_norm_left ↔ is_o.of_norm_left is_o.norm_left
 alias is_o_abs_left ↔ is_o.of_abs_left is_o.abs_left
@@ -1560,7 +1560,7 @@ by { convert is_o_pow_pow h, simp only [pow_one] }
 
 theorem is_o_norm_pow_id {n : ℕ} (h : 1 < n) :
   (λ x : E', ‖x‖^n) =o[𝓝 0] (λ x, x) :=
-by simpa only [pow_one, is_o_norm_right] using @is_o_norm_pow_norm_pow E' _ _ _ h
+by simpa only [pow_one, is_o_norm_right] using @is_o_norm_pow_norm_pow E' _ _ _ _ h
 
 lemma is_O.eq_zero_of_norm_pow_within {f : E'' → F''} {s : set E''} {x₀ : E''} {n : ℕ}
   (h : f =O[𝓝[s] x₀] λ x, ‖x - x₀‖ ^ n) (hx₀ : x₀ ∈ s) (hn : 0 < n) : f x₀ = 0 :=
@@ -1640,13 +1640,15 @@ theorem is_O_one_nat_at_top_iff {f : ℕ → E''} :
 iff.trans (is_O_nat_at_top_iff (λ n h, (one_ne_zero h).elim)) $
   by simp only [norm_one, mul_one]
 
-theorem is_O_with_pi {ι : Type*} [fintype ι] {E' : ι → Type*} [Π i, normed_add_comm_group (E' i)]
+theorem is_O_with_pi {ι : Type*} [fintype ι] {E' : ι → Type*}
+  [Π i, add_comm_group (E' i)] [Π i, normed_add_comm_group (E' i)]
   {f : α → Π i, E' i} {C : ℝ} (hC : 0 ≤ C) :
   is_O_with C l f g' ↔ ∀ i, is_O_with C l (λ x, f x i) g' :=
 have ∀ x, 0 ≤ C * ‖g' x‖, from λ x, mul_nonneg hC (norm_nonneg _),
 by simp only [is_O_with_iff, pi_norm_le_iff_of_nonneg (this _), eventually_all]
 
-@[simp] theorem is_O_pi {ι : Type*} [fintype ι] {E' : ι → Type*} [Π i, normed_add_comm_group (E' i)]
+@[simp] theorem is_O_pi {ι : Type*} [fintype ι] {E' : ι → Type*}
+  [Π i, add_comm_group (E' i)] [Π i, normed_add_comm_group (E' i)]
   {f : α → Π i, E' i} :
   f =O[l] g' ↔ ∀ i, (λ x, f x i) =O[l] g' :=
 begin
@@ -1654,7 +1656,8 @@ begin
   exact eventually_congr (eventually_at_top.2 ⟨0, λ c, is_O_with_pi⟩)
 end
 
-@[simp] theorem is_o_pi {ι : Type*} [fintype ι] {E' : ι → Type*} [Π i, normed_add_comm_group (E' i)]
+@[simp] theorem is_o_pi {ι : Type*} [fintype ι] {E' : ι → Type*}
+  [Π i, add_comm_group (E' i)] [Π i, normed_add_comm_group (E' i)]
   {f : α → Π i, E' i} :
   f =o[l] g' ↔ ∀ i, (λ x, f x i) =o[l] g' :=
 begin
@@ -1666,12 +1669,14 @@ end asymptotics
 
 open asymptotics
 
-lemma summable_of_is_O {ι E} [normed_add_comm_group E] [complete_space E] {f : ι → E} {g : ι → ℝ}
+lemma summable_of_is_O
+  {ι E} [add_comm_group E] [normed_add_comm_group E] [complete_space E] {f : ι → E} {g : ι → ℝ}
   (hg : summable g) (h : f =O[cofinite] g) : summable f :=
 let ⟨C, hC⟩ := h.is_O_with in
 summable_of_norm_bounded_eventually (λ x, C * ‖g x‖) (hg.abs.mul_left _) hC.bound
 
-lemma summable_of_is_O_nat {E} [normed_add_comm_group E] [complete_space E] {f : ℕ → E} {g : ℕ → ℝ}
+lemma summable_of_is_O_nat
+  {E} [add_comm_group E] [normed_add_comm_group E] [complete_space E] {f : ℕ → E} {g : ℕ → ℝ}
   (hg : summable g) (h : f =O[at_top] g) : summable f :=
 summable_of_is_O hg $ nat.cofinite_eq_at_top.symm ▸ h
 

--- a/src/analysis/asymptotics/specific_asymptotics.lean
+++ b/src/analysis/asymptotics/specific_asymptotics.lean
@@ -104,7 +104,7 @@ section real
 open_locale big_operators
 open finset
 
-lemma asymptotics.is_o.sum_range {α : Type*} [normed_add_comm_group α]
+lemma asymptotics.is_o.sum_range {α : Type*} [add_comm_group α] [normed_add_comm_group α]
   {f : ℕ → α} {g : ℕ → ℝ} (h : f =o[at_top] g)
   (hg : 0 ≤ g) (h'g : tendsto (λ n, ∑ i in range n, g i) at_top at_top) :
   (λ n, ∑ i in range n, f i) =o[at_top] (λ n, ∑ i in range n, g i) :=
@@ -143,7 +143,7 @@ begin
   ... = ε * ‖(∑ i in range n, g i)‖ : by { simp [B], ring }
 end
 
-lemma asymptotics.is_o_sum_range_of_tendsto_zero {α : Type*} [normed_add_comm_group α]
+lemma asymptotics.is_o_sum_range_of_tendsto_zero {α : Type*} [add_comm_group α] [normed_add_comm_group α]
   {f : ℕ → α} (h : tendsto f at_top (𝓝 0)) :
   (λ n, ∑ i in range n, f i) =o[at_top] (λ n, (n : ℝ)) :=
 begin
@@ -153,7 +153,7 @@ begin
 end
 
 /-- The Cesaro average of a converging sequence converges to the same limit. -/
-lemma filter.tendsto.cesaro_smul {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+lemma filter.tendsto.cesaro_smul {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   {u : ℕ → E} {l : E} (h : tendsto u at_top (𝓝 l)) :
   tendsto (λ (n : ℕ), (n ⁻¹ : ℝ) • (∑ i in range n, u i)) at_top (𝓝 l) :=
 begin

--- a/src/analysis/asymptotics/theta.lean
+++ b/src/analysis/asymptotics/theta.lean
@@ -23,6 +23,9 @@ variables {α : Type*} {β : Type*} {E : Type*} {F : Type*} {G : Type*}
   {R : Type*} {R' : Type*} {𝕜 : Type*} {𝕜' : Type*}
 
 variables [has_norm E] [has_norm F] [has_norm G]
+variables [add_comm_group E'] [add_comm_group F']
+  [add_comm_group G'] [add_comm_group E''] [add_comm_group F'']
+  [add_comm_group G'']
 variables [seminormed_add_comm_group E'] [seminormed_add_comm_group F']
   [seminormed_add_comm_group G'] [normed_add_comm_group E''] [normed_add_comm_group F'']
   [normed_add_comm_group G''] [semi_normed_ring R] [semi_normed_ring R']

--- a/src/analysis/bounded_variation.lean
+++ b/src/analysis/bounded_variation.lean
@@ -50,7 +50,7 @@ open set measure_theory filter
 
 variables {α β : Type*} [linear_order α] [linear_order β]
 {E F : Type*} [pseudo_emetric_space E] [pseudo_emetric_space F]
-{V : Type*} [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
+{V : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space ℝ V] [finite_dimensional ℝ V]
 
 /-- The (extended real valued) variation of a function `f` on a set `s` inside a linear order is
 the supremum of the sum of `edist (f (u (i+1))) (f (u i))` over all finite increasing

--- a/src/analysis/box_integral/partition/additive.lean
+++ b/src/analysis/box_integral/partition/additive.lean
@@ -154,7 +154,7 @@ end
 
 section to_smul
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
 
 /-- If `f` is a box-additive map, then so is the map sending `I` to the scalar multiplication
 by `f I` as a continuous linear map from `E` to itself. -/

--- a/src/analysis/box_integral/partition/measure.lean
+++ b/src/analysis/box_integral/partition/measure.lean
@@ -114,11 +114,11 @@ namespace box_additive_map
 
 /-- Box-additive map sending each box `I` to the continuous linear endomorphism
 `x ↦ (volume I).to_real • x`. -/
-protected def volume {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] :
+protected def volume {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] :
   ι →ᵇᵃ (E →L[ℝ] E) :=
 (volume : measure (ι → ℝ)).to_box_additive.to_smul
 
-lemma volume_apply {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] (I : box ι) (x : E) :
+lemma volume_apply {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] (I : box ι) (x : E) :
   box_additive_map.volume I x = (∏ j, (I.upper j - I.lower j)) • x :=
 congr_arg2 (•) I.volume_apply rfl
 

--- a/src/analysis/calculus/bump_function_findim.lean
+++ b/src/analysis/calculus/bump_function_findim.lean
@@ -26,7 +26,7 @@ open set metric topological_space function asymptotics measure_theory finite_dim
 continuous_linear_map filter measure_theory.measure
 open_locale pointwise topology nnreal big_operators convolution
 
-variables {E : Type*} [normed_add_comm_group E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 section
 
@@ -478,7 +478,7 @@ variable {E}
 end helper_definitions
 
 @[priority 100]
-instance {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [finite_dimensional ℝ E] :
+instance {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [finite_dimensional ℝ E] :
   has_cont_diff_bump E :=
 begin
   refine ⟨⟨_⟩⟩,

--- a/src/analysis/calculus/bump_function_inner.lean
+++ b/src/analysis/calculus/bump_function_inner.lean
@@ -284,7 +284,7 @@ structure cont_diff_bump (c : E) :=
 add more properties if they are useful and satisfied in the examples of inner product spaces
 and finite dimensional vector spaces, notably derivative norm control in terms of `R - 1`. -/
 @[nolint has_nonempty_instance]
-structure cont_diff_bump_base (E : Type*) [normed_add_comm_group E] [normed_space ℝ E] :=
+structure cont_diff_bump_base (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] :=
 (to_fun : ℝ → E → ℝ)
 (mem_Icc   : ∀ (R : ℝ) (x : E), to_fun R x ∈ Icc (0 : ℝ) 1)
 (symmetric : ∀ (R : ℝ) (x : E), to_fun R (-x) = to_fun R x)
@@ -295,12 +295,12 @@ structure cont_diff_bump_base (E : Type*) [normed_add_comm_group E] [normed_spac
 /-- A class registering that a real vector space admits bump functions. This will be instantiated
 first for inner product spaces, and then for finite-dimensional normed spaces.
 We use a specific class instead of `nonempty (cont_diff_bump_base E)` for performance reasons. -/
-class has_cont_diff_bump (E : Type*) [normed_add_comm_group E] [normed_space ℝ E] : Prop :=
+class has_cont_diff_bump (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] : Prop :=
 (out : nonempty (cont_diff_bump_base E))
 
 /-- In a space with `C^∞` bump functions, register some function that will be used as a basis
 to construct bump functions of arbitrary size around any point. -/
-def some_cont_diff_bump_base (E : Type*) [normed_add_comm_group E] [normed_space ℝ E]
+def some_cont_diff_bump_base (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [hb : has_cont_diff_bump E] : cont_diff_bump_base E :=
 nonempty.some hb.out
 

--- a/src/analysis/calculus/conformal/normed_space.lean
+++ b/src/analysis/calculus/conformal/normed_space.lean
@@ -42,7 +42,7 @@ Maps such as the complex conjugate are considered to be conformal.
 
 noncomputable theory
 
-variables {X Y Z : Type*} [normed_add_comm_group X] [normed_add_comm_group Y]
+variables {X Y Z : Type*} [add_comm_group X] [normed_add_comm_group X] [normed_add_comm_group Y]
   [normed_add_comm_group Z] [normed_space ℝ X] [normed_space ℝ Y] [normed_space ℝ Z]
 
 section loc_conformality

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -173,10 +173,10 @@ open set fin filter function
 open_locale topology
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
-{G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
-{X : Type*} [normed_add_comm_group X] [normed_space 𝕜 X]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+{G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
+{X : Type*} [add_comm_group X] [normed_add_comm_group X] [normed_space 𝕜 X]
 {s s₁ t u : set E} {f f₁ : E → F} {g : F → G} {x x₀ : E} {c : F}
 {b : E × F → G} {m n : ℕ∞}
 
@@ -3415,7 +3415,7 @@ end
 
 /-- If `f` has a formal Taylor series `p` up to order `1` on `{x} ∪ s`, where `s` is a convex set,
 then `f` is Lipschitz in a neighborhood of `x` within `s`. -/
-lemma has_ftaylor_series_up_to_on.exists_lipschitz_on_with {E F : Type*} [normed_add_comm_group E]
+lemma has_ftaylor_series_up_to_on.exists_lipschitz_on_with {E F : Type*} [add_comm_group E] [normed_add_comm_group E]
   [normed_space ℝ E] [normed_add_comm_group F] [normed_space ℝ F] {f : E → F}
   {p : E → formal_multilinear_series ℝ E F} {s : set E} {x : E}
   (hf : has_ftaylor_series_up_to_on 1 f p (insert x s)) (hs : convex ℝ s) :
@@ -3424,7 +3424,7 @@ lemma has_ftaylor_series_up_to_on.exists_lipschitz_on_with {E F : Type*} [normed
 
 /-- If `f` is `C^1` within a conves set `s` at `x`, then it is Lipschitz on a neighborhood of `x`
 within `s`. -/
-lemma cont_diff_within_at.exists_lipschitz_on_with {E F : Type*} [normed_add_comm_group E]
+lemma cont_diff_within_at.exists_lipschitz_on_with {E F : Type*} [add_comm_group E] [normed_add_comm_group E]
   [normed_space ℝ E] [normed_add_comm_group F] [normed_space ℝ F] {f : E → F} {s : set E}
   {x : E} (hf : cont_diff_within_at ℝ 1 f s x) (hs : convex ℝ s) :
   ∃ (K : ℝ≥0) (t ∈ 𝓝[s] x), lipschitz_on_with K f t :=

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -2985,8 +2985,8 @@ end const_smul
 /-! ### Cartesian product of two functions -/
 
 section prod_map
-variables {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
-variables {F' : Type*} [normed_add_comm_group F'] [normed_space 𝕜 F']
+variables {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
+variables {F' : Type*} [add_comm_group F'] [normed_add_comm_group F'] [normed_space 𝕜 F']
 
 /-- The product map of two `C^n` functions within a set at a point is `C^n`
 within the product set at the product point. -/
@@ -3004,8 +3004,8 @@ lemma cont_diff_within_at.prod_map
 cont_diff_within_at.prod_map' hf hg
 
 /-- The product map of two `C^n` functions on a set is `C^n` on the product set. -/
-lemma cont_diff_on.prod_map {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
-  {F' : Type*} [normed_add_comm_group F'] [normed_space 𝕜 F']
+lemma cont_diff_on.prod_map {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
+  {F' : Type*} [add_comm_group F'] [normed_add_comm_group F'] [normed_space 𝕜 F']
   {s : set E} {t : set E'} {f : E → F} {g : E' → F'}
   (hf : cont_diff_on 𝕜 n f s) (hg : cont_diff_on 𝕜 n g t) :
   cont_diff_on 𝕜 n (prod.map f g) (s ×ˢ t) :=
@@ -3334,8 +3334,8 @@ section real
 
 variables
 {𝕂 : Type*} [is_R_or_C 𝕂]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕂 E']
-{F' : Type*} [normed_add_comm_group F'] [normed_space 𝕂 F']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕂 E']
+{F' : Type*} [add_comm_group F'] [normed_add_comm_group F'] [normed_space 𝕂 F']
 
 /-- If a function has a Taylor series at order at least 1, then at points in the interior of the
     domain of definition, the term of order 1 of this series is a strict derivative of `f`. -/

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -461,7 +461,7 @@ lemma differentiable_within_at_Ioi_iff_Ici [partial_order 𝕜] :
 ⟨λ h, h.has_deriv_within_at.Ici_of_Ioi.differentiable_within_at,
 λ h, h.has_deriv_within_at.Ioi_of_Ici.differentiable_within_at⟩
 
-lemma deriv_within_Ioi_eq_Ici {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] (f : ℝ → E)
+lemma deriv_within_Ioi_eq_Ici {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] (f : ℝ → E)
   (x : ℝ) :
   deriv_within f (Ioi x) x = deriv_within f (Ici x) x :=
 begin
@@ -1671,7 +1671,7 @@ section clm_comp_apply
 
 open continuous_linear_map
 
-variables {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G] {c : 𝕜 → F →L[𝕜] G}
+variables {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G] {c : 𝕜 → F →L[𝕜] G}
   {c' : F →L[𝕜] G} {d : 𝕜 → E →L[𝕜] F} {d' : E →L[𝕜] F} {u : 𝕜 → F} {u' : F}
 
 lemma has_strict_deriv_at.clm_comp (hc : has_strict_deriv_at c c' x)
@@ -1968,7 +1968,7 @@ end pow
 
 section zpow
 /-! ### Derivative of `x ↦ x^m` for `m : ℤ` -/
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] {x : 𝕜} {s : set 𝕜} {m : ℤ}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {x : 𝕜} {s : set 𝕜} {m : ℤ}
 
 lemma has_strict_deriv_at_zpow (m : ℤ) (x : 𝕜) (h : x ≠ 0 ∨ 0 ≤ m) :
   has_strict_deriv_at (λx, x^m) ((m : 𝕜) * x^(m-1)) x :=
@@ -2092,7 +2092,7 @@ end zpow
 section support
 
 open function
-variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F] {f : 𝕜 → F}
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] {f : 𝕜 → F}
 
 lemma support_deriv_subset : support (deriv f) ⊆ tsupport f :=
 begin

--- a/src/analysis/calculus/dslope.lean
+++ b/src/analysis/calculus/dslope.lean
@@ -33,7 +33,7 @@ variables {f : 𝕜 → E} {a b : 𝕜} {s : set 𝕜}
 lemma dslope_of_ne (f : 𝕜 → E) (h : b ≠ a) : dslope f a b = slope f a b :=
 update_noteq h _ _
 
-lemma continuous_linear_map.dslope_comp {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+lemma continuous_linear_map.dslope_comp {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
   (f : E →L[𝕜] F) (g : 𝕜 → E) (a b : 𝕜) (H : a = b → differentiable_at 𝕜 g a) :
   dslope (f ∘ g) a b = f (dslope g a b) :=
 begin

--- a/src/analysis/calculus/extend_deriv.lean
+++ b/src/analysis/calculus/extend_deriv.lean
@@ -20,8 +20,8 @@ of the one-dimensional derivative `deriv ℝ f`.
 -/
 
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
-          {F : Type*} [normed_add_comm_group F] [normed_space ℝ F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+          {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F]
 
 open filter set metric continuous_linear_map
 open_locale topology

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -125,7 +125,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 variables {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
-variables {G' : Type*} [normed_add_comm_group G'] [normed_space 𝕜 G']
+variables {G' : Type*} [add_comm_group G'] [normed_add_comm_group G'] [normed_space 𝕜 G']
 
 /-- A function `f` has the continuous linear map `f'` as derivative along the filter `L` if
 `f x' = f x + f' (x' - x) + o (x' - x)` when `x'` converges along the filter `L`. This definition

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -122,9 +122,9 @@ noncomputable theory
 section
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
-variables {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
 variables {G' : Type*} [normed_add_comm_group G'] [normed_space 𝕜 G']
 
 /-- A function `f` has the continuous linear map `f'` as derivative along the filter `L` if
@@ -2225,7 +2225,7 @@ end bilinear_map
 section clm_comp_apply
 /-! ### Derivative of the pointwise composition/application of continuous linear maps -/
 
-variables {H : Type*} [normed_add_comm_group H] [normed_space 𝕜 H] {c : E → G →L[𝕜] H}
+variables {H : Type*} [add_comm_group H] [normed_add_comm_group H] [normed_space 𝕜 H] {c : E → G →L[𝕜] H}
   {c' : E →L[𝕜] G →L[𝕜] H} {d : E → F →L[𝕜] G} {d' : E →L[𝕜] F →L[𝕜] G} {u : E → G}
   {u' : E →L[𝕜] G}
 
@@ -2947,8 +2947,8 @@ section
 -/
 
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
-variables {F : Type*} [normed_add_comm_group F] [normed_space ℝ F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F]
 variables {f : E → F} {f' : E →L[ℝ] F} {x : E}
 
 theorem has_fderiv_at_filter_real_equiv {L : filter E} :
@@ -2974,8 +2974,8 @@ end
 section tangent_cone
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 {f : E → F} {s : set E} {f' : E →L[𝕜] F}
 
 /-- The image of a tangent cone under the differential of a map is included in the tangent cone to
@@ -3040,9 +3040,9 @@ respectively by `𝕜'` and `𝕜` where `𝕜'` is a normed algebra over `𝕜`
 
 variables (𝕜 : Type*) [nontrivially_normed_field 𝕜]
 variables {𝕜' : Type*} [nontrivially_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] [normed_space 𝕜' E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] [normed_space 𝕜' E]
 variables [is_scalar_tower 𝕜 𝕜' E]
-variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F] [normed_space 𝕜' F]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] [normed_space 𝕜' F]
 variables [is_scalar_tower 𝕜 𝕜' F]
 variables {f : E → F} {f' : E →L[𝕜'] F} {s : set E} {x : E}
 

--- a/src/analysis/calculus/fderiv_analytic.lean
+++ b/src/analysis/calculus/fderiv_analytic.lean
@@ -18,8 +18,8 @@ open filter asymptotics
 open_locale ennreal
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 
 section fderiv
 

--- a/src/analysis/calculus/fderiv_measurable.lean
+++ b/src/analysis/calculus/fderiv_measurable.lean
@@ -94,8 +94,8 @@ end continuous_linear_map
 section fderiv
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 variables {f : E → F} (K : set (E →L[𝕜] F))
 
 namespace fderiv_measurable_aux
@@ -432,7 +432,7 @@ end fderiv
 
 section right_deriv
 
-variables {F : Type*} [normed_add_comm_group F] [normed_space ℝ F]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F]
 variables {f : ℝ → F} (K : set F)
 
 namespace right_deriv_measurable_aux

--- a/src/analysis/calculus/fderiv_symmetric.lean
+++ b/src/analysis/calculus/fderiv_symmetric.lean
@@ -50,7 +50,7 @@ rectangle are contained in `s` by convexity. The general case follows by lineari
 open asymptotics set
 open_locale topology
 
-variables {E F : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+variables {E F : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
 [normed_add_comm_group F] [normed_space ℝ F]
 {s : set E} (s_conv : convex ℝ s)
 {f : E → F} {f' : E → (E →L[ℝ] F)} {f'' : E →L[ℝ] (E →L[ℝ] F)}

--- a/src/analysis/calculus/formal_multilinear_series.lean
+++ b/src/analysis/calculus/formal_multilinear_series.lean
@@ -297,7 +297,7 @@ of degree zero is `c`. It is the power series expansion of the constant function
 everywhere. -/
 def const_formal_multilinear_series (𝕜 : Type*) [nontrivially_normed_field 𝕜]
   (E : Type*) [normed_add_comm_group E] [normed_space 𝕜 E] [has_continuous_const_smul 𝕜 E]
-  [topological_add_group E] {F : Type*} [normed_add_comm_group F] [topological_add_group F]
+  [topological_add_group E] {F : Type*} [add_comm_group F] [normed_add_comm_group F] [topological_add_group F]
   [normed_space 𝕜 F]  [has_continuous_const_smul 𝕜 F] (c : F) : formal_multilinear_series 𝕜 E F
 | 0 := continuous_multilinear_map.curry0 _ _ c
 | _ := 0

--- a/src/analysis/calculus/formal_multilinear_series.lean
+++ b/src/analysis/calculus/formal_multilinear_series.lean
@@ -296,7 +296,7 @@ section const
 of degree zero is `c`. It is the power series expansion of the constant function equal to `c`
 everywhere. -/
 def const_formal_multilinear_series (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-  (E : Type*) [normed_add_comm_group E] [normed_space 𝕜 E] [has_continuous_const_smul 𝕜 E]
+  (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] [has_continuous_const_smul 𝕜 E]
   [topological_add_group E] {F : Type*} [add_comm_group F] [normed_add_comm_group F] [topological_add_group F]
   [normed_space 𝕜 F]  [has_continuous_const_smul 𝕜 F] (c : F) : formal_multilinear_series 𝕜 E F
 | 0 := continuous_multilinear_map.curry0 _ _ c

--- a/src/analysis/calculus/formal_multilinear_series.lean
+++ b/src/analysis/calculus/formal_multilinear_series.lean
@@ -121,9 +121,9 @@ end
 namespace formal_multilinear_series
 
 variables [nontrivially_normed_field 𝕜]
-  [normed_add_comm_group E] [normed_space 𝕜 E]
-  [normed_add_comm_group F] [normed_space 𝕜 F]
-  [normed_add_comm_group G] [normed_space 𝕜 G]
+  [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+  [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+  [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
 
 variables (p : formal_multilinear_series 𝕜 E F)
 
@@ -235,7 +235,7 @@ end order
 section coef
 
 variables [nontrivially_normed_field 𝕜]
-  [normed_add_comm_group E] [normed_space 𝕜 E] {s : E}
+  [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {s : E}
   {p : formal_multilinear_series 𝕜 𝕜 E} {f : 𝕜 → E}
   {n : ℕ} {z z₀ : 𝕜} {y : fin n → 𝕜}
 
@@ -268,7 +268,7 @@ end coef
 section fslope
 
 variables [nontrivially_normed_field 𝕜]
-  [normed_add_comm_group E] [normed_space 𝕜 E]
+  [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   {p : formal_multilinear_series 𝕜 𝕜 E} {n : ℕ}
 
 /-- The formal counterpart of `dslope`, corresponding to the expansion of `(f z - f 0) / z`. If `f`
@@ -303,6 +303,7 @@ def const_formal_multilinear_series (𝕜 : Type*) [nontrivially_normed_field �
 | _ := 0
 
 @[simp] lemma const_formal_multilinear_series_apply [nontrivially_normed_field 𝕜]
+  [add_comm_group E] [add_comm_group F]
   [normed_add_comm_group E] [normed_add_comm_group F] [normed_space 𝕜 E] [normed_space 𝕜 F]
   {c : F} {n : ℕ} (hn : n ≠ 0) :
   const_formal_multilinear_series 𝕜 E c n = 0 :=

--- a/src/analysis/calculus/implicit.lean
+++ b/src/analysis/calculus/implicit.lean
@@ -107,9 +107,9 @@ structure implicit_function_data (𝕜 : Type*) [nontrivially_normed_field 𝕜]
 namespace implicit_function_data
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] [complete_space E]
-  {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F] [complete_space F]
-  {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G] [complete_space G]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] [complete_space E]
+  {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] [complete_space F]
+  {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G] [complete_space G]
   (φ : implicit_function_data 𝕜 E F G)
 
 /-- The function given by `x ↦ (left_fun x, right_fun x)`. -/
@@ -205,8 +205,8 @@ complementary to `ker f'` lead to different maps `φ`.
 -/
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] [complete_space E]
-  {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F] [complete_space F]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] [complete_space E]
+  {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] [complete_space F]
   {f : E → F} {f' : E →L[𝕜] F} {a : E}
 
 section defs
@@ -346,8 +346,8 @@ complementary to `ker f'` lead to different maps `φ`.
 section finite_dimensional
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜] [complete_space 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] [complete_space E]
-  {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F] [finite_dimensional 𝕜 F]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] [complete_space E]
+  {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] [finite_dimensional 𝕜 F]
   (f : E → F) (f' : E →L[𝕜] F) {a : E}
 
 /-- Given a map `f : E → F` to a finite dimensional space with a surjective derivative `f'`,

--- a/src/analysis/calculus/implicit.lean
+++ b/src/analysis/calculus/implicit.lean
@@ -90,9 +90,9 @@ such that
 * the kernels of the derivatives are complementary subspaces of `E`. -/
 @[nolint has_nonempty_instance]
 structure implicit_function_data (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-  (E : Type*) [normed_add_comm_group E] [normed_space 𝕜 E] [complete_space E]
-  (F : Type*) [normed_add_comm_group F] [normed_space 𝕜 F] [complete_space F]
-  (G : Type*) [normed_add_comm_group G] [normed_space 𝕜 G] [complete_space G] :=
+  (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] [complete_space E]
+  (F : Type*) [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] [complete_space F]
+  (G : Type*) [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G] [complete_space G] :=
 (left_fun : E → F)
 (left_deriv : E →L[𝕜] F)
 (right_fun : E → G)

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -65,7 +65,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 variables {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
-variables {G' : Type*} [normed_add_comm_group G'] [normed_space 𝕜 G']
+variables {G' : Type*} [add_comm_group G'] [normed_add_comm_group G'] [normed_space 𝕜 G']
 variables {ε : ℝ}
 
 
@@ -725,8 +725,8 @@ is_open_map_iff_nhds_le.2 $ λ x, ((hf x).map_nhds_eq (h0 x)).ge
 
 namespace cont_diff_at
 variables {𝕂 : Type*} [is_R_or_C 𝕂]
-variables {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕂 E']
-variables {F' : Type*} [normed_add_comm_group F'] [normed_space 𝕂 F']
+variables {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕂 E']
+variables {F' : Type*} [add_comm_group F'] [normed_add_comm_group F'] [normed_space 𝕂 F']
 variables [complete_space E'] (f : E' → F') {f' : E' ≃L[𝕂] F'} {a : E'}
 
 /-- Given a `cont_diff` function over `𝕂` (which is `ℝ` or `ℂ`) with an invertible

--- a/src/analysis/calculus/inverse.lean
+++ b/src/analysis/calculus/inverse.lean
@@ -62,9 +62,9 @@ open_locale topology classical nnreal
 noncomputable theory
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
-variables {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
 variables {G' : Type*} [normed_add_comm_group G'] [normed_space 𝕜 G']
 variables {ε : ℝ}
 
@@ -481,8 +481,8 @@ omit cs
 
 /-- In a real vector space, a function `f` that approximates a linear equivalence on a subset `s`
 can be extended to a homeomorphism of the whole space. -/
-lemma exists_homeomorph_extension {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
-  {F : Type*} [normed_add_comm_group F] [normed_space ℝ F] [finite_dimensional ℝ F]
+lemma exists_homeomorph_extension {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+  {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F] [finite_dimensional ℝ F]
   {s : set E} {f : E → F} {f' : E ≃L[ℝ] F} {c : ℝ≥0}
   (hf : approximates_linear_on f (f' : E →L[ℝ] F) s c)
   (hc : subsingleton E ∨ lipschitz_extension_constant F * c < (‖(f'.symm : F →L[ℝ] E)‖₊)⁻¹) :

--- a/src/analysis/calculus/iterated_deriv.lean
+++ b/src/analysis/calculus/iterated_deriv.lean
@@ -46,8 +46,8 @@ open filter asymptotics set
 
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 
 /-- The `n`-th iterated derivative of a function from `𝕜` to `F`, as a function from `𝕜` to `F`. -/
 def iterated_deriv (n : ℕ) (f : 𝕜 → F) (x : 𝕜) : F :=

--- a/src/analysis/calculus/lagrange_multipliers.lean
+++ b/src/analysis/calculus/lagrange_multipliers.lean
@@ -28,7 +28,7 @@ lagrange multiplier, local extremum
 
 open filter set
 open_locale topology filter big_operators
-variables {E F : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
+variables {E F : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
   [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
   {f : E → F} {φ : E → ℝ} {x₀ : E} {f' : E →L[ℝ] F} {φ' : E →L[ℝ] ℝ}
 

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -65,8 +65,8 @@ In this file we prove the following facts:
 -/
 
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
-          {F : Type*} [normed_add_comm_group F] [normed_space ℝ F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+          {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F]
 
 open metric set asymptotics continuous_linear_map filter
 open_locale classical topology nnreal
@@ -1369,8 +1369,8 @@ make sense and are enough. Many formulations of the mean value inequality could 
 balls over `ℝ` or `ℂ`. For now, we only include the ones that we need.
 -/
 
-variables {𝕜 : Type*} [is_R_or_C 𝕜] {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
-  {H : Type*} [normed_add_comm_group H] [normed_space 𝕜 H] {f : G → H} {f' : G → G →L[𝕜] H} {x : G}
+variables {𝕜 : Type*} [is_R_or_C 𝕜] {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
+  {H : Type*} [add_comm_group H] [normed_add_comm_group H] [normed_space 𝕜 H] {f : G → H} {f' : G → G →L[𝕜] H} {x : G}
 
 /-- Over the reals or the complexes, a continuously differentiable function is strictly
 differentiable. -/

--- a/src/analysis/calculus/parametric_integral.lean
+++ b/src/analysis/calculus/parametric_integral.lean
@@ -57,9 +57,9 @@ open topological_space measure_theory filter metric
 open_locale topology filter
 
 variables {α : Type*} [measurable_space α] {μ : measure α} {𝕜 : Type*} [is_R_or_C 𝕜]
-          {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [normed_space 𝕜 E]
+          {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [normed_space 𝕜 E]
           [complete_space E]
-          {H : Type*} [normed_add_comm_group H] [normed_space 𝕜 H]
+          {H : Type*} [add_comm_group H] [normed_add_comm_group H] [normed_space 𝕜 H]
 
 /-- Differentiation under integral of `x ↦ ∫ F x a` at a given point `x₀`, assuming `F x₀` is
 integrable, `‖F x a - F x₀ a‖ ≤ bound a * ‖x - x₀‖` for `x` in a ball around `x₀` for ae `a` with

--- a/src/analysis/calculus/parametric_interval_integral.lean
+++ b/src/analysis/calculus/parametric_interval_integral.lean
@@ -17,9 +17,9 @@ open topological_space measure_theory filter metric
 open_locale topology filter interval
 
 variables {𝕜 : Type*} [is_R_or_C 𝕜] {μ : measure ℝ}
-          {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [normed_space 𝕜 E]
+          {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [normed_space 𝕜 E]
           [complete_space E]
-          {H : Type*} [normed_add_comm_group H] [normed_space 𝕜 H]
+          {H : Type*} [add_comm_group H] [normed_add_comm_group H] [normed_space 𝕜 H]
           {a b ε : ℝ} {bound : ℝ → ℝ}
 
 namespace interval_integral

--- a/src/analysis/calculus/series.lean
+++ b/src/analysis/calculus/series.lean
@@ -26,8 +26,8 @@ open_locale topology nnreal big_operators
 
 variables {α β 𝕜 E F : Type*}
   [is_R_or_C 𝕜]
-  [normed_add_comm_group E] [normed_space 𝕜 E]
-  [normed_add_comm_group F] [complete_space F]
+  [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+  [add_comm_group F] [normed_add_comm_group F] [complete_space F]
   {u : α → ℝ}
 
 /-! ### Continuity -/

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -183,7 +183,7 @@ end
 
 /-- The tangent cone of a product contains the tangent cone of each factor. -/
 lemma maps_to_tangent_cone_pi {ι : Type*} [decidable_eq ι] {E : ι → Type*}
-  [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
+  [Π i, add_comm_group (E i)] [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
   {s : Π i, set (E i)} {x : Π i, E i} {i : ι} (hi : ∀ j ≠ i, x j ∈ closure (s j)) :
   maps_to (linear_map.single i : E i →ₗ[𝕜] Π j, E j) (tangent_cone_at 𝕜 (s i) (x i))
     (tangent_cone_at 𝕜 (set.pi univ s) x) :=
@@ -325,7 +325,7 @@ begin
 end
 
 lemma unique_diff_within_at.univ_pi (ι : Type*) [finite ι] (E : ι → Type*)
-  [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
+  [Π i, add_comm_group (E i)] [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
   (s : Π i, set (E i)) (x : Π i, E i) (h : ∀ i, unique_diff_within_at 𝕜 (s i) (x i)) :
   unique_diff_within_at 𝕜 (set.pi univ s) x :=
 begin
@@ -339,7 +339,7 @@ begin
 end
 
 lemma unique_diff_within_at.pi (ι : Type*) [finite ι] (E : ι → Type*)
-  [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
+  [Π i, add_comm_group (E i)] [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
   (s : Π i, set (E i)) (x : Π i, E i) (I : set ι)
   (h : ∀ i ∈ I, unique_diff_within_at 𝕜 (s i) (x i)) :
   unique_diff_within_at 𝕜 (set.pi I s) x :=
@@ -358,7 +358,7 @@ lemma unique_diff_on.prod {t : set F} (hs : unique_diff_on 𝕜 s) (ht : unique_
 /-- The finite product of a family of sets of unique differentiability is a set of unique
 differentiability. -/
 lemma unique_diff_on.pi (ι : Type*) [finite ι] (E : ι → Type*)
-  [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
+  [Π i, add_comm_group (E i)] [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
   (s : Π i, set (E i)) (I : set ι) (h : ∀ i ∈ I, unique_diff_on 𝕜 (s i)) :
   unique_diff_on 𝕜 (set.pi I s) :=
 λ x hx, unique_diff_within_at.pi _ _ _ _ _ $ λ i hi, h i hi (x i) (hx i hi)
@@ -366,7 +366,7 @@ lemma unique_diff_on.pi (ι : Type*) [finite ι] (E : ι → Type*)
 /-- The finite product of a family of sets of unique differentiability is a set of unique
 differentiability. -/
 lemma unique_diff_on.univ_pi (ι : Type*) [finite ι] (E : ι → Type*)
-  [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
+  [Π i, add_comm_group (E i)] [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
   (s : Π i, set (E i)) (h : ∀ i, unique_diff_on 𝕜 (s i)) :
   unique_diff_on 𝕜 (set.pi univ s) :=
 unique_diff_on.pi _ _ _ _ $ λ i _, h i

--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -63,9 +63,9 @@ def unique_diff_on (s : set E) : Prop :=
 
 end tangent_cone
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
-variables {G : Type*} [normed_add_comm_group G] [normed_space ℝ G]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space ℝ G]
 variables {𝕜} {x y : E} {s t : set E}
 
 section tangent_cone

--- a/src/analysis/calculus/uniform_limits_deriv.lean
+++ b/src/analysis/calculus/uniform_limits_deriv.lean
@@ -98,9 +98,9 @@ open_locale uniformity filter topology
 section limits_of_derivatives
 
 variables {ι : Type*} {l : filter ι}
-  {E : Type*} [normed_add_comm_group E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E]
   {𝕜 : Type*} [is_R_or_C 𝕜] [normed_space 𝕜 E]
-  {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
+  {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
   {f : ι → E → G} {g : E → G} {f' : ι → (E → (E →L[𝕜] G))} {g' : E → (E →L[𝕜] G)}
   {x : E}
 
@@ -473,7 +473,7 @@ derivatives
 
 variables {ι : Type*} {l : filter ι}
   {𝕜 : Type*} [is_R_or_C 𝕜]
-  {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
+  {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
   {f : ι → 𝕜 → G} {g : 𝕜 → G} {f' : ι → 𝕜 → G} {g' : 𝕜 → G}
   {x : 𝕜}
 

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -73,7 +73,7 @@ instance {R : Type*} [normed_field R] [normed_algebra R ℝ] : normed_algebra R 
   end,
   to_algebra := complex.algebra }
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℂ E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E]
 
 /-- The module structure from `module.complex_to_real` is a normed space. -/
 @[priority 900] -- see Note [lower instance priority]

--- a/src/analysis/complex/conformal.lean
+++ b/src/analysis/complex/conformal.lean
@@ -40,7 +40,7 @@ conj_lie.to_linear_isometry.is_conformal_map
 
 section conformal_into_complex_normed
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [normed_space ℂ E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [normed_space ℂ E]
   {z : ℂ} {g : ℂ →L[ℝ] E} {f : ℂ → E}
 
 lemma is_conformal_map_complex_linear {map : ℂ →L[ℂ] E} (nonzero : map ≠ 0) :

--- a/src/analysis/complex/locally_uniform_limit.lean
+++ b/src/analysis/complex/locally_uniform_limit.lean
@@ -23,7 +23,7 @@ subset of the complex plane.
 open set metric measure_theory filter complex interval_integral
 open_locale real topology
 
-variables {E ι : Type*} [normed_add_comm_group E] [normed_space ℂ E] [complete_space E]
+variables {E ι : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E] [complete_space E]
   {U K : set ℂ} {z : ℂ} {M r δ : ℝ} {φ : filter ι} {F : ι → ℂ → E} {f g : ℂ → E}
 
 namespace complex

--- a/src/analysis/complex/open_mapping.lean
+++ b/src/analysis/complex/open_mapping.lean
@@ -32,7 +32,7 @@ second step is implemented in `diff_cont_on_cl.ball_subset_image_closed_ball`.
 open set filter metric complex
 open_locale topology
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℂ E] {U : set E}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E] {U : set E}
   {f : ℂ → ℂ} {g : E → ℂ} {z₀ w : ℂ} {ε r m : ℝ}
 
 /-- If the modulus of a holomorphic function `f` is bounded below by `ε` on a circle, then its range

--- a/src/analysis/complex/phragmen_lindelof.lean
+++ b/src/analysis/complex/phragmen_lindelof.lean
@@ -53,7 +53,7 @@ namespace phragmen_lindelof
 ### Auxiliary lemmas
 -/
 
-variables {E : Type*} [normed_add_comm_group E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 /-- An auxiliary lemma that combines two double exponential estimates into a similar estimate
 on the difference of the functions. -/

--- a/src/analysis/complex/real_deriv.lean
+++ b/src/analysis/complex/real_deriv.lean
@@ -80,7 +80,7 @@ theorem cont_diff.real_of_complex {n : ℕ∞} (h : cont_diff ℂ n e) :
 cont_diff_iff_cont_diff_at.2 $ λ x,
   h.cont_diff_at.real_of_complex
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℂ E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E]
 
 lemma has_strict_deriv_at.complex_to_real_fderiv' {f : ℂ → E} {x : ℂ} {f' : E}
   (h : has_strict_deriv_at f f' x) :
@@ -136,7 +136,7 @@ section conformality
 open complex continuous_linear_map
 open_locale complex_conjugate
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℂ E] {z : ℂ} {f : ℂ → E}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E] {z : ℂ} {f : ℂ → E}
 
 /-- A real differentiable function of the complex plane into some complex normed space `E` is
     conformal at a point `z` if it is holomorphic at that point with a nonvanishing differential.

--- a/src/analysis/complex/schwarz.lean
+++ b/src/analysis/complex/schwarz.lean
@@ -53,7 +53,7 @@ namespace complex
 
 section space
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℂ E] {R R₁ R₂ : ℝ} {f : ℂ → E}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E] {R R₁ R₂ : ℝ} {f : ℂ → E}
   {c z z₀ : ℂ}
 
 /-- An auxiliary lemma for `complex.norm_dslope_le_div_of_maps_to_ball`. -/

--- a/src/analysis/convex/gauge.lean
+++ b/src/analysis/convex/gauge.lean
@@ -434,7 +434,8 @@ lemma seminorm.gauge_seminorm_ball (p : seminorm ℝ E) :
 end add_comm_group
 
 section norm
-variables [seminormed_add_comm_group E] [normed_space ℝ E] {s : set E} {r : ℝ} {x : E}
+variables [add_comm_group E] [seminormed_add_comm_group E] [normed_space ℝ E]
+variables {s : set E} {r : ℝ} {x : E}
 
 lemma gauge_unit_ball (x : E) : gauge (metric.ball (0 : E) 1) x = ‖x‖ :=
 begin

--- a/src/analysis/convex/intrinsic.lean
+++ b/src/analysis/convex/intrinsic.lean
@@ -193,7 +193,9 @@ end
 end add_torsor
 
 namespace affine_isometry
-variables [normed_field 𝕜] [seminormed_add_comm_group V] [seminormed_add_comm_group W]
+variables [normed_field 𝕜]
+  [add_comm_group V] [add_comm_group W]
+  [seminormed_add_comm_group V] [seminormed_add_comm_group W]
   [normed_space 𝕜 V] [normed_space 𝕜 W] [metric_space P] [pseudo_metric_space Q]
   [normed_add_torsor V P] [normed_add_torsor W Q]
 include V W

--- a/src/analysis/convex/measure.lean
+++ b/src/analysis/convex/measure.lean
@@ -18,7 +18,7 @@ convex set in `E`. Then the frontier of `s` has measure zero (see `convex.add_ha
 open measure_theory measure_theory.measure set metric filter finite_dimensional (finrank)
 open_locale topology nnreal ennreal
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E]
   [borel_space E] [finite_dimensional ℝ E] (μ : measure E) [is_add_haar_measure μ] {s : set E}
 
 namespace convex

--- a/src/analysis/convex/normed.lean
+++ b/src/analysis/convex/normed.lean
@@ -30,7 +30,7 @@ variables {ι : Type*} {E : Type*}
 open metric set
 open_locale pointwise convex
 
-variables [seminormed_add_comm_group E] [normed_space ℝ E] {s t : set E}
+variables [add_comm_group E] [seminormed_add_comm_group E] [normed_space ℝ E] {s t : set E}
 
 /-- The norm on a real normed space is convex on any convex set. See also `seminorm.convex_on`
 and `convex_on_univ_norm`. -/

--- a/src/analysis/convex/side.lean
+++ b/src/analysis/convex/side.lean
@@ -815,8 +815,8 @@ end linear_ordered_field
 
 section normed
 
-variables [seminormed_add_comm_group V] [normed_space ℝ V] [pseudo_metric_space P]
-variables [normed_add_torsor V P]
+variables [add_comm_group V] [seminormed_add_comm_group V] [normed_space ℝ V]
+variables [pseudo_metric_space P] [normed_add_torsor V P]
 
 include V
 

--- a/src/analysis/convex/strict_convex_between.lean
+++ b/src/analysis/convex/strict_convex_between.lean
@@ -14,7 +14,7 @@ space.
 
 -/
 
-variables {V P : Type*} [normed_add_comm_group V] [normed_space ℝ V] [pseudo_metric_space P]
+variables {V P : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space ℝ V] [pseudo_metric_space P]
 variables [normed_add_torsor V P] [strict_convex_space ℝ V]
 
 include V

--- a/src/analysis/convex/strict_convex_space.lean
+++ b/src/analysis/convex/strict_convex_space.lean
@@ -237,7 +237,7 @@ by rw [norm_smul, real.norm_of_nonneg (one_div_nonneg.2 zero_le_two), ←inv_eq_
     ←div_eq_inv_mul, div_lt_iff (zero_lt_two' ℝ), mul_two, ←not_same_ray_iff_of_norm_eq h,
     not_same_ray_iff_norm_add_lt, h]
 
-variables {F : Type*} [normed_add_comm_group F] [normed_space ℝ F]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F]
 variables {PF : Type*} {PE : Type*} [metric_space PF] [metric_space PE]
 variables [normed_add_torsor F PF] [normed_add_torsor E PE]
 

--- a/src/analysis/convex/strict_convex_space.lean
+++ b/src/analysis/convex/strict_convex_space.lean
@@ -63,12 +63,13 @@ require balls of positive radius with center at the origin to be strictly convex
 then prove that any closed ball is strictly convex in `strict_convex_closed_ball` below.
 
 See also `strict_convex_space.of_strict_convex_closed_unit_ball`. -/
-class strict_convex_space (𝕜 E : Type*) [normed_linear_ordered_field 𝕜] [normed_add_comm_group E]
+class strict_convex_space (𝕜 E : Type*)
+  [normed_linear_ordered_field 𝕜] [add_comm_group E] [normed_add_comm_group E]
   [normed_space 𝕜 E] : Prop :=
 (strict_convex_closed_ball : ∀ r : ℝ, 0 < r → strict_convex 𝕜 (closed_ball (0 : E) r))
 
 variables (𝕜 : Type*) {E : Type*} [normed_linear_ordered_field 𝕜]
-  [normed_add_comm_group E] [normed_space 𝕜 E]
+  [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 
 /-- A closed ball in a strictly convex space is strictly convex. -/
 lemma strict_convex_closed_ball [strict_convex_space 𝕜 E] (x : E) (r : ℝ) :

--- a/src/analysis/convex/uniform.lean
+++ b/src/analysis/convex/uniform.lean
@@ -44,7 +44,7 @@ class uniform_convex_space (E : Type*) [add_comm_group E] [seminormed_add_comm_g
 variables {E : Type*}
 
 section seminormed_add_comm_group
-variables (E) [seminormed_add_comm_group E] [uniform_convex_space E] {ε : ℝ}
+variables (E) [add_comm_group E] [seminormed_add_comm_group E] [uniform_convex_space E] {ε : ℝ}
 
 lemma exists_forall_sphere_dist_add_le_two_sub (hε : 0 < ε) :
   ∃ δ, 0 < δ ∧ ∀ ⦃x : E⦄, ‖x‖ = 1 → ∀ ⦃y⦄, ‖y‖ = 1 → ε ≤ ‖x - y‖ → ‖x + y‖ ≤ 2 - δ :=

--- a/src/analysis/convex/uniform.lean
+++ b/src/analysis/convex/uniform.lean
@@ -37,7 +37,7 @@ uniform bound. Namely, over the `x` and `y` of norm `1`, `‖x + y‖` is unifor
 by a constant `< 2` when `‖x - y‖` is uniformly bounded below by a positive constant.
 
 See also `uniform_convex_space.of_uniform_convex_closed_unit_ball`. -/
-class uniform_convex_space (E : Type*) [seminormed_add_comm_group E] : Prop :=
+class uniform_convex_space (E : Type*) [add_comm_group E] [seminormed_add_comm_group E] : Prop :=
 (uniform_convex : ∀ ⦃ε : ℝ⦄, 0 < ε → ∃ δ, 0 < δ ∧
   ∀ ⦃x : E⦄, ‖x‖ = 1 → ∀ ⦃y⦄, ‖y‖ = 1 → ε ≤ ‖x - y‖ → ‖x + y‖ ≤ 2 - δ)
 

--- a/src/analysis/convex/uniform.lean
+++ b/src/analysis/convex/uniform.lean
@@ -118,7 +118,7 @@ end
 
 end seminormed_add_comm_group
 
-variables [normed_add_comm_group E] [normed_space ℝ E] [uniform_convex_space E]
+variables [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [uniform_convex_space E]
 
 @[priority 100] -- See note [lower instance priority]
 instance uniform_convex_space.to_strict_convex_space : strict_convex_space ℝ E :=

--- a/src/analysis/convolution.lean
+++ b/src/analysis/convolution.lean
@@ -96,6 +96,7 @@ universes u𝕜 uG uE uE' uE'' uF uF' uF'' uP
 variables {𝕜 : Type u𝕜} {G : Type uG} {E : Type uE} {E' : Type uE'} {E'' : Type uE''}
 {F : Type uF} {F' : Type uF'} {F'' : Type uF''} {P : Type uP}
 
+variables [add_comm_group E] [add_comm_group E'] [add_comm_group E''] [add_comm_group F]
 variables [normed_add_comm_group E] [normed_add_comm_group E'] [normed_add_comm_group E'']
   [normed_add_comm_group F]
   {f f' : G → E} {g g' : G → E'} {x x' : G} {y y' : E}
@@ -941,7 +942,7 @@ namespace cont_diff_bump
 
 variables {n : ℕ∞}
 variables [normed_space ℝ E']
-variables [normed_add_comm_group G] [normed_space ℝ G] [has_cont_diff_bump G]
+variables [add_comm_group G] [normed_add_comm_group G] [normed_space ℝ G] [has_cont_diff_bump G]
 variables [complete_space E']
 variables {a : G} {φ : cont_diff_bump (0 : G)}
 
@@ -1017,7 +1018,9 @@ variables [measurable_space G] {μ ν : measure G}
 variables (L : E →L[𝕜] E' →L[𝕜] F)
 
 section assoc
+variables [add_comm_group F']
 variables [normed_add_comm_group F'] [normed_space ℝ F'] [normed_space 𝕜 F'] [complete_space F']
+variables [add_comm_group F'']
 variables [normed_add_comm_group F''] [normed_space ℝ F''] [normed_space 𝕜 F''] [complete_space F'']
 variables {k : G → E''}
 variables (L₂ : F →L[𝕜] E'' →L[𝕜] F')
@@ -1122,7 +1125,7 @@ end
 
 end assoc
 
-variables [normed_add_comm_group G] [borel_space G]
+variables [add_comm_group G] [normed_add_comm_group G] [borel_space G]
 
 lemma convolution_precompR_apply {g : G → E'' →L[𝕜] E'}
   (hf : locally_integrable f μ) (hcg : has_compact_support g) (hg : continuous g)
@@ -1379,6 +1382,7 @@ In this version, all the types belong to the same universe (to get an induction 
 proof). Use instead `cont_diff_on_convolution_right_with_param`, which removes this restriction. -/
 lemma cont_diff_on_convolution_right_with_param_aux
   {G : Type uP} {E' : Type uP} {F : Type uP} {P : Type uP}
+  [add_comm_group G] [add_comm_group E'] [add_comm_group F] [add_comm_group P]
   [normed_add_comm_group E'] [normed_add_comm_group F]
   [normed_space 𝕜 E'] [normed_space ℝ F] [normed_space 𝕜 F] [complete_space F]
   [measurable_space G] {μ : measure G} [normed_add_comm_group G] [borel_space G] [normed_space 𝕜 G]

--- a/src/analysis/fourier/fourier_transform.lean
+++ b/src/analysis/fourier/fourier_transform.lean
@@ -63,7 +63,7 @@ variables
   {𝕜 : Type*} [comm_ring 𝕜]
   {V : Type*} [add_comm_group V] [module 𝕜 V] [measurable_space V]
   {W : Type*} [add_comm_group W] [module 𝕜 W]
-  {E : Type*} [normed_add_comm_group E] [normed_space ℂ E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E]
 
 section defs
 
@@ -182,7 +182,7 @@ end vector_fourier
 namespace fourier
 
 variables {𝕜 : Type*} [comm_ring 𝕜] [measurable_space 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space ℂ E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E]
 
 section defs
 
@@ -237,7 +237,7 @@ by refl
 lemma continuous_fourier_char : continuous real.fourier_char :=
 (map_continuous exp_map_circle).comp (continuous_const.mul continuous_to_add)
 
-variables {E : Type*} [normed_add_comm_group E] [complete_space E] [normed_space ℂ E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E] [normed_space ℂ E]
 
 lemma vector_fourier_integral_eq_integral_exp_smul
   {V : Type*} [add_comm_group V] [module ℝ V] [measurable_space V]
@@ -256,7 +256,7 @@ lemma fourier_integral_def (f : ℝ → E) (w : ℝ) :
 rfl
 
 lemma fourier_integral_eq_integral_exp_smul
-  {E : Type*} [normed_add_comm_group E] [complete_space E] [normed_space ℂ E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E] [normed_space ℂ E]
   (f : ℝ → E) (w : ℝ) :
   fourier_integral f w = ∫ (v : ℝ), complex.exp (↑(-2 * π * v * w) * complex.I) • f v :=
 by simp_rw [fourier_integral_def, real.fourier_char_apply, mul_neg, neg_mul, mul_assoc]

--- a/src/analysis/fourier/riemann_lebesgue_lemma.lean
+++ b/src/analysis/fourier/riemann_lebesgue_lemma.lean
@@ -34,7 +34,7 @@ open_locale filter topology real ennreal
 
 section continuous_compact_support
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℂ E] {f : ℝ → E}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E] {f : ℝ → E}
 
 /-- The integrand in the Riemann-Lebesgue lemma is integrable. -/
 lemma fourier_integrand_integrable (hf : integrable f) (t : ℝ) :

--- a/src/analysis/inner_product_space/calculus.lean
+++ b/src/analysis/inner_product_space/calculus.lean
@@ -52,7 +52,7 @@ cont_diff_inner.cont_diff_at
 lemma differentiable_inner : differentiable ℝ (λ p : E × E, ⟪p.1, p.2⟫) :=
 is_bounded_bilinear_map_inner.differentiable_at
 
-variables {G : Type*} [normed_add_comm_group G] [normed_space ℝ G]
+variables {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space ℝ G]
   {f g : G → E} {f' g' : G →L[ℝ] E} {s : set G} {x : G} {n : ℕ∞}
 
 include 𝕜

--- a/src/analysis/inner_product_space/euclidean_dist.lean
+++ b/src/analysis/inner_product_space/euclidean_dist.lean
@@ -20,7 +20,7 @@ distance. This way we hide the usage of `to_euclidean` behind an API.
 open_locale topology
 open set
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [finite_dimensional ℝ E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [finite_dimensional ℝ E]
 
 noncomputable theory
 
@@ -106,7 +106,7 @@ nhds_basis_ball.mem_of_mem hr
 
 end euclidean
 
-variables {F : Type*} [normed_add_comm_group F] [normed_space ℝ F] {f g : F → E} {n : ℕ∞}
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F] {f g : F → E} {n : ℕ∞}
 
 lemma cont_diff.euclidean_dist (hf : cont_diff ℝ n f) (hg : cont_diff ℝ n g)
   (h : ∀ x, f x ≠ g x) :

--- a/src/analysis/locally_convex/bounded.lean
+++ b/src/analysis/locally_convex/bounded.lean
@@ -256,7 +256,8 @@ end uniform_add_group
 
 section vonN_bornology_eq_metric
 
-variables (𝕜 E) [nontrivially_normed_field 𝕜] [seminormed_add_comm_group E] [normed_space 𝕜 E]
+variables (𝕜 E) [nontrivially_normed_field 𝕜] [add_comm_group E]
+variables [seminormed_add_comm_group E] [normed_space 𝕜 E]
 
 namespace normed_space
 

--- a/src/analysis/locally_convex/with_seminorms.lean
+++ b/src/analysis/locally_convex/with_seminorms.lean
@@ -422,7 +422,7 @@ begin
   rw [p.with_seminorms_iff_nhds_eq_infi, topological_add_group.ext_iff infer_instance
         (topological_add_group_infi $ λ i, infer_instance), nhds_infi],
   congrm (_ = ⨅ i, _),
-  exact @comap_norm_nhds_zero _ (p i).to_add_group_seminorm.to_seminormed_add_group,
+  exact @comap_norm_nhds_zero _ _ (p i).to_add_group_seminorm.to_seminormed_add_group,
   all_goals {apply_instance}
 end
 
@@ -439,7 +439,7 @@ begin
   rw [p.with_seminorms_iff_nhds_eq_infi, uniform_add_group.ext_iff infer_instance
         (uniform_add_group_infi $ λ i, infer_instance), to_topological_space_infi, nhds_infi],
   congrm (_ = ⨅ i, _),
-  exact @comap_norm_nhds_zero _ (p i).to_add_group_seminorm.to_seminormed_add_group,
+  exact @comap_norm_nhds_zero _ _ (p i).to_add_group_seminorm.to_seminormed_add_group,
   all_goals {apply_instance}
 end
 
@@ -597,7 +597,7 @@ begin
 end
 
 lemma cont_normed_space_to_with_seminorms
-  (E)  [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕝 E]
+  (E) [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕝 E]
   [uniform_space F] [uniform_add_group F]
   {q : ι → seminorm 𝕝₂ F} (hq : with_seminorms q) (f : E →ₛₗ[τ₁₂] F)
   (hf : ∀ i : ι, ∃ C : ℝ≥0, C ≠ 0 ∧ (q i).comp f ≤ C • (norm_seminorm 𝕝 E)) : continuous f :=

--- a/src/analysis/locally_convex/with_seminorms.lean
+++ b/src/analysis/locally_convex/with_seminorms.lean
@@ -448,7 +448,7 @@ end topological_add_group
 section normed_space
 
 /-- The topology of a `normed_space 𝕜 E` is induced by the seminorm `norm_seminorm 𝕜 E`. -/
-lemma norm_with_seminorms (𝕜 E) [normed_field 𝕜] [seminormed_add_comm_group E] [normed_space 𝕜 E] :
+lemma norm_with_seminorms (𝕜 E) [normed_field 𝕜] [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕜 E] :
   with_seminorms (λ (_ : fin 1), norm_seminorm 𝕜 E) :=
 begin
   let p : seminorm_family 𝕜 E (fin 1) := λ _, norm_seminorm 𝕜 E,
@@ -585,7 +585,8 @@ begin
   refl
 end
 
-lemma cont_with_seminorms_normed_space (F) [seminormed_add_comm_group F] [normed_space 𝕝₂ F]
+lemma cont_with_seminorms_normed_space
+  (F) [add_comm_group F] [seminormed_add_comm_group F] [normed_space 𝕝₂ F]
   [uniform_space E] [uniform_add_group E]
   {p : ι → seminorm 𝕝 E} (hp : with_seminorms p) (f : E →ₛₗ[τ₁₂] F)
   (hf : ∃ (s : finset ι) C : ℝ≥0, C ≠ 0 ∧ (norm_seminorm 𝕝₂ F).comp f ≤ C • s.sup p) :
@@ -595,7 +596,8 @@ begin
   exact continuous_from_bounded hp (norm_with_seminorms 𝕝₂ F) f hf,
 end
 
-lemma cont_normed_space_to_with_seminorms (E) [seminormed_add_comm_group E] [normed_space 𝕝 E]
+lemma cont_normed_space_to_with_seminorms
+  (E)  [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕝 E]
   [uniform_space F] [uniform_add_group F]
   {q : ι → seminorm 𝕝₂ F} (hq : with_seminorms q) (f : E →ₛₗ[τ₁₂] F)
   (hf : ∀ i : ι, ∃ C : ℝ≥0, C ≠ 0 ∧ (q i).comp f ≤ C • (norm_seminorm 𝕝 E)) : continuous f :=
@@ -633,7 +635,7 @@ end locally_convex_space
 
 section normed_space
 
-variables (𝕜) [normed_field 𝕜] [normed_space ℝ 𝕜] [seminormed_add_comm_group E]
+variables (𝕜) [normed_field 𝕜] [normed_space ℝ 𝕜] [add_comm_group E] [seminormed_add_comm_group E]
 
 /-- Not an instance since `𝕜` can't be inferred. See `normed_space.to_locally_convex_space` for a
 slightly weaker instance version. -/

--- a/src/analysis/matrix.lean
+++ b/src/analysis/matrix.lean
@@ -175,7 +175,7 @@ section linfty_op
 declared as an instance because there are several natural choices for defining the norm of a
 matrix. -/
 local attribute [instance]
-protected def linfty_op_seminormed_add_comm_group [seminormed_add_comm_group α] :
+protected def linfty_op_seminormed_add_comm_group [add_comm_group α] [seminormed_add_comm_group α] :
   seminormed_add_comm_group (matrix m n α) :=
 (by apply_instance : seminormed_add_comm_group (m → pi_Lp 1 (λ j : n, α)))
 
@@ -183,7 +183,7 @@ protected def linfty_op_seminormed_add_comm_group [seminormed_add_comm_group α]
 declared as an instance because there are several natural choices for defining the norm of a
 matrix. -/
 local attribute [instance]
-protected def linfty_op_normed_add_comm_group [normed_add_comm_group α] :
+protected def linfty_op_normed_add_comm_group [add_comm_group α] [normed_add_comm_group α] :
   normed_add_comm_group (matrix m n α) :=
 (by apply_instance : normed_add_comm_group (m → pi_Lp 1 (λ j : n, α)))
 
@@ -191,7 +191,8 @@ protected def linfty_op_normed_add_comm_group [normed_add_comm_group α] :
 declared as an instance because there are several natural choices for defining the norm of a
 matrix. -/
 local attribute [instance]
-protected def linfty_op_normed_space [normed_field R] [seminormed_add_comm_group α]
+protected def linfty_op_normed_space
+  [normed_field R] [add_comm_group α] [seminormed_add_comm_group α]
   [normed_space R α] :
   normed_space R (matrix m n α) :=
 (by apply_instance : normed_space R (m → pi_Lp 1 (λ j : n, α)))
@@ -351,7 +352,7 @@ def frobenius_seminormed_add_comm_group [seminormed_add_comm_group α] :
 declared as an instance because there are several natural choices for defining the norm of a
 matrix. -/
 local attribute [instance]
-def frobenius_normed_add_comm_group [normed_add_comm_group α] :
+def frobenius_normed_add_comm_group [add_comm_group α] [normed_add_comm_group α] :
   normed_add_comm_group (matrix m n α) :=
 (by apply_instance : normed_add_comm_group (pi_Lp 2 (λ i : m, pi_Lp 2 (λ j : n, α))))
 

--- a/src/analysis/matrix.lean
+++ b/src/analysis/matrix.lean
@@ -54,6 +54,7 @@ variables {R l m n α β : Type*} [fintype l] [fintype m] [fintype n]
 section linf_linf
 
 section seminormed_add_comm_group
+variables [add_comm_group α] [add_comm_group β]
 variables [seminormed_add_comm_group α] [seminormed_add_comm_group β]
 
 /-- Seminormed group instance (using sup norm of sup norm) for matrices over a seminormed group. Not
@@ -142,14 +143,14 @@ end seminormed_add_comm_group
 /-- Normed group instance (using sup norm of sup norm) for matrices over a normed group.  Not
 declared as an instance because there are several natural choices for defining the norm of a
 matrix. -/
-protected def normed_add_comm_group [normed_add_comm_group α] :
+protected def normed_add_comm_group [add_comm_group α] [normed_add_comm_group α] :
   normed_add_comm_group (matrix m n α) :=
 pi.normed_add_comm_group
 
 section normed_space
 local attribute [instance] matrix.seminormed_add_comm_group
 
-variables [normed_field R] [seminormed_add_comm_group α] [normed_space R α]
+variables [normed_field R] [add_comm_group α] [seminormed_add_comm_group α] [normed_space R α]
 
 /-- Normed space instance (using sup norm of sup norm) for matrices over a normed space.  Not
 declared as an instance because there are several natural choices for defining the norm of a

--- a/src/analysis/normed/field/basic.lean
+++ b/src/analysis/normed/field/basic.lean
@@ -106,12 +106,13 @@ export norm_one_class (norm_one)
 
 attribute [simp] norm_one
 
-@[simp] lemma nnnorm_one [seminormed_add_comm_group α] [has_one α] [norm_one_class α] :
+@[simp] lemma nnnorm_one [add_comm_group α] [seminormed_add_comm_group α] [has_one α]
+  [norm_one_class α] :
   ‖(1 : α)‖₊ = 1 :=
 nnreal.eq norm_one
 
-lemma norm_one_class.nontrivial (α : Type*) [seminormed_add_comm_group α] [has_one α]
-  [norm_one_class α] :
+lemma norm_one_class.nontrivial
+  (α : Type*) [add_comm_group α] [seminormed_add_comm_group α] [has_one α] [norm_one_class α] :
   nontrivial α :=
 nontrivial_of_ne 0 1 $ ne_of_apply_ne norm $ by simp
 
@@ -127,15 +128,18 @@ instance non_unital_normed_ring.to_normed_add_comm_group [β : non_unital_normed
 instance non_unital_semi_normed_ring.to_seminormed_add_comm_group [non_unital_semi_normed_ring α] :
   seminormed_add_comm_group α := { ..‹non_unital_semi_normed_ring α› }
 
-instance [seminormed_add_comm_group α] [has_one α] [norm_one_class α] : norm_one_class (ulift α) :=
+instance [add_comm_group α] [seminormed_add_comm_group α] [has_one α] [norm_one_class α] :
+  norm_one_class (ulift α) :=
 ⟨by simp [ulift.norm_def]⟩
 
-instance prod.norm_one_class [seminormed_add_comm_group α] [has_one α] [norm_one_class α]
-  [seminormed_add_comm_group β] [has_one β] [norm_one_class β] :
+instance prod.norm_one_class
+  [add_comm_group α] [seminormed_add_comm_group α] [has_one α] [norm_one_class α]
+  [add_comm_group β] [seminormed_add_comm_group β] [has_one β] [norm_one_class β] :
   norm_one_class (α × β) :=
 ⟨by simp [prod.norm_def]⟩
 
 instance pi.norm_one_class {ι : Type*} {α : ι → Type*} [nonempty ι] [fintype ι]
+  [Π i, add_comm_group (α i)]
   [Π i, seminormed_add_comm_group (α i)] [Π i, has_one (α i)] [∀ i, norm_one_class (α i)] :
   norm_one_class (Π i, α i) :=
 ⟨by simp [pi.norm_def, finset.sup_const finset.univ_nonempty]⟩
@@ -374,7 +378,7 @@ instance prod.normed_ring [normed_ring β] : normed_ring (α × β) :=
 instance pi.normed_ring {π : ι → Type*} [fintype ι] [Π i, normed_ring (π i)] :
   normed_ring (Π i, π i) :=
 { norm_mul := norm_mul_le,
-  ..pi.normed_add_comm_group }
+  ..pi.semi_normed_ring }
 
 end normed_ring
 
@@ -657,15 +661,16 @@ nnreal.eq $ real.norm_of_nonneg x.2
 
 end nnreal
 
-@[simp] lemma norm_norm [seminormed_add_comm_group α] (x : α) : ‖‖x‖‖ = ‖x‖ :=
+@[simp] lemma norm_norm [add_comm_group α] [seminormed_add_comm_group α] (x : α) : ‖‖x‖‖ = ‖x‖ :=
 real.norm_of_nonneg (norm_nonneg _)
 
-@[simp] lemma nnnorm_norm [seminormed_add_comm_group α] (a : α) : ‖‖a‖‖₊ = ‖a‖₊ :=
+@[simp] lemma nnnorm_norm [add_comm_group α] [seminormed_add_comm_group α] (a : α) :
+  ‖‖a‖‖₊ = ‖a‖₊ :=
 by simpa [real.nnnorm_of_nonneg (norm_nonneg a)]
 
 /-- A restatement of `metric_space.tendsto_at_top` in terms of the norm. -/
 lemma normed_add_comm_group.tendsto_at_top [nonempty α] [semilattice_sup α] {β : Type*}
-  [seminormed_add_comm_group β] {f : α → β} {b : β} :
+  [add_comm_group β] [seminormed_add_comm_group β] {f : α → β} {b : β} :
   tendsto f at_top (𝓝 b) ↔ ∀ ε, 0 < ε → ∃ N, ∀ n, N ≤ n → ‖f n - b‖ < ε :=
 (at_top_basis.tendsto_iff metric.nhds_basis_ball).trans (by simp [dist_eq_norm])
 
@@ -674,7 +679,7 @@ A variant of `normed_add_comm_group.tendsto_at_top` that
 uses `∃ N, ∀ n > N, ...` rather than `∃ N, ∀ n ≥ N, ...`
 -/
 lemma normed_add_comm_group.tendsto_at_top' [nonempty α] [semilattice_sup α] [no_max_order α]
-  {β : Type*} [seminormed_add_comm_group β]
+  {β : Type*} [add_comm_group β] [seminormed_add_comm_group β]
   {f : α → β} {b : β} :
   tendsto f at_top (𝓝 b) ↔ ∀ ε, 0 < ε → ∃ N, ∀ n, N < n → ‖f n - b‖ < ε :=
 (at_top_basis_Ioi.tendsto_iff metric.nhds_basis_ball).trans (by simp [dist_eq_norm])

--- a/src/analysis/normed/group/SemiNormedGroup.lean
+++ b/src/analysis/normed/group/SemiNormedGroup.lean
@@ -22,24 +22,33 @@ universes u
 open category_theory
 
 /-- The category of seminormed abelian groups and bounded group homomorphisms. -/
-def SemiNormedGroup : Type (u+1) := bundled seminormed_add_comm_group
+structure SemiNormedGroup : Type (u+1) :=
+(carrier : Type u)
+[is_add_comm_group : add_comm_group carrier]
+[is_seminormed_add_comm_group : seminormed_add_comm_group carrier]
+
+attribute [instance] SemiNormedGroup.is_add_comm_group SemiNormedGroup.is_seminormed_add_comm_group
 
 namespace SemiNormedGroup
 
-instance bundled_hom : bundled_hom @normed_add_group_hom :=
-⟨@normed_add_group_hom.to_fun, @normed_add_group_hom.id, @normed_add_group_hom.comp,
-  @normed_add_group_hom.coe_inj⟩
+instance : has_coe_to_sort SemiNormedGroup.{u} (Type u) := ⟨SemiNormedGroup.carrier⟩
 
-attribute [derive [large_category, concrete_category]] SemiNormedGroup
+instance SemiNormedGroup_large_category : large_category SemiNormedGroup.{u} :=
+{ hom   := λ M N, normed_add_group_hom M N,
+  id    := λ M, normed_add_group_hom.id M,
+  comp  := λ A B C f g, g.comp f,
+  id_comp' := λ X Y f, normed_add_group_hom.ext $ λ _, rfl,
+  comp_id' := λ X Y f, normed_add_group_hom.ext $ λ _, rfl,
+  assoc' := λ W X Y Z f g h, normed_add_group_hom.comp_assoc _ _ _ }
 
-instance : has_coe_to_sort SemiNormedGroup (Type u) := bundled.has_coe_to_sort
+instance SemiNormedGroup_concrete_category : concrete_category.{u} SemiNormedGroup.{u} :=
+{ forget := { obj := λ R, R, map := λ R S f, (f : R → S) },
+  forget_faithful := { } }
 
 /-- Construct a bundled `SemiNormedGroup` from the underlying type and typeclass. -/
-def of (M : Type u) [seminormed_add_comm_group M] : SemiNormedGroup := bundled.of M
+def of (M : Type u) [add_comm_group M] [seminormed_add_comm_group M] : SemiNormedGroup := ⟨M⟩
 
-instance (M : SemiNormedGroup) : seminormed_add_comm_group M := M.str
-
-@[simp] lemma coe_of (V : Type u) [seminormed_add_comm_group V] :
+@[simp] lemma coe_of (V : Type u) [add_comm_group V] [seminormed_add_comm_group V] :
   (SemiNormedGroup.of V : Type u) = V := rfl
 @[simp] lemma coe_id (V : SemiNormedGroup) : ⇑(𝟙 V) = id := rfl
 @[simp] lemma coe_comp {M N K : SemiNormedGroup} (f : M ⟶ N) (g : N ⟶ K) :
@@ -47,7 +56,7 @@ instance (M : SemiNormedGroup) : seminormed_add_comm_group M := M.str
 
 instance : inhabited SemiNormedGroup := ⟨of punit⟩
 
-instance of_unique (V : Type u) [seminormed_add_comm_group V] [i : unique V] :
+instance of_unique (V : Type u) [add_comm_group V] [seminormed_add_comm_group V] [i : unique V] :
   unique (SemiNormedGroup.of V) := i
 
 instance : limits.has_zero_morphisms.{u (u+1)} SemiNormedGroup := {}
@@ -82,11 +91,11 @@ end SemiNormedGroup
 `SemiNormedGroup₁` is a type synonym for `SemiNormedGroup`,
 which we shall equip with the category structure consisting only of the norm non-increasing maps.
 -/
-def SemiNormedGroup₁ : Type (u+1) := bundled seminormed_add_comm_group
+def SemiNormedGroup₁ : Type (u+1) := SemiNormedGroup
 
 namespace SemiNormedGroup₁
 
-instance : has_coe_to_sort SemiNormedGroup₁ (Type u) := bundled.has_coe_to_sort
+instance : has_coe_to_sort SemiNormedGroup₁ (Type u) := SemiNormedGroup.has_coe_to_sort
 
 instance : large_category.{u} SemiNormedGroup₁ :=
 { hom := λ X Y, { f : normed_add_group_hom X Y // f.norm_noninc },
@@ -105,9 +114,8 @@ instance : concrete_category.{u} SemiNormedGroup₁ :=
   forget_faithful := {} }
 
 /-- Construct a bundled `SemiNormedGroup₁` from the underlying type and typeclass. -/
-def of (M : Type u) [seminormed_add_comm_group M] : SemiNormedGroup₁ := bundled.of M
-
-instance (M : SemiNormedGroup₁) : seminormed_add_comm_group M := M.str
+def of (M : Type u) [add_comm_group M] [seminormed_add_comm_group M] : SemiNormedGroup₁ :=
+⟨M⟩
 
 /-- Promote a morphism in `SemiNormedGroup` to a morphism in `SemiNormedGroup₁`. -/
 def mk_hom {M N : SemiNormedGroup} (f : M ⟶ N) (i : f.norm_noninc) :
@@ -131,7 +139,7 @@ instance : has_forget₂ SemiNormedGroup₁ SemiNormedGroup :=
   { obj := λ X, X,
     map := λ X Y f, f.1, }, }
 
-@[simp] lemma coe_of (V : Type u) [seminormed_add_comm_group V] :
+@[simp] lemma coe_of (V : Type u) [add_comm_group V] [seminormed_add_comm_group V] :
   (SemiNormedGroup₁.of V : Type u) = V := rfl
 @[simp] lemma coe_id (V : SemiNormedGroup₁) : ⇑(𝟙 V) = id := rfl
 @[simp] lemma coe_comp {M N K : SemiNormedGroup₁} (f : M ⟶ N) (g : N ⟶ K) :
@@ -142,7 +150,7 @@ instance : has_forget₂ SemiNormedGroup₁ SemiNormedGroup :=
 
 instance : inhabited SemiNormedGroup₁ := ⟨of punit⟩
 
-instance of_unique (V : Type u) [seminormed_add_comm_group V] [i : unique V] :
+instance of_unique (V : Type u) [add_comm_group V] [seminormed_add_comm_group V] [i : unique V] :
   unique (SemiNormedGroup₁.of V) := i
 
 instance : limits.has_zero_morphisms.{u (u+1)} SemiNormedGroup₁ :=

--- a/src/analysis/normed/group/SemiNormedGroup/completion.lean
+++ b/src/analysis/normed/group/SemiNormedGroup/completion.lean
@@ -79,9 +79,9 @@ add_monoid_hom.mk' (category_theory.functor.map Completion) $ λ f g,
 instance : preadditive SemiNormedGroup.{u} :=
 { hom_group := λ P Q, infer_instance,
   add_comp' := by { intros, ext,
-    simp only [normed_add_group_hom.add_apply, category_theory.comp_apply, map_add] },
+    simp only [normed_add_group_hom.add_apply, category_theory.comp_apply, map_add g] },
   comp_add' := by { intros, ext,
-    simp only [normed_add_group_hom.add_apply, category_theory.comp_apply, map_add] } }
+    simp only [normed_add_group_hom.add_apply, category_theory.comp_apply, map_add f] } }
 
 instance : functor.additive Completion :=
 { map_add' := λ X Y, (Completion.map_hom _ _).map_add }

--- a/src/analysis/normed/group/add_torsor.lean
+++ b/src/analysis/normed/group/add_torsor.lean
@@ -26,6 +26,7 @@ norm (which in fact implies the distance yields a pseudometric space, but
 bundling just the distance and using an instance for the pseudometric space
 results in type class problems). -/
 class normed_add_torsor (V : out_param $ Type*) (P : Type*)
+  [out_param $ add_comm_group V]
   [out_param $ seminormed_add_comm_group V] [pseudo_metric_space P]
   extends add_torsor V P :=
 (dist_eq_norm' : ∀ (x y : P), dist x y = ‖(x -ᵥ y : V)‖)
@@ -35,7 +36,8 @@ class normed_add_torsor (V : out_param $ Type*) (P : Type*)
 instance normed_add_torsor.to_add_torsor' {V P : Type*} [add_comm_group V] [normed_add_comm_group V] [metric_space P]
   [normed_add_torsor V P] : add_torsor V P := normed_add_torsor.to_add_torsor
 
-variables {α V P W Q : Type*} [add_comm_group V] [seminormed_add_comm_group V] [pseudo_metric_space P]
+variables {α V P W Q : Type*} [add_comm_group V] [add_comm_group W]
+  [seminormed_add_comm_group V] [pseudo_metric_space P]
   [normed_add_torsor V P] [normed_add_comm_group W] [metric_space Q] [normed_add_torsor W Q]
 
 @[priority 100]
@@ -136,7 +138,7 @@ omit V
 is not an instance because it depends on `V` to define a `metric_space
 P`. -/
 def pseudo_metric_space_of_normed_add_comm_group_of_add_torsor (V P : Type*)
-  [seminormed_add_comm_group V] [add_torsor V P] : pseudo_metric_space P :=
+  [add_comm_group V] [seminormed_add_comm_group V] [add_torsor V P] : pseudo_metric_space P :=
 { dist := λ x y, ‖(x -ᵥ y : V)‖,
   dist_self := λ x, by simp,
   dist_comm := λ x y, by simp only [←neg_vsub_eq_vsub_rev y x, norm_neg],
@@ -151,7 +153,7 @@ def pseudo_metric_space_of_normed_add_comm_group_of_add_torsor (V P : Type*)
 is not an instance because it depends on `V` to define a `metric_space
 P`. -/
 def metric_space_of_normed_add_comm_group_of_add_torsor (V P : Type*)
-  [normed_add_comm_group V] [add_torsor V P] :
+  [add_comm_group V] [normed_add_comm_group V] [add_torsor V P] :
   metric_space P :=
 { dist := λ x y, ‖(x -ᵥ y : V)‖,
   dist_self := λ x, by simp,

--- a/src/analysis/normed/group/add_torsor.lean
+++ b/src/analysis/normed/group/add_torsor.lean
@@ -32,10 +32,10 @@ class normed_add_torsor (V : out_param $ Type*) (P : Type*)
 
 /-- Shortcut instance to help typeclass inference out. -/
 @[priority 100]
-instance normed_add_torsor.to_add_torsor' {V P : Type*} [normed_add_comm_group V] [metric_space P]
+instance normed_add_torsor.to_add_torsor' {V P : Type*} [add_comm_group V] [normed_add_comm_group V] [metric_space P]
   [normed_add_torsor V P] : add_torsor V P := normed_add_torsor.to_add_torsor
 
-variables {α V P W Q : Type*} [seminormed_add_comm_group V] [pseudo_metric_space P]
+variables {α V P W Q : Type*} [add_comm_group V] [seminormed_add_comm_group V] [pseudo_metric_space P]
   [normed_add_torsor V P] [normed_add_comm_group W] [metric_space Q] [normed_add_torsor W Q]
 
 @[priority 100]

--- a/src/analysis/normed/group/ball_sphere.lean
+++ b/src/analysis/normed/group/ball_sphere.lean
@@ -14,7 +14,7 @@ semi normed group.
 
 open metric set
 
-variables {E : Type*} [seminormed_add_comm_group E] {r : ℝ}
+variables {E : Type*} [add_comm_group E] [seminormed_add_comm_group E] {r : ℝ}
 
 /-- We equip the sphere, in a seminormed group, with a formal operation of negation, namely the
 antipodal map. -/

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -90,27 +90,37 @@ class normed_group (E : Type*) [group E] extends has_norm E, metric_space E :=
 defines a pseudometric space structure.
 
 TODO: remove this, it is the same as `seminormed_add_group` -/
-class seminormed_add_comm_group (E : Type*) [add_comm_group E] extends seminormed_add_group E
+class seminormed_add_comm_group (E : Type*) [add_comm_group E]
+  extends has_norm E, pseudo_metric_space E :=
+(dist := λ x y, ‖x - y‖)
+(dist_eq : ∀ x y, dist x y = ‖x - y‖ . obviously)
 
 /-- A seminormed group is a group endowed with a norm for which `dist x y = ‖x / y‖`
 defines a pseudometric space structure.
 
 TODO: remove this, it is the same as `seminormed_group` -/
 @[to_additive]
-class seminormed_comm_group (E : Type*) [comm_group E] extends seminormed_group E
+class seminormed_comm_group (E : Type*) [comm_group E]
+  extends has_norm E, pseudo_metric_space E :=
+(dist := λ x y, ‖x / y‖)
+(dist_eq : ∀ x y, dist x y = ‖x / y‖ . obviously)
 
 /-- A normed group is an additive group endowed with a norm for which `dist x y = ‖x - y‖` defines a
 metric space structure.
 
 TODO: remove this, it is the same as `normed_add_group` -/
-class normed_add_comm_group (E : Type*) [add_comm_group E] extends normed_add_group E
+class normed_add_comm_group (E : Type*) [add_comm_group E] extends has_norm E, metric_space E :=
+(dist := λ x y, ‖x - y‖)
+(dist_eq : ∀ x y, dist x y = ‖x - y‖ . obviously)
 
 /-- A normed group is a group endowed with a norm for which `dist x y = ‖x / y‖` defines a metric
 space structure.
 
 TODO: remove this, it is the same as `normed_group` -/
 @[to_additive]
-class normed_comm_group (E : Type*) [comm_group E] extends normed_group E
+class normed_comm_group (E : Type*) [comm_group E] extends has_norm E, metric_space E :=
+(dist := λ x y, ‖x / y‖)
+(dist_eq : ∀ x y, dist x y = ‖x / y‖ . obviously)
 
 @[priority 100, to_additive] -- See note [lower instance priority]
 instance normed_group.to_seminormed_group [group E] [normed_group E] : seminormed_group E :=
@@ -119,6 +129,15 @@ instance normed_group.to_seminormed_group [group E] [normed_group E] : seminorme
 @[priority 100, to_additive] -- See note [lower instance priority]
 instance normed_comm_group.to_seminormed_comm_group [comm_group E] [normed_comm_group E] :
   seminormed_comm_group E :=
+{ ..‹normed_comm_group E› }
+
+@[priority 100, to_additive] -- See note [lower instance priority]
+instance seminormed_comm_group.to_seminormed_group [comm_group E] [seminormed_comm_group E] :
+  seminormed_group E :=
+{ ..‹seminormed_comm_group E› }
+
+@[priority 100, to_additive] -- See note [lower instance priority]
+instance normed_comm_group.to_normed_group [comm_group E] [normed_comm_group E] : normed_group E :=
 { ..‹normed_comm_group E› }
 
 /-- Construct a `normed_group` from a `seminormed_group` satisfying `∀ x, ‖x‖ = 0 → x = 1`. This

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -62,73 +62,63 @@ notation `‖` e `‖₊` := nnnorm e
 
 /-- A seminormed group is an additive group endowed with a norm for which `dist x y = ‖x - y‖`
 defines a pseudometric space structure. -/
-class seminormed_add_group (E : Type*) extends has_norm E, add_group E, pseudo_metric_space E :=
+class seminormed_add_group (E : Type*) [add_group E] extends has_norm E,  pseudo_metric_space E :=
 (dist := λ x y, ‖x - y‖)
 (dist_eq : ∀ x y, dist x y = ‖x - y‖ . obviously)
 
 /-- A seminormed group is a group endowed with a norm for which `dist x y = ‖x / y‖` defines a
 pseudometric space structure. -/
 @[to_additive]
-class seminormed_group (E : Type*) extends has_norm E, group E, pseudo_metric_space E :=
+class seminormed_group (E : Type*) [group E] extends has_norm E, pseudo_metric_space E :=
 (dist := λ x y, ‖x / y‖)
 (dist_eq : ∀ x y, dist x y = ‖x / y‖ . obviously)
 
 /-- A normed group is an additive group endowed with a norm for which `dist x y = ‖x - y‖` defines a
 metric space structure. -/
-class normed_add_group (E : Type*) extends has_norm E, add_group E, metric_space E :=
+class normed_add_group (E : Type*) [add_group E] extends has_norm E, metric_space E :=
 (dist := λ x y, ‖x - y‖)
 (dist_eq : ∀ x y, dist x y = ‖x - y‖ . obviously)
 
 /-- A normed group is a group endowed with a norm for which `dist x y = ‖x / y‖` defines a metric
 space structure. -/
 @[to_additive]
-class normed_group (E : Type*) extends has_norm E, group E, metric_space E :=
+class normed_group (E : Type*) [group E] extends has_norm E, metric_space E :=
 (dist := λ x y, ‖x / y‖)
 (dist_eq : ∀ x y, dist x y = ‖x / y‖ . obviously)
 
 /-- A seminormed group is an additive group endowed with a norm for which `dist x y = ‖x - y‖`
-defines a pseudometric space structure. -/
-class seminormed_add_comm_group (E : Type*)
-  extends has_norm E, add_comm_group E, pseudo_metric_space E :=
-(dist := λ x y, ‖x - y‖)
-(dist_eq : ∀ x y, dist x y = ‖x - y‖ . obviously)
+defines a pseudometric space structure.
+
+TODO: remove this, it is the same as `seminormed_add_group` -/
+class seminormed_add_comm_group (E : Type*) [add_comm_group E] extends seminormed_add_group E
 
 /-- A seminormed group is a group endowed with a norm for which `dist x y = ‖x / y‖`
-defines a pseudometric space structure. -/
+defines a pseudometric space structure.
+
+TODO: remove this, it is the same as `seminormed_group` -/
 @[to_additive]
-class seminormed_comm_group (E : Type*)
-  extends has_norm E, comm_group E, pseudo_metric_space E :=
-(dist := λ x y, ‖x / y‖)
-(dist_eq : ∀ x y, dist x y = ‖x / y‖ . obviously)
+class seminormed_comm_group (E : Type*) [comm_group E] extends seminormed_group E
 
 /-- A normed group is an additive group endowed with a norm for which `dist x y = ‖x - y‖` defines a
-metric space structure. -/
-class normed_add_comm_group (E : Type*) extends has_norm E, add_comm_group E, metric_space E :=
-(dist := λ x y, ‖x - y‖)
-(dist_eq : ∀ x y, dist x y = ‖x - y‖ . obviously)
+metric space structure.
+
+TODO: remove this, it is the same as `normed_add_group` -/
+class normed_add_comm_group (E : Type*) [add_comm_group E] extends normed_add_group E
 
 /-- A normed group is a group endowed with a norm for which `dist x y = ‖x / y‖` defines a metric
-space structure. -/
+space structure.
+
+TODO: remove this, it is the same as `normed_group` -/
 @[to_additive]
-class normed_comm_group (E : Type*) extends has_norm E, comm_group E, metric_space E :=
-(dist := λ x y, ‖x / y‖)
-(dist_eq : ∀ x y, dist x y = ‖x / y‖ . obviously)
+class normed_comm_group (E : Type*) [comm_group E] extends normed_group E
 
 @[priority 100, to_additive] -- See note [lower instance priority]
-instance normed_group.to_seminormed_group [normed_group E] : seminormed_group E :=
+instance normed_group.to_seminormed_group [group E] [normed_group E] : seminormed_group E :=
 { ..‹normed_group E› }
 
 @[priority 100, to_additive] -- See note [lower instance priority]
-instance normed_comm_group.to_seminormed_comm_group [normed_comm_group E] :
+instance normed_comm_group.to_seminormed_comm_group [comm_group E] [normed_comm_group E] :
   seminormed_comm_group E :=
-{ ..‹normed_comm_group E› }
-
-@[priority 100, to_additive] -- See note [lower instance priority]
-instance seminormed_comm_group.to_seminormed_group [seminormed_comm_group E] : seminormed_group E :=
-{ ..‹seminormed_comm_group E› }
-
-@[priority 100, to_additive] -- See note [lower instance priority]
-instance normed_comm_group.to_normed_group [normed_comm_group E] : normed_group E :=
 { ..‹normed_comm_group E› }
 
 /-- Construct a `normed_group` from a `seminormed_group` satisfying `∀ x, ‖x‖ = 0 → x = 1`. This
@@ -138,7 +128,7 @@ instance as a special case of a more general `seminormed_group` instance. -/
 `∀ x, ‖x‖ = 0 → x = 0`. This avoids having to go back to the `(pseudo_)metric_space` level when
 declaring a `normed_add_group` instance as a special case of a more general `seminormed_add_group`
 instance.", reducible] -- See note [reducible non-instances]
-def normed_group.of_separation [seminormed_group E] (h : ∀ x : E, ‖x‖ = 0 → x = 1) :
+def normed_group.of_separation [group E] [seminormed_group E] (h : ∀ x : E, ‖x‖ = 0 → x = 1) :
   normed_group E :=
 { to_metric_space :=
   { eq_of_dist_eq_zero := λ x y hxy, div_eq_one.1 $ h _ $ by rwa ←‹seminormed_group E›.dist_eq },
@@ -152,7 +142,8 @@ instance. -/
 `∀ x, ‖x‖ = 0 → x = 0`. This avoids having to go back to the `(pseudo_)metric_space` level when
 declaring a `normed_add_comm_group` instance as a special case of a more general
 `seminormed_add_comm_group` instance.", reducible] -- See note [reducible non-instances]
-def normed_comm_group.of_separation [seminormed_comm_group E] (h : ∀ x : E, ‖x‖ = 0 → x = 1) :
+def normed_comm_group.of_separation [comm_group E] [seminormed_comm_group E]
+  (h : ∀ x : E, ‖x‖ = 0 → x = 1) :
   normed_comm_group E :=
 { ..‹seminormed_comm_group E›, ..normed_group.of_separation h }
 
@@ -280,6 +271,7 @@ instance : normed_add_comm_group punit :=
 @[simp] lemma punit.norm_eq_zero (r : punit) : ‖r‖ = 0 := rfl
 
 section seminormed_group
+variables [group E] [group F] [group G]
 variables [seminormed_group E] [seminormed_group F] [seminormed_group G] {s : set E}
   {a a₁ a₂ b b₁ b₂ : E} {r r₁ r₂ : ℝ}
 
@@ -888,7 +880,8 @@ structure on the domain. -/
 @[reducible, -- See note [reducible non-instances]
 to_additive "A group homomorphism from an `add_group` to a `seminormed_add_group` induces a
 `seminormed_add_group` structure on the domain."]
-def seminormed_group.induced [group E] [seminormed_group F] [monoid_hom_class 𝓕 E F] (f : 𝓕) :
+def seminormed_group.induced [group E] [group F] [seminormed_group F] [monoid_hom_class 𝓕 E F]
+  (f : 𝓕) :
   seminormed_group E :=
 { norm := λ x, ‖f x‖,
   dist_eq := λ x y, by simpa only [map_div, ←dist_eq_norm_div],
@@ -899,7 +892,8 @@ def seminormed_group.induced [group E] [seminormed_group F] [monoid_hom_class �
 @[reducible, -- See note [reducible non-instances]
 to_additive "A group homomorphism from an `add_comm_group` to a `seminormed_add_group` induces a
 `seminormed_add_comm_group` structure on the domain."]
-def seminormed_comm_group.induced [comm_group E] [seminormed_group F] [monoid_hom_class 𝓕 E F]
+def seminormed_comm_group.induced [comm_group E] [comm_group F] [seminormed_group F]
+  [monoid_hom_class 𝓕 E F]
   (f : 𝓕) : seminormed_comm_group E :=
 { ..seminormed_group.induced E F f }
 
@@ -908,7 +902,7 @@ structure on the domain. -/
 @[reducible,  -- See note [reducible non-instances].
 to_additive "An injective group homomorphism from an `add_group` to a `normed_add_group` induces a
 `normed_add_group` structure on the domain."]
-def normed_group.induced [group E] [normed_group F] [monoid_hom_class 𝓕 E F] (f : 𝓕)
+def normed_group.induced [group E] [group F] [normed_group F] [monoid_hom_class 𝓕 E F] (f : 𝓕)
   (h : injective f) : normed_group E :=
 { ..seminormed_group.induced E F f, ..metric_space.induced f h _ }
 
@@ -917,13 +911,14 @@ def normed_group.induced [group E] [normed_group F] [monoid_hom_class 𝓕 E F] 
 @[reducible,  -- See note [reducible non-instances].
 to_additive "An injective group homomorphism from an `comm_group` to a `normed_comm_group` induces a
 `normed_comm_group` structure on the domain."]
-def normed_comm_group.induced [comm_group E] [normed_group F] [monoid_hom_class 𝓕 E F] (f : 𝓕)
-  (h : injective f) : normed_comm_group E :=
+def normed_comm_group.induced [comm_group E] [group F] [normed_group F] [monoid_hom_class 𝓕 E F]
+  (f : 𝓕) (h : injective f) : normed_comm_group E :=
 { ..seminormed_group.induced E F f, ..metric_space.induced f h _ }
 
 end induced
 
 section seminormed_comm_group
+variables [comm_group E] [comm_group F]
 variables [seminormed_comm_group E] [seminormed_comm_group F] {a a₁ a₂ b b₁ b₂ : E} {r r₁ r₂ : ℝ}
 
 @[to_additive] instance normed_group.to_has_isometric_smul_left : has_isometric_smul E E :=
@@ -965,7 +960,7 @@ by simpa only [div_eq_mul_inv, dist_inv_inv] using dist_mul_mul_le a₁ a₂⁻�
 by simpa only [dist_mul_left, dist_mul_right, dist_comm b₂]
   using abs_dist_sub_le (a₁ * a₂) (b₁ * b₂) (b₁ * a₂)
 
-lemma norm_multiset_sum_le {E} [seminormed_add_comm_group E] (m : multiset E) :
+lemma norm_multiset_sum_le {E} [add_comm_group E] [seminormed_add_comm_group E] (m : multiset E) :
   ‖m.sum‖ ≤ (m.map (λ x, ‖x‖)).sum :=
 m.le_sum_of_subadditive norm norm_zero norm_add_le
 
@@ -978,7 +973,7 @@ begin
   { exact norm_mul_le' _ _ }
 end
 
-lemma norm_sum_le {E} [seminormed_add_comm_group E] (s : finset ι) (f : ι → E) :
+lemma norm_sum_le {E} [add_comm_group E] [seminormed_add_comm_group E] (s : finset ι) (f : ι → E) :
   ‖∑ i in s, f i‖ ≤ ∑ i in s, ‖f i‖ :=
 s.le_sum_of_subadditive norm norm_zero norm_add_le f
 
@@ -1231,7 +1226,7 @@ end rat
 -- Now that we've installed the norm on `ℤ`,
 -- we can state some lemmas about `zsmul`.
 section
-variables [seminormed_comm_group α]
+variables [comm_group α] [seminormed_comm_group α]
 
 @[to_additive norm_zsmul_le]
 lemma norm_zpow_le_mul_norm (n : ℤ) (a : α) : ‖a^n‖ ≤ ‖n‖ * ‖a‖ :=
@@ -1322,7 +1317,7 @@ end
 end seminormed_comm_group
 
 section normed_group
-variables [normed_group E] [normed_group F] {a b : E}
+variables [group E] [group F] [normed_group E] [normed_group F] {a b : E}
 
 @[simp, to_additive norm_eq_zero] lemma norm_eq_zero'' : ‖a‖ = 0 ↔ a = 1 := norm_eq_zero'''
 
@@ -1372,7 +1367,7 @@ def norm_group_norm : group_norm E :=
 end normed_group
 
 section normed_add_group
-variables [normed_add_group E] [topological_space α] {f : α → E}
+variables [add_group E] [normed_add_group E] [topological_space α] {f : α → E}
 
 /-! Some relations with `has_compact_support` -/
 
@@ -1389,7 +1384,7 @@ end normed_add_group
 
 section normed_add_group_source
 
-variables [normed_add_group α] {f : α → E}
+variables [add_group α] [normed_add_group α] {f : α → E}
 
 @[to_additive]
 lemma has_compact_mul_support.exists_pos_le_norm [has_one E] (hf : has_compact_mul_support f) :
@@ -1429,18 +1424,19 @@ lemma nnnorm_def (x : ulift E) : ‖x‖₊ = ‖x.down‖₊ := rfl
 
 end has_nnnorm
 
-@[to_additive] instance seminormed_group [seminormed_group E] : seminormed_group (ulift E) :=
+@[to_additive] instance seminormed_group [group E] [seminormed_group E] : seminormed_group (ulift E) :=
 seminormed_group.induced _ _ (⟨ulift.down, rfl, λ _ _, rfl⟩ : ulift E →* E)
 
 @[to_additive]
-instance seminormed_comm_group [seminormed_comm_group E] : seminormed_comm_group (ulift E) :=
+instance seminormed_comm_group [comm_group E] [seminormed_comm_group E] :
+  seminormed_comm_group (ulift E) :=
 seminormed_comm_group.induced _ _ (⟨ulift.down, rfl, λ _ _, rfl⟩ : ulift E →* E)
 
-@[to_additive] instance normed_group [normed_group E] : normed_group (ulift E) :=
+@[to_additive] instance normed_group [group E] [normed_group E] : normed_group (ulift E) :=
 normed_group.induced _ _ (⟨ulift.down, rfl, λ _ _, rfl⟩ : ulift E →* E) down_injective
 
 @[to_additive]
-instance normed_comm_group [normed_comm_group E] : normed_comm_group (ulift E) :=
+instance normed_comm_group [comm_group E] [normed_comm_group E] : normed_comm_group (ulift E) :=
 normed_comm_group.induced _ _ (⟨ulift.down, rfl, λ _ _, rfl⟩ : ulift E →* E) down_injective
 
 end ulift
@@ -1477,28 +1473,29 @@ instance : has_nnnorm (multiplicative E) := ‹has_nnnorm E›
 
 end has_nnnorm
 
-instance [seminormed_group E] : seminormed_add_group (additive E) :=
+instance [group E] [seminormed_group E] : seminormed_add_group (additive E) :=
 { dist_eq := dist_eq_norm_div }
 
-instance [seminormed_add_group E] : seminormed_group (multiplicative E) :=
+instance [add_group E] [seminormed_add_group E] : seminormed_group (multiplicative E) :=
 { dist_eq := dist_eq_norm_sub }
 
-instance [seminormed_comm_group E] : seminormed_add_comm_group (additive E) :=
+instance [comm_group E] [seminormed_comm_group E] : seminormed_add_comm_group (additive E) :=
 { ..additive.seminormed_add_group }
 
-instance [seminormed_add_comm_group E] : seminormed_comm_group (multiplicative E) :=
+instance [add_comm_group E] [seminormed_add_comm_group E] :
+  seminormed_comm_group (multiplicative E) :=
 { ..multiplicative.seminormed_group }
 
-instance [normed_group E] : normed_add_group (additive E) :=
+instance [group E] [normed_group E] : normed_add_group (additive E) :=
 { ..additive.seminormed_add_group }
 
-instance [normed_add_group E] : normed_group (multiplicative E) :=
+instance [add_group E] [normed_add_group E] : normed_group (multiplicative E) :=
 { ..multiplicative.seminormed_group }
 
-instance [normed_comm_group E] : normed_add_comm_group (additive E) :=
+instance [comm_group E] [normed_comm_group E] : normed_add_comm_group (additive E) :=
 { ..additive.seminormed_add_group }
 
-instance [normed_add_comm_group E] : normed_comm_group (multiplicative E) :=
+instance [add_comm_group E] [normed_add_comm_group E] : normed_comm_group (multiplicative E) :=
 { ..multiplicative.seminormed_group }
 
 end additive_multiplicative
@@ -1530,16 +1527,18 @@ instance : has_nnnorm Eᵒᵈ := ‹has_nnnorm E›
 end has_nnnorm
 
 @[priority 100, to_additive] -- See note [lower instance priority]
-instance [seminormed_group E] : seminormed_group Eᵒᵈ := ‹seminormed_group E›
+instance [group E] [seminormed_group E] : seminormed_group Eᵒᵈ := ‹seminormed_group E›
 
 @[priority 100, to_additive] -- See note [lower instance priority]
-instance [seminormed_comm_group E] : seminormed_comm_group Eᵒᵈ := ‹seminormed_comm_group E›
+instance [comm_group E] [seminormed_comm_group E] : seminormed_comm_group Eᵒᵈ :=
+‹seminormed_comm_group E›
 
 @[priority 100, to_additive] -- See note [lower instance priority]
-instance [normed_group E] : normed_group Eᵒᵈ := ‹normed_group E›
+instance [group E] [normed_group E] : normed_group Eᵒᵈ := ‹normed_group E›
 
 @[priority 100, to_additive] -- See note [lower instance priority]
-instance [normed_comm_group E] : normed_comm_group Eᵒᵈ := ‹normed_comm_group E›
+instance [comm_group E] [normed_comm_group E] : normed_comm_group Eᵒᵈ :=
+‹normed_comm_group E›
 
 end order_dual
 
@@ -1559,7 +1558,7 @@ lemma norm_prod_le_iff : ‖x‖ ≤ r ↔ ‖x.1‖ ≤ r ∧ ‖x.2‖ ≤ r :
 end has_norm
 
 section seminormed_group
-variables [seminormed_group E] [seminormed_group F]
+variables [group E] [group F] [seminormed_group E] [seminormed_group F]
 
 /-- Product of seminormed groups, using the sup norm. -/
 @[to_additive "Product of seminormed groups, using the sup norm."]
@@ -1573,16 +1572,19 @@ end seminormed_group
 
 /-- Product of seminormed groups, using the sup norm. -/
 @[to_additive "Product of seminormed groups, using the sup norm."]
-instance [seminormed_comm_group E] [seminormed_comm_group F] : seminormed_comm_group (E × F) :=
+instance [comm_group E] [comm_group F] [seminormed_comm_group E] [seminormed_comm_group F] :
+  seminormed_comm_group (E × F) :=
 { ..prod.seminormed_group }
 
 /-- Product of normed groups, using the sup norm. -/
 @[to_additive "Product of normed groups, using the sup norm."]
-instance [normed_group E] [normed_group F] : normed_group (E × F) := { ..prod.seminormed_group }
+instance [group E] [group F][normed_group E] [normed_group F] : normed_group (E × F) :=
+{ ..prod.seminormed_group }
 
 /-- Product of normed groups, using the sup norm. -/
 @[to_additive "Product of normed groups, using the sup norm."]
-instance [normed_comm_group E] [normed_comm_group F] : normed_comm_group (E × F) :=
+instance [comm_group E] [comm_group F] [normed_comm_group E] [normed_comm_group F] :
+  normed_comm_group (E × F) :=
 { ..prod.seminormed_group }
 
 
@@ -1592,7 +1594,8 @@ section pi
 variables {π : ι → Type*} [fintype ι]
 
 section seminormed_group
-variables [Π i, seminormed_group (π i)] [seminormed_group E] (f : Π i, π i) {x : Π i, π i} {r : ℝ}
+variables [Π i, group (π i)] [group E] [Π i, seminormed_group (π i)] [seminormed_group E]
+variables (f : Π i, π i) {x : Π i, π i} {r : ℝ}
 
 /-- Finite product of seminormed groups, using the sup norm. -/
 @[to_additive "Finite product of seminormed groups, using the sup norm."]
@@ -1673,18 +1676,19 @@ end seminormed_group
 
 /-- Finite product of seminormed groups, using the sup norm. -/
 @[to_additive "Finite product of seminormed groups, using the sup norm."]
-instance pi.seminormed_comm_group [Π i, seminormed_comm_group (π i)] :
+instance pi.seminormed_comm_group [Π i, comm_group (π i)] [Π i, seminormed_comm_group (π i)] :
   seminormed_comm_group (Π i, π i) :=
 { ..pi.seminormed_group }
 
 /-- Finite product of normed groups, using the sup norm. -/
 @[to_additive "Finite product of seminormed groups, using the sup norm."]
-instance pi.normed_group [Π i, normed_group (π i)] : normed_group (Π i, π i) :=
+instance pi.normed_group [Π i, group (π i)] [Π i, normed_group (π i)] : normed_group (Π i, π i) :=
 { ..pi.seminormed_group }
 
 /-- Finite product of normed groups, using the sup norm. -/
 @[to_additive "Finite product of seminormed groups, using the sup norm."]
-instance pi.normed_comm_group [Π i, normed_comm_group (π i)] : normed_comm_group (Π i, π i) :=
+instance pi.normed_comm_group [Π i, comm_group (π i)] [Π i, normed_comm_group (π i)] :
+  normed_comm_group (Π i, π i) :=
 { ..pi.seminormed_group }
 
 end pi
@@ -1693,7 +1697,7 @@ end pi
 
 namespace subgroup
 section seminormed_group
-variables [seminormed_group E] {s : subgroup E}
+variables [group E] [seminormed_group E] {s : subgroup E}
 
 /-- A subgroup of a seminormed group is also a seminormed group,
 with the restriction of the norm. -/
@@ -1719,15 +1723,18 @@ lemma norm_coe {s : subgroup E} (x : s) : ‖(x : E)‖ = ‖x‖ := rfl
 
 end seminormed_group
 
-@[to_additive] instance seminormed_comm_group [seminormed_comm_group E] {s : subgroup E} :
+@[to_additive] instance seminormed_comm_group [comm_group E] [seminormed_comm_group E]
+  {s : subgroup E} :
   seminormed_comm_group s :=
 seminormed_comm_group.induced _ _ s.subtype
 
-@[to_additive] instance normed_group [normed_group E] {s : subgroup E} : normed_group s :=
+@[to_additive] instance normed_group [group E] [normed_group E] {s : subgroup E} :
+  normed_group s :=
 normed_group.induced _ _ s.subtype subtype.coe_injective
 
 @[to_additive]
-instance normed_comm_group [normed_comm_group E] {s : subgroup E} : normed_comm_group s :=
+instance normed_comm_group [comm_group E] [normed_comm_group E] {s : subgroup E} :
+  normed_comm_group s :=
 normed_comm_group.induced _ _ s.subtype subtype.coe_injective
 
 end subgroup
@@ -1739,16 +1746,16 @@ namespace submodule
 /-- A submodule of a seminormed group is also a seminormed group, with the restriction of the norm.
 -/
 -- See note [implicit instance arguments]
-instance seminormed_add_comm_group {_ : ring 𝕜} [seminormed_add_comm_group E] {_ : module 𝕜 E}
-  (s : submodule 𝕜 E) :
+instance seminormed_add_comm_group {_ : ring 𝕜} [add_comm_group E] [seminormed_add_comm_group E]
+  {_ : module 𝕜 E} (s : submodule 𝕜 E) :
   seminormed_add_comm_group s :=
 seminormed_add_comm_group.induced _ _ s.subtype.to_add_monoid_hom
 
 /-- If `x` is an element of a submodule `s` of a normed group `E`, its norm in `s` is equal to its
 norm in `E`. -/
 -- See note [implicit instance arguments].
-@[simp] lemma coe_norm {_ : ring 𝕜} [seminormed_add_comm_group E] {_ : module 𝕜 E}
-  {s : submodule 𝕜 E} (x : s) :
+@[simp] lemma coe_norm {_ : ring 𝕜} [add_comm_group E] [seminormed_add_comm_group E]
+  {_ : module 𝕜 E} {s : submodule 𝕜 E} (x : s) :
   ‖x‖ = ‖(x : E)‖ := rfl
 
 /-- If `x` is an element of a submodule `s` of a normed group `E`, its norm in `E` is equal to its
@@ -1756,13 +1763,14 @@ norm in `s`.
 
 This is a reversed version of the `simp` lemma `submodule.coe_norm` for use by `norm_cast`. -/
 -- See note [implicit instance arguments].
-@[norm_cast] lemma norm_coe {_ : ring 𝕜} [seminormed_add_comm_group E] {_ : module 𝕜 E}
-  {s : submodule 𝕜 E} (x : s) :
+@[norm_cast] lemma norm_coe {_ : ring 𝕜} [add_comm_group E] [seminormed_add_comm_group E]
+  {_ : module 𝕜 E} {s : submodule 𝕜 E} (x : s) :
   ‖(x : E)‖ = ‖x‖ := rfl
 
 /-- A submodule of a normed group is also a normed group, with the restriction of the norm. -/
 -- See note [implicit instance arguments].
-instance {_ : ring 𝕜} [normed_add_comm_group E] {_ : module 𝕜 E} (s : submodule 𝕜 E) :
+instance {_ : ring 𝕜} [add_comm_group E] [normed_add_comm_group E] {_ : module 𝕜 E}
+  (s : submodule 𝕜 E) :
   normed_add_comm_group s :=
 { ..submodule.seminormed_add_comm_group s }
 

--- a/src/analysis/normed/group/completion.lean
+++ b/src/analysis/normed/group/completion.lean
@@ -28,11 +28,11 @@ instance [uniform_space E] [has_norm E] :
   has_norm (completion E) :=
 { norm := completion.extension has_norm.norm }
 
-@[simp] lemma norm_coe {E} [seminormed_add_comm_group E] (x : E) :
+@[simp] lemma norm_coe {E} [add_comm_group E] [seminormed_add_comm_group E] (x : E) :
   ‖(x : completion E)‖ = ‖x‖ :=
 completion.extension_coe uniform_continuous_norm x
 
-instance [seminormed_add_comm_group E] : normed_add_comm_group (completion E) :=
+instance [add_comm_group E] [seminormed_add_comm_group E] : normed_add_comm_group (completion E) :=
 { dist_eq :=
   begin
     intros x y,

--- a/src/analysis/normed/group/controlled_closure.lean
+++ b/src/analysis/normed/group/controlled_closure.lean
@@ -17,8 +17,8 @@ lemmas in this file]."
 open filter finset
 open_locale topology big_operators
 
-variables {G : Type*} [normed_add_comm_group G] [complete_space G]
-variables {H : Type*} [normed_add_comm_group H]
+variables {G : Type*} [add_comm_group G] [normed_add_comm_group G] [complete_space G]
+variables {H : Type*} [add_comm_group H] [normed_add_comm_group H]
 
 /-- Given `f : normed_add_group_hom G H` for some complete `G` and a subgroup `K` of `H`, if every
 element `x` of `K` has a preimage under `f` whose norm is at most `C*‖x‖` then the same holds for
@@ -108,7 +108,7 @@ This is useful in particular if `j` is the inclusion of a normed group into its 
 (in this case the closure is the full target group).
 -/
 lemma controlled_closure_range_of_complete {f : normed_add_group_hom G H}
-  {K : Type*} [seminormed_add_comm_group K] {j : normed_add_group_hom K H} (hj : ∀ x, ‖j x‖ = ‖x‖)
+  {K : Type*} [add_comm_group K] [seminormed_add_comm_group K] {j : normed_add_group_hom K H} (hj : ∀ x, ‖j x‖ = ‖x‖)
   {C ε : ℝ} (hC : 0 < C) (hε : 0 < ε) (hyp : ∀ k, ∃ g, f g = j k ∧ ‖g‖ ≤ C*‖k‖) :
   f.surjective_on_with j.range.topological_closure (C + ε) :=
 begin

--- a/src/analysis/normed/group/hom.lean
+++ b/src/analysis/normed/group/hom.lean
@@ -27,15 +27,17 @@ noncomputable theory
 open_locale nnreal big_operators
 
 /-- A morphism of seminormed abelian groups is a bounded group homomorphism. -/
-structure normed_add_group_hom (V W : Type*) [seminormed_add_comm_group V]
-  [seminormed_add_comm_group W] :=
+structure normed_add_group_hom (V W : Type*)
+  [add_comm_group V] [add_comm_group W]
+  [seminormed_add_comm_group V] [seminormed_add_comm_group W] :=
 (to_fun : V → W)
 (map_add' : ∀ v₁ v₂, to_fun (v₁ + v₂) = to_fun v₁ + to_fun v₂)
 (bound' : ∃ C, ∀ v, ‖to_fun v‖ ≤ C * ‖v‖)
 
 namespace add_monoid_hom
 
-variables {V W : Type*} [seminormed_add_comm_group V] [seminormed_add_comm_group W]
+variables {V W : Type*}
+  [add_comm_group V] [add_comm_group W] [seminormed_add_comm_group V] [seminormed_add_comm_group W]
   {f g : normed_add_group_hom V W}
 
 /-- Associate to a group homomorphism a bounded group homomorphism under a norm control condition.
@@ -54,8 +56,9 @@ def mk_normed_add_group_hom' (f : V →+ W) (C : ℝ≥0) (hC : ∀ x, ‖f x‖
 
 end add_monoid_hom
 
-lemma exists_pos_bound_of_bound {V W : Type*} [seminormed_add_comm_group V]
-  [seminormed_add_comm_group W]
+lemma exists_pos_bound_of_bound {V W : Type*}
+  [add_comm_group V] [add_comm_group W]
+  [seminormed_add_comm_group V] [seminormed_add_comm_group W]
   {f : V → W} (M : ℝ) (h : ∀x, ‖f x‖ ≤ M * ‖x‖) :
   ∃ N, 0 < N ∧ ∀x, ‖f x‖ ≤ N * ‖x‖ :=
 ⟨max M 1, lt_of_lt_of_le zero_lt_one (le_max_right _ _), λx, calc
@@ -64,7 +67,9 @@ lemma exists_pos_bound_of_bound {V W : Type*} [seminormed_add_comm_group V]
 
 namespace normed_add_group_hom
 
-variables {V V₁ V₂ V₃ : Type*} [seminormed_add_comm_group V] [seminormed_add_comm_group V₁]
+variables {V V₁ V₂ V₃ : Type*}
+  [add_comm_group V] [add_comm_group V₁] [add_comm_group V₂] [add_comm_group V₃]
+  [seminormed_add_comm_group V] [seminormed_add_comm_group V₁]
   [seminormed_add_comm_group V₂] [seminormed_add_comm_group V₃]
 variables {f g : normed_add_group_hom V₁ V₂}
 
@@ -104,7 +109,7 @@ add_monoid_hom.mk' f f.map_add'
 @[simp] lemma coe_to_add_monoid_hom : ⇑f.to_add_monoid_hom = f := rfl
 
 lemma to_add_monoid_hom_injective :
-  function.injective (@normed_add_group_hom.to_add_monoid_hom V₁ V₂ _ _) :=
+  function.injective (@normed_add_group_hom.to_add_monoid_hom V₁ V₂ _ _ _ _) :=
 λ f g h, coe_inj $ show ⇑f.to_add_monoid_hom = g, by { rw h, refl }
 
 @[simp] lemma mk_to_add_monoid_hom (f) (h₁) (h₂) :
@@ -286,7 +291,9 @@ le_antisymm (cInf_le bounds_bdd_below
     (op_norm_nonneg _)
 
 /-- For normed groups, an operator is zero iff its norm vanishes. -/
-theorem op_norm_zero_iff {V₁ V₂ : Type*} [normed_add_comm_group V₁] [normed_add_comm_group V₂]
+theorem op_norm_zero_iff {V₁ V₂ : Type*}
+  [add_comm_group V₁] [add_comm_group V₂]
+  [normed_add_comm_group V₁] [normed_add_comm_group V₂]
   {f : normed_add_group_hom V₁ V₂} : ‖f‖ = 0 ↔ f = 0 :=
 iff.intro
   (λ hn, ext (λ x, norm_le_zero_iff.1
@@ -324,7 +331,8 @@ have _ := (id V).ratio_le_op_norm x,
 by rwa [id_apply, div_self hx] at this
 
 /-- If a normed space is non-trivial, then the norm of the identity equals `1`. -/
-lemma norm_id {V : Type*} [normed_add_comm_group V] [nontrivial V] : ‖(id V)‖ = 1 :=
+lemma norm_id {V : Type*} [add_comm_group V] [normed_add_comm_group V] [nontrivial V] :
+  ‖(id V)‖ = 1 :=
 begin
   refine norm_id_of_nontrivial_seminorm V _,
   obtain ⟨x, hx⟩ := exists_ne (0 : V),
@@ -445,8 +453,9 @@ add_group_seminorm.to_seminormed_add_comm_group
 
 /-- Normed group homomorphisms themselves form a normed group with respect to
     the operator norm. -/
-instance to_normed_add_comm_group {V₁ V₂ : Type*} [normed_add_comm_group V₁]
-  [normed_add_comm_group V₂] :
+instance to_normed_add_comm_group {V₁ V₂ : Type*}
+  [add_comm_group V₁] [add_comm_group V₂]
+  [normed_add_comm_group V₁] [normed_add_comm_group V₂] :
   normed_add_comm_group (normed_add_group_hom V₁ V₂) :=
 add_group_norm.to_normed_add_comm_group
 { to_fun := op_norm,
@@ -521,7 +530,8 @@ by { ext, exact map_zero f }
   (0 : normed_add_group_hom V₂ V₃).comp f = 0 :=
 by { ext, refl }
 
-lemma comp_assoc {V₄: Type* } [seminormed_add_comm_group V₄] (h : normed_add_group_hom V₃ V₄)
+lemma comp_assoc {V₄: Type*}
+  [add_comm_group V₄] [seminormed_add_comm_group V₄] (h : normed_add_group_hom V₃ V₄)
   (g : normed_add_group_hom V₂ V₃) (f : normed_add_group_hom V₁ V₂) :
   (h.comp g).comp f = h.comp (g.comp f) :=
 by { ext, refl }
@@ -533,7 +543,10 @@ end normed_add_group_hom
 
 namespace normed_add_group_hom
 
-variables {V W V₁ V₂ V₃ : Type*} [seminormed_add_comm_group V] [seminormed_add_comm_group W]
+variables {V W V₁ V₂ V₃ : Type*}
+  [add_comm_group V] [add_comm_group W]
+  [add_comm_group V₁] [add_comm_group V₂] [add_comm_group V₃]
+  [seminormed_add_comm_group V] [seminormed_add_comm_group W]
   [seminormed_add_comm_group V₁] [seminormed_add_comm_group V₂] [seminormed_add_comm_group V₃]
 
 /-- The inclusion of an `add_subgroup`, as bounded group homomorphism. -/
@@ -574,7 +587,8 @@ by { ext, simp [mem_ker] }
 
 lemma coe_ker : (f.ker : set V₁) = (f : V₁ → V₂) ⁻¹' {0} := rfl
 
-lemma is_closed_ker {V₂ : Type*} [normed_add_comm_group V₂] (f : normed_add_group_hom V₁ V₂) :
+lemma is_closed_ker {V₂ : Type*} [add_comm_group V₂] [normed_add_comm_group V₂]
+  (f : normed_add_group_hom V₁ V₂) :
   is_closed (f.ker : set V₁) :=
 f.coe_ker ▸ is_closed.preimage f.continuous (t1_space.t1 0)
 
@@ -659,8 +673,9 @@ lemma norm_noninc_of_isometry (hf : isometry f) : f.norm_noninc :=
 
 end isometry
 
-variables {W₁ W₂ W₃ : Type*} [seminormed_add_comm_group W₁] [seminormed_add_comm_group W₂]
-  [seminormed_add_comm_group W₃]
+variables {W₁ W₂ W₃ : Type*}
+  [add_comm_group W₁] [add_comm_group W₂] [add_comm_group W₃]
+  [seminormed_add_comm_group W₁] [seminormed_add_comm_group W₂] [seminormed_add_comm_group W₃]
 variables (f) (g : normed_add_group_hom V W)
 variables {f₁ g₁ : normed_add_group_hom V₁ W₁}
 variables {f₂ g₂ : normed_add_group_hom V₂ W₂}

--- a/src/analysis/normed/group/hom_completion.lean
+++ b/src/analysis/normed/group/hom_completion.lean
@@ -52,9 +52,9 @@ open set normed_add_group_hom uniform_space
 
 section completion
 
-variables {G : Type*} [seminormed_add_comm_group G]
-variables {H : Type*} [seminormed_add_comm_group H]
-variables {K : Type*} [seminormed_add_comm_group K]
+variables {G : Type*} [add_comm_group G] [seminormed_add_comm_group G]
+variables {H : Type*} [add_comm_group H] [seminormed_add_comm_group H]
+variables {K : Type*} [add_comm_group K] [seminormed_add_comm_group K]
 
 /-- The normed group hom induced between completions. -/
 def normed_add_group_hom.completion (f : normed_add_group_hom G H) :
@@ -239,8 +239,9 @@ end completion
 
 section extension
 
-variables {G : Type*} [seminormed_add_comm_group G]
-variables {H : Type*} [seminormed_add_comm_group H] [separated_space H] [complete_space H]
+variables {G : Type*} [add_comm_group G] [seminormed_add_comm_group G]
+variables {H : Type*} [add_comm_group H] [seminormed_add_comm_group H]
+variables [separated_space H] [complete_space H]
 
 /-- If `H` is complete, the extension of `f : normed_add_group_hom G H` to a
 `normed_add_group_hom (completion G) H`. -/

--- a/src/analysis/normed/group/infinite_sum.lean
+++ b/src/analysis/normed/group/infinite_sum.lean
@@ -30,7 +30,9 @@ infinite series, absolute convergence, normed group
 open_locale classical big_operators topology nnreal
 open finset filter metric
 
-variables {ι α E F : Type*} [seminormed_add_comm_group E] [seminormed_add_comm_group F]
+variables {ι α E F : Type*}
+variables [add_comm_group E] [add_comm_group F]
+variables [seminormed_add_comm_group E] [seminormed_add_comm_group F]
 
 lemma cauchy_seq_finset_iff_vanishing_norm {f : ι → E} :
   cauchy_seq (λ s : finset ι, ∑ i in s, f i) ↔

--- a/src/analysis/normed/group/pointwise.lean
+++ b/src/analysis/normed/group/pointwise.lean
@@ -19,7 +19,7 @@ open_locale pointwise topology
 variables {E : Type*}
 
 section seminormed_group
-variables [seminormed_group E] {ε δ : ℝ} {s t : set E} {x y : E}
+variables [group E] [seminormed_group E] {ε δ : ℝ} {s t : set E} {x y : E}
 
 @[to_additive] lemma metric.bounded.mul (hs : bounded s) (ht : bounded t) : bounded (s * t) :=
 begin
@@ -39,7 +39,7 @@ by { simp_rw [bounded_iff_forall_norm_le', ←image_inv, ball_image_iff, norm_in
 end seminormed_group
 
 section seminormed_comm_group
-variables [seminormed_comm_group E] {ε δ : ℝ} {s t : set E} {x y : E}
+variables [comm_group E] [seminormed_comm_group E] {ε δ : ℝ} {s t : set E} {x y : E}
 
 section emetric
 open emetric

--- a/src/analysis/normed/group/pointwise.lean
+++ b/src/analysis/normed/group/pointwise.lean
@@ -126,7 +126,8 @@ lemma closed_ball_one_div_singleton : closed_ball 1 δ / {x} = closed_ball x⁻�
 -- `vadd_closed_ball` for `normed_add_torsor`s, so we give it higher simp priority.
 -- (There is no `normed_mul_torsor`, hence the asymmetry between additive and multiplicative
 -- versions.)
-@[simp, priority 1100] lemma vadd_closed_ball_zero {E : Type*} [seminormed_add_comm_group E] (δ : ℝ)
+@[simp, priority 1100] lemma vadd_closed_ball_zero {E : Type*} [add_comm_group E]
+  [seminormed_add_comm_group E] (δ : ℝ)
   (x : E) :
   x +ᵥ metric.closed_ball 0 δ = metric.closed_ball x δ :=
 by { ext, simp [mem_vadd_set_iff_neg_vadd_mem, neg_add_eq_sub, dist_eq_norm_sub] }

--- a/src/analysis/normed/group/quotient.lean
+++ b/src/analysis/normed/group/quotient.lean
@@ -94,7 +94,9 @@ noncomputable theory
 open quotient_add_group metric set
 open_locale topology nnreal
 
-variables {M N : Type*} [seminormed_add_comm_group M] [seminormed_add_comm_group N]
+variables {M N : Type*}
+variables [add_comm_group M] [add_comm_group N]
+variables [seminormed_add_comm_group M] [seminormed_add_comm_group N]
 
 /-- The definition of the norm on the quotient by an additive subgroup. -/
 noncomputable
@@ -443,7 +445,8 @@ structure is_quotient (f : normed_add_group_hom M N) : Prop :=
 /-- Given  `f : normed_add_group_hom M N` such that `f s = 0` for all `s ∈ S`, where,
 `S : add_subgroup M` is closed, the induced morphism `normed_add_group_hom (M ⧸ S) N`. -/
 noncomputable
-def lift {N : Type*} [seminormed_add_comm_group N] (S : add_subgroup M)
+def lift {N : Type*}
+  [add_comm_group N] [seminormed_add_comm_group N] (S : add_subgroup M)
   (f : normed_add_group_hom M N) (hf : ∀ s ∈ S, f s = 0) :
   normed_add_group_hom (M ⧸ S) N :=
 { bound' :=
@@ -458,11 +461,11 @@ def lift {N : Type*} [seminormed_add_comm_group N] (S : add_subgroup M)
   end,
   .. quotient_add_group.lift S f.to_add_monoid_hom hf }
 
-lemma lift_mk {N : Type*} [seminormed_add_comm_group N] (S : add_subgroup M)
+lemma lift_mk {N : Type*} [add_comm_group N] [seminormed_add_comm_group N] (S : add_subgroup M)
   (f : normed_add_group_hom M N) (hf : ∀ s ∈ S, f s = 0) (m : M) :
   lift S f hf (S.normed_mk m) = f m := rfl
 
-lemma lift_unique {N : Type*} [seminormed_add_comm_group N] (S : add_subgroup M)
+lemma lift_unique {N : Type*} [add_comm_group N] [seminormed_add_comm_group N] (S : add_subgroup M)
   (f : normed_add_group_hom M N) (hf : ∀ s ∈ S, f s = 0)
   (g : normed_add_group_hom (M ⧸ S) N) :
   g.comp (S.normed_mk) = f → g = lift S f hf :=

--- a/src/analysis/normed/group/quotient.lean
+++ b/src/analysis/normed/group/quotient.lean
@@ -505,7 +505,7 @@ begin
   { exact ⟨0, f.ker.zero_mem, by simp⟩ }
 end
 
-lemma lift_norm_le {N : Type*} [seminormed_add_comm_group N] (S : add_subgroup M)
+lemma lift_norm_le {N : Type*} [add_comm_group N] [seminormed_add_comm_group N] (S : add_subgroup M)
   (f : normed_add_group_hom M N) (hf : ∀ s ∈ S, f s = 0)
   {c : ℝ≥0} (fb : ‖f‖ ≤ c) :
   ‖lift S f hf‖ ≤ c :=
@@ -532,7 +532,7 @@ begin
     { rw [mul_add, mul_div_cancel'], exact_mod_cast hc.ne' } },
 end
 
-lemma lift_norm_noninc {N : Type*} [seminormed_add_comm_group N] (S : add_subgroup M)
+lemma lift_norm_noninc {N : Type*} [add_comm_group N] [seminormed_add_comm_group N] (S : add_subgroup M)
   (f : normed_add_group_hom M N) (hf : ∀ s ∈ S, f s = 0)
   (fb : f.norm_noninc) :
   (lift S f hf).norm_noninc :=

--- a/src/analysis/normed/group/quotient.lean
+++ b/src/analysis/normed/group/quotient.lean
@@ -568,7 +568,7 @@ add_subgroup.seminormed_add_comm_group_quotient S.to_add_subgroup
 
 instance submodule.quotient.normed_add_comm_group [hS : is_closed (S : set M)] :
   normed_add_comm_group (M ⧸ S) :=
-@add_subgroup.normed_add_comm_group_quotient _ _ S.to_add_subgroup hS
+@add_subgroup.normed_add_comm_group_quotient _ _ _ S.to_add_subgroup hS
 
 instance submodule.quotient.complete_space [complete_space M] : complete_space (M ⧸ S) :=
 quotient_add_group.complete_space M S.to_add_subgroup

--- a/src/analysis/normed/order/lattice.lean
+++ b/src/analysis/normed/order/lattice.lean
@@ -42,7 +42,7 @@ respect which `α` forms a lattice. Suppose that `α` is *solid*, that is to say
 said to be a normed lattice ordered group.
 -/
 class normed_lattice_add_comm_group (α : Type*)
-  extends normed_add_comm_group α, lattice α :=
+  extends add_comm_group α, normed_add_comm_group α, lattice α :=
 (add_le_add_left : ∀ a b : α, a ≤ b → ∀ c : α, c + a ≤ c + b)
 (solid : ∀ a b : α, |a| ≤ |b| → ‖a‖ ≤ ‖b‖)
 

--- a/src/analysis/normed_space/M_structure.lean
+++ b/src/analysis/normed_space/M_structure.lean
@@ -58,7 +58,7 @@ M-summand, M-projection, L-summand, L-projection, M-ideal, M-structure
 
 -/
 
-variables (X : Type*) [normed_add_comm_group X]
+variables (X : Type*) [add_comm_group X] [normed_add_comm_group X]
 variables {M : Type} [ring M] [module M X]
 /--
 A projection on a normed space `X` is said to be an L-projection if, for all `x` in `X`,

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -19,7 +19,8 @@ noncomputable theory
 open_locale nnreal topology
 open filter
 
-variables {α V P W Q : Type*} [add_comm_group V] [seminormed_add_comm_group V] [pseudo_metric_space P]
+variables {α V P W Q : Type*} [add_comm_group V] [add_comm_group W]
+  [seminormed_add_comm_group V] [pseudo_metric_space P]
   [normed_add_torsor V P] [normed_add_comm_group W] [metric_space Q] [normed_add_torsor W Q]
 
 section normed_space

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -19,7 +19,7 @@ noncomputable theory
 open_locale nnreal topology
 open filter
 
-variables {α V P W Q : Type*} [seminormed_add_comm_group V] [pseudo_metric_space P]
+variables {α V P W Q : Type*} [add_comm_group V] [seminormed_add_comm_group V] [pseudo_metric_space P]
   [normed_add_torsor V P] [normed_add_comm_group W] [metric_space Q] [normed_add_torsor W Q]
 
 section normed_space

--- a/src/analysis/normed_space/add_torsor_bases.lean
+++ b/src/analysis/normed_space/add_torsor_bases.lean
@@ -73,7 +73,7 @@ begin
       interior_Ici, mem_Inter, mem_set_of_eq, mem_Ioi, mem_preimage], },
 end
 
-variables {V P : Type*} [normed_add_comm_group V] [normed_space ℝ V] [metric_space P]
+variables {V P : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space ℝ V] [metric_space P]
   [normed_add_torsor V P]
 include V
 

--- a/src/analysis/normed_space/affine_isometry.lean
+++ b/src/analysis/normed_space/affine_isometry.lean
@@ -33,7 +33,9 @@ algebra-homomorphisms.)
 open function set
 
 variables (𝕜 : Type*) {V V₁ V₂ V₃ V₄ : Type*} {P₁ : Type*} (P P₂ : Type*) {P₃ P₄ : Type*}
-  [normed_field 𝕜] [seminormed_add_comm_group V] [seminormed_add_comm_group V₁]
+  [normed_field 𝕜]
+  [add_comm_group V] [add_comm_group V₁] [add_comm_group V₂] [add_comm_group V₃] [add_comm_group V₄]
+  [seminormed_add_comm_group V] [seminormed_add_comm_group V₁]
   [seminormed_add_comm_group V₂] [seminormed_add_comm_group V₃]
     [seminormed_add_comm_group V₄]
   [normed_space 𝕜 V] [normed_space 𝕜 V₁] [normed_space 𝕜 V₂] [normed_space 𝕜 V₃]

--- a/src/analysis/normed_space/ball_action.lean
+++ b/src/analysis/normed_space/ball_action.lean
@@ -16,7 +16,7 @@ multiplicative actions.
 - The unit sphere in `𝕜` acts on open balls, closed balls, and spheres centered at `0` in `E`.
 -/
 open metric set
-variables {𝕜 𝕜' E : Type*} [normed_field 𝕜] [normed_field 𝕜']
+variables {𝕜 𝕜' E : Type*} [normed_field 𝕜] [normed_field 𝕜'] [add_comm_group E]
   [seminormed_add_comm_group E] [normed_space 𝕜 E] [normed_space 𝕜' E] {r : ℝ}
 
 section closed_ball

--- a/src/analysis/normed_space/banach.lean
+++ b/src/analysis/normed_space/banach.lean
@@ -18,8 +18,8 @@ open function metric set filter finset linear_map (range ker)
 open_locale classical topology big_operators nnreal
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 (f : E →L[𝕜] F)
 include 𝕜
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -35,12 +35,13 @@ equality `‖c • x‖ = ‖c‖ ‖x‖`. We require only `‖c • x‖ ≤ �
 Note that since this requires `seminormed_add_comm_group` and not `normed_add_comm_group`, this
 typeclass can be used for "semi normed spaces" too, just as `module` can be used for
 "semi modules". -/
-class normed_space (α : Type*) (β : Type*) [normed_field α] [seminormed_add_comm_group β]
+class normed_space (α : Type*) (β : Type*) [normed_field α] [add_comm_group β]
+  [seminormed_add_comm_group β]
   extends module α β :=
 (norm_smul_le : ∀ (a:α) (b:β), ‖a • b‖ ≤ ‖a‖ * ‖b‖)
 end prio
 
-variables [normed_field α] [seminormed_add_comm_group β]
+variables [normed_field α] [add_comm_group β] [seminormed_add_comm_group β]
 
 @[priority 100] -- see Note [lower instance priority]
 instance normed_space.has_bounded_smul [normed_space α β] : has_bounded_smul α β :=
@@ -96,8 +97,8 @@ lipschitz_with_iff_dist_le_mul.2 $ λ x y, by rw [dist_smul₀, coe_nnnorm]
 lemma norm_smul_of_nonneg [normed_space ℝ β] {t : ℝ} (ht : 0 ≤ t) (x : β) :
   ‖t • x‖ = t * ‖x‖ := by rw [norm_smul, real.norm_eq_abs, abs_of_nonneg ht]
 
-variables {E : Type*} [seminormed_add_comm_group E] [normed_space α E]
-variables {F : Type*} [seminormed_add_comm_group F] [normed_space α F]
+variables {E : Type*} [add_comm_group E] [seminormed_add_comm_group E] [normed_space α E]
+variables {F : Type*} [add_comm_group F] [seminormed_add_comm_group F] [normed_space α F]
 
 theorem eventually_nhds_norm_smul_sub_lt (c : α) (x : E) {ε : ℝ} (h : 0 < ε) :
   ∀ᶠ y in 𝓝 x, ‖c • (y - x)‖ < ε :=
@@ -165,7 +166,7 @@ theorem frontier_closed_ball [normed_space ℝ E] (x : E) {r : ℝ} (hr : r ≠ 
 by rw [frontier, closure_closed_ball, interior_closed_ball x hr,
   closed_ball_diff_ball]
 
-instance {E : Type*} [normed_add_comm_group E] [normed_space ℚ E] (e : E) :
+instance {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℚ E] (e : E) :
   discrete_topology $ add_subgroup.zmultiples e :=
 begin
   rcases eq_or_ne e 0 with rfl | he,
@@ -241,7 +242,8 @@ instance prod.normed_space : normed_space α (E × F) :=
   ..prod.module }
 
 /-- The product of finitely many normed spaces is a normed space, with the sup norm. -/
-instance pi.normed_space {E : ι → Type*} [fintype ι] [∀i, seminormed_add_comm_group (E i)]
+instance pi.normed_space {E : ι → Type*} [fintype ι]
+  [∀i, add_comm_group (E i)] [∀i, seminormed_add_comm_group (E i)]
   [∀i, normed_space α (E i)] : normed_space α (Πi, E i) :=
 { norm_smul_le := λ a f, le_of_eq $
     show (↑(finset.sup finset.univ (λ (b : ι), ‖a • f b‖₊)) : ℝ) =
@@ -250,7 +252,7 @@ instance pi.normed_space {E : ι → Type*} [fintype ι] [∀i, seminormed_add_c
 
 /-- A subspace of a normed space is also a normed space, with the restriction of the norm. -/
 instance submodule.normed_space {𝕜 R : Type*} [has_smul 𝕜 R] [normed_field 𝕜] [ring R]
-  {E : Type*} [seminormed_add_comm_group E] [normed_space 𝕜 E] [module R E]
+  {E : Type*} [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕜 E] [module R E]
   [is_scalar_tower 𝕜 R E] (s : submodule R E) :
   normed_space 𝕜 s :=
 { norm_smul_le := λc x, le_of_eq $ norm_smul c (x : E) }
@@ -290,15 +292,16 @@ domain, using the `seminormed_add_comm_group.induced` norm.
 See note [reducible non-instances] -/
 @[reducible]
 def normed_space.induced {F : Type*} (α β γ : Type*) [normed_field α] [add_comm_group β]
-  [module α β] [seminormed_add_comm_group γ] [normed_space α γ] [linear_map_class F α β γ]
-  (f : F) : @normed_space α β _ (seminormed_add_comm_group.induced β γ f) :=
+  [module α β] [add_comm_group γ] [seminormed_add_comm_group γ] [normed_space α γ]
+  [linear_map_class F α β γ]
+  (f : F) : @normed_space α β _ _ (seminormed_add_comm_group.induced β γ f) :=
 { norm_smul_le := λ a b, by {unfold norm, exact (map_smul f a b).symm ▸ (norm_smul a (f b)).le } }
 
 section normed_add_comm_group
 
 variables [normed_field α]
-variables {E : Type*} [normed_add_comm_group E] [normed_space α E]
-variables {F : Type*} [normed_add_comm_group F] [normed_space α F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space α E]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space α F]
 
 open normed_field
 
@@ -375,7 +378,8 @@ end normed_add_comm_group
 
 section nontrivially_normed_space
 
-variables (𝕜 E : Type*) [nontrivially_normed_field 𝕜] [normed_add_comm_group E] [normed_space 𝕜 E]
+variables (𝕜 E : Type*) [nontrivially_normed_field 𝕜]
+  [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   [nontrivial E]
 
 include 𝕜
@@ -516,7 +520,7 @@ instance prod.normed_algebra {E F : Type*} [semi_normed_ring E] [semi_normed_rin
 instance pi.normed_algebra {E : ι → Type*} [fintype ι]
   [Π i, semi_normed_ring (E i)] [Π i, normed_algebra 𝕜 (E i)] :
   normed_algebra 𝕜 (Π i, E i) :=
-{ .. pi.normed_space,
+{ .. @pi.normed_space _ _ _ E _ _ (λ i, by apply_instance) _,
   .. pi.algebra _ E }
 
 end normed_algebra
@@ -538,12 +542,12 @@ instance subalgebra.to_normed_algebra {𝕜 A : Type*} [semi_normed_ring A] [nor
 section restrict_scalars
 
 variables (𝕜 : Type*) (𝕜' : Type*) [normed_field 𝕜] [normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
-(E : Type*) [seminormed_add_comm_group E] [normed_space 𝕜' E]
+(E : Type*) [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕜' E]
 
-instance {𝕜 : Type*} {𝕜' : Type*} {E : Type*} [I : seminormed_add_comm_group E] :
+instance {𝕜 : Type*} {𝕜' : Type*} {E : Type*} [add_comm_group E] [I : seminormed_add_comm_group E] :
   seminormed_add_comm_group (restrict_scalars 𝕜 𝕜' E) := I
 
-instance {𝕜 : Type*} {𝕜' : Type*} {E : Type*} [I : normed_add_comm_group E] :
+instance {𝕜 : Type*} {𝕜' : Type*} {E : Type*} [add_comm_group E] [I : normed_add_comm_group E] :
   normed_add_comm_group (restrict_scalars 𝕜 𝕜' E) := I
 
 /-- If `E` is a normed space over `𝕜'` and `𝕜` is a normed algebra over `𝕜'`, then
@@ -560,7 +564,7 @@ This is not an instance as it would be contrary to the purpose of `restrict_scal
 -- If you think you need this, consider instead reproducing `restrict_scalars.lsmul`
 -- appropriately modified here.
 def module.restrict_scalars.normed_space_orig {𝕜 : Type*} {𝕜' : Type*} {E : Type*}
-  [normed_field 𝕜'] [seminormed_add_comm_group E] [I : normed_space 𝕜' E] :
+  [normed_field 𝕜'] [add_comm_group E] [seminormed_add_comm_group E] [I : normed_space 𝕜' E] :
   normed_space 𝕜' (restrict_scalars 𝕜 𝕜' E) := I
 
 /-- Warning: This declaration should be used judiciously.

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -243,7 +243,7 @@ variables {R : Type*}
 variables {𝕜₂ 𝕜' : Type*} [nontrivially_normed_field 𝕜'] [nontrivially_normed_field 𝕜₂]
 variables {M : Type*} [topological_space M]
 variables {σ₁₂ : 𝕜 →+* 𝕜₂}
-variables {G' : Type*} [normed_add_comm_group G'] [normed_space 𝕜₂ G'] [normed_space 𝕜' G']
+variables {G' : Type*} [add_comm_group G'] [normed_add_comm_group G'] [normed_space 𝕜₂ G'] [normed_space 𝕜' G']
 variables [smul_comm_class 𝕜₂ 𝕜' G']
 
 section semiring

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -54,15 +54,15 @@ open_locale classical big_operators topology
 open filter (tendsto) metric continuous_linear_map
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-          {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-          {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
-          {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
+          {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+          {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+          {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
 
 /-- A function `f` satisfies `is_bounded_linear_map 𝕜 f` if it is linear and satisfies the
 inequality `‖f x‖ ≤ M * ‖x‖` for some positive constant `M`. -/
 structure is_bounded_linear_map (𝕜 : Type*) [normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-  {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F] (f : E → F)
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+  {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] (f : E → F)
   extends is_linear_map 𝕜 f : Prop :=
 (bound : ∃ M, 0 < M ∧ ∀ x : E, ‖f x‖ ≤ M * ‖x‖)
 
@@ -405,7 +405,7 @@ lemma is_bounded_bilinear_map.is_bounded_linear_map_right
   end }
 
 lemma is_bounded_bilinear_map_smul {𝕜' : Type*} [normed_field 𝕜']
-  [normed_algebra 𝕜 𝕜'] {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] [normed_space 𝕜' E]
+  [normed_algebra 𝕜 𝕜'] {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] [normed_space 𝕜' E]
   [is_scalar_tower 𝕜 𝕜' E] :
   is_bounded_bilinear_map 𝕜 (λ (p : 𝕜' × E), p.1 • p.2) :=
 (lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E).is_bounded_bilinear_map

--- a/src/analysis/normed_space/compact_operator.lean
+++ b/src/analysis/normed_space/compact_operator.lean
@@ -115,7 +115,7 @@ end bounded
 section normed_space
 
 variables {𝕜₁ 𝕜₂ : Type*} [nontrivially_normed_field 𝕜₁] [semi_normed_ring 𝕜₂] {σ₁₂ : 𝕜₁ →+* 𝕜₂}
-  {M₁ M₂ M₃ : Type*} [seminormed_add_comm_group M₁] [topological_space M₂]
+  {M₁ M₂ M₃ : Type*} [add_comm_group M₁] [seminormed_add_comm_group M₁] [topological_space M₂]
   [add_comm_monoid M₂] [normed_space 𝕜₁ M₁] [module 𝕜₂ M₂]
 
 lemma is_compact_operator.image_subset_compact_of_bounded [has_continuous_const_smul 𝕜₂ M₂]
@@ -373,7 +373,7 @@ end continuous
 /-- The set of compact operators from a normed space to a complete topological vector space is
 closed. -/
 lemma is_closed_set_of_is_compact_operator {𝕜₁ 𝕜₂ : Type*} [nontrivially_normed_field 𝕜₁]
-  [normed_field 𝕜₂] {σ₁₂ : 𝕜₁ →+* 𝕜₂} {M₁ M₂ : Type*} [seminormed_add_comm_group M₁]
+  [normed_field 𝕜₂] {σ₁₂ : 𝕜₁ →+* 𝕜₂} {M₁ M₂ : Type*} [add_comm_group M₁] [seminormed_add_comm_group M₁]
   [add_comm_group M₂] [normed_space 𝕜₁ M₁] [module 𝕜₂ M₂] [uniform_space M₂] [uniform_add_group M₂]
   [has_continuous_const_smul 𝕜₂ M₂] [t2_space M₂] [complete_space M₂] :
   is_closed {f : M₁ →SL[σ₁₂] M₂ | is_compact_operator f} :=

--- a/src/analysis/normed_space/complemented.lean
+++ b/src/analysis/normed_space/complemented.lean
@@ -20,9 +20,10 @@ is always a complemented subspace.
 complemented subspace, normed vector space
 -/
 
-variables {𝕜 E F G : Type*} [nontrivially_normed_field 𝕜] [normed_add_comm_group E]
-  [normed_space 𝕜 E] [normed_add_comm_group F] [normed_space 𝕜 F] [normed_add_comm_group G]
-  [normed_space 𝕜 G]
+variables {𝕜 E F G : Type*} [nontrivially_normed_field 𝕜]
+  [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+  [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+  [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
 
 noncomputable theory
 

--- a/src/analysis/normed_space/conformal_linear_map.lean
+++ b/src/analysis/normed_space/conformal_linear_map.lean
@@ -45,14 +45,16 @@ open function linear_isometry continuous_linear_map
 /-- A continuous linear map `f'` is said to be conformal if it's
     a nonzero multiple of a linear isometry. -/
 def is_conformal_map {R : Type*} {X Y : Type*} [normed_field R]
+  [add_comm_group X] [add_comm_group Y]
   [seminormed_add_comm_group X] [seminormed_add_comm_group Y] [normed_space R X] [normed_space R Y]
   (f' : X →L[R] Y) :=
 ∃ (c : R) (hc : c ≠ 0) (li : X →ₗᵢ[R] Y), f' = c • li.to_continuous_linear_map
 
 variables {R M N G M' : Type*} [normed_field R]
+  [add_comm_group M] [add_comm_group N] [add_comm_group G]
   [seminormed_add_comm_group M] [seminormed_add_comm_group N] [seminormed_add_comm_group G]
   [normed_space R M] [normed_space R N] [normed_space R G]
-  [normed_add_comm_group M'] [normed_space R M']
+  [add_comm_group M'] [normed_add_comm_group M'] [normed_space R M']
   {f : M →L[R] N} {g : N →L[R] G} {c : R}
 
 lemma is_conformal_map_id : is_conformal_map (id R M) :=

--- a/src/analysis/normed_space/continuous_affine_map.lean
+++ b/src/analysis/normed_space/continuous_affine_map.lean
@@ -41,9 +41,9 @@ submultiplicative: for a composition of maps, we have only `‖f.comp g‖ ≤ �
 namespace continuous_affine_map
 
 variables {𝕜 R V W W₂ P Q Q₂ : Type*}
-variables [normed_add_comm_group V] [metric_space P] [normed_add_torsor V P]
-variables [normed_add_comm_group W] [metric_space Q] [normed_add_torsor W Q]
-variables [normed_add_comm_group W₂] [metric_space Q₂] [normed_add_torsor W₂ Q₂]
+variables [add_comm_group V] [normed_add_comm_group V] [metric_space P] [normed_add_torsor V P]
+variables [add_comm_group W] [normed_add_comm_group W] [metric_space Q] [normed_add_torsor W Q]
+variables [add_comm_group W₂] [normed_add_comm_group W₂] [metric_space Q₂] [normed_add_torsor W₂ Q₂]
 variables [normed_field R] [normed_space R V] [normed_space R W] [normed_space R W₂]
 variables [nontrivially_normed_field 𝕜] [normed_space 𝕜 V] [normed_space 𝕜 W] [normed_space 𝕜 W₂]
 

--- a/src/analysis/normed_space/continuous_linear_map.lean
+++ b/src/analysis/normed_space/continuous_linear_map.lean
@@ -38,6 +38,7 @@ variables [normed_field 𝕜] [normed_field 𝕜₂]
 
 section seminormed
 
+variables [add_comm_group E] [add_comm_group F] [add_comm_group G]
 variables [seminormed_add_comm_group E] [seminormed_add_comm_group F] [seminormed_add_comm_group G]
 variables [normed_space 𝕜 E] [normed_space 𝕜₂ F] [normed_space 𝕜 G]
 variables {σ : 𝕜 →+* 𝕜₂} (f : E →ₛₗ[σ] F)
@@ -126,6 +127,7 @@ end seminormed
 
 section normed
 
+variables [add_comm_group E] [add_comm_group F]
 variables [normed_add_comm_group E] [normed_add_comm_group F] [normed_space 𝕜 E] [normed_space 𝕜₂ F]
 variables {σ : 𝕜 →+* 𝕜₂} (f g : E →SL[σ] F) (x y z : E)
 
@@ -139,6 +141,7 @@ end normed
 
 section seminormed
 
+variables [add_comm_group E] [add_comm_group F]
 variables [seminormed_add_comm_group E] [seminormed_add_comm_group F]
 variables [normed_space 𝕜 E] [normed_space 𝕜₂ F]
 variables {σ : 𝕜 →+* 𝕜₂} (f : E →ₛₗ[σ] F)
@@ -179,7 +182,7 @@ end seminormed
 
 section seminormed
 
-variables [seminormed_add_comm_group E] [normed_space 𝕜 E]
+variables [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕜 E]
 
 namespace continuous_linear_map
 
@@ -230,7 +233,7 @@ end seminormed
 
 section normed
 
-variables [normed_add_comm_group E] [normed_space 𝕜 E]
+variables [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 
 namespace continuous_linear_equiv
 variable (𝕜)

--- a/src/analysis/normed_space/dual.lean
+++ b/src/analysis/normed_space/dual.lean
@@ -41,8 +41,8 @@ namespace normed_space
 
 section general
 variables (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-variables (E : Type*) [seminormed_add_comm_group E] [normed_space 𝕜 E]
-variables (F : Type*) [normed_add_comm_group F] [normed_space 𝕜 F]
+variables (E : Type*) [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕜 E]
+variables (F : Type*) [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 
 /-- The topological dual of a seminormed space `E`. -/
 @[derive [inhabited, seminormed_add_comm_group, normed_space 𝕜]] def dual := E →L[𝕜] 𝕜

--- a/src/analysis/normed_space/dual.lean
+++ b/src/analysis/normed_space/dual.lean
@@ -144,11 +144,11 @@ open metric set normed_space
 `polar 𝕜 s` is the subset of `dual 𝕜 E` consisting of those functionals which
 evaluate to something of norm at most one at all points `z ∈ s`. -/
 def polar (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-  {E : Type*} [seminormed_add_comm_group E] [normed_space 𝕜 E] : set E → set (dual 𝕜 E) :=
+  {E : Type*} [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕜 E] : set E → set (dual 𝕜 E) :=
 (dual_pairing 𝕜 E).flip.polar
 
 variables (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-variables {E : Type*} [seminormed_add_comm_group E] [normed_space 𝕜 E]
+variables {E : Type*} [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕜 E]
 
 lemma mem_polar_iff {x' : dual 𝕜 E} (s : set E) : x' ∈ polar 𝕜 s ↔ ∀ z ∈ s, ‖x' z‖ ≤ 1 := iff.rfl
 

--- a/src/analysis/normed_space/extend.lean
+++ b/src/analysis/normed_space/extend.lean
@@ -33,7 +33,7 @@ Alternate forms which operate on `[is_scalar_tower ℝ 𝕜 F]` instead are prov
 
 open is_R_or_C
 
-variables {𝕜 : Type*} [is_R_or_C 𝕜] {F : Type*} [seminormed_add_comm_group F] [normed_space 𝕜 F]
+variables {𝕜 : Type*} [is_R_or_C 𝕜] {F : Type*} [add_comm_group F] [seminormed_add_comm_group F] [normed_space 𝕜 F]
 local notation `abs𝕜` := @is_R_or_C.abs 𝕜 _
 
 /-- Extend `fr : F →ₗ[ℝ] ℝ` to `F →ₗ[𝕜] 𝕜` in a way that will also be continuous and have its norm

--- a/src/analysis/normed_space/extr.lean
+++ b/src/analysis/normed_space/extr.lean
@@ -21,7 +21,7 @@ Then we specialize it to the case `y = f c` and to different special cases of `i
 local maximum, normed space
 -/
 
-variables {α X E : Type*} [seminormed_add_comm_group E] [normed_space ℝ E] [topological_space X]
+variables {α X E : Type*} [add_comm_group E] [seminormed_add_comm_group E] [normed_space ℝ E] [topological_space X]
 
 section
 

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -170,12 +170,12 @@ vector space `E'` can be extended to a Lipschitz map on the whole space `α`, wi
 constant `C * K` where `C` only depends on `E'`. We record a working value for this constant `C`
 as `lipschitz_extension_constant E'`. -/
 @[irreducible] def lipschitz_extension_constant
-  (E' : Type*) [normed_add_comm_group E'] [normed_space ℝ E'] [finite_dimensional ℝ E'] : ℝ≥0 :=
+  (E' : Type*) [add_comm_group E'] [normed_add_comm_group E'] [normed_space ℝ E'] [finite_dimensional ℝ E'] : ℝ≥0 :=
 let A := (basis.of_vector_space ℝ E').equiv_fun.to_continuous_linear_equiv in
   max (‖A.symm.to_continuous_linear_map‖₊ * ‖A.to_continuous_linear_map‖₊) 1
 
 lemma lipschitz_extension_constant_pos
-  (E' : Type*) [normed_add_comm_group E'] [normed_space ℝ E'] [finite_dimensional ℝ E'] :
+  (E' : Type*) [add_comm_group E'] [normed_add_comm_group E'] [normed_space ℝ E'] [finite_dimensional ℝ E'] :
   0 < lipschitz_extension_constant E' :=
 by { rw lipschitz_extension_constant, exact zero_lt_one.trans_le (le_max_right _ _) }
 
@@ -184,7 +184,7 @@ vector space `E'` can be extended to a Lipschitz map on the whole space `α`, wi
 constant `lipschitz_extension_constant E' * K`. -/
 theorem lipschitz_on_with.extend_finite_dimension
   {α : Type*} [pseudo_metric_space α]
-  {E' : Type*} [normed_add_comm_group E'] [normed_space ℝ E'] [finite_dimensional ℝ E']
+  {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space ℝ E'] [finite_dimensional ℝ E']
   {s : set α} {f : α → E'} {K : ℝ≥0} (hf : lipschitz_on_with K f s) :
   ∃ (g : α → E'), lipschitz_with (lipschitz_extension_constant E' * K) g ∧ eq_on f g s :=
 begin

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -56,7 +56,7 @@ open linear_map
 
 variables {R : Type*} [semiring R]
 
-variables {F E₁ : Type*} [seminormed_add_comm_group F]
+variables {F E₁ : Type*} [add_comm_group F] [seminormed_add_comm_group F]
   [normed_add_comm_group E₁] [module R E₁]
 
 variables {R₁ : Type*} [field R₁] [module R₁ E₁] [module R₁ F]
@@ -643,7 +643,7 @@ finite_dimensional.proper ℝ E
 `x` that is not equal to the whole space, then there exists a point `y ∈ frontier s` at distance
 `metric.inf_dist x sᶜ` from `x`. See also
 `is_compact.exists_mem_frontier_inf_dist_compl_eq_dist`. -/
-lemma exists_mem_frontier_inf_dist_compl_eq_dist {E : Type*} [normed_add_comm_group E]
+lemma exists_mem_frontier_inf_dist_compl_eq_dist {E : Type*} [add_comm_group E] [normed_add_comm_group E]
   [normed_space ℝ E] [finite_dimensional ℝ E] {x : E} {s : set E} (hx : x ∈ s) (hs : s ≠ univ) :
   ∃ y ∈ frontier s, metric.inf_dist x sᶜ = dist x y :=
 begin
@@ -657,7 +657,7 @@ end
 /-- If `K` is a compact set in a nontrivial real normed space and `x ∈ K`, then there exists a point
 `y` of the boundary of `K` at distance `metric.inf_dist x Kᶜ` from `x`. See also
 `exists_mem_frontier_inf_dist_compl_eq_dist`. -/
-lemma is_compact.exists_mem_frontier_inf_dist_compl_eq_dist {E : Type*} [normed_add_comm_group E]
+lemma is_compact.exists_mem_frontier_inf_dist_compl_eq_dist {E : Type*} [add_comm_group E] [normed_add_comm_group E]
   [normed_space ℝ E] [nontrivial E] {x : E} {K : set E} (hK : is_compact K) (hx : x ∈ K) :
   ∃ y ∈ frontier K, metric.inf_dist x Kᶜ = dist x y :=
 begin
@@ -677,7 +677,7 @@ end
 /-- In a finite dimensional vector space over `ℝ`, the series `∑ x, ‖f x‖` is unconditionally
 summable if and only if the series `∑ x, f x` is unconditionally summable. One implication holds in
 any complete normed space, while the other holds only in finite dimensional spaces. -/
-lemma summable_norm_iff {α E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+lemma summable_norm_iff {α E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] {f : α → E} : summable (λ x, ‖f x‖) ↔ summable f :=
 begin
   refine ⟨summable_of_summable_norm, λ hf, _⟩,
@@ -700,32 +700,32 @@ begin
   { exact finset.sum_nonneg (λ _ _, norm_nonneg _) }
 end
 
-lemma summable_of_is_O' {ι E F : Type*} [normed_add_comm_group E] [complete_space E]
+lemma summable_of_is_O' {ι E F : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E]
   [normed_add_comm_group F] [normed_space ℝ F] [finite_dimensional ℝ F] {f : ι → E} {g : ι → F}
   (hg : summable g) (h : f =O[cofinite] g) : summable f :=
 summable_of_is_O (summable_norm_iff.mpr hg) h.norm_right
 
-lemma summable_of_is_O_nat' {E F : Type*} [normed_add_comm_group E] [complete_space E]
+lemma summable_of_is_O_nat' {E F : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E]
   [normed_add_comm_group F] [normed_space ℝ F] [finite_dimensional ℝ F] {f : ℕ → E} {g : ℕ → F}
   (hg : summable g) (h : f =O[at_top] g) : summable f :=
 summable_of_is_O_nat (summable_norm_iff.mpr hg) h.norm_right
 
-lemma summable_of_is_equivalent {ι E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+lemma summable_of_is_equivalent {ι E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] {f : ι → E} {g : ι → E}
   (hg : summable g) (h : f ~[cofinite] g) : summable f :=
 hg.trans_sub (summable_of_is_O' hg h.is_o.is_O)
 
-lemma summable_of_is_equivalent_nat {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+lemma summable_of_is_equivalent_nat {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] {f : ℕ → E} {g : ℕ → E}
   (hg : summable g) (h : f ~[at_top] g) : summable f :=
 hg.trans_sub (summable_of_is_O_nat' hg h.is_o.is_O)
 
-lemma is_equivalent.summable_iff {ι E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+lemma is_equivalent.summable_iff {ι E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] {f : ι → E} {g : ι → E}
   (h : f ~[cofinite] g) : summable f ↔ summable g :=
 ⟨λ hf, summable_of_is_equivalent hf h.symm, λ hg, summable_of_is_equivalent hg h⟩
 
-lemma is_equivalent.summable_iff_nat {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+lemma is_equivalent.summable_iff_nat {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] {f : ℕ → E} {g : ℕ → E}
   (h : f ~[at_top] g) : summable f ↔ summable g :=
 ⟨λ hf, summable_of_is_equivalent_nat hf h.symm, λ hg, summable_of_is_equivalent_nat hg h⟩

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -711,13 +711,15 @@ end
 
 lemma summable_of_is_O'
   {ι E F : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E]
-  [normed_add_comm_group F] [normed_space ℝ F] [finite_dimensional ℝ F] {f : ι → E} {g : ι → F}
+  [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F] [finite_dimensional ℝ F]
+  {f : ι → E} {g : ι → F}
   (hg : summable g) (h : f =O[cofinite] g) : summable f :=
 summable_of_is_O (summable_norm_iff.mpr hg) h.norm_right
 
 lemma summable_of_is_O_nat'
   {E F : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E]
-  [normed_add_comm_group F] [normed_space ℝ F] [finite_dimensional ℝ F] {f : ℕ → E} {g : ℕ → F}
+  [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F] [finite_dimensional ℝ F]
+  {f : ℕ → E} {g : ℕ → F}
   (hg : summable g) (h : f =O[at_top] g) : summable f :=
 summable_of_is_O_nat (summable_norm_iff.mpr hg) h.norm_right
 

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -57,7 +57,7 @@ open linear_map
 variables {R : Type*} [semiring R]
 
 variables {F E₁ : Type*} [add_comm_group F] [seminormed_add_comm_group F]
-  [normed_add_comm_group E₁] [module R E₁]
+  [add_comm_group E₁] [normed_add_comm_group E₁] [module R E₁]
 
 variables {R₁ : Type*} [field R₁] [module R₁ E₁] [module R₁ F]
   [finite_dimensional R₁ E₁] [finite_dimensional R₁ F]
@@ -86,6 +86,7 @@ open affine_map
 
 variables {𝕜 : Type*} {V₁ V₂  : Type*} {P₁ P₂ : Type*}
   [normed_field 𝕜]
+  [add_comm_group V₁] [add_comm_group V₂]
   [normed_add_comm_group V₁] [seminormed_add_comm_group V₂]
   [normed_space 𝕜 V₁] [normed_space 𝕜 V₂]
   [metric_space P₁] [pseudo_metric_space P₂]
@@ -113,8 +114,8 @@ end affine_isometry
 section complete_field
 
 variables {𝕜 : Type u} [nontrivially_normed_field 𝕜]
-{E : Type v} [normed_add_comm_group E] [normed_space 𝕜 E]
-{F : Type w} [normed_add_comm_group F] [normed_space 𝕜 F]
+{E : Type v} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+{F : Type w} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 {F' : Type x} [add_comm_group F'] [module 𝕜 F'] [topological_space F']
 [topological_add_group F'] [has_continuous_smul 𝕜 F']
 [complete_space 𝕜]
@@ -618,7 +619,7 @@ end complete_field
 
 section proper_field
 variables (𝕜 : Type u) [nontrivially_normed_field 𝕜]
-(E : Type v) [normed_add_comm_group E] [normed_space 𝕜 E] [proper_space 𝕜]
+(E : Type v) [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] [proper_space 𝕜]
 
 /-- Any finite-dimensional vector space over a proper field is proper.
 We do not register this as an instance to avoid an instance loop when trying to prove the
@@ -635,7 +636,8 @@ end proper_field
 /- Over the real numbers, we can register the previous statement as an instance as it will not
 cause problems in instance resolution since the properness of `ℝ` is already known. -/
 @[priority 900]
-instance finite_dimensional.proper_real (E : Type u) [normed_add_comm_group E] [normed_space ℝ E]
+instance finite_dimensional.proper_real
+  (E : Type u) [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] : proper_space E :=
 finite_dimensional.proper ℝ E
 
@@ -643,7 +645,8 @@ finite_dimensional.proper ℝ E
 `x` that is not equal to the whole space, then there exists a point `y ∈ frontier s` at distance
 `metric.inf_dist x sᶜ` from `x`. See also
 `is_compact.exists_mem_frontier_inf_dist_compl_eq_dist`. -/
-lemma exists_mem_frontier_inf_dist_compl_eq_dist {E : Type*} [add_comm_group E] [normed_add_comm_group E]
+lemma exists_mem_frontier_inf_dist_compl_eq_dist
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E]
   [normed_space ℝ E] [finite_dimensional ℝ E] {x : E} {s : set E} (hx : x ∈ s) (hs : s ≠ univ) :
   ∃ y ∈ frontier s, metric.inf_dist x sᶜ = dist x y :=
 begin
@@ -657,7 +660,8 @@ end
 /-- If `K` is a compact set in a nontrivial real normed space and `x ∈ K`, then there exists a point
 `y` of the boundary of `K` at distance `metric.inf_dist x Kᶜ` from `x`. See also
 `exists_mem_frontier_inf_dist_compl_eq_dist`. -/
-lemma is_compact.exists_mem_frontier_inf_dist_compl_eq_dist {E : Type*} [add_comm_group E] [normed_add_comm_group E]
+lemma is_compact.exists_mem_frontier_inf_dist_compl_eq_dist
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E]
   [normed_space ℝ E] [nontrivial E] {x : E} {K : set E} (hK : is_compact K) (hx : x ∈ K) :
   ∃ y ∈ frontier K, metric.inf_dist x Kᶜ = dist x y :=
 begin
@@ -677,7 +681,8 @@ end
 /-- In a finite dimensional vector space over `ℝ`, the series `∑ x, ‖f x‖` is unconditionally
 summable if and only if the series `∑ x, f x` is unconditionally summable. One implication holds in
 any complete normed space, while the other holds only in finite dimensional spaces. -/
-lemma summable_norm_iff {α E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+lemma summable_norm_iff
+  {α E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] {f : α → E} : summable (λ x, ‖f x‖) ↔ summable f :=
 begin
   refine ⟨summable_of_summable_norm, λ hf, _⟩,
@@ -700,32 +705,38 @@ begin
   { exact finset.sum_nonneg (λ _ _, norm_nonneg _) }
 end
 
-lemma summable_of_is_O' {ι E F : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E]
+lemma summable_of_is_O'
+  {ι E F : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E]
   [normed_add_comm_group F] [normed_space ℝ F] [finite_dimensional ℝ F] {f : ι → E} {g : ι → F}
   (hg : summable g) (h : f =O[cofinite] g) : summable f :=
 summable_of_is_O (summable_norm_iff.mpr hg) h.norm_right
 
-lemma summable_of_is_O_nat' {E F : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E]
+lemma summable_of_is_O_nat'
+  {E F : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E]
   [normed_add_comm_group F] [normed_space ℝ F] [finite_dimensional ℝ F] {f : ℕ → E} {g : ℕ → F}
   (hg : summable g) (h : f =O[at_top] g) : summable f :=
 summable_of_is_O_nat (summable_norm_iff.mpr hg) h.norm_right
 
-lemma summable_of_is_equivalent {ι E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+lemma summable_of_is_equivalent
+  {ι E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] {f : ι → E} {g : ι → E}
   (hg : summable g) (h : f ~[cofinite] g) : summable f :=
 hg.trans_sub (summable_of_is_O' hg h.is_o.is_O)
 
-lemma summable_of_is_equivalent_nat {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+lemma summable_of_is_equivalent_nat
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] {f : ℕ → E} {g : ℕ → E}
   (hg : summable g) (h : f ~[at_top] g) : summable f :=
 hg.trans_sub (summable_of_is_O_nat' hg h.is_o.is_O)
 
-lemma is_equivalent.summable_iff {ι E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+lemma is_equivalent.summable_iff
+  {ι E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] {f : ι → E} {g : ι → E}
   (h : f ~[cofinite] g) : summable f ↔ summable g :=
 ⟨λ hf, summable_of_is_equivalent hf h.symm, λ hg, summable_of_is_equivalent hg h⟩
 
-lemma is_equivalent.summable_iff_nat {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+lemma is_equivalent.summable_iff_nat
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [finite_dimensional ℝ E] {f : ℕ → E} {g : ℕ → E}
   (h : f ~[at_top] g) : summable f ↔ summable g :=
 ⟨λ hf, summable_of_is_equivalent_nat hf h.symm, λ hg, summable_of_is_equivalent_nat hg h⟩

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -224,6 +224,7 @@ protected lemma linear_independent.eventually {ι} [finite ι] {f : ι → E}
 begin
   casesI nonempty_fintype ι,
   simp only [fintype.linear_independent_iff'] at hf ⊢,
+  letI : normed_space 𝕜 (ι → 𝕜) := pi.normed_space, -- Lean needs help to find this after #18462
   rcases linear_map.exists_antilipschitz_with _ hf with ⟨K, K0, hK⟩,
   have : tendsto (λ g : ι → E, ∑ i, ‖g i - f i‖) (𝓝 f) (𝓝 $ ∑ i, ‖f i - f i‖),
     from tendsto_finset_sum _ (λ i hi, tendsto.norm $
@@ -238,7 +239,10 @@ begin
     ← finset.sum_sub_distrib, ← smul_sub, ← sub_smul, nnreal.coe_sum, coe_nnnorm, finset.sum_mul],
   refine norm_sum_le_of_le _ (λ i _, _),
   rw [norm_smul, mul_comm],
-  exact mul_le_mul_of_nonneg_left (norm_le_pi_norm (v - u) i) (norm_nonneg _)
+  refine mul_le_mul_of_nonneg_left _ (norm_nonneg _),
+  -- TODO: this worked with `exact` before #18462
+  convert (norm_le_pi_norm _ i),
+  refl
 end
 
 lemma is_open_set_of_linear_independent {ι : Type*} [finite ι] :

--- a/src/analysis/normed_space/hahn_banach/extension.lean
+++ b/src/analysis/normed_space/hahn_banach/extension.lean
@@ -31,7 +31,7 @@ of `𝕜`).
 universes u v
 
 namespace real
-variables {E : Type*} [seminormed_add_comm_group E] [normed_space ℝ E]
+variables {E : Type*} [add_comm_group E] [seminormed_add_comm_group E] [normed_space ℝ E]
 
 /-- Hahn-Banach theorem for continuous linear functions over `ℝ`. -/
 theorem exists_extension_norm_eq (p : subspace ℝ E) (f : p →L[ℝ] ℝ) :
@@ -58,7 +58,7 @@ end real
 section is_R_or_C
 open is_R_or_C
 
-variables {𝕜 : Type*} [is_R_or_C 𝕜] {F : Type*} [seminormed_add_comm_group F] [normed_space 𝕜 F]
+variables {𝕜 : Type*} [is_R_or_C 𝕜] {F : Type*} [add_comm_group F] [seminormed_add_comm_group F] [normed_space 𝕜 F]
 
 /-- Hahn-Banach theorem for continuous linear functions over `𝕜` satisyfing `is_R_or_C 𝕜`. -/
 theorem exists_extension_norm_eq (p : subspace 𝕜 F) (f : p →L[𝕜] 𝕜) :

--- a/src/analysis/normed_space/indicator_function.lean
+++ b/src/analysis/normed_space/indicator_function.lean
@@ -15,7 +15,7 @@ This file contains a few simple lemmas about `set.indicator` and `norm`.
 indicator, norm
 -/
 
-variables {α E : Type*} [seminormed_add_comm_group E] {s t : set α} (f : α → E) (a : α)
+variables {α E : Type*} [add_comm_group E] [seminormed_add_comm_group E] {s t : set α} (f : α → E) (a : α)
 
 open set
 

--- a/src/analysis/normed_space/is_R_or_C.lean
+++ b/src/analysis/normed_space/is_R_or_C.lean
@@ -28,7 +28,7 @@ This file exists mainly to avoid importing `is_R_or_C` in the main normed space 
 
 open metric
 
-variables {𝕜 : Type*} [is_R_or_C 𝕜] {E : Type*} [normed_add_comm_group E]
+variables {𝕜 : Type*} [is_R_or_C 𝕜] {E : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 lemma is_R_or_C.norm_coe_norm {z : E} : ‖(‖z‖ : 𝕜)‖ = ‖z‖ := by simp
 

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -37,13 +37,16 @@ variables {R R₂ R₃ R₄ E E₂ E₃ E₄ F 𝓕 : Type*} [semiring R] [semir
   [ring_hom_comp_triple σ₂₃ σ₃₄ σ₂₄] [ring_hom_comp_triple σ₁₃ σ₃₄ σ₁₄]
   [ring_hom_comp_triple σ₃₂ σ₂₁ σ₃₁] [ring_hom_comp_triple σ₄₂ σ₂₁ σ₄₁]
   [ring_hom_comp_triple σ₄₃ σ₃₂ σ₄₂] [ring_hom_comp_triple σ₄₃ σ₃₁ σ₄₁]
+  [add_comm_group E] [add_comm_group E₂] [add_comm_group E₃] [add_comm_group E₄]
   [seminormed_add_comm_group E] [seminormed_add_comm_group E₂] [seminormed_add_comm_group E₃]
   [seminormed_add_comm_group E₄] [module R E] [module R₂ E₂] [module R₃ E₃] [module R₄ E₄]
-  [normed_add_comm_group F] [module R F]
+  [add_comm_group F] [normed_add_comm_group F] [module R F]
 
 /-- A `σ₁₂`-semilinear isometric embedding of a normed `R`-module into an `R₂`-module. -/
-structure linear_isometry (σ₁₂ : R →+* R₂) (E E₂ : Type*) [seminormed_add_comm_group E]
-  [seminormed_add_comm_group E₂] [module R E] [module R₂ E₂] extends E →ₛₗ[σ₁₂] E₂ :=
+structure linear_isometry (σ₁₂ : R →+* R₂) (E E₂ : Type*)
+  [add_comm_group E] [add_comm_group E₂]
+  [seminormed_add_comm_group E] [seminormed_add_comm_group E₂]
+  [module R E] [module R₂ E₂] extends E →ₛₗ[σ₁₂] E₂ :=
 (norm_map' : ∀ x, ‖to_linear_map x‖ = ‖x‖)
 
 notation E ` →ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry σ₁₂ E E₂
@@ -60,8 +63,9 @@ A map `f` between an `R`-module and an `S`-module over a ring homomorphism `σ :
 is semilinear if it satisfies the two properties `f (x + y) = f x + f y` and
 `f (c • x) = (σ c) • f x`. -/
 class semilinear_isometry_class (𝓕 : Type*) {R R₂ : out_param Type*} [semiring R] [semiring R₂]
-  (σ₁₂ : out_param $ R →+* R₂) (E E₂ : out_param Type*) [seminormed_add_comm_group E]
-  [seminormed_add_comm_group E₂] [module R E] [module R₂ E₂]
+  (σ₁₂ : out_param $ R →+* R₂) (E E₂ : out_param Type*)
+  [add_comm_group E] [add_comm_group E₂]
+  [seminormed_add_comm_group E] [seminormed_add_comm_group E₂] [module R E] [module R₂ E₂]
   extends semilinear_map_class 𝓕 σ₁₂ E E₂ :=
 (norm_map : ∀ (f : 𝓕) (x : E), ‖f x‖ = ‖x‖)
 
@@ -71,6 +75,7 @@ class semilinear_isometry_class (𝓕 : Type*) {R R₂ : out_param Type*} [semir
 This is an abbreviation for `semilinear_isometry_class F (ring_hom.id R) E E₂`.
 -/
 abbreviation linear_isometry_class (𝓕 : Type*) (R E E₂ : out_param Type*) [semiring R]
+  [add_comm_group E] [add_comm_group E₂]
   [seminormed_add_comm_group E] [seminormed_add_comm_group E₂] [module R E] [module R E₂] :=
 semilinear_isometry_class 𝓕 (ring_hom.id R) E E₂
 
@@ -152,8 +157,10 @@ fun_like.coe_injective
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
   because it is a composition of multiple projections. -/
-def simps.apply (σ₁₂ : R →+* R₂) (E E₂ : Type*) [seminormed_add_comm_group E]
-  [seminormed_add_comm_group E₂] [module R E] [module R₂ E₂] (h : E →ₛₗᵢ[σ₁₂] E₂) : E → E₂ := h
+def simps.apply (σ₁₂ : R →+* R₂) (E E₂ : Type*)
+  [add_comm_group E] [add_comm_group E₂]
+  [seminormed_add_comm_group E] [seminormed_add_comm_group E₂]
+  [module R E] [module R₂ E₂] (h : E →ₛₗᵢ[σ₁₂] E₂) : E → E₂ := h
 
 initialize_simps_projections linear_isometry (to_linear_map_to_fun → apply)
 
@@ -336,8 +343,10 @@ end submodule
 
 /-- A semilinear isometric equivalence between two normed vector spaces. -/
 structure linear_isometry_equiv (σ₁₂ : R →+* R₂) {σ₂₁ : R₂ →+* R} [ring_hom_inv_pair σ₁₂ σ₂₁]
-  [ring_hom_inv_pair σ₂₁ σ₁₂] (E E₂ : Type*) [seminormed_add_comm_group E]
-  [seminormed_add_comm_group E₂] [module R E] [module R₂ E₂] extends E ≃ₛₗ[σ₁₂] E₂ :=
+  [ring_hom_inv_pair σ₂₁ σ₁₂] (E E₂ : Type*)
+  [add_comm_group E] [add_comm_group E₂]
+  [seminormed_add_comm_group E] [seminormed_add_comm_group E₂]
+  [module R E] [module R₂ E₂] extends E ≃ₛₗ[σ₁₂] E₂ :=
 (norm_map' : ∀ x, ‖to_linear_equiv x‖ = ‖x‖)
 
 notation E ` ≃ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry_equiv σ₁₂ E E₂
@@ -357,6 +366,7 @@ is semilinear if it satisfies the two properties `f (x + y) = f x + f y` and
 class semilinear_isometry_equiv_class (𝓕 : Type*) {R R₂ : out_param Type*}
   [semiring R] [semiring R₂] (σ₁₂ : out_param $ R →+* R₂) {σ₂₁ : out_param $ R₂ →+* R}
   [ring_hom_inv_pair σ₁₂ σ₂₁] [ring_hom_inv_pair σ₂₁ σ₁₂] (E E₂ : out_param Type*)
+  [add_comm_group E] [add_comm_group E₂]
   [seminormed_add_comm_group E] [seminormed_add_comm_group E₂] [module R E] [module R₂ E₂]
   extends semilinear_equiv_class 𝓕 σ₁₂ E E₂ :=
 (norm_map : ∀ (f : 𝓕) (x : E), ‖f x‖ = ‖x‖)
@@ -367,6 +377,7 @@ class semilinear_isometry_equiv_class (𝓕 : Type*) {R R₂ : out_param Type*}
 This is an abbreviation for `semilinear_isometry_equiv_class F (ring_hom.id R) E E₂`.
 -/
 abbreviation linear_isometry_equiv_class (𝓕 : Type*) (R E E₂ : out_param Type*) [semiring R]
+  [add_comm_group E] [add_comm_group E₂]
   [seminormed_add_comm_group E] [seminormed_add_comm_group E₂] [module R E] [module R E₂] :=
 semilinear_isometry_equiv_class 𝓕 (ring_hom.id R) E E₂
 
@@ -537,13 +548,16 @@ def symm : E₂ ≃ₛₗᵢ[σ₂₁] E :=
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
   because it is a composition of multiple projections. -/
 def simps.apply (σ₁₂ : R →+* R₂) {σ₂₁ : R₂ →+* R} [ring_hom_inv_pair σ₁₂ σ₂₁]
-  [ring_hom_inv_pair σ₂₁ σ₁₂] (E E₂ : Type*) [seminormed_add_comm_group E]
-  [seminormed_add_comm_group E₂] [module R E] [module R₂ E₂] (h : E ≃ₛₗᵢ[σ₁₂] E₂) : E → E₂ := h
+  [ring_hom_inv_pair σ₂₁ σ₁₂] (E E₂ : Type*)
+  [add_comm_group E] [add_comm_group E₂]
+  [seminormed_add_comm_group E] [seminormed_add_comm_group E₂]
+  [module R E] [module R₂ E₂] (h : E ≃ₛₗᵢ[σ₁₂] E₂) : E → E₂ := h
 
 /-- See Note [custom simps projection] -/
 def simps.symm_apply (σ₁₂ : R →+* R₂) {σ₂₁ : R₂ →+* R} [ring_hom_inv_pair σ₁₂ σ₂₁]
-  [ring_hom_inv_pair σ₂₁ σ₁₂] (E E₂ : Type*) [seminormed_add_comm_group E]
-  [seminormed_add_comm_group E₂]
+  [ring_hom_inv_pair σ₂₁ σ₁₂] (E E₂ : Type*)
+  [add_comm_group E] [add_comm_group E₂]
+  [seminormed_add_comm_group E] [seminormed_add_comm_group E₂]
   [module R E] [module R₂ E₂] (h : E ≃ₛₗᵢ[σ₁₂] E₂) : E₂ → E := h.symm
 
 initialize_simps_projections linear_isometry_equiv

--- a/src/analysis/normed_space/mazur_ulam.lean
+++ b/src/analysis/normed_space/mazur_ulam.lean
@@ -27,8 +27,10 @@ The formalization is based on [Jussi Väisälä, *A Proof of the Mazur-Ulam Theo
 isometry, affine map, linear map
 -/
 
-variables {E PE F PF : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [metric_space PE]
-  [normed_add_torsor E PE] [normed_add_comm_group F] [normed_space ℝ F] [metric_space PF]
+variables {E PE F PF : Type*}
+  [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [metric_space PE]
+  [normed_add_torsor E PE]
+  [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F] [metric_space PF]
   [normed_add_torsor F PF]
 
 open set affine_map affine_isometry_equiv

--- a/src/analysis/normed_space/mazur_ulam.lean
+++ b/src/analysis/normed_space/mazur_ulam.lean
@@ -27,7 +27,7 @@ The formalization is based on [Jussi Väisälä, *A Proof of the Mazur-Ulam Theo
 isometry, affine map, linear map
 -/
 
-variables {E PE F PF : Type*} [normed_add_comm_group E] [normed_space ℝ E] [metric_space PE]
+variables {E PE F PF : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [metric_space PE]
   [normed_add_torsor E PE] [normed_add_comm_group F] [normed_space ℝ F] [metric_space PF]
   [normed_add_torsor F PF]
 

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -727,7 +727,7 @@ variables {𝕜 ι} {A : Type*} [normed_comm_ring A] [normed_algebra 𝕜 A]
 lemma norm_mk_pi_algebra_le [nonempty ι] :
   ‖continuous_multilinear_map.mk_pi_algebra 𝕜 ι A‖ ≤ 1 :=
 begin
-  have := λ f, @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ f _ zero_le_one,
+  have := λ f, @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ _ _ f _ zero_le_one,
   refine this _ _,
   intros m,
   simp only [continuous_multilinear_map.mk_pi_algebra_apply, one_mul],
@@ -738,7 +738,7 @@ lemma norm_mk_pi_algebra_of_empty [is_empty ι] :
   ‖continuous_multilinear_map.mk_pi_algebra 𝕜 ι A‖ = ‖(1 : A)‖ :=
 begin
   apply le_antisymm,
-  { have := λ f, @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ f _ (norm_nonneg (1 : A)),
+  { have := λ f, @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ _ _ f _ (norm_nonneg (1 : A)),
     refine this _ _,
     simp, },
   { convert ratio_le_op_norm _ (λ _, (1 : A)),
@@ -764,7 +764,7 @@ variables {𝕜 n} {A : Type*} [normed_ring A] [normed_algebra 𝕜 A]
 lemma norm_mk_pi_algebra_fin_succ_le :
   ‖continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n.succ A‖ ≤ 1 :=
 begin
-  have := λ f, @op_norm_le_bound 𝕜 (fin n.succ) (λ i, A) A _ _ _ _ _ _ _ f _ zero_le_one,
+  have := λ f, @op_norm_le_bound 𝕜 (fin n.succ) (λ i, A) A _ _ _ _ _ _ _ _ _ f _ zero_le_one,
   refine this _ _,
   intros m,
   simp only [continuous_multilinear_map.mk_pi_algebra_fin_apply, one_mul, list.of_fn_eq_map,

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -58,7 +58,7 @@ open_locale classical big_operators nnreal
 open finset metric
 
 local attribute [instance, priority 1001]
-add_comm_group.to_add_comm_monoid normed_add_comm_group.to_add_comm_group normed_space.to_module'
+add_comm_group.to_add_comm_monoid normed_space.to_module'
 
 /-!
 ### Type variables
@@ -78,11 +78,12 @@ variables {𝕜 : Type u} {ι : Type v} {ι' : Type v'} {n : ℕ}
   {E : ι → Type wE} {E₁ : ι → Type wE₁} {E' : ι' → Type wE'} {Ei : fin n.succ → Type wEi}
   {G : Type wG} {G' : Type wG'}
   [decidable_eq ι] [fintype ι] [decidable_eq ι'] [fintype ι'] [nontrivially_normed_field 𝕜]
-  [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
-  [Π i, normed_add_comm_group (E₁ i)] [Π i, normed_space 𝕜 (E₁ i)]
-  [Π i, normed_add_comm_group (E' i)] [Π i, normed_space 𝕜 (E' i)]
-  [Π i, normed_add_comm_group (Ei i)] [Π i, normed_space 𝕜 (Ei i)]
-  [normed_add_comm_group G] [normed_space 𝕜 G] [normed_add_comm_group G'] [normed_space 𝕜 G']
+  [Π i, add_comm_group (E i)] [Π i, normed_add_comm_group (E i)] [Π i, normed_space 𝕜 (E i)]
+  [Π i, add_comm_group (E₁ i)] [Π i, normed_add_comm_group (E₁ i)] [Π i, normed_space 𝕜 (E₁ i)]
+  [Π i, add_comm_group (E' i)] [Π i, normed_add_comm_group (E' i)] [Π i, normed_space 𝕜 (E' i)]
+  [Π i, add_comm_group (Ei i)] [Π i, normed_add_comm_group (Ei i)] [Π i, normed_space 𝕜 (Ei i)]
+  [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
+  [add_comm_group G'] [normed_add_comm_group G'] [normed_space 𝕜 G']
 
 /-!
 ### Continuity properties of multilinear maps
@@ -397,7 +398,8 @@ theorem le_op_norm_mul_pow_card_of_le {b : ℝ} (hm : ∀ i, ‖m i‖ ≤ b) :
   ‖f m‖ ≤ ‖f‖ * b ^ fintype.card ι :=
 by simpa only [prod_const] using f.le_op_norm_mul_prod_of_le m hm
 
-theorem le_op_norm_mul_pow_of_le {Ei : fin n → Type*} [Π i, normed_add_comm_group (Ei i)]
+theorem le_op_norm_mul_pow_of_le
+  {Ei : fin n → Type*} [Π i, add_comm_group (Ei i)] [Π i, normed_add_comm_group (Ei i)]
   [Π i, normed_space 𝕜 (Ei i)] (f : continuous_multilinear_map 𝕜 Ei G) (m : Π i, Ei i)
   {b : ℝ} (hm : ‖m‖ ≤ b) :
   ‖f m‖ ≤ ‖f‖ * b ^ n :=
@@ -423,7 +425,8 @@ le_antisymm
     (f.op_norm_le_bound (norm_nonneg _) $ λ m, (le_max_left _ _).trans ((f.prod g).le_op_norm _))
     (g.op_norm_le_bound (norm_nonneg _) $ λ m, (le_max_right _ _).trans ((f.prod g).le_op_norm _))
 
-lemma norm_pi {ι' : Type v'} [fintype ι'] {E' : ι' → Type wE'} [Π i', normed_add_comm_group (E' i')]
+lemma norm_pi {ι' : Type v'} [fintype ι'] {E' : ι' → Type wE'}
+  [Π i', add_comm_group (E' i')] [Π i', normed_add_comm_group (E' i')]
   [Π i', normed_space 𝕜 (E' i')] (f : Π i', continuous_multilinear_map 𝕜 E (E' i')) :
   ‖pi f‖ = ‖f‖ :=
 begin
@@ -491,10 +494,12 @@ def prodL :
   norm_map' := λ f, op_norm_prod f.1 f.2 }
 
 /-- `continuous_multilinear_map.pi` as a `linear_isometry_equiv`. -/
-def piₗᵢ {ι' : Type v'} [fintype ι'] {E' : ι' → Type wE'} [Π i', normed_add_comm_group (E' i')]
+def piₗᵢ {ι' : Type v'} [fintype ι'] {E' : ι' → Type wE'}
+  [Π i', add_comm_group (E' i')] [Π i', normed_add_comm_group (E' i')]
   [Π i', normed_space 𝕜 (E' i')] :
   @linear_isometry_equiv 𝕜 𝕜 _ _ (ring_hom.id 𝕜) _ _ _
-    (Π i', continuous_multilinear_map 𝕜 E (E' i')) (continuous_multilinear_map 𝕜 E (Π i, E' i)) _ _
+    (Π i', continuous_multilinear_map 𝕜 E (E' i')) (continuous_multilinear_map 𝕜 E (Π i, E' i))
+    _ _ _ _
       (@pi.module ι' _ 𝕜 _ _ (λ i', infer_instance)) _ :=
 { to_linear_equiv :=
   -- note: `pi_linear_equiv` does not unify correctly here, presumably due to issues with dependent
@@ -998,7 +1003,7 @@ linear_map.mk_continuous
 rfl
 
 lemma norm_comp_continuous_linear_mapL_le (f : Π i, E i →L[𝕜] E₁ i) :
-  ‖@comp_continuous_linear_mapL 𝕜 ι E E₁ G _ _ _ _ _ _ _ _ _ f‖ ≤ (∏ i, ‖f i‖) :=
+  ‖@comp_continuous_linear_mapL 𝕜 ι E E₁ G _ _ _ _ _ _ _ _ _ _ _ _ f‖ ≤ (∏ i, ‖f i‖) :=
 linear_map.mk_continuous_norm_le _ (prod_nonneg $ λ i _, norm_nonneg _) _
 
 end continuous_multilinear_map

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -1083,7 +1083,7 @@ end continuous_linear_equiv
 variables {σ₂₁ : 𝕜₂ →+* 𝕜} [ring_hom_inv_pair σ₁₂ σ₂₁] [ring_hom_inv_pair σ₂₁ σ₁₂]
 
 namespace continuous_linear_map
-variables {E' F' : Type*} [seminormed_add_comm_group E'] [seminormed_add_comm_group F']
+variables {E' F' : Type*} [add_comm_group E'] [seminormed_add_comm_group E'] [seminormed_add_comm_group F']
 
 variables {𝕜₁' : Type*} {𝕜₂' : Type*} [nontrivially_normed_field 𝕜₁']
   [nontrivially_normed_field 𝕜₂'] [normed_space 𝕜₁' E'] [normed_space 𝕜₂' F']
@@ -1253,7 +1253,7 @@ section completeness
 open_locale topology
 open filter
 
-variables {E' : Type*} [seminormed_add_comm_group E'] [normed_space 𝕜 E'] [ring_hom_isometric σ₁₂]
+variables {E' : Type*} [add_comm_group E'] [seminormed_add_comm_group E'] [normed_space 𝕜 E'] [ring_hom_isometric σ₁₂]
 
 /-- Construct a bundled continuous (semi)linear map from a map `f : E → F` and a proof of the fact
 that it belongs to the closure of the image of a bounded set `s : set (E →SL[σ₁₂] F)` under coercion
@@ -1519,7 +1519,7 @@ variables [nontrivially_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   [normed_space 𝕜 Fₗ] (c : 𝕜)
   {σ₁₂ : 𝕜 →+* 𝕜₂} {σ₂₃ : 𝕜₂ →+* 𝕜₃}
 
-variables {𝕜₂' : Type*} [nontrivially_normed_field 𝕜₂'] {F' : Type*} [normed_add_comm_group F']
+variables {𝕜₂' : Type*} [nontrivially_normed_field 𝕜₂'] {F' : Type*} [add_comm_group F'] [normed_add_comm_group F']
   [normed_space 𝕜₂' F'] {σ₂' : 𝕜₂' →+* 𝕜₂} {σ₂'' : 𝕜₂ →+* 𝕜₂'}
   {σ₂₃' : 𝕜₂' →+* 𝕜₃}
   [ring_hom_inv_pair σ₂' σ₂''] [ring_hom_inv_pair σ₂'' σ₂']

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -455,7 +455,7 @@ lemma exists_mul_lt_of_lt_op_norm (f : E →SL[σ₁₂] F) {r : ℝ} (hr₀ : 0
   ∃ x, r * ‖x‖ < ‖f x‖ :=
 by { lift r to ℝ≥0 using hr₀, exact f.exists_mul_lt_apply_of_lt_op_nnnorm hr }
 
-lemma exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+lemma exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ‖f‖₊) : ∃ x : E, ‖x‖₊ < 1 ∧ r < ‖f x‖₊ :=
@@ -472,7 +472,7 @@ begin
   rwa [map_smulₛₗ f, nnnorm_smul, ←nnreal.div_lt_iff hfy, div_eq_mul_inv, this],
 end
 
-lemma exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+lemma exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) {r : ℝ} (hr : r < ‖f‖) : ∃ x : E, ‖x‖ < 1 ∧ r < ‖f x‖ :=
@@ -483,7 +483,7 @@ begin
     exact f.exists_lt_apply_of_lt_op_nnnorm hr, }
 end
 
-lemma Sup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+lemma Sup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ‖f x‖₊) '' ball 0 1) = ‖f‖₊ :=
@@ -496,13 +496,13 @@ begin
     exact ⟨_, ⟨x, mem_ball_zero_iff.2 hx, rfl⟩, hxf⟩ },
 end
 
-lemma Sup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+lemma Sup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ‖f x‖) '' ball 0 1) = ‖f‖ :=
 by simpa only [nnreal.coe_Sup, set.image_image] using nnreal.coe_eq.2 f.Sup_unit_ball_eq_nnnorm
 
-lemma Sup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+lemma Sup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ‖f x‖₊) '' closed_ball 0 1) = ‖f‖₊ :=
@@ -515,7 +515,7 @@ begin
     (set.image_subset _ ball_subset_closed_ball),
 end
 
-lemma Sup_closed_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type*} [normed_add_comm_group E]
+lemma Sup_closed_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ‖f x‖) '' closed_ball 0 1) = ‖f‖ :=
@@ -1696,7 +1696,7 @@ begin
 end
 
 variables {𝕜} {𝕜₄ : Type*} [nontrivially_normed_field 𝕜₄]
-variables {H : Type*} [normed_add_comm_group H] [normed_space 𝕜₄ H] [normed_space 𝕜₃ G]
+variables {H : Type*} [add_comm_group H] [normed_add_comm_group H] [normed_space 𝕜₄ H] [normed_space 𝕜₃ G]
 variables {σ₂₃ : 𝕜₂ →+* 𝕜₃} {σ₁₃ : 𝕜 →+* 𝕜₃}
 variables {σ₃₄ : 𝕜₃ →+* 𝕜₄} {σ₄₃ : 𝕜₄ →+* 𝕜₃}
 variables {σ₂₄ : 𝕜₂ →+* 𝕜₄} {σ₁₄ : 𝕜 →+* 𝕜₄}
@@ -1729,7 +1729,7 @@ omit σ₂₁ σ₃₄ σ₁₃ σ₂₄
 
 /-- A pair of continuous linear equivalences generates an continuous linear equivalence between
 the spaces of continuous linear maps. -/
-def arrow_congr {F H : Type*} [normed_add_comm_group F] [normed_add_comm_group H]
+def arrow_congr {F H : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_add_comm_group H]
   [normed_space 𝕜 F] [normed_space 𝕜 G] [normed_space 𝕜 H]
   (e₁ : E ≃L[𝕜] F) (e₂ : H ≃L[𝕜] G) :
   (E →L[𝕜] H) ≃L[𝕜] (F →L[𝕜] G) :=

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -33,6 +33,8 @@ section semi_normed
 
 open metric continuous_linear_map
 
+variables [add_comm_group E] [add_comm_group Eₗ] [add_comm_group F]
+  [add_comm_group Fₗ] [add_comm_group G] [add_comm_group Gₗ]
 variables [seminormed_add_comm_group E] [seminormed_add_comm_group Eₗ] [seminormed_add_comm_group F]
   [seminormed_add_comm_group Fₗ] [seminormed_add_comm_group G] [seminormed_add_comm_group Gₗ]
 
@@ -338,7 +340,7 @@ begin
       ⟨normed_space.is_vonN_bounded_closed_ball _ _ _, hε⟩, λ f hf, _⟩,
     change ∀ x, _ at hf,
     simp_rw mem_closed_ball_zero_iff at hf,
-    rw @mem_closed_ball_zero_iff _ seminormed_add_comm_group.to_seminormed_add_group,
+    rw mem_closed_ball_zero_iff,
     refine op_norm_le_of_shell' (div_pos one_pos hc₀) hε.le hc₁ (λ x hx₁ hxc, _),
     rw div_mul_cancel 1 hc₀.ne.symm at hx₁,
     exact (hf x hxc.le).trans (le_mul_of_one_le_right hε.le hx₁) },
@@ -455,7 +457,8 @@ lemma exists_mul_lt_of_lt_op_norm (f : E →SL[σ₁₂] F) {r : ℝ} (hr₀ : 0
   ∃ x, r * ‖x‖ < ‖f x‖ :=
 by { lift r to ℝ≥0 using hr₀, exact f.exists_mul_lt_apply_of_lt_op_nnnorm hr }
 
-lemma exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
+lemma exists_lt_apply_of_lt_op_nnnorm
+  {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [add_comm_group F] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ‖f‖₊) : ∃ x : E, ‖x‖₊ < 1 ∧ r < ‖f x‖₊ :=
@@ -472,7 +475,8 @@ begin
   rwa [map_smulₛₗ f, nnnorm_smul, ←nnreal.div_lt_iff hfy, div_eq_mul_inv, this],
 end
 
-lemma exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
+lemma exists_lt_apply_of_lt_op_norm
+  {𝕜 𝕜₂ E F : Type*} [add_comm_group E][add_comm_group F] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) {r : ℝ} (hr : r < ‖f‖) : ∃ x : E, ‖x‖ < 1 ∧ r < ‖f x‖ :=
@@ -483,7 +487,8 @@ begin
     exact f.exists_lt_apply_of_lt_op_nnnorm hr, }
 end
 
-lemma Sup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
+lemma Sup_unit_ball_eq_nnnorm
+  {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [add_comm_group F] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ‖f x‖₊) '' ball 0 1) = ‖f‖₊ :=
@@ -496,13 +501,15 @@ begin
     exact ⟨_, ⟨x, mem_ball_zero_iff.2 hx, rfl⟩, hxf⟩ },
 end
 
-lemma Sup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
+lemma Sup_unit_ball_eq_norm
+  {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [add_comm_group F] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ‖f x‖) '' ball 0 1) = ‖f‖ :=
 by simpa only [nnreal.coe_Sup, set.image_image] using nnreal.coe_eq.2 f.Sup_unit_ball_eq_nnnorm
 
-lemma Sup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
+lemma Sup_closed_unit_ball_eq_nnnorm
+  {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [add_comm_group F] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ‖f x‖₊) '' closed_ball 0 1) = ‖f‖₊ :=
@@ -515,7 +522,8 @@ begin
     (set.image_subset _ ball_subset_closed_ball),
 end
 
-lemma Sup_closed_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [normed_add_comm_group E]
+lemma Sup_closed_unit_ball_eq_norm
+  {𝕜 𝕜₂ E F : Type*} [add_comm_group E] [add_comm_group F] [normed_add_comm_group E]
   [seminormed_add_comm_group F] [densely_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} [normed_space 𝕜 E] [normed_space 𝕜₂ F] [ring_hom_isometric σ₁₂]
   (f : E →SL[σ₁₂] F) : Sup ((λ x, ‖f x‖) '' closed_ball 0 1) = ‖f‖ :=
@@ -803,7 +811,7 @@ lemma _root_.continuous.const_clm_comp {X} [topological_space X] {f : X → E �
 -- Giving the implicit argument speeds up elaboration significantly
 lemma _root_.continuous.clm_comp_const {X} [topological_space X] {g : X → F →SL[σ₂₃] G}
   (hg : continuous g) (f : E →SL[σ₁₂] F) : continuous (λ x, (g x).comp f : X → E →SL[σ₁₃] G) :=
-(@continuous_linear_map.flip _ _ _ _ _ (E →SL[σ₁₃] G) _ _ _ _ _ _ _ _ _ _ _ _ _
+(@continuous_linear_map.flip _ _ _ _ _ (E →SL[σ₁₃] G) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
   (compSL E F G σ₁₂ σ₂₃) f).continuous.comp hg
 
 omit σ₁₃
@@ -828,10 +836,10 @@ def precompL (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : (Eₗ →L[𝕜] E) →L[
 section prod
 
 universes u₁ u₂ u₃ u₄
-variables (M₁ : Type u₁) [seminormed_add_comm_group M₁] [normed_space 𝕜 M₁]
-          (M₂ : Type u₂) [seminormed_add_comm_group M₂] [normed_space 𝕜 M₂]
-          (M₃ : Type u₃) [seminormed_add_comm_group M₃] [normed_space 𝕜 M₃]
-          (M₄ : Type u₄) [seminormed_add_comm_group M₄] [normed_space 𝕜 M₄]
+variables (M₁ : Type u₁) [add_comm_group M₁] [seminormed_add_comm_group M₁] [normed_space 𝕜 M₁]
+          (M₂ : Type u₂) [add_comm_group M₂] [seminormed_add_comm_group M₂] [normed_space 𝕜 M₂]
+          (M₃ : Type u₃) [add_comm_group M₃] [seminormed_add_comm_group M₃] [normed_space 𝕜 M₃]
+          (M₄ : Type u₄) [add_comm_group M₄] [seminormed_add_comm_group M₄] [normed_space 𝕜 M₄]
 
 variables {Eₗ} (𝕜)
 /-- `continuous_linear_map.prod_map` as a continuous linear map. -/
@@ -1043,7 +1051,7 @@ end continuous_linear_map
 namespace submodule
 
 lemma norm_subtypeL_le (K : submodule 𝕜 E) : ‖K.subtypeL‖ ≤ 1 :=
-K.subtypeₗᵢ.norm_to_continuous_linear_map_le
+(K.subtypeₗᵢ : _).norm_to_continuous_linear_map_le
 
 end submodule
 
@@ -1083,7 +1091,8 @@ end continuous_linear_equiv
 variables {σ₂₁ : 𝕜₂ →+* 𝕜} [ring_hom_inv_pair σ₁₂ σ₂₁] [ring_hom_inv_pair σ₂₁ σ₁₂]
 
 namespace continuous_linear_map
-variables {E' F' : Type*} [add_comm_group E'] [seminormed_add_comm_group E'] [seminormed_add_comm_group F']
+variables {E' F' : Type*} [add_comm_group E'] [add_comm_group F']
+variables [seminormed_add_comm_group E'] [seminormed_add_comm_group F']
 
 variables {𝕜₁' : Type*} {𝕜₂' : Type*} [nontrivially_normed_field 𝕜₁']
   [nontrivially_normed_field 𝕜₂'] [normed_space 𝕜₁' E'] [normed_space 𝕜₂' F']
@@ -1125,6 +1134,8 @@ end semi_normed
 
 section normed
 
+variables [add_comm_group E] [add_comm_group F] [add_comm_group G]
+  [add_comm_group Fₗ]
 variables [normed_add_comm_group E] [normed_add_comm_group F] [normed_add_comm_group G]
   [normed_add_comm_group Fₗ]
 
@@ -1729,7 +1740,8 @@ omit σ₂₁ σ₃₄ σ₁₃ σ₂₄
 
 /-- A pair of continuous linear equivalences generates an continuous linear equivalence between
 the spaces of continuous linear maps. -/
-def arrow_congr {F H : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_add_comm_group H]
+def arrow_congr {F H : Type*} [add_comm_group F] [add_comm_group H]
+  [normed_add_comm_group F] [normed_add_comm_group H]
   [normed_space 𝕜 F] [normed_space 𝕜 G] [normed_space 𝕜 H]
   (e₁ : E ≃L[𝕜] F) (e₂ : H ≃L[𝕜] G) :
   (E →L[𝕜] H) ≃L[𝕜] (F →L[𝕜] G) :=
@@ -1746,6 +1758,6 @@ A bounded bilinear form `B` in a real normed space is *coercive*
 if there is some positive constant C such that `C * ‖u‖ * ‖u‖ ≤ B u u`.
 -/
 def is_coercive
-  [normed_add_comm_group E] [normed_space ℝ E]
+  [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   (B : E →L[ℝ] E →L[ℝ] ℝ) : Prop :=
 ∃ C, (0 < C) ∧ ∀ u, C * ‖u‖ * ‖u‖ ≤ B u u

--- a/src/analysis/normed_space/pi_Lp.lean
+++ b/src/analysis/normed_space/pi_Lp.lean
@@ -581,7 +581,7 @@ def equivₗᵢ : pi_Lp ∞ β ≃ₗᵢ[𝕜] Π i, β i :=
 variables {ι' : Type*}
 variables [fintype ι']
 
-variables (p 𝕜) (E : Type*) [normed_add_comm_group E] [normed_space 𝕜 E]
+variables (p 𝕜) (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 
 /-- An equivalence of finite domains induces a linearly isometric equivalence of finitely supported
 functions-/

--- a/src/analysis/normed_space/pointwise.lean
+++ b/src/analysis/normed_space/pointwise.lean
@@ -21,7 +21,7 @@ open_locale pointwise topology
 variables {𝕜 E : Type*} [normed_field 𝕜]
 
 section seminormed_add_comm_group
-variables [seminormed_add_comm_group E] [normed_space 𝕜 E]
+variables [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕜 E]
 
 theorem smul_ball {c : 𝕜} (hc : c ≠ 0) (x : E) (r : ℝ) :
   c • ball x r = ball (c • x) (‖c‖ * r) :=
@@ -309,7 +309,7 @@ by simp_rw [sub_eq_add_neg, neg_closed_ball, closed_ball_add_closed_ball hε hδ
 end seminormed_add_comm_group
 
 section normed_add_comm_group
-variables [normed_add_comm_group E] [normed_space 𝕜 E]
+variables [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 
 theorem smul_closed_ball (c : 𝕜) (x : E) {r : ℝ} (hr : 0 ≤ r) :
   c • closed_ball x r = closed_ball (c • x) (‖c‖ * r) :=

--- a/src/analysis/normed_space/ray.lean
+++ b/src/analysis/normed_space/ray.lean
@@ -16,8 +16,8 @@ norms and `‖y‖ • x = ‖x‖ • y`.
 
 open real
 
-variables {E : Type*} [seminormed_add_comm_group E] [normed_space ℝ E]
-  {F : Type*} [normed_add_comm_group F] [normed_space ℝ F]
+variables {E : Type*} [add_comm_group E] [seminormed_add_comm_group E] [normed_space ℝ E]
+  {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F]
 
 namespace same_ray
 

--- a/src/analysis/normed_space/riesz_lemma.lean
+++ b/src/analysis/normed_space/riesz_lemma.lean
@@ -24,8 +24,8 @@ open set metric
 open_locale topology
 
 variables {𝕜 : Type*} [normed_field 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-variables {F : Type*} [seminormed_add_comm_group F] [normed_space ℝ F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+variables {F : Type*} [add_comm_group F] [seminormed_add_comm_group F] [normed_space ℝ F]
 
 /-- Riesz's lemma, which usually states that it is possible to find a
 vector with norm 1 whose distance to a closed proper subspace is

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -44,7 +44,7 @@ attribute [simp] norm_star
 variables {𝕜 E α : Type*}
 
 section normed_star_group
-variables [seminormed_add_comm_group E] [star_add_monoid E] [normed_star_group E]
+variables [add_comm_group E] [seminormed_add_comm_group E] [star_add_monoid E] [normed_star_group E]
 
 @[simp] lemma nnnorm_star (x : E) : ‖star x‖₊ = ‖x‖₊ := subtype.ext $ norm_star _
 
@@ -237,7 +237,7 @@ x.prop.nnnorm_pow_two_pow _
 section starₗᵢ
 
 variables [comm_semiring 𝕜] [star_ring 𝕜]
-variables [seminormed_add_comm_group E] [star_add_monoid E] [normed_star_group E]
+variables [add_comm_group E] [seminormed_add_comm_group E] [star_add_monoid E] [normed_star_group E]
 variables [module 𝕜 E] [star_module 𝕜 E]
 
 variables (𝕜)

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -35,7 +35,7 @@ open_locale topology
 local postfix `⋆`:std.prec.max_plus := star
 
 /-- A normed star group is a normed group with a compatible `star` which is isometric. -/
-class normed_star_group (E : Type*) [seminormed_add_comm_group E] [star_add_monoid E] : Prop :=
+class normed_star_group (E : Type*) [add_comm_group E] [seminormed_add_comm_group E] [star_add_monoid E] : Prop :=
 (norm_star : ∀ x : E, ‖x⋆‖ = ‖x‖)
 
 export normed_star_group (norm_star)

--- a/src/analysis/normed_space/weak_dual.lean
+++ b/src/analysis/normed_space/weak_dual.lean
@@ -99,7 +99,7 @@ by the dual-norm (i.e. the operator-norm).
 -/
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-variables {E : Type*} [seminormed_add_comm_group E] [normed_space 𝕜 E]
+variables {E : Type*} [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕜 E]
 
 namespace normed_space
 

--- a/src/analysis/schwartz_space.lean
+++ b/src/analysis/schwartz_space.lean
@@ -55,8 +55,8 @@ noncomputable theory
 
 variables {𝕜 𝕜' E F : Type*}
 
-variables [normed_add_comm_group E] [normed_space ℝ E]
-variables [normed_add_comm_group F] [normed_space ℝ F]
+variables [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
+variables [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F]
 
 variables (E F)
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -1029,7 +1029,9 @@ end seminorm
 /-! ### The norm as a seminorm -/
 
 section norm_seminorm
-variables (𝕜) (E) [normed_field 𝕜] [seminormed_add_comm_group E] [normed_space 𝕜 E] {r : ℝ}
+variables (𝕜) (E)
+variables [normed_field 𝕜] [add_comm_group E] [seminormed_add_comm_group E] [normed_space 𝕜 E]
+variables {r : ℝ}
 
 /-- The norm of a seminormed group as a seminorm. -/
 def norm_seminorm : seminorm 𝕜 E :=

--- a/src/analysis/special_functions/arsinh.lean
+++ b/src/analysis/special_functions/arsinh.lean
@@ -167,7 +167,7 @@ end continuous
 
 section fderiv
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {s : set E} {a : E}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {s : set E} {a : E}
   {f' : E →L[ℝ] ℝ} {n : ℕ∞}
 
 lemma has_strict_fderiv_at.arsinh (hf : has_strict_fderiv_at f f' a) :

--- a/src/analysis/special_functions/compare_exp.lean
+++ b/src/analysis/special_functions/compare_exp.lean
@@ -66,7 +66,7 @@ lemma of_bounded_under_abs_im (hre : tendsto re l at_top)
   (him : is_bounded_under (≤) l (λ z, |z.im|)) :
   is_exp_cmp_filter l :=
 of_is_O_im_re_pow hre 0 $
-  by simpa only [pow_zero] using @is_bounded_under.is_O_const ℂ ℝ ℝ _ _ _ l him 1 one_ne_zero
+  by simpa only [pow_zero] using @is_bounded_under.is_O_const ℂ ℝ ℝ _ _ _ _ l him 1 one_ne_zero
 
 lemma of_bounded_under_im (hre : tendsto re l at_top) (him_le : is_bounded_under (≤) l im)
   (him_ge : is_bounded_under (≥) l im) :

--- a/src/analysis/special_functions/complex/log_deriv.lean
+++ b/src/analysis/special_functions/complex/log_deriv.lean
@@ -68,7 +68,7 @@ section log_deriv
 open complex filter
 open_locale topology
 
-variables {α : Type*} [topological_space α] {E : Type*} [normed_add_comm_group E] [normed_space ℂ E]
+variables {α : Type*} [topological_space α] {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E]
 
 lemma has_strict_fderiv_at.clog {f : E → ℂ} {f' : E →L[ℂ] ℂ} {x : E}
   (h₁ : has_strict_fderiv_at f f' x) (h₂ : 0 < (f x).re ∨ (f x).im ≠ 0) :

--- a/src/analysis/special_functions/exp_deriv.lean
+++ b/src/analysis/special_functions/exp_deriv.lean
@@ -102,7 +102,7 @@ end
 
 section
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜] [normed_algebra 𝕜 ℂ]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] {f : E → ℂ} {f' : E →L[𝕜] ℂ}
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {f : E → ℂ} {f' : E →L[𝕜] ℂ}
   {x : E} {s : set E}
 
 lemma has_strict_fderiv_at.cexp (hf : has_strict_fderiv_at f f' x) :
@@ -213,7 +213,7 @@ section
 /-! Register lemmas for the derivatives of the composition of `real.exp` with a differentiable
 function, for standalone use and use with `simp`. -/
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {f' : E →L[ℝ] ℝ}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {f' : E →L[ℝ] ℝ}
   {x : E} {s : set E}
 
 lemma cont_diff.exp {n} (hf : cont_diff ℝ n f) :

--- a/src/analysis/special_functions/japanese_bracket.lean
+++ b/src/analysis/special_functions/japanese_bracket.lean
@@ -31,7 +31,7 @@ open_locale big_operators nnreal filter topology ennreal
 
 open asymptotics filter set real measure_theory finite_dimensional
 
-variables {E : Type*} [normed_add_comm_group E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 lemma sqrt_one_add_norm_sq_le (x : E) : real.sqrt (1 + ‖x‖^2) ≤ 1 + ‖x‖ :=
 begin

--- a/src/analysis/special_functions/log/deriv.lean
+++ b/src/analysis/special_functions/log/deriv.lean
@@ -115,7 +115,7 @@ end deriv
 
 section fderiv
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {x : E}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {x : E}
   {f' : E →L[ℝ] ℝ} {s : set E}
 
 lemma has_fderiv_within_at.log (hf : has_fderiv_within_at f f' s x) (hx : f x ≠ 0) :

--- a/src/analysis/special_functions/non_integrable.lean
+++ b/src/analysis/special_functions/non_integrable.lean
@@ -39,7 +39,7 @@ integrable function
 open_locale measure_theory topology interval nnreal ennreal
 open measure_theory topological_space set filter asymptotics interval_integral
 
-variables {E F : Type*} [normed_add_comm_group E] [normed_space ℝ E] [second_countable_topology E]
+variables {E F : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [second_countable_topology E]
 [complete_space E] [normed_add_comm_group F]
 
 /-- If `f` is eventually differentiable along a nontrivial filter `l : filter ℝ` that is generated

--- a/src/analysis/special_functions/polar_coord.lean
+++ b/src/analysis/special_functions/polar_coord.lean
@@ -125,7 +125,7 @@ begin
 end
 
 theorem integral_comp_polar_coord_symm
-  {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E] (f : ℝ × ℝ → E) :
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [complete_space E] (f : ℝ × ℝ → E) :
   ∫ p in polar_coord.target, p.1 • f (polar_coord.symm p) = ∫ p, f p :=
 begin
   set B : (ℝ × ℝ) → ((ℝ × ℝ) →L[ℝ] (ℝ × ℝ)) := λ p,

--- a/src/analysis/special_functions/pow_deriv.lean
+++ b/src/analysis/special_functions/pow_deriv.lean
@@ -68,7 +68,7 @@ section fderiv
 
 open complex
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℂ E] {f g : E → ℂ} {f' g' : E →L[ℂ] ℂ}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E] {f g : E → ℂ} {f' g' : E →L[ℂ] ℂ}
   {x : E} {s : set E} {c : ℂ}
 
 lemma has_strict_fderiv_at.cpow (hf : has_strict_fderiv_at f f' x)
@@ -377,7 +377,7 @@ open real
 
 section fderiv
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] {f g : E → ℝ} {f' g' : E →L[ℝ] ℝ}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] {f g : E → ℝ} {f' g' : E →L[ℝ] ℝ}
   {x : E} {s : set E} {c p : ℝ} {n : ℕ∞}
 
 lemma has_fderiv_within_at.rpow (hf : has_fderiv_within_at f f' s x)

--- a/src/analysis/special_functions/sqrt.lean
+++ b/src/analysis/special_functions/sqrt.lean
@@ -98,7 +98,7 @@ end deriv
 
 section fderiv
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {n : ℕ∞}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {n : ℕ∞}
   {s : set E} {x : E} {f' : E →L[ℝ] ℝ}
 
 lemma has_fderiv_at.sqrt (hf : has_fderiv_at f f' x) (hx : f x ≠ 0) :

--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -23,7 +23,7 @@ noncomputable theory
 namespace real
 
 /-- The type of angles -/
-@[derive [normed_add_comm_group, inhabited, has_coe_t ℝ]]
+@[derive [add_comm_group, normed_add_comm_group, inhabited, has_coe_t ℝ]]
 def angle : Type := add_circle (2 * π)
 
 namespace angle

--- a/src/analysis/special_functions/trigonometric/arctan_deriv.lean
+++ b/src/analysis/special_functions/trigonometric/arctan_deriv.lean
@@ -131,7 +131,7 @@ end deriv
 
 section fderiv
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {f' : E →L[ℝ] ℝ}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {f' : E →L[ℝ] ℝ}
   {x : E} {s : set E} {n : ℕ∞}
 
 lemma has_strict_fderiv_at.arctan (hf : has_strict_fderiv_at f f' x) :

--- a/src/analysis/special_functions/trigonometric/deriv.lean
+++ b/src/analysis/special_functions/trigonometric/deriv.lean
@@ -242,7 +242,7 @@ end
 section
 /-! ### Simp lemmas for derivatives of `λ x, complex.cos (f x)` etc., `f : E → ℂ` -/
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℂ E] {f : E → ℂ} {f' : E →L[ℂ] ℂ}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E] {f : E → ℂ} {f' : E →L[ℂ] ℂ}
   {x : E} {s : set E}
 
 /-! #### `complex.cos` -/
@@ -717,7 +717,7 @@ section
 
 /-! ### Simp lemmas for derivatives of `λ x, real.cos (f x)` etc., `f : E → ℝ` -/
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {f' : E →L[ℝ] ℝ}
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] {f : E → ℝ} {f' : E →L[ℝ] ℝ}
   {x : E} {s : set E}
 
 /-! #### `real.cos` -/

--- a/src/analysis/specific_limits/normed.lean
+++ b/src/analysis/specific_limits/normed.lean
@@ -37,7 +37,7 @@ lemma summable_of_absolute_convergence_real {f : ℕ → ℝ} :
 
 /-! ### Powers -/
 
-lemma tendsto_norm_zero' {𝕜 : Type*} [normed_add_comm_group 𝕜] :
+lemma tendsto_norm_zero' {𝕜 : Type*} [add_comm_group 𝕜] [normed_add_comm_group 𝕜] :
   tendsto (norm : 𝕜 → ℝ) (𝓝[≠] 0) (𝓝[>] 0) :=
 tendsto_norm_zero.inf $ tendsto_principal_principal.2 $ λ x hx, norm_pos_iff.2 hx
 
@@ -474,7 +474,7 @@ end normed_ring_geometric
 
 /-! ### Summability tests based on comparison with geometric series -/
 
-lemma summable_of_ratio_norm_eventually_le {α : Type*} [seminormed_add_comm_group α]
+lemma summable_of_ratio_norm_eventually_le {α : Type*} [add_comm_group α] [seminormed_add_comm_group α]
   [complete_space α] {f : ℕ → α} {r : ℝ} (hr₁ : r < 1)
   (h : ∀ᶠ n in at_top, ‖f (n+1)‖ ≤ r * ‖f n‖) : summable f :=
 begin
@@ -496,7 +496,7 @@ begin
     exact not_lt.mpr (norm_nonneg _) (lt_of_le_of_lt hn $ mul_neg_of_neg_of_pos hr₀ h), },
 end
 
-lemma summable_of_ratio_test_tendsto_lt_one {α : Type*} [normed_add_comm_group α] [complete_space α]
+lemma summable_of_ratio_test_tendsto_lt_one {α : Type*} [add_comm_group α] [normed_add_comm_group α] [complete_space α]
   {f : ℕ → α} {l : ℝ} (hl₁ : l < 1) (hf : ∀ᶠ n in at_top, f n ≠ 0)
   (h : tendsto (λ n, ‖f (n+1)‖/‖f n‖) at_top (𝓝 l)) : summable f :=
 begin
@@ -506,7 +506,7 @@ begin
   rwa ← div_le_iff (norm_pos_iff.mpr h₁),
 end
 
-lemma not_summable_of_ratio_norm_eventually_ge {α : Type*} [seminormed_add_comm_group α]
+lemma not_summable_of_ratio_norm_eventually_ge {α : Type*} [add_comm_group α] [seminormed_add_comm_group α]
   {f : ℕ → α} {r : ℝ} (hr : 1 < r) (hf : ∃ᶠ n in at_top, ‖f n‖ ≠ 0)
   (h : ∀ᶠ n in at_top, r * ‖f n‖ ≤ ‖f (n+1)‖) : ¬ summable f :=
 begin
@@ -529,7 +529,7 @@ begin
     ac_refl }
 end
 
-lemma not_summable_of_ratio_test_tendsto_gt_one {α : Type*} [seminormed_add_comm_group α]
+lemma not_summable_of_ratio_test_tendsto_gt_one {α : Type*} [add_comm_group α] [seminormed_add_comm_group α]
   {f : ℕ → α} {l : ℝ} (hl : 1 < l)
   (h : tendsto (λ n, ‖f (n+1)‖/‖f n‖) at_top (𝓝 l)) : ¬ summable f :=
 begin
@@ -546,7 +546,7 @@ end
 section
 /-! ### Dirichlet and alternating series tests -/
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
 variables {b : ℝ} {f : ℕ → ℝ} {z : ℕ → E}
 
 /-- **Dirichlet's Test** for monotone sequences. -/

--- a/src/analysis/specific_limits/normed.lean
+++ b/src/analysis/specific_limits/normed.lean
@@ -59,6 +59,7 @@ end
 
 /-- The (scalar) product of a sequence that tends to zero with a bounded one also tends to zero. -/
 lemma tendsto_zero_smul_of_tendsto_zero_of_bounded {ι 𝕜 𝔸 : Type*} [normed_field 𝕜]
+  [add_comm_group 𝔸]
   [normed_add_comm_group 𝔸] [normed_space 𝕜 𝔸] {l : filter ι} {ε : ι → 𝕜} {f : ι → 𝔸}
   (hε : tendsto ε l (𝓝 0)) (hf : filter.is_bounded_under (≤) l (norm ∘ f)) :
   tendsto (ε • f) l (𝓝 0) :=
@@ -342,7 +343,7 @@ end mul_geometric
 
 section summable_le_geometric
 
-variables [seminormed_add_comm_group α] {r C : ℝ} {f : ℕ → α}
+variables [add_comm_group α] [seminormed_add_comm_group α] {r C : ℝ} {f : ℕ → α}
 
 lemma seminormed_add_comm_group.cauchy_seq_of_le_geometric {C : ℝ} {r : ℝ} (hr : r < 1)
   {u : ℕ → α} (h : ∀ n, ‖u n - u (n + 1)‖ ≤ C*r^n) : cauchy_seq u :=

--- a/src/combinatorics/additive/salem_spencer.lean
+++ b/src/combinatorics/additive/salem_spencer.lean
@@ -263,7 +263,8 @@ begin
     (add_halves _) hc.2,
 end
 
-lemma add_salem_spencer_sphere [normed_add_comm_group E] [normed_space ℝ E]
+lemma add_salem_spencer_sphere
+  [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [strict_convex_space ℝ E] (x : E) (r : ℝ) : add_salem_spencer (sphere x r) :=
 begin
   obtain rfl | hr := eq_or_ne r 0,

--- a/src/geometry/manifold/algebra/left_invariant_derivation.lean
+++ b/src/geometry/manifold/algebra/left_invariant_derivation.lean
@@ -24,7 +24,7 @@ noncomputable theory
 open_locale lie_group manifold derivation
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 (G : Type*) [topological_space G] [charted_space H G] [monoid G] [has_smooth_mul I G] (g h : G)
 

--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -69,10 +69,10 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
 {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] {J : model_with_corners 𝕜 F F}
 {G : Type*} [topological_space G] [charted_space H G] [group G] [lie_group I G]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
 {M : Type*} [topological_space M] [charted_space H' M]
-{E'' : Type*} [normed_add_comm_group E''] [normed_space 𝕜 E'']
+{E'' : Type*} [add_comm_group E''] [normed_add_comm_group E''] [normed_space 𝕜 E'']
 {H'' : Type*} [topological_space H''] {I'' : model_with_corners 𝕜 E'' H''}
 {M' : Type*} [topological_space M'] [charted_space H'' M']
 
@@ -124,7 +124,7 @@ section prod_lie_group
 instance {𝕜 : Type*} [nontrivially_normed_field 𝕜] {H : Type*} [topological_space H]
   {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]  {I : model_with_corners 𝕜 E H}
   {G : Type*} [topological_space G] [charted_space H G] [group G] [lie_group I G]
-  {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+  {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
   {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
   {G' : Type*} [topological_space G'] [charted_space H' G']
   [group G'] [lie_group I' G'] :

--- a/src/geometry/manifold/algebra/lie_group.lean
+++ b/src/geometry/manifold/algebra/lie_group.lean
@@ -46,7 +46,7 @@ the addition and negation operations are smooth. -/
 @[ancestor has_smooth_add]
 class lie_add_group {𝕜 : Type*} [nontrivially_normed_field 𝕜]
   {H : Type*} [topological_space H]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
   (G : Type*) [add_group G] [topological_space G] [charted_space H G]
   extends has_smooth_add I G : Prop :=
 (smooth_neg : smooth I I (λ a:G, -a))
@@ -57,7 +57,7 @@ the multiplication and inverse operations are smooth. -/
 @[ancestor has_smooth_mul, to_additive]
 class lie_group {𝕜 : Type*} [nontrivially_normed_field 𝕜]
   {H : Type*} [topological_space H]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
   (G : Type*) [group G] [topological_space G] [charted_space H G]
   extends has_smooth_mul I G : Prop :=
 (smooth_inv : smooth I I (λ a:G, a⁻¹))
@@ -66,8 +66,8 @@ section lie_group
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H : Type*} [topological_space H]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F] {J : model_with_corners 𝕜 F F}
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] {J : model_with_corners 𝕜 F F}
 {G : Type*} [topological_space G] [charted_space H G] [group G] [lie_group I G]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
@@ -122,7 +122,7 @@ section prod_lie_group
 /- Instance of product group -/
 @[to_additive]
 instance {𝕜 : Type*} [nontrivially_normed_field 𝕜] {H : Type*} [topological_space H]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]  {I : model_with_corners 𝕜 E H}
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]  {I : model_with_corners 𝕜 E H}
   {G : Type*} [topological_space G] [charted_space H G] [group G] [lie_group I G]
   {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
   {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
@@ -137,7 +137,7 @@ end prod_lie_group
 /-! ### Normed spaces are Lie groups -/
 
 instance normed_space_lie_add_group {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] :
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] :
   lie_add_group (𝓘(𝕜, E)) E :=
 { smooth_add := smooth_iff.2 ⟨continuous_add, λ x y, cont_diff_add.cont_diff_on⟩,
   smooth_neg := smooth_iff.2 ⟨continuous_neg, λ x y, cont_diff_neg.cont_diff_on⟩,

--- a/src/geometry/manifold/algebra/monoid.lean
+++ b/src/geometry/manifold/algebra/monoid.lean
@@ -67,7 +67,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H : Type*} [topological_space H]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
 {G : Type*} [has_mul G] [topological_space G] [charted_space H G] [has_smooth_mul I G]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
 {M : Type*} [topological_space M] [charted_space H' M]
 
@@ -191,7 +191,7 @@ instance has_smooth_mul.prod {𝕜 : Type*} [nontrivially_normed_field 𝕜]
   {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
   (G : Type*) [topological_space G] [charted_space H G]
   [has_mul G] [has_smooth_mul I G]
-  {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+  {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
   {H' : Type*} [topological_space H'] (I' : model_with_corners 𝕜 E' H')
   (G' : Type*) [topological_space G'] [charted_space H' G']
   [has_mul G'] [has_smooth_mul I' G'] :
@@ -209,7 +209,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
 {G : Type*} [monoid G] [topological_space G] [charted_space H G] [has_smooth_mul I G]
 {H' : Type*} [topological_space H']
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E'] {I' : model_with_corners 𝕜 E' H'}
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E'] {I' : model_with_corners 𝕜 E' H'}
 {G' : Type*} [monoid G'] [topological_space G'] [charted_space H' G'] [has_smooth_mul I' G']
 
 lemma smooth_pow : ∀ n : ℕ, smooth I I (λ a : G, a ^ n)
@@ -252,7 +252,7 @@ variables {ι 𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H : Type*} [topological_space H]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
 {G : Type*} [comm_monoid G] [topological_space G] [charted_space H G] [has_smooth_mul I G]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
 {M : Type*} [topological_space M] [charted_space H' M] {s : set M} {x : M}
 {t : finset ι} {f : ι → M → G} {n : ℕ∞} {p : ι → Prop}

--- a/src/geometry/manifold/algebra/monoid.lean
+++ b/src/geometry/manifold/algebra/monoid.lean
@@ -44,7 +44,7 @@ instances `add_monoid α` and `has_smooth_add α`. -/
 @[ancestor smooth_manifold_with_corners]
 class has_smooth_add {𝕜 : Type*} [nontrivially_normed_field 𝕜]
   {H : Type*} [topological_space H]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
   (G : Type*) [has_add G] [topological_space G] [charted_space H G]
   extends smooth_manifold_with_corners I G : Prop :=
 (smooth_add : smooth (I.prod I) I (λ p : G×G, p.1 + p.2))
@@ -56,7 +56,7 @@ and `has_smooth_mul I G`. -/
 @[ancestor smooth_manifold_with_corners, to_additive]
 class has_smooth_mul {𝕜 : Type*} [nontrivially_normed_field 𝕜]
   {H : Type*} [topological_space H]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] (I : model_with_corners 𝕜 E H)
   (G : Type*) [has_mul G] [topological_space G] [charted_space H G]
   extends smooth_manifold_with_corners I G : Prop :=
 (smooth_mul : smooth (I.prod I) I (λ p : G×G, p.1 * p.2))
@@ -65,7 +65,7 @@ section has_smooth_mul
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H : Type*} [topological_space H]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
 {G : Type*} [has_mul G] [topological_space G] [charted_space H G] [has_smooth_mul I G]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
@@ -187,7 +187,7 @@ end
 /- Instance of product -/
 @[to_additive]
 instance has_smooth_mul.prod {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
   (G : Type*) [topological_space G] [charted_space H G]
   [has_mul G] [has_smooth_mul I G]
@@ -206,7 +206,7 @@ section monoid
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H : Type*} [topological_space H]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
 {G : Type*} [monoid G] [topological_space G] [charted_space H G] [has_smooth_mul I G]
 {H' : Type*} [topological_space H']
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E'] {I' : model_with_corners 𝕜 E' H'}
@@ -250,7 +250,7 @@ open_locale big_operators
 
 variables {ι 𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H : Type*} [topological_space H]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {I : model_with_corners 𝕜 E H}
 {G : Type*} [comm_monoid G] [topological_space G] [charted_space H G] [has_smooth_mul I G]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}

--- a/src/geometry/manifold/algebra/smooth_functions.lean
+++ b/src/geometry/manifold/algebra/smooth_functions.lean
@@ -17,7 +17,7 @@ noncomputable theory
 open_locale manifold
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
@@ -179,26 +179,26 @@ In this section we show that smooth functions valued in a vector space `M` over 
 field `𝕜` inherit a vector space structure.
 -/
 
-instance has_smul {V : Type*} [normed_add_comm_group V] [normed_space 𝕜 V] :
+instance has_smul {V : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space 𝕜 V] :
   has_smul 𝕜 C^∞⟮I, N; 𝓘(𝕜, V), V⟯ :=
 ⟨λ r f, ⟨r • f, smooth_const.smul f.smooth⟩⟩
 
 @[simp]
-lemma coe_smul {V : Type*} [normed_add_comm_group V] [normed_space 𝕜 V]
+lemma coe_smul {V : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space 𝕜 V]
   (r : 𝕜) (f : C^∞⟮I, N; 𝓘(𝕜, V), V⟯) :
   ⇑(r • f) = r • f := rfl
 
-@[simp] lemma smul_comp {V : Type*} [normed_add_comm_group V] [normed_space 𝕜 V]
+@[simp] lemma smul_comp {V : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space 𝕜 V]
   (r : 𝕜) (g : C^∞⟮I'', N'; 𝓘(𝕜, V), V⟯) (h : C^∞⟮I, N; I'', N'⟯) :
 (r • g).comp h = r • (g.comp h) := rfl
 
-instance module {V : Type*} [normed_add_comm_group V] [normed_space 𝕜 V] :
+instance module {V : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space 𝕜 V] :
   module 𝕜 C^∞⟮I, N; 𝓘(𝕜, V), V⟯ :=
 function.injective.module 𝕜 coe_fn_add_monoid_hom cont_mdiff_map.coe_inj coe_smul
 
 /-- Coercion to a function as a `linear_map`. -/
 @[simps]
-def coe_fn_linear_map {V : Type*} [normed_add_comm_group V] [normed_space 𝕜 V] :
+def coe_fn_linear_map {V : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space 𝕜 V] :
 C^∞⟮I, N; 𝓘(𝕜, V), V⟯ →ₗ[𝕜] (N → V) :=
 { to_fun := coe_fn,
   map_smul' := coe_smul,
@@ -254,15 +254,15 @@ section module_over_continuous_functions
 If `V` is a module over `𝕜`, then we show that the space of smooth functions from `N` to `V`
 is naturally a vector space over the ring of smooth functions from `N` to `𝕜`. -/
 
-instance has_smul' {V : Type*} [normed_add_comm_group V] [normed_space 𝕜 V] :
+instance has_smul' {V : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space 𝕜 V] :
   has_smul C^∞⟮I, N; 𝕜⟯ C^∞⟮I, N; 𝓘(𝕜, V), V⟯ :=
 ⟨λ f g, ⟨λ x, (f x) • (g x), (smooth.smul f.2 g.2)⟩⟩
 
-@[simp] lemma smul_comp' {V : Type*} [normed_add_comm_group V] [normed_space 𝕜 V]
+@[simp] lemma smul_comp' {V : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space 𝕜 V]
   (f : C^∞⟮I'', N'; 𝕜⟯) (g : C^∞⟮I'', N'; 𝓘(𝕜, V), V⟯) (h : C^∞⟮I, N; I'', N'⟯) :
 (f • g).comp h = (f.comp h) • (g.comp h) := rfl
 
-instance module' {V : Type*} [normed_add_comm_group V] [normed_space 𝕜 V] :
+instance module' {V : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space 𝕜 V] :
   module C^∞⟮I, N; 𝓘(𝕜), 𝕜⟯ C^∞⟮I, N; 𝓘(𝕜, V), V⟯ :=
 { smul     := (•),
   smul_add := λ c f g, by ext x; exact smul_add (c x) (f x) (g x),

--- a/src/geometry/manifold/algebra/smooth_functions.lean
+++ b/src/geometry/manifold/algebra/smooth_functions.lean
@@ -18,11 +18,11 @@ open_locale manifold
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
 {N : Type*} [topological_space N] [charted_space H N]
-{E'' : Type*} [normed_add_comm_group E''] [normed_space 𝕜 E'']
+{E'' : Type*} [add_comm_group E''] [normed_add_comm_group E''] [normed_space 𝕜 E'']
 {H'' : Type*} [topological_space H''] {I'' : model_with_corners 𝕜 E'' H''}
 {N' : Type*} [topological_space N'] [charted_space H'' N']
 

--- a/src/geometry/manifold/algebra/structures.lean
+++ b/src/geometry/manifold/algebra/structures.lean
@@ -17,7 +17,7 @@ open_locale manifold
 section smooth_ring
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H : Type*} [topological_space H]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 
 set_option default_priority 100 -- see Note [default priority]
 

--- a/src/geometry/manifold/complex.lean
+++ b/src/geometry/manifold/complex.lean
@@ -41,8 +41,8 @@ open complex
 
 namespace mdifferentiable
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℂ E]
-variables {F : Type*} [normed_add_comm_group F] [normed_space ℂ F] [strict_convex_space ℝ F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℂ E]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℂ F] [strict_convex_space ℝ F]
 
 variables {M : Type*} [topological_space M] [compact_space M] [charted_space E M]
   [smooth_manifold_with_corners 𝓘(ℂ, E) M]

--- a/src/geometry/manifold/conformal_groupoid.lean
+++ b/src/geometry/manifold/conformal_groupoid.lean
@@ -20,7 +20,7 @@ In this file we define the groupoid of conformal maps on normed spaces.
 conformal, groupoid
 -/
 
-variables {X : Type*} [normed_add_comm_group X] [normed_space ℝ X]
+variables {X : Type*} [add_comm_group X] [normed_add_comm_group X] [normed_space ℝ X]
 
 /-- The pregroupoid of conformal maps. -/
 def conformal_pregroupoid : pregroupoid X :=

--- a/src/geometry/manifold/cont_mdiff.lean
+++ b/src/geometry/manifold/cont_mdiff.lean
@@ -53,11 +53,11 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 {M : Type*} [topological_space M] [charted_space H M] [Is : smooth_manifold_with_corners I M]
 -- declare a smooth manifold `M'` over the pair `(E', H')`.
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] (I' : model_with_corners 𝕜 E' H')
 {M' : Type*} [topological_space M'] [charted_space H' M'] [I's : smooth_manifold_with_corners I' M']
 -- declare a manifold `M''` over the pair `(E'', H'')`.
-{E'' : Type*} [normed_add_comm_group E''] [normed_space 𝕜 E'']
+{E'' : Type*} [add_comm_group E''] [normed_add_comm_group E''] [normed_space 𝕜 E'']
 {H'' : Type*} [topological_space H''] {I'' : model_with_corners 𝕜 E'' H''}
 {M'' : Type*} [topological_space M''] [charted_space H'' M'']
 -- declare a smooth manifold `N` over the pair `(F, G)`.
@@ -65,11 +65,11 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {G : Type*} [topological_space G] {J : model_with_corners 𝕜 F G}
 {N : Type*} [topological_space N] [charted_space G N] [Js : smooth_manifold_with_corners J N]
 -- declare a smooth manifold `N'` over the pair `(F', G')`.
-{F' : Type*} [normed_add_comm_group F'] [normed_space 𝕜 F']
+{F' : Type*} [add_comm_group F'] [normed_add_comm_group F'] [normed_space 𝕜 F']
 {G' : Type*} [topological_space G'] {J' : model_with_corners 𝕜 F' G'}
 {N' : Type*} [topological_space N'] [charted_space G' N'] [J's : smooth_manifold_with_corners J' N']
 -- F'' is a normed space
-{F'' : Type*} [normed_add_comm_group F''] [normed_space 𝕜 F'']
+{F'' : Type*} [add_comm_group F''] [normed_add_comm_group F''] [normed_space 𝕜 F'']
 -- declare functions, sets, points and smoothness indices
 {e : local_homeomorph M H} {e' : local_homeomorph M' H'}
 {f f₁ : M → M'} {s s₁ t : set M} {x : M} {m n : ℕ∞}

--- a/src/geometry/manifold/cont_mdiff.lean
+++ b/src/geometry/manifold/cont_mdiff.lean
@@ -49,7 +49,7 @@ open_locale topology manifold
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 -- declare a smooth manifold `M` over the pair `(E, H)`.
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 {M : Type*} [topological_space M] [charted_space H M] [Is : smooth_manifold_with_corners I M]
 -- declare a smooth manifold `M'` over the pair `(E', H')`.
@@ -61,7 +61,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H'' : Type*} [topological_space H''] {I'' : model_with_corners 𝕜 E'' H''}
 {M'' : Type*} [topological_space M''] [charted_space H'' M'']
 -- declare a smooth manifold `N` over the pair `(F, G)`.
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 {G : Type*} [topological_space G] {J : model_with_corners 𝕜 F G}
 {N : Type*} [topological_space N] [charted_space G N] [Js : smooth_manifold_with_corners J N]
 -- declare a smooth manifold `N'` over the pair `(F', G')`.
@@ -1632,7 +1632,7 @@ lemma cont_mdiff.clm_comp {g : M → F →L[𝕜] F''} {f : M → F' →L[𝕜] 
 
 /-! ### Smoothness of standard operations -/
 
-variables {V : Type*} [normed_add_comm_group V] [normed_space 𝕜 V]
+variables {V : Type*} [add_comm_group V] [normed_add_comm_group V] [normed_space 𝕜 V]
 
 /-- On any vector space, multiplication by a scalar is a smooth operation. -/
 lemma smooth_smul : smooth (𝓘(𝕜).prod 𝓘(𝕜, V)) 𝓘(𝕜, V) (λp : 𝕜 × V, p.1 • p.2) :=

--- a/src/geometry/manifold/cont_mdiff_map.lean
+++ b/src/geometry/manifold/cont_mdiff_map.lean
@@ -16,13 +16,13 @@ bundled maps.
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H : Type*} [topological_space H]
 {H' : Type*} [topological_space H']
 (I : model_with_corners 𝕜 E H) (I' : model_with_corners 𝕜 E' H')
 (M : Type*) [topological_space M] [charted_space H M]
 (M' : Type*) [topological_space M'] [charted_space H' M']
-{E'' : Type*} [normed_add_comm_group E''] [normed_space 𝕜 E'']
+{E'' : Type*} [add_comm_group E''] [normed_add_comm_group E''] [normed_space 𝕜 E'']
 {H'' : Type*} [topological_space H'']
 {I'' : model_with_corners 𝕜 E'' H''}
 {M'' : Type*} [topological_space M''] [charted_space H'' M'']

--- a/src/geometry/manifold/cont_mdiff_map.lean
+++ b/src/geometry/manifold/cont_mdiff_map.lean
@@ -15,7 +15,7 @@ bundled maps.
 -/
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H : Type*} [topological_space H]
 {H' : Type*} [topological_space H']

--- a/src/geometry/manifold/cont_mdiff_mfderiv.lean
+++ b/src/geometry/manifold/cont_mdiff_mfderiv.lean
@@ -27,7 +27,7 @@ open_locale topology manifold
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 -- declare a smooth manifold `M` over the pair `(E, H)`.
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
 {M : Type*} [topological_space M] [charted_space H M] [Is : smooth_manifold_with_corners I M]
 -- declare a smooth manifold `M'` over the pair `(E', H')`.
@@ -35,7 +35,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
 {M' : Type*} [topological_space M'] [charted_space H' M'] [I's : smooth_manifold_with_corners I' M']
 -- declare a smooth manifold `N` over the pair `(F, G)`.
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 {G : Type*} [topological_space G] {J : model_with_corners 𝕜 F G}
 {N : Type*} [topological_space N] [charted_space G N] [Js : smooth_manifold_with_corners J N]
 -- declare a smooth manifold `N'` over the pair `(F', G')`.

--- a/src/geometry/manifold/cont_mdiff_mfderiv.lean
+++ b/src/geometry/manifold/cont_mdiff_mfderiv.lean
@@ -31,7 +31,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
 {M : Type*} [topological_space M] [charted_space H M] [Is : smooth_manifold_with_corners I M]
 -- declare a smooth manifold `M'` over the pair `(E', H')`.
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
 {M' : Type*} [topological_space M'] [charted_space H' M'] [I's : smooth_manifold_with_corners I' M']
 -- declare a smooth manifold `N` over the pair `(F, G)`.
@@ -39,7 +39,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {G : Type*} [topological_space G] {J : model_with_corners 𝕜 F G}
 {N : Type*} [topological_space N] [charted_space G N] [Js : smooth_manifold_with_corners J N]
 -- declare a smooth manifold `N'` over the pair `(F', G')`.
-{F' : Type*} [normed_add_comm_group F'] [normed_space 𝕜 F']
+{F' : Type*} [add_comm_group F'] [normed_add_comm_group F'] [normed_space 𝕜 F']
 {G' : Type*} [topological_space G'] {J' : model_with_corners 𝕜 F' G'}
 {N' : Type*} [topological_space N'] [charted_space G' N'] [J's : smooth_manifold_with_corners J' N']
 -- declare functions, sets, points and smoothness indices

--- a/src/geometry/manifold/derivation_bundle.lean
+++ b/src/geometry/manifold/derivation_bundle.lean
@@ -21,7 +21,7 @@ of the Lie algebra for a Lie group.
 -/
 
 variables (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 (M : Type*) [topological_space M] [charted_space H M] (n : ℕ∞)
 

--- a/src/geometry/manifold/derivation_bundle.lean
+++ b/src/geometry/manifold/derivation_bundle.lean
@@ -95,7 +95,7 @@ lemma eval_at_apply (x : M) : eval_at x X f = (X f) x := rfl
 
 end derivation
 
-variables {I} {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+variables {I} {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
 {M' : Type*} [topological_space M'] [charted_space H' M']
 
@@ -131,7 +131,7 @@ localized "notation (name := hfdifferential) `𝒅ₕ` := hfdifferential" in man
 @[simp] lemma apply_hfdifferential {f : C^∞⟮I, M; I', M'⟯} {x : M} {y : M'} (h : f x = y)
   (v : point_derivation I x) (g : C^∞⟮I', M'; 𝕜⟯) : 𝒅ₕh v g = 𝒅f x v g := rfl
 
-variables {E'' : Type*} [normed_add_comm_group E''] [normed_space 𝕜 E'']
+variables {E'' : Type*} [add_comm_group E''] [normed_add_comm_group E''] [normed_space 𝕜 E'']
 {H'' : Type*} [topological_space H''] {I'' : model_with_corners 𝕜 E'' H''}
 {M'' : Type*} [topological_space M''] [charted_space H'' M'']
 

--- a/src/geometry/manifold/diffeomorph.lean
+++ b/src/geometry/manifold/diffeomorph.lean
@@ -47,9 +47,9 @@ open_locale manifold topology
 open function set
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 {H : Type*} [topological_space H]
 {H' : Type*} [topological_space H']
 {G : Type*} [topological_space G]

--- a/src/geometry/manifold/diffeomorph.lean
+++ b/src/geometry/manifold/diffeomorph.lean
@@ -48,7 +48,7 @@ open function set
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 {H : Type*} [topological_space H]
 {H' : Type*} [topological_space H']

--- a/src/geometry/manifold/instances/sphere.lean
+++ b/src/geometry/manifold/instances/sphere.lean
@@ -417,7 +417,7 @@ begin
       (ℝ ∙ ((-v):E))ᗮ.subtypeL.cont_diff).comp U.symm.cont_diff).cont_diff_on }
 end
 
-variables {F : Type*} [normed_add_comm_group F] [normed_space ℝ F]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F]
 variables {H : Type*} [topological_space H] {I : model_with_corners ℝ F H}
 variables {M : Type*} [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
 

--- a/src/geometry/manifold/metrizable.lean
+++ b/src/geometry/manifold/metrizable.lean
@@ -19,7 +19,7 @@ open topological_space
 /-- A σ-compact Hausdorff topological manifold over a finite dimensional real vector space is
 metrizable. -/
 lemma manifold_with_corners.metrizable_space
-  {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [finite_dimensional ℝ E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [finite_dimensional ℝ E]
   {H : Type*} [topological_space H] (I : model_with_corners ℝ E H)
   (M : Type*) [topological_space M] [charted_space H M]
   [sigma_compact_space M] [t2_space M] : metrizable_space M :=

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -115,7 +115,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 {M : Type*} [topological_space M] [charted_space H M]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] (I' : model_with_corners 𝕜 E' H')
 {M' : Type*} [topological_space M'] [charted_space H' M']
 
@@ -311,10 +311,10 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 {M : Type*} [topological_space M] [charted_space H M] --
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
 {M' : Type*} [topological_space M'] [charted_space H' M']
-{E'' : Type*} [normed_add_comm_group E''] [normed_space 𝕜 E'']
+{E'' : Type*} [add_comm_group E''] [normed_add_comm_group E''] [normed_space 𝕜 E'']
 {H'' : Type*} [topological_space H''] {I'' : model_with_corners 𝕜 E'' H''}
 {M'' : Type*} [topological_space M''] [charted_space H'' M'']
 {f f₀ f₁ : M → M'}
@@ -953,7 +953,7 @@ this and related statements.
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {f : E → E'} {s : set E} {x : E}
 
 lemma unique_mdiff_within_at_iff_unique_diff_within_at :
@@ -1061,7 +1061,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 {M : Type*} [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] (I' : model_with_corners 𝕜 E' H')
 {M' : Type*} [topological_space M'] [charted_space H' M'] [smooth_manifold_with_corners I' M']
 
@@ -1512,10 +1512,10 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
 {M : Type*} [topological_space M] [charted_space H M]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
 {M' : Type*} [topological_space M'] [charted_space H' M']
-{E'' : Type*} [normed_add_comm_group E''] [normed_space 𝕜 E'']
+{E'' : Type*} [add_comm_group E''] [normed_add_comm_group E''] [normed_space 𝕜 E'']
 {H'' : Type*} [topological_space H''] {I'' : model_with_corners 𝕜 E'' H''}
 {M'' : Type*} [topological_space M''] [charted_space H'' M'']
 {e : local_homeomorph M M'} (he : e.mdifferentiable I I')
@@ -1651,7 +1651,7 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
 {M : Type*} [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
-{E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+{E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
 {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
 {M' : Type*} [topological_space M'] [charted_space H' M']
 {s : set M}

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -112,7 +112,7 @@ We use the names `mdifferentiable` and `mfderiv`, where the prefix letter `m` me
 -/
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 {M : Type*} [topological_space M] [charted_space H M]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
@@ -308,7 +308,7 @@ section derivatives_properties
 /-! ### Unique differentiability sets in manifolds -/
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 {M : Type*} [topological_space M] [charted_space H M] --
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
@@ -952,7 +952,7 @@ this and related statements.
 -/
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
 {f : E → E'} {s : set E} {x : E}
 
@@ -1058,7 +1058,7 @@ section specific_functions
 /-! ### Differentiability of specific functions -/
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 {M : Type*} [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
@@ -1509,7 +1509,7 @@ end specific_functions
 namespace local_homeomorph.mdifferentiable
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
 {M : Type*} [topological_space M] [charted_space H M]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
@@ -1621,7 +1621,7 @@ end local_homeomorph.mdifferentiable
 section ext_chart_at
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 {M : Type*} [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
 {s : set M} {x y : M}
@@ -1648,7 +1648,7 @@ end ext_chart_at
 section unique_mdiff
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
 {M : Type*} [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
 {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
@@ -1761,7 +1761,7 @@ begin
   exact this.unique_diff_on_target_inter _
 end
 
-variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 (Z : basic_smooth_vector_bundle_core I M F)
 
 /-- In a smooth fiber bundle constructed from core, the preimage under the projection of a set with

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -126,7 +126,7 @@ define a smooth manifold with model space `H`, and model vector space `E`.
 -/
 @[ext, nolint has_nonempty_instance]
 structure model_with_corners (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-  (E : Type*) [normed_add_comm_group E] [normed_space 𝕜 E] (H : Type*) [topological_space H]
+  (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] (H : Type*) [topological_space H]
   extends local_equiv H E :=
 (source_eq          : source = univ)
 (unique_diff'       : unique_diff_on 𝕜 to_local_equiv.target)
@@ -137,7 +137,7 @@ attribute [simp, mfld_simps] model_with_corners.source_eq
 
 /-- A vector space is a model with corners. -/
 def model_with_corners_self (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-  (E : Type*) [normed_add_comm_group E] [normed_space 𝕜 E] : model_with_corners 𝕜 E E :=
+  (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] : model_with_corners 𝕜 E E :=
 { to_local_equiv := local_equiv.refl E,
   source_eq    := rfl,
   unique_diff' := unique_diff_on_univ,
@@ -165,12 +165,12 @@ protected def symm : local_equiv E H := I.to_local_equiv.symm
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
   because it is a composition of multiple projections. -/
 def simps.apply (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-  (E : Type*) [normed_add_comm_group E] [normed_space 𝕜 E] (H : Type*) [topological_space H]
+  (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] (H : Type*) [topological_space H]
   (I : model_with_corners 𝕜 E H) : H → E := I
 
 /-- See Note [custom simps projection] -/
 def simps.symm_apply (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-  (E : Type*) [normed_add_comm_group E] [normed_space 𝕜 E] (H : Type*) [topological_space H]
+  (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] (H : Type*) [topological_space H]
   (I : model_with_corners 𝕜 E H) : E → H := I.symm
 
 initialize_simps_projections model_with_corners
@@ -368,8 +368,8 @@ as the model to tangent bundles. -/
 I.prod (𝓘(𝕜, E))
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜] {E : Type*} [add_comm_group E] [normed_add_comm_group E]
-  [normed_space 𝕜 E] {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E'] {F : Type*}
-   [normed_add_comm_group F] [normed_space 𝕜 F] {F' : Type*} [normed_add_comm_group F']
+  [normed_space 𝕜 E] {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E'] {F : Type*}
+   [normed_add_comm_group F] [normed_space 𝕜 F] {F' : Type*} [add_comm_group F'] [normed_add_comm_group F']
    [normed_space 𝕜 F']
 {H : Type*} [topological_space H] {H' : Type*} [topological_space H']
 {G : Type*} [topological_space G] {G' : Type*} [topological_space G']
@@ -405,7 +405,7 @@ class model_with_corners.boundaryless {𝕜 : Type*} [nontrivially_normed_field 
 
 /-- The trivial model with corners has no boundary -/
 instance model_with_corners_self_boundaryless (𝕜 : Type*) [nontrivially_normed_field 𝕜]
-  (E : Type*) [normed_add_comm_group E] [normed_space 𝕜 E] :
+  (E : Type*) [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] :
   (model_with_corners_self 𝕜 E).boundaryless :=
 ⟨by simp⟩
 
@@ -538,7 +538,7 @@ begin
     (of_set_mem_cont_diff_groupoid n I e.open_target) this
 end
 
-variables {E' H' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E'] [topological_space H']
+variables {E' H' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E'] [topological_space H']
 
 /-- The product of two smooth local homeomorphisms is smooth. -/
 lemma cont_diff_groupoid_prod
@@ -651,7 +651,7 @@ structure_groupoid.compatible_of_mem_maximal_atlas he he'
 /-- The product of two smooth manifolds with corners is naturally a smooth manifold with corners. -/
 instance prod {𝕜 : Type*} [nontrivially_normed_field 𝕜]
   {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
-  {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
+  {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space 𝕜 E']
   {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
   {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
   (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]

--- a/src/geometry/manifold/smooth_manifold_with_corners.lean
+++ b/src/geometry/manifold/smooth_manifold_with_corners.lean
@@ -63,7 +63,7 @@ In the same way, it would not apply to product manifolds, modelled on
 The right invocation does not focus on one specific construction, but on all constructions sharing
 the right properties, like
 
-  `variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [finite_dimensional ℝ E]
+  `variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [finite_dimensional ℝ E]
   {I : model_with_corners ℝ E E} [I.boundaryless]
   {M : Type*} [topological_space M] [charted_space E M] [smooth_manifold_with_corners I M]`
 
@@ -152,7 +152,7 @@ localized "notation (name := model_with_corners_self.self) `𝓘(` 𝕜 `)` :=
 
 section
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] {H : Type*} [topological_space H]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {H : Type*} [topological_space H]
   (I : model_with_corners 𝕜 E H)
 
 namespace model_with_corners
@@ -367,7 +367,7 @@ as the model to tangent bundles. -/
   (I : model_with_corners 𝕜 E H) : model_with_corners 𝕜 (E × E) (model_prod H E) :=
 I.prod (𝓘(𝕜, E))
 
-variables {𝕜 : Type*} [nontrivially_normed_field 𝕜] {E : Type*} [normed_add_comm_group E]
+variables {𝕜 : Type*} [nontrivially_normed_field 𝕜] {E : Type*} [add_comm_group E] [normed_add_comm_group E]
   [normed_space 𝕜 E] {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E'] {F : Type*}
    [normed_add_comm_group F] [normed_space 𝕜 F] {F' : Type*} [normed_add_comm_group F']
    [normed_space 𝕜 F']
@@ -399,7 +399,7 @@ section boundaryless
 
 /-- Property ensuring that the model with corners `I` defines manifolds without boundary. -/
 class model_with_corners.boundaryless {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] {H : Type*} [topological_space H]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {H : Type*} [topological_space H]
   (I : model_with_corners 𝕜 E H) : Prop :=
 (range_eq_univ : range I = univ)
 
@@ -429,7 +429,7 @@ section cont_diff_groupoid
 /-! ### Smooth functions on models with corners -/
 
 variables {m n : ℕ∞} {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H]
 (I : model_with_corners 𝕜 E H)
 {M : Type*} [topological_space M]
@@ -582,13 +582,13 @@ section smooth_manifold_with_corners
 field `𝕜` and with infinite smoothness to simplify typeclass search and statements later on. -/
 @[ancestor has_groupoid]
 class smooth_manifold_with_corners {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
   (M : Type*) [topological_space M] [charted_space H M] extends
   has_groupoid M (cont_diff_groupoid ∞ I) : Prop
 
 lemma smooth_manifold_with_corners.mk' {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
   (M : Type*) [topological_space M] [charted_space H M]
   [gr : has_groupoid M (cont_diff_groupoid ∞ I)] :
@@ -596,7 +596,7 @@ lemma smooth_manifold_with_corners.mk' {𝕜 : Type*} [nontrivially_normed_field
 
 lemma smooth_manifold_with_corners_of_cont_diff_on
   {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
   (M : Type*) [topological_space M] [charted_space H M]
   (h : ∀ (e e' : local_homeomorph M H), e ∈ atlas H M → e' ∈ atlas H M →
@@ -611,7 +611,7 @@ lemma smooth_manifold_with_corners_of_cont_diff_on
 
 /-- For any model with corners, the model space is a smooth manifold -/
 instance model_space_smooth {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] {H : Type*} [topological_space H]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] {H : Type*} [topological_space H]
   {I : model_with_corners 𝕜 E H} :
   smooth_manifold_with_corners I H := { .. has_groupoid_model_space _ _ }
 
@@ -623,7 +623,7 @@ charted space with a structure groupoid, avoiding the need to specify the groupo
 `cont_diff_groupoid ∞ I` explicitly. -/
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
   (M : Type*) [topological_space M] [charted_space H M]
 
@@ -650,7 +650,7 @@ structure_groupoid.compatible_of_mem_maximal_atlas he he'
 
 /-- The product of two smooth manifolds with corners is naturally a smooth manifold with corners. -/
 instance prod {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   {E' : Type*} [normed_add_comm_group E'] [normed_space 𝕜 E']
   {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
   {H' : Type*} [topological_space H'] {I' : model_with_corners 𝕜 E' H'}
@@ -670,7 +670,7 @@ end smooth_manifold_with_corners
 
 lemma local_homeomorph.singleton_smooth_manifold_with_corners
   {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
   {M : Type*} [topological_space M]
   (e : local_homeomorph M H) (h : e.source = set.univ) :
@@ -680,7 +680,7 @@ e.singleton_has_groupoid h (cont_diff_groupoid ∞ I)
 
 lemma open_embedding.singleton_smooth_manifold_with_corners
   {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
   {M : Type*} [topological_space M]
   [nonempty M] {f : M → H} (h : open_embedding f) :
@@ -692,7 +692,7 @@ namespace topological_space.opens
 open topological_space
 
 variables  {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-  {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
   {M : Type*} [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
   (s : opens M)

--- a/src/geometry/manifold/tangent_bundle.lean
+++ b/src/geometry/manifold/tangent_bundle.lean
@@ -84,7 +84,7 @@ of `M`. This structure registers the changes in the fibers when one changes coor
 base. We require the change of coordinates of the fibers to be linear, so that the resulting bundle
 is a vector bundle. -/
 structure basic_smooth_vector_bundle_core {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
 (F : Type*) [normed_add_comm_group F] [normed_space 𝕜 F] :=
@@ -99,7 +99,7 @@ structure basic_smooth_vector_bundle_core {𝕜 : Type*} [nontrivially_normed_fi
 /-- The trivial basic smooth bundle core, in which all the changes of coordinates are the
 identity. -/
 def trivial_basic_smooth_vector_bundle_core {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
 (F : Type*) [normed_add_comm_group F] [normed_space 𝕜 F] : basic_smooth_vector_bundle_core I M F :=
@@ -111,10 +111,10 @@ def trivial_basic_smooth_vector_bundle_core {𝕜 : Type*} [nontrivially_normed_
 namespace basic_smooth_vector_bundle_core
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] {I : model_with_corners 𝕜 E H}
 {M : Type*} [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
-{F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+{F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 (Z : basic_smooth_vector_bundle_core I M F)
 
 instance : inhabited (basic_smooth_vector_bundle_core I M F) :=
@@ -328,7 +328,7 @@ end basic_smooth_vector_bundle_core
 section tangent_bundle
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-{E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
 

--- a/src/geometry/manifold/tangent_bundle.lean
+++ b/src/geometry/manifold/tangent_bundle.lean
@@ -87,7 +87,7 @@ structure basic_smooth_vector_bundle_core {𝕜 : Type*} [nontrivially_normed_fi
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
-(F : Type*) [normed_add_comm_group F] [normed_space 𝕜 F] :=
+(F : Type*) [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] :=
 (coord_change      : atlas H M → atlas H M → H → (F →L[𝕜] F))
 (coord_change_self : ∀ i : atlas H M, ∀ x ∈ i.1.target, ∀ v, coord_change i i x v = v)
 (coord_change_comp : ∀ i j k : atlas H M,
@@ -102,7 +102,7 @@ def trivial_basic_smooth_vector_bundle_core {𝕜 : Type*} [nontrivially_normed_
 {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
-(F : Type*) [normed_add_comm_group F] [normed_space 𝕜 F] : basic_smooth_vector_bundle_core I M F :=
+(F : Type*) [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F] : basic_smooth_vector_bundle_core I M F :=
 { coord_change := λ i j x, continuous_linear_map.id 𝕜 F,
   coord_change_self := λ i x hx v, rfl,
   coord_change_comp := λ i j k x hx v, rfl,

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -2020,8 +2020,8 @@ end limits
 namespace continuous_linear_map
 
 variables {𝕜 : Type*} [normed_field 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] [measurable_space E]
-  [opens_measurable_space E] {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] [measurable_space E]
+  [opens_measurable_space E] {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
   [measurable_space F] [borel_space F]
 
 @[measurability]
@@ -2037,8 +2037,8 @@ end continuous_linear_map
 namespace continuous_linear_map
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-          {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+          {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 
 instance : measurable_space (E →L[𝕜] F) := borel _
 
@@ -2065,8 +2065,8 @@ end continuous_linear_map
 section continuous_linear_map_nontrivially_normed_field
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E] [measurable_space E]
-  [borel_space E] {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E] [measurable_space E]
+  [borel_space E] {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
 
 @[measurability]
 lemma measurable.apply_continuous_linear_map  {φ : α → F →L[𝕜] E} (hφ : measurable φ) (v : F) :
@@ -2082,7 +2082,7 @@ end continuous_linear_map_nontrivially_normed_field
 
 section normed_space
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜] [complete_space 𝕜] [measurable_space 𝕜]
-variables [borel_space 𝕜] {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+variables [borel_space 𝕜] {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
   [measurable_space E] [borel_space E]
 
 lemma measurable_smul_const {f : α → 𝕜} {c : E} (hc : c ≠ 0) :

--- a/src/measure_theory/constructions/prod.lean
+++ b/src/measure_theory/constructions/prod.lean
@@ -940,7 +940,7 @@ begin
   rw [← integral_map measurable_swap.ae_measurable hf, prod_swap]
 end
 
-variables {E' : Type*} [normed_add_comm_group E'] [complete_space E'] [normed_space ℝ E']
+variables {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [complete_space E'] [normed_space ℝ E']
 
 /-! Some rules about the sum/difference of double integrals. They follow from `integral_add`, but
   we separate them out as separate lemmas, because they involve quite some steps. -/

--- a/src/measure_theory/covering/besicovitch_vector_space.lean
+++ b/src/measure_theory/covering/besicovitch_vector_space.lean
@@ -123,7 +123,7 @@ end satellite_config
 
 /-- The maximum cardinality of a `1`-separated set in the ball of radius `2`. This is also the
 optimal number of families in the Besicovitch covering theorem. -/
-def multiplicity (E : Type*) [normed_add_comm_group E] :=
+def multiplicity (E : Type*) [add_comm_group E] [normed_add_comm_group E] :=
 Sup {N | ∃ s : finset E, s.card = N ∧ (∀ c ∈ s, ‖c‖ ≤ 2) ∧ (∀ c ∈ s, ∀ d ∈ s, c ≠ d → 1 ≤ ‖c - d‖)}
 
 section

--- a/src/measure_theory/covering/besicovitch_vector_space.lean
+++ b/src/measure_theory/covering/besicovitch_vector_space.lean
@@ -49,7 +49,7 @@ noncomputable theory
 
 namespace besicovitch
 
-variables {E : Type*} [normed_add_comm_group E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 namespace satellite_config
 variables [normed_space ℝ E] {N : ℕ} {τ : ℝ} (a : satellite_config E N τ)

--- a/src/measure_theory/covering/density_theorem.lean
+++ b/src/measure_theory/covering/density_theorem.lean
@@ -134,7 +134,7 @@ end
 
 section applications
 variables [second_countable_topology α] [borel_space α] [is_locally_finite_measure μ]
-  {E : Type*} [normed_add_comm_group E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 /-- A version of *Lebesgue's density theorem* for a sequence of closed balls whose centers are
 not required to be fixed.

--- a/src/measure_theory/covering/differentiation.lean
+++ b/src/measure_theory/covering/differentiation.lean
@@ -79,7 +79,7 @@ open_locale filter ennreal measure_theory nnreal topology
 
 variables {α : Type*} [metric_space α] {m0 : measurable_space α}
 {μ : measure α} (v : vitali_family μ)
-{E : Type*} [normed_add_comm_group E]
+{E : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 include v
 

--- a/src/measure_theory/function/continuous_map_dense.lean
+++ b/src/measure_theory/function/continuous_map_dense.lean
@@ -45,7 +45,7 @@ open_locale ennreal nnreal topology bounded_continuous_function
 open measure_theory topological_space continuous_map
 
 variables {α : Type*} [measurable_space α] [topological_space α] [normal_space α] [borel_space α]
-variables (E : Type*) [normed_add_comm_group E]
+variables (E : Type*) [add_comm_group E] [normed_add_comm_group E]
   [second_countable_topology_either α E]
 variables {p : ℝ≥0∞} [_i : fact (1 ≤ p)] (hp : p ≠ ∞) (μ : measure α)
 

--- a/src/measure_theory/function/jacobian.lean
+++ b/src/measure_theory/function/jacobian.lean
@@ -88,7 +88,7 @@ open measure_theory measure_theory.measure metric filter set finite_dimensional 
 topological_space
 open_locale nnreal ennreal topology pointwise
 
-variables {E F : Type*} [normed_add_comm_group E] [normed_space ℝ E] [finite_dimensional ℝ E]
+variables {E F : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [finite_dimensional ℝ E]
 [normed_add_comm_group F] [normed_space ℝ F] {s : set E} {f : E → E} {f' : E → E →L[ℝ] E}
 
 /-!

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -722,7 +722,7 @@ begin
 end
 
 section
-variables  {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+variables  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
 
 lemma integrable_with_density_iff_integrable_coe_smul
   {f : α → ℝ≥0} (hf : measurable f) {g : α → E} :
@@ -793,7 +793,7 @@ begin
 end
 
 section
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
 
 lemma mem_ℒ1_smul_of_L1_with_density {f : α → ℝ≥0} (f_meas : measurable f)
   (u : Lp E 1 (μ.with_density (λ x, f x))) :
@@ -916,7 +916,7 @@ end normed_space
 
 section normed_space_over_complete_field
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜] [complete_space 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 
 lemma integrable_smul_const {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
   integrable (λ x, f x • c) μ ↔ integrable f μ :=
@@ -995,7 +995,7 @@ end inner_product
 
 section trim
 
-variables {H : Type*} [normed_add_comm_group H] {m0 : measurable_space α} {μ' : measure α}
+variables {H : Type*} [add_comm_group H] [normed_add_comm_group H] {m0 : measurable_space α} {μ' : measure α}
   {f : α → H}
 
 lemma integrable.trim (hm : m ≤ m0) (hf_int : integrable f μ') (hf : strongly_measurable[m] f) :
@@ -1227,9 +1227,9 @@ end measure_theory
 
 open measure_theory
 
-variables {E : Type*} [normed_add_comm_group E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E]
           {𝕜 : Type*} [nontrivially_normed_field 𝕜] [normed_space 𝕜 E]
-          {H : Type*} [normed_add_comm_group H] [normed_space 𝕜 H]
+          {H : Type*} [add_comm_group H] [normed_add_comm_group H] [normed_space 𝕜 H]
 
 lemma measure_theory.integrable.apply_continuous_linear_map {φ : α → H →L[𝕜] E}
   (φ_int : integrable φ μ) (v : H) : integrable (λ a, φ a v) μ :=

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -1847,7 +1847,7 @@ end
 
 variables (hs)
 
-lemma snorm_indicator_le {E : Type*} [normed_add_comm_group E] (f : α → E) :
+lemma snorm_indicator_le {E : Type*} [add_comm_group E] [normed_add_comm_group E] (f : α → E) :
   snorm (s.indicator f) p μ ≤ snorm f p μ :=
 begin
   refine snorm_mono_ae (eventually_of_forall (λ x, _)),

--- a/src/measure_theory/function/strongly_measurable/basic.lean
+++ b/src/measure_theory/function/strongly_measurable/basic.lean
@@ -779,17 +779,17 @@ protected lemma dist {m : measurable_space α} {β : Type*} [pseudo_metric_space
   strongly_measurable (λ x, dist (f x) (g x)) :=
 continuous_dist.comp_strongly_measurable (hf.prod_mk hg)
 
-protected lemma norm {m : measurable_space α} {β : Type*} [seminormed_add_comm_group β]
+protected lemma norm {m : measurable_space α} {β : Type*} [add_comm_group β] [seminormed_add_comm_group β]
   {f : α → β} (hf : strongly_measurable f) :
   strongly_measurable (λ x, ‖f x‖) :=
 continuous_norm.comp_strongly_measurable hf
 
-protected lemma nnnorm {m : measurable_space α} {β : Type*} [seminormed_add_comm_group β]
+protected lemma nnnorm {m : measurable_space α} {β : Type*} [add_comm_group β] [seminormed_add_comm_group β]
   {f : α → β} (hf : strongly_measurable f) :
   strongly_measurable (λ x, ‖f x‖₊) :=
 continuous_nnnorm.comp_strongly_measurable hf
 
-protected lemma ennnorm {m : measurable_space α} {β : Type*} [seminormed_add_comm_group β]
+protected lemma ennnorm {m : measurable_space α} {β : Type*} [add_comm_group β] [seminormed_add_comm_group β]
   {f : α → β} (hf : strongly_measurable f) :
   measurable (λ a, (‖f a‖₊ : ℝ≥0∞)) :=
 (ennreal.continuous_coe.comp_strongly_measurable hf.nnnorm).measurable
@@ -1380,22 +1380,22 @@ protected lemma dist {β : Type*} [pseudo_metric_space β] {f g : α → β}
   ae_strongly_measurable (λ x, dist (f x) (g x)) μ :=
 continuous_dist.comp_ae_strongly_measurable (hf.prod_mk hg)
 
-protected lemma norm {β : Type*} [seminormed_add_comm_group β] {f : α → β}
+protected lemma norm {β : Type*} [add_comm_group β] [seminormed_add_comm_group β] {f : α → β}
   (hf : ae_strongly_measurable f μ) :
   ae_strongly_measurable (λ x, ‖f x‖) μ :=
 continuous_norm.comp_ae_strongly_measurable hf
 
-protected lemma nnnorm {β : Type*} [seminormed_add_comm_group β] {f : α → β}
+protected lemma nnnorm {β : Type*} [add_comm_group β] [seminormed_add_comm_group β] {f : α → β}
   (hf : ae_strongly_measurable f μ) :
   ae_strongly_measurable (λ x, ‖f x‖₊) μ :=
 continuous_nnnorm.comp_ae_strongly_measurable hf
 
-protected lemma ennnorm {β : Type*} [seminormed_add_comm_group β] {f : α → β}
+protected lemma ennnorm {β : Type*} [add_comm_group β] [seminormed_add_comm_group β] {f : α → β}
   (hf : ae_strongly_measurable f μ) :
   ae_measurable (λ a, (‖f a‖₊ : ℝ≥0∞)) μ :=
 (ennreal.continuous_coe.comp_ae_strongly_measurable hf.nnnorm).ae_measurable
 
-protected lemma edist {β : Type*} [seminormed_add_comm_group β] {f g : α → β}
+protected lemma edist {β : Type*} [add_comm_group β] [seminormed_add_comm_group β] {f g : α → β}
   (hf : ae_strongly_measurable f μ) (hg : ae_strongly_measurable g μ) :
   ae_measurable (λ a, edist (f a) (g a)) μ :=
 (continuous_edist.comp_ae_strongly_measurable (hf.prod_mk hg)).ae_measurable
@@ -1652,7 +1652,7 @@ lemma smul_measure {R : Type*} [monoid R] [distrib_mul_action R ℝ≥0∞]
 
 section normed_space
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜] [complete_space 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
 
 lemma _root_.ae_strongly_measurable_smul_const_iff {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
   ae_strongly_measurable (λ x, f x • c) μ ↔ ae_strongly_measurable f μ :=
@@ -1685,9 +1685,9 @@ end mul_action
 section continuous_linear_map_nontrivially_normed_field
 
 variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
-variables {E : Type*} [normed_add_comm_group E] [normed_space 𝕜 E]
-variables {F : Type*} [normed_add_comm_group F] [normed_space 𝕜 F]
-variables {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space 𝕜 E]
+variables {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space 𝕜 F]
+variables {G : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_space 𝕜 G]
 
 lemma _root_.strongly_measurable.apply_continuous_linear_map
   {m : measurable_space α} {φ : α → F →L[𝕜] E} (hφ : strongly_measurable φ) (v : F) :
@@ -1707,7 +1707,7 @@ L.continuous₂.comp_ae_strongly_measurable $ hf.prod_mk hg
 
 end continuous_linear_map_nontrivially_normed_field
 
-lemma _root_.ae_strongly_measurable_with_density_iff {E : Type*} [normed_add_comm_group E]
+lemma _root_.ae_strongly_measurable_with_density_iff {E : Type*} [add_comm_group E] [normed_add_comm_group E]
   [normed_space ℝ E] {f : α → ℝ≥0} (hf : measurable f) {g : α → E} :
   ae_strongly_measurable g (μ.with_density (λ x, (f x : ℝ≥0∞))) ↔
     ae_strongly_measurable (λ x, (f x : ℝ) • g x) μ :=

--- a/src/measure_theory/group/measure.lean
+++ b/src/measure_theory/group/measure.lean
@@ -721,7 +721,7 @@ end
 
 /- The above instance applies in particular to show that an additive Haar measure on a nontrivial
 finite-dimensional real vector space has no atom. -/
-example {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [nontrivial E]
+example {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [nontrivial E]
   [finite_dimensional ℝ E] [measurable_space E] [borel_space E] (μ : measure E)
   [is_add_haar_measure μ] :
   has_no_atoms μ := by apply_instance

--- a/src/measure_theory/integral/bochner.lean
+++ b/src/measure_theory/integral/bochner.lean
@@ -277,7 +277,7 @@ and prove basic property of this integral.
 open finset
 
 variables [normed_add_comm_group E] [normed_add_comm_group F] [normed_space ℝ F] {p : ℝ≥0∞}
-  {G F' : Type*} [normed_add_comm_group G] [normed_add_comm_group F'] [normed_space ℝ F']
+  {G F' : Type*} [add_comm_group G] [normed_add_comm_group G] [normed_add_comm_group F'] [normed_space ℝ F']
   {m : measurable_space α} {μ : measure α}
 
 /-- Bochner integral of simple functions whose codomain is a real `normed_space`.
@@ -1178,7 +1178,7 @@ lemma integral_pos_iff_support_of_nonneg {f : α → ℝ} (hf : 0 ≤ f) (hfi : 
 integral_pos_iff_support_of_nonneg_ae (eventually_of_forall hf) hfi
 
 section normed_add_comm_group
-variables {H : Type*} [normed_add_comm_group H]
+variables {H : Type*} [add_comm_group H] [normed_add_comm_group H]
 
 lemma L1.norm_eq_integral_norm (f : α →₁[μ] H) : ‖f‖ = ∫ a, ‖f a‖ ∂μ :=
 begin
@@ -1613,7 +1613,7 @@ attribute [integral_simps] integral_neg integral_smul L1.integral_add L1.integra
 
 section integral_trim
 
-variables {H β γ : Type*} [normed_add_comm_group H]
+variables {H β γ : Type*} [add_comm_group H] [normed_add_comm_group H]
   {m m0 : measurable_space β} {μ : measure β}
 
 /-- Simple function seen as simple function of a larger `measurable_space`. -/

--- a/src/measure_theory/integral/bochner.lean
+++ b/src/measure_theory/integral/bochner.lean
@@ -465,7 +465,7 @@ Define the Bochner integral on `α →₁ₛ[μ] E` by extension from the simple
 and prove basic properties of this integral. -/
 
 variables [normed_field 𝕜] [normed_space 𝕜 E] [normed_space ℝ E] [smul_comm_class ℝ 𝕜 E]
-  {F' : Type*} [normed_add_comm_group F'] [normed_space ℝ F']
+  {F' : Type*} [add_comm_group F'] [normed_add_comm_group F'] [normed_space ℝ F']
 
 local attribute [instance] simple_func.normed_space
 
@@ -497,7 +497,7 @@ begin
   exact (to_simple_func f).norm_integral_le_integral_norm (simple_func.integrable f)
 end
 
-variables {E' : Type*} [normed_add_comm_group E'] [normed_space ℝ E'] [normed_space 𝕜 E']
+variables {E' : Type*} [add_comm_group E'] [normed_add_comm_group E'] [normed_space ℝ E'] [normed_space 𝕜 E']
 
 
 variables (α E μ 𝕜)

--- a/src/measure_theory/integral/circle_integral.lean
+++ b/src/measure_theory/integral/circle_integral.lean
@@ -65,7 +65,7 @@ some lemmas use, e.g., `(z - c)⁻¹ • f z` instead of `f z / (z - c)`.
 integral, circle, Cauchy integral
 -/
 
-variables {E : Type*} [normed_add_comm_group E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 noncomputable theory
 

--- a/src/measure_theory/integral/divergence_theorem.lean
+++ b/src/measure_theory/integral/divergence_theorem.lean
@@ -295,7 +295,7 @@ end
 /-- An auxiliary lemma that is used to specialize the general divergence theorem to spaces that do
 not have the form `fin n → ℝ`. -/
 lemma integral_divergence_of_has_fderiv_within_at_off_countable_of_equiv
-  {F : Type*} [normed_add_comm_group F] [normed_space ℝ F] [partial_order F] [measure_space F]
+  {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F] [partial_order F] [measure_space F]
   [borel_space F] (eL : F ≃L[ℝ] ℝⁿ⁺¹) (he_ord : ∀ x y, eL x ≤ eL y ↔ x ≤ y)
   (he_vol : measure_preserving eL volume volume) (f : fin (n + 1) → F → E)
   (f' : fin (n + 1) → F → F →L[ℝ] E) (s : set F) (hs : s.countable)

--- a/src/measure_theory/integral/interval_average.lean
+++ b/src/measure_theory/integral/interval_average.lean
@@ -27,7 +27,7 @@ We also prove that `⨍ x in a..b, f x = ⨍ x in b..a, f x`, see `interval_aver
 open measure_theory set topological_space
 open_locale interval
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
 
 notation `⨍` binders ` in ` a `..` b `, `
   r:(scoped:60 f, average (measure.restrict volume (Ι a b)) f) := r

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -168,7 +168,7 @@ open measure_theory set classical filter function
 
 open_locale classical topology filter ennreal big_operators interval nnreal
 
-variables {ι 𝕜 E F A : Type*} [normed_add_comm_group E]
+variables {ι 𝕜 E F A : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 /-!
 ### Integrability at an interval

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -2561,7 +2561,7 @@ begin
   { exact hf (measurable_set_singleton 0).compl },
 end
 
-lemma ae_measurable_with_density_iff {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+lemma ae_measurable_with_density_iff {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E]
   [topological_space.second_countable_topology E] [measurable_space E] [borel_space E]
   {f : α → ℝ≥0} (hf : measurable f) {g : α → E} :
   ae_measurable g (μ.with_density (λ x, (f x : ℝ≥0∞))) ↔ ae_measurable (λ x, (f x : ℝ) • g x) μ :=
@@ -2858,7 +2858,7 @@ by rw [lintegral_congr_ae (ae_eq_of_ae_eq_trim hf.ae_eq_mk),
 
 section sigma_finite
 
-variables {E : Type*} [normed_add_comm_group E] [measurable_space E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [measurable_space E]
   [opens_measurable_space E]
 
 lemma univ_le_of_forall_fin_meas_le {μ : measure α} (hm : m ≤ m0) [sigma_finite (μ.trim hm)]

--- a/src/measure_theory/integral/periodic.lean
+++ b/src/measure_theory/integral/periodic.lean
@@ -157,7 +157,7 @@ begin
     refl, }
 end
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
 
 /-- The integral of an almost-everywhere strongly measurable function over `add_circle T` is equal
 to the integral over an interval (t, t + T] in `ℝ` of its lift to `ℝ`. -/
@@ -211,7 +211,7 @@ protected lemma lintegral_preimage (t : ℝ) (f : unit_add_circle → ℝ≥0∞
   ∫⁻ a in Ioc t (t + 1), f a = ∫⁻ b : unit_add_circle, f b :=
 add_circle.lintegral_preimage 1 t f
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
 
 /-- The integral of an almost-everywhere strongly measurable function over `unit_add_circle` is
 equal to the integral over an interval (t, t + 1] in `ℝ` of its lift to `ℝ`. -/
@@ -227,7 +227,7 @@ add_circle.interval_integral_preimage 1 t f
 
 end unit_add_circle
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
 
 namespace function
 

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -846,7 +846,7 @@ end measure_theory
 
 open measure_theory asymptotics metric
 
-variables {ι : Type*} [normed_add_comm_group E]
+variables {ι : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 /-- Fundamental theorem of calculus for set integrals: if `μ` is a measure that is finite at a
 filter `l` and `f` is a measurable function that has a finite limit `b` at `l ⊓ μ.ae`, then `∫ x in
@@ -998,7 +998,7 @@ begin
   all_goals { assumption }
 end
 
-lemma integral_apply {H : Type*} [normed_add_comm_group H] [normed_space 𝕜 H]
+lemma integral_apply {H : Type*} [add_comm_group H] [normed_add_comm_group H] [normed_space 𝕜 H]
   {φ : α → H →L[𝕜] E} (φ_int : integrable φ μ) (v : H) :
   (∫ a, φ a ∂μ) v = ∫ a, φ a v ∂μ :=
 ((continuous_linear_map.apply 𝕜 E v).integral_comp_comm φ_int).symm

--- a/src/measure_theory/integral/set_to_l1.lean
+++ b/src/measure_theory/integral/set_to_l1.lean
@@ -186,7 +186,7 @@ fin_meas_additive μ T ∧ ∀ s, measurable_set s → μ s < ∞ → ‖T s‖ 
 
 namespace dominated_fin_meas_additive
 
-variables {β : Type*} [seminormed_add_comm_group β] {T T' : set α → β} {C C' : ℝ}
+variables {β : Type*} [add_comm_group β] [seminormed_add_comm_group β] {T T' : set α → β} {C C' : ℝ}
 
 lemma zero {m : measurable_space α} (μ : measure α) (hC : 0 ≤ C) :
   dominated_fin_meas_additive μ (0 : set α → β) C :=
@@ -196,7 +196,7 @@ begin
   exact mul_nonneg hC to_real_nonneg,
 end
 
-lemma eq_zero_of_measure_zero {β : Type*} [normed_add_comm_group β] {T : set α → β} {C : ℝ}
+lemma eq_zero_of_measure_zero {β : Type*} [add_comm_group β] [normed_add_comm_group β] {T : set α → β} {C : ℝ}
   (hT : dominated_fin_meas_additive μ T C) {s : set α}
   (hs : measurable_set s) (hs_zero : μ s = 0) :
   T s = 0 :=
@@ -206,7 +206,7 @@ begin
   rw [hs_zero, ennreal.zero_to_real, mul_zero],
 end
 
-lemma eq_zero {β : Type*} [normed_add_comm_group β] {T : set α → β} {C : ℝ}
+lemma eq_zero {β : Type*} [add_comm_group β] [normed_add_comm_group β] {T : set α → β} {C : ℝ}
   {m : measurable_space α} (hT : dominated_fin_meas_additive (0 : measure α) T C)
   {s : set α} (hs : measurable_set s) :
   T s = 0 :=

--- a/src/measure_theory/integral/torus_integral.lean
+++ b/src/measure_theory/integral/torus_integral.lean
@@ -53,7 +53,7 @@ integral, torus
 -/
 
 variable {n : ℕ}
-variables {E : Type*} [normed_add_comm_group E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E]
 
 noncomputable theory
 

--- a/src/measure_theory/measure/haar_lebesgue.lean
+++ b/src/measure_theory/measure/haar_lebesgue.lean
@@ -95,7 +95,7 @@ namespace measure
 /-- If a set is disjoint of its translates by infinitely many bounded vectors, then it has measure
 zero. This auxiliary lemma proves this assuming additionally that the set is bounded. -/
 lemma add_haar_eq_zero_of_disjoint_translates_aux
-  {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E] [borel_space E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E] [borel_space E]
   [finite_dimensional ℝ E] (μ : measure E) [is_add_haar_measure μ]
   {s : set E} (u : ℕ → E) (sb : bounded s) (hu : bounded (range u))
   (hs : pairwise (disjoint on (λ n, {u n} + s))) (h's : measurable_set s) :
@@ -117,7 +117,7 @@ end
 /-- If a set is disjoint of its translates by infinitely many bounded vectors, then it has measure
 zero. -/
 lemma add_haar_eq_zero_of_disjoint_translates
-  {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E] [borel_space E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E] [borel_space E]
   [finite_dimensional ℝ E] (μ : measure E) [is_add_haar_measure μ]
   {s : set E} (u : ℕ → E) (hu : bounded (range u))
   (hs : pairwise (disjoint on (λ n, {u n} + s))) (h's : measurable_set s) :
@@ -138,7 +138,7 @@ end
 
 /-- A strict vector subspace has measure zero. -/
 lemma add_haar_submodule
-  {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E] [borel_space E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E] [borel_space E]
   [finite_dimensional ℝ E] (μ : measure E) [is_add_haar_measure μ]
   (s : submodule ℝ E) (hs : s ≠ ⊤) : μ s = 0 :=
 begin
@@ -168,7 +168,7 @@ end
 
 /-- A strict affine subspace has measure zero. -/
 lemma add_haar_affine_subspace
-  {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E] [borel_space E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E] [borel_space E]
   [finite_dimensional ℝ E] (μ : measure E) [is_add_haar_measure μ]
   (s : affine_subspace ℝ E) (hs : s ≠ ⊤) : μ s = 0 :=
 begin
@@ -203,9 +203,9 @@ begin
     real.map_linear_map_volume_pi_eq_smul_volume_pi hf, smul_comm],
 end
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [measurable_space E]
   [borel_space E] [finite_dimensional ℝ E] (μ : measure E) [is_add_haar_measure μ]
-  {F : Type*} [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
+  {F : Type*} [add_comm_group F] [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
 
 lemma map_linear_map_add_haar_eq_smul_add_haar
   {f : E →ₗ[ℝ] E} (hf : f.det ≠ 0) :
@@ -407,7 +407,7 @@ general Haar measures on general commutative groups. -/
 /-! ### Measure of balls -/
 
 lemma add_haar_ball_center
-  {E : Type*} [normed_add_comm_group E] [measurable_space E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [measurable_space E]
   [borel_space E] (μ : measure E) [is_add_haar_measure μ] (x : E) (r : ℝ) :
   μ (ball x r) = μ (ball (0 : E) r) :=
 begin
@@ -416,7 +416,7 @@ begin
 end
 
 lemma add_haar_closed_ball_center
-  {E : Type*} [normed_add_comm_group E] [measurable_space E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [measurable_space E]
   [borel_space E] (μ : measure E) [is_add_haar_measure μ] (x : E) (r : ℝ) :
   μ (closed_ball x r) = μ (closed_ball (0 : E) r) :=
 begin

--- a/src/measure_theory/measure/probability_measure.lean
+++ b/src/measure_theory/measure/probability_measure.lean
@@ -335,7 +335,7 @@ end
 /-- Averaging with respect to a finite measure is the same as integraing against
 `measure_theory.finite_measure.normalize`. -/
 lemma average_eq_integral_normalize
-  {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
+  {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
   (nonzero : μ ≠ 0) (f : Ω → E) :
   average (μ : measure Ω) f = ∫ ω, f ω ∂(μ.normalize : measure Ω) :=
 begin

--- a/src/measure_theory/measure/with_density_vector_measure.lean
+++ b/src/measure_theory/measure/with_density_vector_measure.lean
@@ -31,7 +31,7 @@ namespace measure_theory
 open topological_space
 
 variables {μ ν : measure α}
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
 
 /-- Given a measure `μ` and an integrable function `f`, `μ.with_densityᵥ f` is
 the vector measure which maps the set `s` to `∫ₛ f ∂μ`. -/

--- a/src/number_theory/well_approximable.lean
+++ b/src/number_theory/well_approximable.lean
@@ -59,11 +59,11 @@ open_locale measure_theory topology pointwise
 elements within a distance `δ` of a point of order `n`. -/
 @[to_additive approx_add_order_of "In a seminormed additive group `A`, given `n : ℕ` and `δ : ℝ`,
 `approx_add_order_of A n δ` is the set of elements within a distance `δ` of a point of order `n`."]
-def approx_order_of (A : Type*) [seminormed_group A] (n : ℕ) (δ : ℝ) : set A :=
+def approx_order_of (A : Type*) [group A] [seminormed_group A] (n : ℕ) (δ : ℝ) : set A :=
 thickening δ {y | order_of y = n}
 
 @[to_additive mem_approx_add_order_of_iff]
-lemma mem_approx_order_of_iff {A : Type*} [seminormed_group A] {n : ℕ} {δ : ℝ} {a : A} :
+lemma mem_approx_order_of_iff {A : Type*} [group A] [seminormed_group A] {n : ℕ} {δ : ℝ} {a : A} :
   a ∈ approx_order_of A n δ ↔ ∃ (b : A), order_of b = n ∧ a ∈ ball b δ :=
 by simp only [approx_order_of, thickening_eq_bUnion_ball, mem_Union₂, mem_set_of_eq, exists_prop]
 
@@ -74,17 +74,17 @@ lie in infinitely many of the sets `approx_order_of A n δₙ`. -/
 distances `δ₁, δ₂, ...`, `add_well_approximable A δ` is the limsup as `n → ∞` of the sets
 `approx_add_order_of A n δₙ`. Thus, it is the set of points that lie in infinitely many of the sets
 `approx_add_order_of A n δₙ`."]
-def well_approximable (A : Type*) [seminormed_group A] (δ : ℕ → ℝ) : set A :=
+def well_approximable (A : Type*) [group A] [seminormed_group A] (δ : ℕ → ℝ) : set A :=
 blimsup (λ n, approx_order_of A n (δ n)) at_top (λ n, 0 < n)
 
 @[to_additive mem_add_well_approximable_iff]
-lemma mem_well_approximable_iff {A : Type*} [seminormed_group A] {δ : ℕ → ℝ} {a : A} :
+lemma mem_well_approximable_iff {A : Type*} [group A] [seminormed_group A] {δ : ℕ → ℝ} {a : A} :
   a ∈ well_approximable A δ ↔ a ∈ blimsup (λ n, approx_order_of A n (δ n)) at_top (λ n, 0 < n) :=
 iff.rfl
 
 namespace approx_order_of
 
-variables {A : Type*} [seminormed_comm_group A] {a : A} {m n : ℕ} (δ : ℝ)
+variables {A : Type*} [comm_group A] [seminormed_comm_group A] {a : A} {m n : ℕ} (δ : ℝ)
 
 @[to_additive]
 lemma image_pow_subset_of_coprime (hm : 0 < m) (hmn : n.coprime m) :

--- a/src/order/filter/zero_and_bounded_at_filter.lean
+++ b/src/order/filter/zero_and_bounded_at_filter.lean
@@ -70,7 +70,8 @@ if `f =O[l] 1`. -/
 def bounded_at_filter [has_norm β] (l : filter α) (f : α → β) : Prop :=
 asymptotics.is_O l f (1 : α → ℝ)
 
-lemma zero_at_filter.bounded_at_filter [normed_add_comm_group β] {l : filter α} {f : α → β}
+lemma zero_at_filter.bounded_at_filter
+  [add_comm_group β] [normed_add_comm_group β] {l : filter α} {f : α → β}
   (hf : zero_at_filter l f) : bounded_at_filter l f :=
 begin
   rw [zero_at_filter, ← asymptotics.is_o_const_iff (one_ne_zero' ℝ)] at hf,
@@ -81,18 +82,21 @@ lemma const_bounded_at_filter [normed_field β] (l : filter α) (c : β) :
   bounded_at_filter l (function.const α c : α → β) :=
 asymptotics.is_O_const_const c one_ne_zero l
 
-lemma bounded_at_filter.add [normed_add_comm_group β] {l : filter α} {f g : α → β}
+lemma bounded_at_filter.add
+  [add_comm_group β] [normed_add_comm_group β] {l : filter α} {f g : α → β}
   (hf : bounded_at_filter l f) (hg : bounded_at_filter l g) :
   bounded_at_filter l (f + g) :=
 by simpa using hf.add hg
 
-lemma bounded_at_filter.neg [normed_add_comm_group β] {l : filter α} {f : α → β}
+lemma bounded_at_filter.neg
+  [add_comm_group β] [normed_add_comm_group β] {l : filter α} {f : α → β}
   (hf : bounded_at_filter l f) :
   bounded_at_filter l (-f) :=
 hf.neg_left
 
-lemma bounded_at_filter.smul {𝕜 : Type*} [normed_field 𝕜] [normed_add_comm_group β]
-  [normed_space 𝕜 β] {l : filter α} {f : α → β} (c : 𝕜) (hf : bounded_at_filter l f) :
+lemma bounded_at_filter.smul
+  {𝕜 : Type*} [normed_field 𝕜] [add_comm_group β] [normed_add_comm_group β] [normed_space 𝕜 β]
+  {l : filter α} {f : α → β} (c : 𝕜) (hf : bounded_at_filter l f) :
   bounded_at_filter l (c • f) :=
 hf.const_smul_left c
 

--- a/src/probability/conditional_expectation.lean
+++ b/src/probability/conditional_expectation.lean
@@ -28,7 +28,7 @@ namespace measure_theory
 
 open probability_theory
 
-variables {Ω E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
+variables {Ω E : Type*} [add_comm_group E] [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
   {m₁ m₂ m : measurable_space Ω} {μ : measure Ω} {f : Ω → E}
 
 /-- If `m₁, m₂` are independent σ-algebras and `f` is `m₁`-measurable, then `𝔼[f | m₂] = 𝔼[f]`

--- a/src/probability/process/filtration.lean
+++ b/src/probability/process/filtration.lean
@@ -320,7 +320,7 @@ lemma strongly_measurable_limit_process' :
 strongly_measurable_limit_process.mono (Sup_le (λ m ⟨n, hn⟩, hn ▸ ℱ.le _))
 
 lemma mem_ℒp_limit_process_of_snorm_bdd {R : ℝ≥0} {p : ℝ≥0∞}
-  {F : Type*} [normed_add_comm_group F] {ℱ : filtration ℕ m} {f : ℕ → Ω → F}
+  {F : Type*} [add_comm_group F] [normed_add_comm_group F] {ℱ : filtration ℕ m} {f : ℕ → Ω → F}
   (hfm : ∀ n, ae_strongly_measurable (f n) μ) (hbdd : ∀ n, snorm (f n) p μ ≤ R) :
   mem_ℒp (limit_process f ℱ μ) p μ :=
 begin

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -414,7 +414,7 @@ section weierstrass
 open topological_space
 
 variables {X : Type*} [topological_space X] [t2_space X] [locally_compact_space X]
-variables {E : Type*} [normed_add_comm_group E] [complete_space E]
+variables {E : Type*} [add_comm_group E] [normed_add_comm_group E] [complete_space E]
 
 lemma summable_of_locally_summable_norm {ι : Type*} {F : ι → C(X, E)}
   (hF : ∀ K : compacts X, summable (λ i, ‖(F i).restrict K‖)) :

--- a/src/topology/urysohns_lemma.lean
+++ b/src/topology/urysohns_lemma.lean
@@ -220,7 +220,7 @@ lemma lim_eq_midpoint (c : CU X) (x : X) :
 begin
   refine tendsto_nhds_unique (c.tendsto_approx_at_top x) ((tendsto_add_at_top_iff_nat 1).1 _),
   simp only [approx],
-  exact (c.left.tendsto_approx_at_top x).midpoint (c.right.tendsto_approx_at_top x)
+  exact ((c.left.tendsto_approx_at_top x).midpoint (c.right.tendsto_approx_at_top x) : _)
 end
 
 lemma approx_le_lim (c : CU X) (x : X) (n : ℕ) : c.approx n x ≤ c.lim x :=

--- a/src/topology/vector_bundle/constructions.lean
+++ b/src/topology/vector_bundle/constructions.lean
@@ -71,9 +71,9 @@ end bundle.trivial
 
 section
 variables (𝕜 : Type*) {B : Type*} [nontrivially_normed_field 𝕜] [topological_space B]
-  (F₁ : Type*) [normed_add_comm_group F₁] [normed_space 𝕜 F₁]
+  (F₁ : Type*) [add_comm_group F₁] [normed_add_comm_group F₁] [normed_space 𝕜 F₁]
   (E₁ : B → Type*) [topological_space (total_space E₁)]
-  (F₂ : Type*) [normed_add_comm_group F₂] [normed_space 𝕜 F₂]
+  (F₂ : Type*) [add_comm_group F₂] [normed_add_comm_group F₂] [normed_space 𝕜 F₂]
   (E₂ : B → Type*) [topological_space (total_space E₂)]
 
 namespace trivialization

--- a/src/topology/vector_bundle/hom.lean
+++ b/src/topology/vector_bundle/hom.lean
@@ -85,10 +85,10 @@ variables {𝕜₁ : Type*} [nontrivially_normed_field 𝕜₁] {𝕜₂ : Type*
 
 variables {B : Type*} [topological_space B]
 
-variables (F₁ : Type*) [normed_add_comm_group F₁] [normed_space 𝕜₁ F₁]
+variables (F₁ : Type*) [add_comm_group F₁] [normed_add_comm_group F₁] [normed_space 𝕜₁ F₁]
   (E₁ : B → Type*) [Π x, add_comm_monoid (E₁ x)] [Π x, module 𝕜₁ (E₁ x)]
   [topological_space (total_space E₁)]
-variables (F₂ : Type*) [normed_add_comm_group F₂] [normed_space 𝕜₂ F₂]
+variables (F₂ : Type*) [add_comm_group F₂] [normed_add_comm_group F₂] [normed_space 𝕜₂ F₂]
   (E₂ : B → Type*) [Π x, add_comm_monoid (E₂ x)] [Π x, module 𝕜₂ (E₂ x)]
   [topological_space (total_space E₂)]
 

--- a/src/topology/vector_bundle/hom.lean
+++ b/src/topology/vector_bundle/hom.lean
@@ -88,7 +88,7 @@ variables {B : Type*} [topological_space B]
 variables (F₁ : Type*) [normed_add_comm_group F₁] [normed_space 𝕜₁ F₁]
   (E₁ : B → Type*) [Π x, add_comm_monoid (E₁ x)] [Π x, module 𝕜₁ (E₁ x)]
   [topological_space (total_space E₁)]
-variables (F₂ : Type*) [normed_add_comm_group F₂][normed_space 𝕜₂ F₂]
+variables (F₂ : Type*) [normed_add_comm_group F₂] [normed_space 𝕜₂ F₂]
   (E₂ : B → Type*) [Π x, add_comm_monoid (E₂ x)] [Π x, module 𝕜₂ (E₂ x)]
   [topological_space (total_space E₂)]
 

--- a/test/calc.lean
+++ b/test/calc.lean
@@ -8,7 +8,7 @@ section is_equivalent
 
 open_locale asymptotics
 
-example {l : filter α} {u v w : α → β} [normed_add_comm_group β]
+example {l : filter α} {u v w : α → β} [add_comm_group β] [normed_add_comm_group β]
   (huv : u ~[l] v) (hvw : v ~[l] w) : u ~[l] w :=
 calc u ~[l] v : huv
    ... ~[l] w : hvw

--- a/test/measurability.lean
+++ b/test/measurability.lean
@@ -76,7 +76,8 @@ example [add_comm_monoid β] [has_measurable_add₂ β] {s : finset ℕ} {F : �
 by measurability
 
 -- even with many assumptions, the tactic is not trapped by a bad lemma
-example [topological_space α] [borel_space α] [normed_add_comm_group β] [borel_space β]
+example [topological_space α] [borel_space α]
+  [add_comm_group β] [normed_add_comm_group β] [borel_space β]
   [has_measurable_add₂ β] [has_measurable_sub₂ β] {s : finset ℕ} {F : ℕ → α → β}
   (hF : ∀ i, measurable (F i)) :
   ae_measurable (∑ i in s, (λ x, F (i+1) x - F i x)) μ :=

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -225,7 +225,7 @@ example {r : ℝ} : 0 < real.exp r := by positivity
 example [ordered_add_comm_group α] (s : nonempty_interval α) : 0 ≤ s.length := by positivity
 example [ordered_add_comm_group α] (s : interval α) : 0 ≤ s.length := by positivity
 
-example {V : Type*} [normed_add_comm_group V] (x : V) : 0 ≤ ‖x‖ := by positivity
+example {V : Type*} [add_comm_group V] [normed_add_comm_group V] (x : V) : 0 ≤ ‖x‖ := by positivity
 
 example [metric_space α] (x y : α) : 0 ≤ dist x y := by positivity
 example [metric_space α] {s : set α} : 0 ≤ metric.diam s := by positivity


### PR DESCRIPTION
This removes the `add_comm_group` base class from `normed_group` etc.

To try and restrict the scope of this change, it deliberately does not:
* do the same for any of the downstream `normed_ring` , `normed_space`, or `normed_lattice_add_comm_group` classes.
* attempt to remove the vestigial `comm_` versions, as these make it harder to accidentally ungeneralize a downstream result while fixing this everywhere.

We can do this in a later PR.

Zulip threads:
* [normed_field](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/normed_field/near/297799021)
* [normed_ring vs normed_field](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/normed_ring.20vs.20normed_field/near/281148597)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
