### PR TITLE
[Merged by Bors] - feat(algebra/triv_sq_zero_ext): lemmas about big operators

### DIFF
--- a/src/algebra/triv_sq_zero_ext.lean
+++ b/src/algebra/triv_sq_zero_ext.lean
@@ -550,19 +550,21 @@ lemma snd_multiset_prod {ι} [decidable_eq ι] [comm_semiring R] [add_comm_monoi
   (s.map f).prod.snd =
     (s.map (λ i, ((s.erase i).map (λ j, (f j).fst)).prod • (f i).snd)).sum :=
 begin
-  have : ∀ (l : list ι) (f : ι → tsze R M), (l.map f).enum = l.enum.map (prod.map id f),
-  { intros l f,
-    induction l with x xs ih,
-    { refl },
-    { rw [list.map_cons, list.enum_cons, list.enum_cons, list.map_cons,
-        ←list.map_fst_add_enum_eq_enum_from, ←list.map_fst_add_enum_eq_enum_from,
-        ih, list.map_map, list.map_map, prod.map_comp_map,
-        function.comp.left_id, function.comp.right_id, prod.map_mk, list.map_map, id], },
-    },
-  induction s,
+  rcases s with ⟨l⟩,
   dsimp,
-  simp only [multiset.coe_prod, multiset.coe_sum, snd_list_prod, list.map_enum],
+  simp_rw [multiset.coe_prod, multiset.coe_sum, snd_list_prod, list.enum_map,
+    op_smul_eq_smul, list.map_map, function.comp, prod.map_snd, prod.map_fst, smul_smul,
+    id.def, ←list.prod_append],
+  conv_rhs
+  { find (list.map _ _)
+    { congr,
+      { skip },
+      { rw ← list.enum_map_snd l } } },
+  simp_rw [list.map_map, function.comp],
+  congr' 2 with ⟨n, i⟩,
   congr' 1,
+  dsimp only,
+  sorry
 end
 
 lemma snd_prod {ι} [decidable_eq ι] [comm_semiring R] [add_comm_monoid M]

--- a/src/algebra/triv_sq_zero_ext.lean
+++ b/src/algebra/triv_sq_zero_ext.lean
@@ -507,7 +507,7 @@ instance [semiring R] [add_comm_monoid M]
   .. triv_sq_zero_ext.non_assoc_semiring }
 
 /-- The second element of a product $\prod_{i=0}^n (r_i + m_i)$ is a sum of terms of the form
-$r_0\cdots r_{i-1}m_ir_{i+1}\cdotsr_n$. -/
+$r_0\cdots r_{i-1}m_ir_{i+1}\cdots r_n$. -/
 lemma snd_list_prod [semiring R] [add_comm_monoid M]
   [module R M] [module Rᵐᵒᵖ M] [smul_comm_class R Rᵐᵒᵖ M]
   (l : list (tsze R M)) :
@@ -543,38 +543,6 @@ instance [comm_semiring R] [add_comm_monoid M]
   comm_semiring (tsze R M) :=
 { .. triv_sq_zero_ext.comm_monoid,
   .. triv_sq_zero_ext.non_assoc_semiring }
-
-lemma snd_multiset_prod {ι} [decidable_eq ι] [comm_semiring R] [add_comm_monoid M]
-  [module R M] [module Rᵐᵒᵖ M] [is_central_scalar R M]
-  (s : multiset ι) (f : ι → tsze R M) :
-  (s.map f).prod.snd =
-    (s.map (λ i, ((s.erase i).map (λ j, (f j).fst)).prod • (f i).snd)).sum :=
-begin
-  rcases s with ⟨l⟩,
-  dsimp,
-  simp_rw [multiset.coe_prod, multiset.coe_sum, snd_list_prod, list.enum_map,
-    op_smul_eq_smul, list.map_map, function.comp, prod.map_snd, prod.map_fst, smul_smul,
-    id.def, ←list.prod_append],
-  conv_rhs
-  { find (list.map _ _)
-    { congr,
-      { skip },
-      { rw ← list.enum_map_snd l } } },
-  simp_rw [list.map_map, function.comp],
-  congr' 2 with ⟨n, i⟩,
-  congr' 1,
-  dsimp only,
-  sorry
-end
-
-lemma snd_prod {ι} [decidable_eq ι] [comm_semiring R] [add_comm_monoid M]
-  [module R M] [module Rᵐᵒᵖ M] [is_central_scalar R M]
-  (s : finset ι) (f : ι → tsze R M) :
-  (∏ i in s, f i).snd =
-    ∑ i in s, (∏ j in s.erase i, (f j).fst) • (f i).snd :=
-begin
-  induction s,
-end
 
 instance [comm_ring R] [add_comm_group M]
   [module R M] [module Rᵐᵒᵖ M] [is_central_scalar R M] : comm_ring (tsze R M) :=

--- a/src/algebra/triv_sq_zero_ext.lean
+++ b/src/algebra/triv_sq_zero_ext.lean
@@ -494,11 +494,35 @@ instance [monoid R] [add_monoid M]
   end,
   .. triv_sq_zero_ext.mul_one_class }
 
+lemma fst_list_prod [monoid R] [add_monoid M]
+  [distrib_mul_action R M] [distrib_mul_action Rᵐᵒᵖ M] [smul_comm_class R Rᵐᵒᵖ M]
+  (l : list (tsze R M)) :
+  l.prod.fst = (l.map fst).prod :=
+map_list_prod (⟨fst, fst_one, fst_mul⟩ : tsze R M →* R) _
+
 instance [semiring R] [add_comm_monoid M]
   [module R M] [module Rᵐᵒᵖ M] [smul_comm_class R Rᵐᵒᵖ M] :
   semiring (tsze R M) :=
 { .. triv_sq_zero_ext.monoid,
   .. triv_sq_zero_ext.non_assoc_semiring }
+
+/-- The second element of a product $\prod_{i=0}^n (r_i + m_i)$ is a sum of terms of the form
+$r_0\cdots r_{i-1}m_ir_{i+1}\cdotsr_n$. -/
+lemma snd_list_prod_eq_sum [semiring R] [add_comm_monoid M]
+  [module R M] [module Rᵐᵒᵖ M] [smul_comm_class R Rᵐᵒᵖ M]
+  (l : list (tsze R M)) :
+  l.prod.snd =
+    (l.enum.map (λ x : ℕ × tsze R M,
+      ((l.map fst).take x.1).prod • op ((l.map fst).drop x.1.succ).prod • x.snd.snd)).sum :=
+begin
+  induction l with x xs ih,
+  { simp },
+  { rw [list.enum_cons, ←list.map_fst_add_enum_eq_enum_from],
+    simp_rw [list.map_cons, list.map_map, function.comp, prod.map_snd, prod.map_fst, id,
+      list.take_zero, list.take_cons, list.prod_nil, list.prod_cons, snd_mul, one_smul,
+      list.drop, mul_smul, list.sum_cons, fst_list_prod, ih, list.smul_sum, list.map_map],
+    exact add_comm _ _, }
+end
 
 instance [ring R] [add_comm_group M]
   [module R M] [module Rᵐᵒᵖ M] [smul_comm_class R Rᵐᵒᵖ M] :

--- a/src/algebra/triv_sq_zero_ext.lean
+++ b/src/algebra/triv_sq_zero_ext.lean
@@ -508,7 +508,7 @@ instance [semiring R] [add_comm_monoid M]
 
 /-- The second element of a product $\prod_{i=0}^n (r_i + m_i)$ is a sum of terms of the form
 $r_0\cdots r_{i-1}m_ir_{i+1}\cdotsr_n$. -/
-lemma snd_list_prod_eq_sum [semiring R] [add_comm_monoid M]
+lemma snd_list_prod [semiring R] [add_comm_monoid M]
   [module R M] [module Rᵐᵒᵖ M] [smul_comm_class R Rᵐᵒᵖ M]
   (l : list (tsze R M)) :
   l.prod.snd =
@@ -543,6 +543,36 @@ instance [comm_semiring R] [add_comm_monoid M]
   comm_semiring (tsze R M) :=
 { .. triv_sq_zero_ext.comm_monoid,
   .. triv_sq_zero_ext.non_assoc_semiring }
+
+lemma snd_multiset_prod {ι} [decidable_eq ι] [comm_semiring R] [add_comm_monoid M]
+  [module R M] [module Rᵐᵒᵖ M] [is_central_scalar R M]
+  (s : multiset ι) (f : ι → tsze R M) :
+  (s.map f).prod.snd =
+    (s.map (λ i, ((s.erase i).map (λ j, (f j).fst)).prod • (f i).snd)).sum :=
+begin
+  have : ∀ (l : list ι) (f : ι → tsze R M), (l.map f).enum = l.enum.map (prod.map id f),
+  { intros l f,
+    induction l with x xs ih,
+    { refl },
+    { rw [list.map_cons, list.enum_cons, list.enum_cons, list.map_cons,
+        ←list.map_fst_add_enum_eq_enum_from, ←list.map_fst_add_enum_eq_enum_from,
+        ih, list.map_map, list.map_map, prod.map_comp_map,
+        function.comp.left_id, function.comp.right_id, prod.map_mk, list.map_map, id], },
+    },
+  induction s,
+  dsimp,
+  simp only [multiset.coe_prod, multiset.coe_sum, snd_list_prod, list.map_enum],
+  congr' 1,
+end
+
+lemma snd_prod {ι} [decidable_eq ι] [comm_semiring R] [add_comm_monoid M]
+  [module R M] [module Rᵐᵒᵖ M] [is_central_scalar R M]
+  (s : finset ι) (f : ι → tsze R M) :
+  (∏ i in s, f i).snd =
+    ∑ i in s, (∏ j in s.erase i, (f j).fst) • (f i).snd :=
+begin
+  induction s,
+end
 
 instance [comm_ring R] [add_comm_group M]
   [module R M] [module Rᵐᵒᵖ M] [is_central_scalar R M] : comm_ring (tsze R M) :=


### PR DESCRIPTION
Some more results following on from #18384.

For now this just has the list lemmas. The multiset and finset lemmas are hard to state cleanly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

My attempt at stating the omitted `multiset` and `finset` versions can be found in the git history of this PR as
```lean
lemma snd_multiset_prod {ι} [decidable_eq ι] [comm_semiring R] [add_comm_monoid M]
  [module R M] [module Rᵐᵒᵖ M] [is_central_scalar R M]
  (s : multiset ι) (f : ι → tsze R M) :
  (s.map f).prod.snd =
    (s.map (λ i, ((s.erase i).map (λ j, (f j).fst)).prod • (f i).snd)).sum :=

lemma snd_prod {ι} [decidable_eq ι] [comm_semiring R] [add_comm_monoid M]
  [module R M] [module Rᵐᵒᵖ M] [is_central_scalar R M]
  (s : finset ι) (f : ι → tsze R M) :
  (∏ i in s, f i).snd =
    ∑ i in s, (∏ j in s.erase i, (f j).fst) • (f i).snd :=
```
With some extra machinery it should be possible to avoid `[decidable_eq ι]`.