### PR TITLE
[Merged by Bors] - feat(topology/uniform_space/cauchy): `mul_opposite X` is complete when `X` is

### DIFF
--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import topology.algebra.constructions
 import topology.bases
 import topology.uniform_space.basic
 /-!
@@ -370,6 +371,12 @@ instance complete_space.prod [uniform_space β] [complete_space α] [complete_sp
     ⟨(x1, x2), by rw [nhds_prod_eq, filter.prod_def];
       from filter.le_lift.2 (λ s hs, filter.le_lift'.2 $ λ t ht,
         inter_mem (hx1 hs) (hx2 ht))⟩ }
+
+@[to_additive]
+instance complete_space.mul_opposite [complete_space α] : complete_space (αᵐᵒᵖ) :=
+{ complete := λ f hf, mul_opposite.op_surjective.exists.mpr $
+    let ⟨x, hx⟩ := complete_space.complete (hf.map mul_opposite.uniform_continuous_unop) in
+    ⟨x, (map_le_iff_le_comap.mp hx).trans_eq $ mul_opposite.comap_unop_nhds _⟩}
 
 /--If `univ` is complete, the space is a complete space -/
 lemma complete_space_of_is_complete_univ (h : is_complete (univ : set α)) : complete_space α :=

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -373,7 +373,7 @@ instance complete_space.prod [uniform_space β] [complete_space α] [complete_sp
         inter_mem (hx1 hs) (hx2 ht))⟩ }
 
 @[to_additive]
-instance complete_space.mul_opposite [complete_space α] : complete_space (αᵐᵒᵖ) :=
+instance complete_space.mul_opposite [complete_space α] : complete_space αᵐᵒᵖ :=
 { complete := λ f hf, mul_opposite.op_surjective.exists.mpr $
     let ⟨x, hx⟩ := complete_space.complete (hf.map mul_opposite.uniform_continuous_unop) in
     ⟨x, (map_le_iff_le_comap.mp hx).trans_eq $ mul_opposite.comap_unop_nhds _⟩}


### PR DESCRIPTION
The new import is needed because the lemmas about the topology on `mul_opposite` aren't available yet, even though the instance itself is (via the uniformity instance).

Forward-ported as https://github.com/leanprover-community/mathlib4/pull/2404.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
