### PR TITLE
[Merged by Bors] - refactor(linear_algebra/bilinear_map): move lemmas about `basis` to a new file.

### DIFF
--- a/src/linear_algebra/affine_space/combination.lean
+++ b/src/linear_algebra/affine_space/combination.lean
@@ -6,6 +6,7 @@ Authors: Joseph Myers
 import algebra.invertible
 import algebra.indicator_function
 import algebra.module.big_operators
+import data.fintype.big_operators
 import linear_algebra.affine_space.affine_map
 import linear_algebra.affine_space.affine_subspace
 import linear_algebra.finsupp

--- a/src/linear_algebra/basis/bilinear.lean
+++ b/src/linear_algebra/basis/bilinear.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2022 Moritz Doll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Moritz Doll
+-/
+import linear_algebra.basis
+import linear_algebra.bilinear_map
+
+/-!
+# Lemmas about bilinear maps with a basis over each argument
+-/
+namespace linear_map
+
+variables {ι₁ ι₂ : Type*}
+variables {R R₂ S S₂ M N P : Type*}
+variables {Mₗ Nₗ Pₗ : Type*}
+variables [comm_ring R] [comm_ring S] [comm_ring R₂] [comm_ring S₂]
+
+section add_comm_monoid
+
+variables [comm_semiring R]
+variables [add_comm_monoid M] [add_comm_monoid N] [add_comm_monoid P]
+variables [add_comm_monoid Mₗ] [add_comm_monoid Nₗ] [add_comm_monoid Pₗ]
+variables [module R M] [module S N] [module R₂ P] [module S₂ P]
+variables [module R Mₗ] [module R Nₗ] [module R Pₗ]
+variables [smul_comm_class S₂ R₂ P]
+variables {ρ₁₂ : R →+* R₂} {σ₁₂ : S →+* S₂}
+variables (b₁ : basis ι₁ R M) (b₂ : basis ι₂ S N) (b₁' : basis ι₁ R Mₗ) (b₂' : basis ι₂ R Nₗ)
+
+
+/-- Two bilinear maps are equal when they are equal on all basis vectors. -/
+lemma ext_basis {B B' : M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁₂] P}
+  (h : ∀ i j, B (b₁ i) (b₂ j) = B' (b₁ i) (b₂ j)) : B = B' :=
+b₁.ext $ λ i, b₂.ext $ λ j, h i j
+
+/-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis.
+
+Version for semi-bilinear maps, see `sum_repr_mul_repr_mul` for the bilinear version. -/
+lemma sum_repr_mul_repr_mulₛₗ {B : M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁₂] P} (x y) :
+  (b₁.repr x).sum (λ i xi, (b₂.repr y).sum (λ j yj, (ρ₁₂ xi) • (σ₁₂ yj) • B (b₁ i) (b₂ j))) =
+  B x y :=
+begin
+  conv_rhs { rw [← b₁.total_repr x, ← b₂.total_repr y] },
+  simp_rw [finsupp.total_apply, finsupp.sum, map_sum₂, map_sum,
+    linear_map.map_smulₛₗ₂, linear_map.map_smulₛₗ],
+end
+
+/-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis.
+
+Version for bilinear maps, see `sum_repr_mul_repr_mulₛₗ` for the semi-bilinear version. -/
+lemma sum_repr_mul_repr_mul {B : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ} (x y) :
+  (b₁'.repr x).sum (λ i xi, (b₂'.repr y).sum (λ j yj, xi • yj • B (b₁' i) (b₂' j))) =
+  B x y :=
+begin
+  conv_rhs { rw [← b₁'.total_repr x, ← b₂'.total_repr y] },
+  simp_rw [finsupp.total_apply, finsupp.sum, map_sum₂, map_sum,
+    linear_map.map_smul₂, linear_map.map_smul],
+end
+
+end add_comm_monoid
+
+end linear_map

--- a/src/linear_algebra/basis/bilinear.lean
+++ b/src/linear_algebra/basis/bilinear.lean
@@ -14,11 +14,10 @@ namespace linear_map
 variables {ι₁ ι₂ : Type*}
 variables {R R₂ S S₂ M N P : Type*}
 variables {Mₗ Nₗ Pₗ : Type*}
-variables [comm_ring R] [comm_ring S] [comm_ring R₂] [comm_ring S₂]
+variables [comm_semiring R] [comm_semiring S] [comm_semiring R₂] [comm_semiring S₂]
 
 section add_comm_monoid
 
-variables [comm_semiring R]
 variables [add_comm_monoid M] [add_comm_monoid N] [add_comm_monoid P]
 variables [add_comm_monoid Mₗ] [add_comm_monoid Nₗ] [add_comm_monoid Pₗ]
 variables [module R M] [module S N] [module R₂ P] [module S₂ P]

--- a/src/linear_algebra/bilinear_map.lean
+++ b/src/linear_algebra/bilinear_map.lean
@@ -5,7 +5,6 @@ Authors: Kenny Lau, Mario Carneiro
 -/
 
 import linear_algebra.basic
-import linear_algebra.basis
 
 /-!
 # Basics on bilinear maps
@@ -30,7 +29,6 @@ commuting actions, and `ρ₁₂ : R →+* R₂` and `σ₁₂ : S →+* S₂`.
 bilinear
 -/
 
-variables {ι₁ ι₂ : Type*}
 
 namespace linear_map
 
@@ -310,48 +308,6 @@ section comm_ring
 variables {R R₂ S S₂ M N P : Type*}
 variables {Mₗ Nₗ Pₗ : Type*}
 variables [comm_ring R] [comm_ring S] [comm_ring R₂] [comm_ring S₂]
-
-section add_comm_monoid
-
-variables [add_comm_monoid M] [add_comm_monoid N] [add_comm_monoid P]
-variables [add_comm_monoid Mₗ] [add_comm_monoid Nₗ] [add_comm_monoid Pₗ]
-variables [module R M] [module S N] [module R₂ P] [module S₂ P]
-variables [module R Mₗ] [module R Nₗ] [module R Pₗ]
-variables [smul_comm_class S₂ R₂ P]
-variables {ρ₁₂ : R →+* R₂} {σ₁₂ : S →+* S₂}
-variables (b₁ : basis ι₁ R M) (b₂ : basis ι₂ S N) (b₁' : basis ι₁ R Mₗ) (b₂' : basis ι₂ R Nₗ)
-
-
-/-- Two bilinear maps are equal when they are equal on all basis vectors. -/
-lemma ext_basis {B B' : M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁₂] P}
-  (h : ∀ i j, B (b₁ i) (b₂ j) = B' (b₁ i) (b₂ j)) : B = B' :=
-b₁.ext $ λ i, b₂.ext $ λ j, h i j
-
-/-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis.
-
-Version for semi-bilinear maps, see `sum_repr_mul_repr_mul` for the bilinear version. -/
-lemma sum_repr_mul_repr_mulₛₗ {B : M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁₂] P} (x y) :
-  (b₁.repr x).sum (λ i xi, (b₂.repr y).sum (λ j yj, (ρ₁₂ xi) • (σ₁₂ yj) • B (b₁ i) (b₂ j))) =
-  B x y :=
-begin
-  conv_rhs { rw [← b₁.total_repr x, ← b₂.total_repr y] },
-  simp_rw [finsupp.total_apply, finsupp.sum, map_sum₂, map_sum,
-    linear_map.map_smulₛₗ₂, linear_map.map_smulₛₗ],
-end
-
-/-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis.
-
-Version for bilinear maps, see `sum_repr_mul_repr_mulₛₗ` for the semi-bilinear version. -/
-lemma sum_repr_mul_repr_mul {B : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ} (x y) :
-  (b₁'.repr x).sum (λ i xi, (b₂'.repr y).sum (λ j yj, xi • yj • B (b₁' i) (b₂' j))) =
-  B x y :=
-begin
-  conv_rhs { rw [← b₁'.total_repr x, ← b₂'.total_repr y] },
-  simp_rw [finsupp.total_apply, finsupp.sum, map_sum₂, map_sum,
-    linear_map.map_smul₂, linear_map.map_smul],
-end
-
-end add_comm_monoid
 
 section add_comm_group
 

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andreas Swerdlow
 -/
 import algebra.module.linear_map
+import linear_algebra.basis.bilinear
 import linear_algebra.bilinear_map
 import algebra.euclidean_domain.instances
 import ring_theory.non_zero_divisors

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau
 import algebra.algebra.operations
 import algebra.ring.equiv
 import data.nat.choose.sum
+import linear_algebra.basis.bilinear
 import ring_theory.coprime.lemmas
 import ring_theory.ideal.quotient
 import ring_theory.non_zero_divisors


### PR DESCRIPTION
This cuts the import path. The copyright comes from #12269.

I chose not to just move these lemmas to `linear_algebra/basis` as this file is already huge.

The moved lemmas are now stated slightly more generally (`comm_semiring` rather than `comm_ring`), which seems to have been an accident in the original file as no proofs had to change.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Motivated by [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Proving.20Pell's.20equation.20is.20solvable/near/328854849)