### PR TITLE
[Merged by Bors] - feat(analysis/normed): `mul_opposite X` inherits the same norm as `X`.

### DIFF
--- a/src/analysis/normed/field/basic.lean
+++ b/src/analysis/normed/field/basic.lean
@@ -141,7 +141,7 @@ instance pi.norm_one_class {ι : Type*} {α : ι → Type*} [nonempty ι] [finty
 ⟨by simp [pi.norm_def, finset.sup_const finset.univ_nonempty]⟩
 
 instance mul_opposite.norm_one_class [seminormed_add_comm_group α] [has_one α] [norm_one_class α] :
-  norm_one_class (αᵐᵒᵖ) :=
+  norm_one_class αᵐᵒᵖ :=
 ⟨@norm_one α _ _ _⟩
 
 section non_unital_semi_normed_ring

--- a/src/analysis/normed/field/basic.lean
+++ b/src/analysis/normed/field/basic.lean
@@ -142,7 +142,7 @@ instance pi.norm_one_class {ι : Type*} {α : ι → Type*} [nonempty ι] [finty
 
 instance mul_opposite.norm_one_class [seminormed_add_comm_group α] [has_one α] [norm_one_class α] :
   norm_one_class (αᵐᵒᵖ) :=
-⟨by simp [←mul_opposite.norm_op]⟩
+⟨@norm_one α _ _ _⟩
 
 section non_unital_semi_normed_ring
 variables [non_unital_semi_normed_ring α]

--- a/src/analysis/normed/field/basic.lean
+++ b/src/analysis/normed/field/basic.lean
@@ -140,6 +140,10 @@ instance pi.norm_one_class {ι : Type*} {α : ι → Type*} [nonempty ι] [finty
   norm_one_class (Π i, α i) :=
 ⟨by simp [pi.norm_def, finset.sup_const finset.univ_nonempty]⟩
 
+instance mul_opposite.norm_one_class [seminormed_add_comm_group α] [has_one α] [norm_one_class α] :
+  norm_one_class (αᵐᵒᵖ) :=
+⟨by simp [←mul_opposite.norm_op]⟩
+
 section non_unital_semi_normed_ring
 variables [non_unital_semi_normed_ring α]
 
@@ -210,6 +214,11 @@ instance pi.non_unital_semi_normed_ring {π : ι → Type*} [fintype ι]
     ... ≤ finset.univ.sup (λ i, ‖x i‖₊) * finset.univ.sup (λ i, ‖y i‖₊) :
             finset.sup_mul_le_mul_sup_of_nonneg _ (λ i _, zero_le _) (λ i _, zero_le _),
   ..pi.seminormed_add_comm_group }
+
+instance mul_opposite.non_unital_semi_normed_ring : non_unital_semi_normed_ring αᵐᵒᵖ :=
+{ norm_mul := mul_opposite.rec $ λ x, mul_opposite.rec $ λ y,
+    (norm_mul_le y x).trans_eq (mul_comm _ _),
+  ..mul_opposite.seminormed_add_comm_group }
 
 end non_unital_semi_normed_ring
 
@@ -326,6 +335,10 @@ instance pi.semi_normed_ring {π : ι → Type*} [fintype ι]
 { ..pi.non_unital_semi_normed_ring,
   ..pi.seminormed_add_comm_group, }
 
+instance mul_opposite.semi_normed_ring : semi_normed_ring αᵐᵒᵖ :=
+{ ..mul_opposite.non_unital_semi_normed_ring,
+  ..mul_opposite.seminormed_add_comm_group }
+
 end semi_normed_ring
 
 section non_unital_normed_ring
@@ -348,6 +361,10 @@ instance pi.non_unital_normed_ring {π : ι → Type*} [fintype ι] [Π i, non_u
   non_unital_normed_ring (Π i, π i) :=
 { norm_mul := norm_mul_le,
   ..pi.normed_add_comm_group }
+
+instance mul_opposite.non_unital_normed_ring : non_unital_normed_ring αᵐᵒᵖ :=
+{ norm_mul := norm_mul_le,
+  ..mul_opposite.normed_add_comm_group }
 
 end non_unital_normed_ring
 
@@ -375,6 +392,10 @@ instance pi.normed_ring {π : ι → Type*} [fintype ι] [Π i, normed_ring (π 
   normed_ring (Π i, π i) :=
 { norm_mul := norm_mul_le,
   ..pi.normed_add_comm_group }
+
+instance mul_opposite.normed_ring : normed_ring αᵐᵒᵖ :=
+{ norm_mul := norm_mul_le,
+  ..mul_opposite.normed_add_comm_group }
 
 end normed_ring
 

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -1693,16 +1693,21 @@ end pi
 
 namespace mul_opposite
 
-instance [has_norm E] : has_norm Eᵐᵒᵖ :=
-{ norm := λ x, ‖x.unop‖ }
+/-- The (additive) norm on the multiplicative opposite is the same as the norm on the original type.
 
-lemma norm_op [has_norm E] (a : E) : ‖mul_opposite.op a‖ = ‖a‖ := rfl
-lemma norm_unop [has_norm E] (a : Eᵐᵒᵖ) : ‖mul_opposite.unop a‖ = ‖a‖ := rfl
+Note that we do not provide this more generally as `has_norm Eᵐᵒᵖ`, as this is not always a good
+choice of norm in the multiplicative `seminormed_group E` case.
 
+We could repeat this instance to provide a `[seminormed_group E] : seminormed_group Eᵃᵒᵖ` instance,
+but that case would likely never be used.
+-/
 instance [seminormed_add_group E] : seminormed_add_group Eᵐᵒᵖ :=
 { norm := λ x, ‖x.unop‖,
   dist_eq := λ _ _, dist_eq_norm _ _,
-  to_pseudo_metric_space := by apply_instance }
+  to_pseudo_metric_space := mul_opposite.pseudo_metric_space }
+
+lemma norm_op [seminormed_add_group E] (a : E) : ‖mul_opposite.op a‖ = ‖a‖ := rfl
+lemma norm_unop [seminormed_add_group E] (a : Eᵐᵒᵖ) : ‖mul_opposite.unop a‖ = ‖a‖ := rfl
 
 lemma nnnorm_op [seminormed_add_group E] (a : E) : ‖mul_opposite.op a‖₊ = ‖a‖₊ := rfl
 lemma nnnorm_unop [seminormed_add_group E] (a : Eᵐᵒᵖ) : ‖mul_opposite.unop a‖₊ = ‖a‖₊ := rfl
@@ -1711,9 +1716,7 @@ instance [normed_add_group E] : normed_add_group Eᵐᵒᵖ :=
 { .. mul_opposite.seminormed_add_group }
 
 instance [seminormed_add_comm_group E] : seminormed_add_comm_group Eᵐᵒᵖ :=
-{ norm := λ x, ‖x.unop‖,
-  dist_eq := λ _ _, dist_eq_norm _ _,
-  to_pseudo_metric_space := by apply_instance }
+{ dist_eq := λ _ _, dist_eq_norm _ _ }
 
 instance [normed_add_comm_group E] : normed_add_comm_group Eᵐᵒᵖ :=
 { .. mul_opposite.seminormed_add_comm_group }

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -1693,13 +1693,13 @@ end pi
 
 namespace mul_opposite
 
-instance [has_norm E] : has_norm (Eᵐᵒᵖ) :=
+instance [has_norm E] : has_norm Eᵐᵒᵖ :=
 { norm := λ x, ‖x.unop‖ }
 
 lemma norm_op [has_norm E] (a : E) : ‖mul_opposite.op a‖ = ‖a‖ := rfl
 lemma norm_unop [has_norm E] (a : Eᵐᵒᵖ) : ‖mul_opposite.unop a‖ = ‖a‖ := rfl
 
-instance [seminormed_add_group E] : seminormed_add_group (Eᵐᵒᵖ) :=
+instance [seminormed_add_group E] : seminormed_add_group Eᵐᵒᵖ :=
 { norm := λ x, ‖x.unop‖,
   dist_eq := λ _ _, dist_eq_norm _ _,
   to_pseudo_metric_space := by apply_instance }
@@ -1707,15 +1707,15 @@ instance [seminormed_add_group E] : seminormed_add_group (Eᵐᵒᵖ) :=
 lemma nnnorm_op [seminormed_add_group E] (a : E) : ‖mul_opposite.op a‖₊ = ‖a‖₊ := rfl
 lemma nnnorm_unop [seminormed_add_group E] (a : Eᵐᵒᵖ) : ‖mul_opposite.unop a‖₊ = ‖a‖₊ := rfl
 
-instance [normed_add_group E] : normed_add_group (Eᵐᵒᵖ) :=
+instance [normed_add_group E] : normed_add_group Eᵐᵒᵖ :=
 { .. mul_opposite.seminormed_add_group }
 
-instance [seminormed_add_comm_group E] : seminormed_add_comm_group (Eᵐᵒᵖ) :=
+instance [seminormed_add_comm_group E] : seminormed_add_comm_group Eᵐᵒᵖ :=
 { norm := λ x, ‖x.unop‖,
   dist_eq := λ _ _, dist_eq_norm _ _,
   to_pseudo_metric_space := by apply_instance }
 
-instance [normed_add_comm_group E] : normed_add_comm_group (Eᵐᵒᵖ) :=
+instance [normed_add_comm_group E] : normed_add_comm_group Eᵐᵒᵖ :=
 { .. mul_opposite.seminormed_add_comm_group }
 
 end mul_opposite

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -1689,6 +1689,37 @@ instance pi.normed_comm_group [Π i, normed_comm_group (π i)] : normed_comm_gro
 
 end pi
 
+/-! ### Multiplicative opposite -/
+
+namespace mul_opposite
+
+instance [has_norm E] : has_norm (Eᵐᵒᵖ) :=
+{ norm := λ x, ‖x.unop‖ }
+
+lemma norm_op [has_norm E] (a : E) : ‖mul_opposite.op a‖ = ‖a‖ := rfl
+lemma norm_unop [has_norm E] (a : Eᵐᵒᵖ) : ‖mul_opposite.unop a‖ = ‖a‖ := rfl
+
+instance [seminormed_add_group E] : seminormed_add_group (Eᵐᵒᵖ) :=
+{ norm := λ x, ‖x.unop‖,
+  dist_eq := λ _ _, dist_eq_norm _ _,
+  to_pseudo_metric_space := by apply_instance }
+
+lemma nnnorm_op [seminormed_add_group E] (a : E) : ‖mul_opposite.op a‖₊ = ‖a‖₊ := rfl
+lemma nnnorm_unop [seminormed_add_group E] (a : Eᵐᵒᵖ) : ‖mul_opposite.unop a‖₊ = ‖a‖₊ := rfl
+
+instance [normed_add_group E] : normed_add_group (Eᵐᵒᵖ) :=
+{ .. mul_opposite.seminormed_add_group }
+
+instance [seminormed_add_comm_group E] : seminormed_add_comm_group (Eᵐᵒᵖ) :=
+{ norm := λ x, ‖x.unop‖,
+  dist_eq := λ _ _, dist_eq_norm _ _,
+  to_pseudo_metric_space := by apply_instance }
+
+instance [normed_add_comm_group E] : normed_add_comm_group (Eᵐᵒᵖ) :=
+{ .. mul_opposite.seminormed_add_comm_group }
+
+end mul_opposite
+
 /-! ### Subgroups of normed groups -/
 
 namespace subgroup

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -249,9 +249,9 @@ instance pi.normed_space {E : ι → Type*} [fintype ι] [∀i, seminormed_add_c
     by simp only [(nnreal.coe_mul _ _).symm, nnreal.mul_finset_sup, nnnorm_smul] }
 
 instance mul_opposite.normed_space : normed_space α (Eᵐᵒᵖ) :=
-{ norm_smul_le := λ s x, norm_smul_le s x.unop,
+{ norm_smul_le := λ s x, (norm_smul s x.unop).le,
   ..mul_opposite.normed_add_comm_group,
-  ..mul_opposite.module }
+  ..mul_opposite.module _ }
 
 /-- A subspace of a normed space is also a normed space, with the restriction of the norm. -/
 instance submodule.normed_space {𝕜 R : Type*} [has_smul 𝕜 R] [normed_field 𝕜] [ring R]

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -248,6 +248,11 @@ instance pi.normed_space {E : ι → Type*} [fintype ι] [∀i, seminormed_add_c
       ‖a‖₊ * ↑(finset.sup finset.univ (λ (b : ι), ‖f b‖₊)),
     by simp only [(nnreal.coe_mul _ _).symm, nnreal.mul_finset_sup, nnnorm_smul] }
 
+instance mul_opposite.normed_space : normed_space α (Eᵐᵒᵖ) :=
+{ norm_smul_le := λ s x, norm_smul_le s x.unop,
+  ..mul_opposite.normed_add_comm_group,
+  ..mul_opposite.module }
+
 /-- A subspace of a normed space is also a normed space, with the restriction of the norm. -/
 instance submodule.normed_space {𝕜 R : Type*} [has_smul 𝕜 R] [normed_field 𝕜] [ring R]
   {E : Type*} [seminormed_add_comm_group E] [normed_space 𝕜 E] [module R E]
@@ -518,6 +523,10 @@ instance pi.normed_algebra {E : ι → Type*} [fintype ι]
   normed_algebra 𝕜 (Π i, E i) :=
 { .. pi.normed_space,
   .. pi.algebra _ E }
+
+instance mul_opposite.normed_algebra {E : Type*} [semi_normed_ring E] [normed_algebra 𝕜 E] :
+  normed_algebra 𝕜 (Eᵐᵒᵖ) :=
+{ ..mul_opposite.normed_space }
 
 end normed_algebra
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -248,7 +248,7 @@ instance pi.normed_space {E : ι → Type*} [fintype ι] [∀i, seminormed_add_c
       ‖a‖₊ * ↑(finset.sup finset.univ (λ (b : ι), ‖f b‖₊)),
     by simp only [(nnreal.coe_mul _ _).symm, nnreal.mul_finset_sup, nnnorm_smul] }
 
-instance mul_opposite.normed_space : normed_space α (Eᵐᵒᵖ) :=
+instance mul_opposite.normed_space : normed_space α Eᵐᵒᵖ :=
 { norm_smul_le := λ s x, (norm_smul s x.unop).le,
   ..mul_opposite.normed_add_comm_group,
   ..mul_opposite.module _ }
@@ -525,7 +525,7 @@ instance pi.normed_algebra {E : ι → Type*} [fintype ι]
   .. pi.algebra _ E }
 
 instance mul_opposite.normed_algebra {E : Type*} [semi_normed_ring E] [normed_algebra 𝕜 E] :
-  normed_algebra 𝕜 (Eᵐᵒᵖ) :=
+  normed_algebra 𝕜 Eᵐᵒᵖ :=
 { ..mul_opposite.normed_space }
 
 end normed_algebra

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import topology.algebra.constructions
 import topology.bases
 import topology.uniform_space.basic
 /-!
@@ -370,6 +371,12 @@ instance complete_space.prod [uniform_space β] [complete_space α] [complete_sp
     ⟨(x1, x2), by rw [nhds_prod_eq, filter.prod_def];
       from filter.le_lift.2 (λ s hs, filter.le_lift'.2 $ λ t ht,
         inter_mem (hx1 hs) (hx2 ht))⟩ }
+
+@[to_additive]
+instance complete_space.mul_opposite [complete_space α] : complete_space (αᵐᵒᵖ) :=
+{ complete := λ f hf, mul_opposite.op_surjective.exists.mpr $
+    let ⟨x, hx⟩ := complete_space.complete (hf.map mul_opposite.uniform_continuous_unop) in
+    ⟨x, (map_le_iff_le_comap.mp hx).trans_eq $ mul_opposite.comap_unop_nhds _⟩}
 
 /--If `univ` is complete, the space is a complete space -/
 lemma complete_space_of_is_complete_univ (h : is_complete (univ : set α)) : complete_space α :=

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
-import topology.algebra.constructions
 import topology.bases
 import topology.uniform_space.basic
 /-!
@@ -371,12 +370,6 @@ instance complete_space.prod [uniform_space β] [complete_space α] [complete_sp
     ⟨(x1, x2), by rw [nhds_prod_eq, filter.prod_def];
       from filter.le_lift.2 (λ s hs, filter.le_lift'.2 $ λ t ht,
         inter_mem (hx1 hs) (hx2 ht))⟩ }
-
-@[to_additive]
-instance complete_space.mul_opposite [complete_space α] : complete_space (αᵐᵒᵖ) :=
-{ complete := λ f hf, mul_opposite.op_surjective.exists.mpr $
-    let ⟨x, hx⟩ := complete_space.complete (hf.map mul_opposite.uniform_continuous_unop) in
-    ⟨x, (map_le_iff_le_comap.mp hx).trans_eq $ mul_opposite.comap_unop_nhds _⟩}
 
 /--If `univ` is complete, the space is a complete space -/
 lemma complete_space_of_is_complete_univ (h : is_complete (univ : set α)) : complete_space α :=


### PR DESCRIPTION
This adds a `normed_*` instance for `mul_opposite` everywhere that we also have one for `prod` and `pi`.

The intention is to only do this for the additive case. It's not clear to me whether it's sensible to put the same norm on _multiplicative_ normed groups.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

#18471 is PR'd independently.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
