### PR TITLE
[Merged by Bors] - feat(probability/probability_mass_function): basic lawful monad lemmas for `pmf`.

### DIFF
--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -53,7 +53,7 @@ lemma tsum_coe_indicator_ne_top (p : pmf α) (s : set α) : ∑' a, s.indicator 
 ne_of_lt (lt_of_le_of_lt (tsum_le_tsum (λ a, set.indicator_apply_le (λ _, le_rfl))
   ennreal.summable ennreal.summable) (lt_of_le_of_ne le_top p.tsum_coe_ne_top))
 
-lemma coe_fn_ne_zero (p : pmf α) : ⇑p ≠ 0 :=
+lemma coe_ne_zero (p : pmf α) : ⇑p ≠ 0 :=
 λ hp, zero_ne_one ((tsum_zero.symm.trans (tsum_congr $
   λ x, symm (congr_fun hp x))).trans p.tsum_coe)
 
@@ -63,7 +63,7 @@ def support (p : pmf α) : set α := function.support p
 @[simp] lemma mem_support_iff (p : pmf α) (a : α) : a ∈ p.support ↔ p a ≠ 0 := iff.rfl
 
 lemma support_nonempty (p : pmf α) : p.support.nonempty :=
-function.support_nonempty_iff.2 p.coe_fn_ne_zero
+function.support_nonempty_iff.2 p.coe_ne_zero
 
 lemma apply_eq_zero_iff (p : pmf α) (a : α) : p a = 0 ↔ a ∉ p.support :=
 by rw [mem_support_iff, not_not]

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -35,7 +35,7 @@ def {u} pmf (α : Type u) : Type u := { f : α → ℝ≥0∞ // has_sum f 1 }
 
 namespace pmf
 
-instance pmf.fun_like : fun_like (pmf α) α (λ p, ℝ≥0∞) :=
+instance fun_like : fun_like (pmf α) α (λ p, ℝ≥0∞) :=
 { coe := λ p a, p.1 a,
   coe_injective' := λ p q h, subtype.eq h }
 
@@ -53,7 +53,7 @@ lemma tsum_coe_indicator_ne_top (p : pmf α) (s : set α) : ∑' a, s.indicator 
 ne_of_lt (lt_of_le_of_lt (tsum_le_tsum (λ a, set.indicator_apply_le (λ _, le_rfl))
   ennreal.summable ennreal.summable) (lt_of_le_of_ne le_top p.tsum_coe_ne_top))
 
-lemma coe_ne_zero (p : pmf α) : ⇑p ≠ 0 :=
+@[simp] lemma coe_ne_zero (p : pmf α) : ⇑p ≠ 0 :=
 λ hp, zero_ne_one ((tsum_zero.symm.trans (tsum_congr $
   λ x, symm (congr_fun hp x))).trans p.tsum_coe)
 
@@ -62,7 +62,7 @@ def support (p : pmf α) : set α := function.support p
 
 @[simp] lemma mem_support_iff (p : pmf α) (a : α) : a ∈ p.support ↔ p a ≠ 0 := iff.rfl
 
-lemma support_nonempty (p : pmf α) : p.support.nonempty :=
+@[simp] lemma support_nonempty (p : pmf α) : p.support.nonempty :=
 function.support_nonempty_iff.2 p.coe_ne_zero
 
 lemma apply_eq_zero_iff (p : pmf α) (a : α) : p a = 0 ↔ a ∉ p.support :=

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -53,17 +53,17 @@ lemma tsum_coe_indicator_ne_top (p : pmf α) (s : set α) : ∑' a, s.indicator 
 ne_of_lt (lt_of_le_of_lt (tsum_le_tsum (λ a, set.indicator_apply_le (λ _, le_rfl))
   ennreal.summable ennreal.summable) (lt_of_le_of_ne le_top p.tsum_coe_ne_top))
 
+lemma coe_fn_ne_zero (p : pmf α) : ⇑p ≠ 0 :=
+λ hp, zero_ne_one ((tsum_zero.symm.trans (tsum_congr $
+  λ x, symm (congr_fun hp x))).trans p.tsum_coe)
+
 /-- The support of a `pmf` is the set where it is nonzero. -/
 def support (p : pmf α) : set α := function.support p
 
 @[simp] lemma mem_support_iff (p : pmf α) (a : α) : a ∈ p.support ↔ p a ≠ 0 := iff.rfl
 
 lemma support_nonempty (p : pmf α) : p.support.nonempty :=
-begin
-  refine set.nonempty_def.2 (by_contra $ λ h, _),
-  simp only [pmf.mem_support_iff, not_exists, not_not] at h,
-  exact zero_ne_one (((tsum_congr h).trans tsum_zero).symm.trans p.tsum_coe),
-end
+function.support_nonempty_iff.2 p.coe_fn_ne_zero
 
 lemma apply_eq_zero_iff (p : pmf α) (a : α) : p a = 0 ↔ a ∉ p.support :=
 by rw [mem_support_iff, not_not]

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -35,13 +35,13 @@ def {u} pmf (α : Type u) : Type u := { f : α → ℝ≥0∞ // has_sum f 1 }
 
 namespace pmf
 
-instance : has_coe_to_fun (pmf α) (λ p, α → ℝ≥0∞) := ⟨λ p a, p.1 a⟩
+instance pmf.fun_like : fun_like (pmf α) α (λ p, ℝ≥0∞) :=
+{ coe := λ p a, p.1 a,
+  coe_injective' := λ p q h, subtype.eq h }
 
-@[ext] protected lemma ext : ∀ {p q : pmf α}, (∀ a, p a = q a) → p = q
-| ⟨f, hf⟩ ⟨g, hg⟩ eq :=  subtype.eq $ funext eq
+@[ext] protected lemma ext {p q : pmf α} (h : ∀ x, p x = q x) : p = q := fun_like.ext p q h
 
-lemma ext_iff (p q : pmf α) : p = q ↔ ∀ x, p x = q x :=
-⟨λ h x, congr_fun (congr_arg _ h) x, pmf.ext⟩
+lemma ext_iff {p q : pmf α} : p = q ↔ ∀ x, p x = q x := fun_like.ext_iff
 
 lemma has_sum_coe_one (p : pmf α) : has_sum p 1 := p.2
 

--- a/src/probability/probability_mass_function/basic.lean
+++ b/src/probability/probability_mass_function/basic.lean
@@ -40,6 +40,9 @@ instance : has_coe_to_fun (pmf α) (λ p, α → ℝ≥0∞) := ⟨λ p a, p.1 a
 @[ext] protected lemma ext : ∀ {p q : pmf α}, (∀ a, p a = q a) → p = q
 | ⟨f, hf⟩ ⟨g, hg⟩ eq :=  subtype.eq $ funext eq
 
+lemma ext_iff (p q : pmf α) : p = q ↔ ∀ x, p x = q x :=
+⟨λ h x, congr_fun (congr_arg _ h) x, pmf.ext⟩
+
 lemma has_sum_coe_one (p : pmf α) : has_sum p 1 := p.2
 
 @[simp] lemma tsum_coe (p : pmf α) : ∑' a, p a = 1 := p.has_sum_coe_one.tsum_eq
@@ -54,6 +57,13 @@ ne_of_lt (lt_of_le_of_lt (tsum_le_tsum (λ a, set.indicator_apply_le (λ _, le_r
 def support (p : pmf α) : set α := function.support p
 
 @[simp] lemma mem_support_iff (p : pmf α) (a : α) : a ∈ p.support ↔ p a ≠ 0 := iff.rfl
+
+lemma support_nonempty (p : pmf α) : p.support.nonempty :=
+begin
+  refine set.nonempty_def.2 (by_contra $ λ h, _),
+  simp only [pmf.mem_support_iff, not_exists, not_not] at h,
+  exact zero_ne_one (((tsum_congr h).trans tsum_zero).symm.trans p.tsum_coe),
+end
 
 lemma apply_eq_zero_iff (p : pmf α) (a : α) : p a = 0 ↔ a ∉ p.support :=
 by rw [mem_support_iff, not_not]

--- a/src/probability/probability_mass_function/constructions.lean
+++ b/src/probability/probability_mass_function/constructions.lean
@@ -61,8 +61,8 @@ lemma map_bind (q : α → pmf β) (f : β → γ) :
   (p.map f).bind q = p.bind (q ∘ f) :=
 (bind_bind _ _ _).trans (congr_arg _ (funext (λ a, pure_bind _ _)))
 
-lemma map_const (p : pmf α) (b : β) :
-  p.map (function.const α b) = pure b := by simp only [map, bind_const, function.comp_const]
+@[simp] lemma map_const : p.map (function.const α b) = pure b :=
+by simp only [map, bind_const, function.comp_const]
 
 section measure
 

--- a/src/probability/probability_mass_function/constructions.lean
+++ b/src/probability/probability_mass_function/constructions.lean
@@ -49,8 +49,7 @@ lemma bind_pure_comp : bind p (pure ∘ f) = map f p := rfl
 
 lemma map_id : map id p = p := bind_pure _
 
-lemma map_comp (g : β → γ) : (p.map f).map g = p.map (g ∘ f) :=
-by simp only [map, bind_bind, pure_bind]
+lemma map_comp (g : β → γ) : (p.map f).map g = p.map (g ∘ f) := by simp [map]
 
 lemma pure_map (a : α) : (pure a).map f = pure (f a) := pure_bind _ _
 

--- a/src/probability/probability_mass_function/constructions.lean
+++ b/src/probability/probability_mass_function/constructions.lean
@@ -47,13 +47,22 @@ lemma mem_support_map_iff : b ∈ (map f p).support ↔ ∃ a ∈ p.support, f a
 
 lemma bind_pure_comp : bind p (pure ∘ f) = map f p := rfl
 
-lemma map_id : map id p = p := by simp [map]
+lemma map_id : map id p = p := bind_pure _
 
 lemma map_comp (g : β → γ) : (p.map f).map g = p.map (g ∘ f) :=
-by simp [map]
+by simp only [map, bind_bind, pure_bind]
 
-lemma pure_map (a : α) : (pure a).map f = pure (f a) :=
-by simp [map]
+lemma pure_map (a : α) : (pure a).map f = pure (f a) := pure_bind _ _
+
+lemma map_bind (q : α → pmf β) (f : β → γ) :
+  (p.bind q).map f = p.bind (λ a, (q a).map f) := pmf.bind_bind _ _ _
+
+@[simp] lemma bind_map {α β γ : Type*} (p : pmf α) (f : α → β) (q : β → pmf γ) :
+  (p.map f).bind q = p.bind (q ∘ f) :=
+(bind_bind _ _ _).trans (congr_arg _ (funext (λ a, pure_bind _ _)))
+
+lemma pmmap_const {α β : Type*} (p : pmf α) (b : β) :
+  p.map (function.const α b) = pmf.pure b := by simp only [map, bind_const, function.comp_const]
 
 section measure
 

--- a/src/probability/probability_mass_function/constructions.lean
+++ b/src/probability/probability_mass_function/constructions.lean
@@ -57,11 +57,11 @@ lemma pure_map (a : α) : (pure a).map f = pure (f a) := pure_bind _ _
 lemma map_bind (q : α → pmf β) (f : β → γ) :
   (p.bind q).map f = p.bind (λ a, (q a).map f) := bind_bind _ _ _
 
-@[simp] lemma bind_map {α β γ : Type*} (p : pmf α) (f : α → β) (q : β → pmf γ) :
+@[simp] lemma bind_map (p : pmf α) (f : α → β) (q : β → pmf γ) :
   (p.map f).bind q = p.bind (q ∘ f) :=
 (bind_bind _ _ _).trans (congr_arg _ (funext (λ a, pure_bind _ _)))
 
-lemma map_const {α β : Type*} (p : pmf α) (b : β) :
+lemma map_const (p : pmf α) (b : β) :
   p.map (function.const α b) = pure b := by simp only [map, bind_const, function.comp_const]
 
 section measure

--- a/src/probability/probability_mass_function/constructions.lean
+++ b/src/probability/probability_mass_function/constructions.lean
@@ -55,14 +55,14 @@ by simp only [map, bind_bind, pure_bind]
 lemma pure_map (a : α) : (pure a).map f = pure (f a) := pure_bind _ _
 
 lemma map_bind (q : α → pmf β) (f : β → γ) :
-  (p.bind q).map f = p.bind (λ a, (q a).map f) := pmf.bind_bind _ _ _
+  (p.bind q).map f = p.bind (λ a, (q a).map f) := bind_bind _ _ _
 
 @[simp] lemma bind_map {α β γ : Type*} (p : pmf α) (f : α → β) (q : β → pmf γ) :
   (p.map f).bind q = p.bind (q ∘ f) :=
 (bind_bind _ _ _).trans (congr_arg _ (funext (λ a, pure_bind _ _)))
 
-lemma pmmap_const {α β : Type*} (p : pmf α) (b : β) :
-  p.map (function.const α b) = pmf.pure b := by simp only [map, bind_const, function.comp_const]
+lemma map_const {α β : Type*} (p : pmf α) (b : β) :
+  p.map (function.const α b) = pure b := by simp only [map, bind_const, function.comp_const]
 
 section measure
 

--- a/src/probability/probability_mass_function/monad.lean
+++ b/src/probability/probability_mass_function/monad.lean
@@ -38,9 +38,9 @@ variables (a a' : α)
 
 lemma mem_support_pure_iff: a' ∈ (pure a).support ↔ a' = a := by simp
 
-@[simp] lemma pure_apply_self : pure a a = 1 := by rw [pure_apply, eq_self_iff_true, if_true]
+@[simp] lemma pure_apply_self : pure a a = 1 := if_pos rfl
 
-lemma pure_apply_of_ne (h : a' ≠ a) : pure a a' = 0 := by simp only [pure_apply, h, if_false]
+lemma pure_apply_of_ne (h : a' ≠ a) : pure a a' = 0 := if_neg h
 
 instance [inhabited α] : inhabited (pmf α) := ⟨pure default⟩
 
@@ -93,7 +93,7 @@ by ext b; simp [this]
 pmf.ext (λ x, (bind_apply _ _ _).trans (trans (tsum_eq_single x $
   (λ y hy, by rw [pure_apply_of_ne _ _ hy.symm, mul_zero])) $ by rw [pure_apply_self, mul_one]))
 
-lemma bind_const (p : pmf α) (q : pmf β) : (p.bind $ λ _, q) = q :=
+@[simp] lemma bind_const (p : pmf α) (q : pmf β) : p.bind (λ _, q) = q :=
 pmf.ext (λ x, by rw [bind_apply, ennreal.tsum_mul_right, tsum_coe, one_mul])
 
 @[simp] lemma bind_bind : (p.bind f).bind g = p.bind (λ a, (f a).bind g) :=

--- a/src/probability/probability_mass_function/monad.lean
+++ b/src/probability/probability_mass_function/monad.lean
@@ -93,7 +93,7 @@ by ext b; simp [this]
 pmf.ext (λ x, (bind_apply _ _ _).trans (trans (tsum_eq_single x $
   (λ y hy, by rw [pure_apply_of_ne _ _ hy.symm, mul_zero])) $ by rw [pure_apply_self, mul_one]))
 
-lemma bind_const {α β : Type*} (p : pmf α) (q : pmf β) : (p.bind $ λ _, q) = q :=
+lemma bind_const (p : pmf α) (q : pmf β) : (p.bind $ λ _, q) = q :=
 pmf.ext (λ x, by rw [bind_apply, ennreal.tsum_mul_right, tsum_coe, one_mul])
 
 @[simp] lemma bind_bind : (p.bind f).bind g = p.bind (λ a, (f a).bind g) :=

--- a/src/probability/probability_mass_function/monad.lean
+++ b/src/probability/probability_mass_function/monad.lean
@@ -90,11 +90,11 @@ have ∀ b a', ite (a' = a) 1 0 * f a' b = ite (a' = a) (f a b) 0, from
 by ext b; simp [this]
 
 @[simp] lemma bind_pure : p.bind pure = p :=
-pmf.ext (λ x, (pmf.bind_apply _ _ _).trans (trans (tsum_eq_single x $
+pmf.ext (λ x, (bind_apply _ _ _).trans (trans (tsum_eq_single x $
   (λ y hy, by rw [pure_apply_of_ne _ _ hy.symm, mul_zero])) $ by rw [pure_apply_self, mul_one]))
 
 lemma bind_const {α β : Type*} (p : pmf α) (q : pmf β) : (p.bind $ λ _, q) = q :=
-pmf.ext (λ x, by rw [pmf.bind_apply, ennreal.tsum_mul_right, pmf.tsum_coe, one_mul])
+pmf.ext (λ x, by rw [bind_apply, ennreal.tsum_mul_right, tsum_coe, one_mul])
 
 @[simp] lemma bind_bind : (p.bind f).bind g = p.bind (λ a, (f a).bind g) :=
 pmf.ext (λ b, by simpa only [ennreal.coe_eq_coe.symm, bind_apply, ennreal.tsum_mul_left.symm,

--- a/src/probability/probability_mass_function/monad.lean
+++ b/src/probability/probability_mass_function/monad.lean
@@ -38,6 +38,10 @@ variables (a a' : α)
 
 lemma mem_support_pure_iff: a' ∈ (pure a).support ↔ a' = a := by simp
 
+@[simp] lemma pure_apply_self : pure a a = 1 := by rw [pure_apply, eq_self_iff_true, if_true]
+
+lemma pure_apply_of_ne (h : a' ≠ a) : pure a a' = 0 := by simp only [pure_apply, h, if_false]
+
 instance [inhabited α] : inhabited (pmf α) := ⟨pure default⟩
 
 section measure
@@ -86,9 +90,11 @@ have ∀ b a', ite (a' = a) 1 0 * f a' b = ite (a' = a) (f a b) 0, from
 by ext b; simp [this]
 
 @[simp] lemma bind_pure : p.bind pure = p :=
-have ∀ a a', (p a * ite (a' = a) 1 0) = ite (a = a') (p a') 0, from
-  assume a a', begin split_ifs; try { subst a }; try { subst a' }; simp * at * end,
-by ext b; simp [this]
+pmf.ext (λ x, (pmf.bind_apply _ _ _).trans (trans (tsum_eq_single x $
+  (λ y hy, by rw [pure_apply_of_ne _ _ hy.symm, mul_zero])) $ by rw [pure_apply_self, mul_one]))
+
+lemma bind_const {α β : Type*} (p : pmf α) (q : pmf β) : (p.bind $ λ _, q) = q :=
+pmf.ext (λ x, by rw [pmf.bind_apply, ennreal.tsum_mul_right, pmf.tsum_coe, one_mul])
 
 @[simp] lemma bind_bind : (p.bind f).bind g = p.bind (λ a, (f a).bind g) :=
 pmf.ext (λ b, by simpa only [ennreal.coe_eq_coe.symm, bind_apply, ennreal.tsum_mul_left.symm,


### PR DESCRIPTION
This file adds basic lemmas for monadic operations on `pmf`, mirroring the lemmas for `is_lawful_monad`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
