### PR TITLE
[Merged by Bors] - refactor(number_theory/pell): Small golf using `int.eq_of_mul_eq_one`

### DIFF
--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -118,9 +118,8 @@ theorem exists_iff_not_is_square {d : ℤ} (h₀ : 0 < d) :
 begin
   refine ⟨_, exists_of_not_is_square h₀⟩,
   rintros ⟨x, y, hxy, hy⟩ ⟨a, rfl⟩,
-  rw [← sq, ← mul_pow, sq_sub_sq, int.mul_eq_one_iff_eq_one_or_neg_one] at hxy,
-  replace hxy := hxy.elim (λ h, h.1.trans h.2.symm) (λ h, h.1.trans h.2.symm),
-  simpa [mul_self_pos.mp h₀, sub_eq_add_neg, eq_neg_self_iff] using hxy,
+  rw [← sq, ← mul_pow, sq_sub_sq] at hxy,
+  simpa [mul_self_pos.mp h₀, sub_eq_add_neg, eq_neg_self_iff] using int.eq_of_mul_eq_one hxy,
 end
 
 end existence


### PR DESCRIPTION
This is a small golf using `int.eq_of_mul_eq_one`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
