### PR TITLE
[Merged by Bors] - feat(data/int/units): If `z * w = 1`, then `z = w`

### DIFF
--- a/src/data/int/units.lean
+++ b/src/data/int/units.lean
@@ -57,6 +57,9 @@ begin
   tauto,
 end
 
+theorem eq_of_mul_eq_one {z w : ℤ} (h : z * w = 1) : z = w :=
+(eq_one_or_neg_one_of_mul_eq_one' h).elim (λ h, h.1.trans h.2.symm) (λ h, h.1.trans h.2.symm)
+
 lemma mul_eq_one_iff_eq_one_or_neg_one {z w : ℤ} :
   z * w = 1 ↔ z = 1 ∧ w = 1 ∨ z = -1 ∧ w = -1 :=
 begin


### PR DESCRIPTION
This PR adds a lemma stating that if `z * w = 1`, then `z = w`.

mathlib4 PR: https://github.com/leanprover-community/mathlib4/pull/2497

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
