### PR TITLE
[Merged by Bors] - feat(data/list/cycle): well-founded or transitive irreflexive relations don't have cycles

### DIFF
--- a/src/data/list/cycle.lean
+++ b/src/data/list/cycle.lean
@@ -810,6 +810,10 @@ begin
     exact p.imp H }
 end
 
+/-- As a function from a relation to a predicate, `chain` is monotonic. -/
+theorem chain_mono : monotone (chain : (α → α → Prop) → cycle α → Prop) :=
+λ a b hab s, chain.imp hab
+
 theorem chain_of_pairwise : (∀ (a ∈ s) (b ∈ s), r a b) → chain r s :=
 begin
   induction s using cycle.induction_on with a l _,

--- a/src/data/list/cycle.lean
+++ b/src/data/list/cycle.lean
@@ -850,7 +850,7 @@ theorem chain_iff_pairwise [is_trans α r] : chain r s ↔ ∀ (a ∈ s) (b ∈ 
   { exact trans (hs.2.2 b hb) (hs.1 c (or.inl hc)) }
 end, cycle.chain_of_pairwise⟩
 
-theorem not_chain_of_trans_of_irrefl [is_trans α r] [is_irrefl α r] (h : chain r s) : s = nil :=
+theorem chain.eq_nil_of_irrefl [is_trans α r] [is_irrefl α r] (h : chain r s) : s = nil :=
 begin
   induction s using cycle.induction_on with a l _ h,
   { refl },
@@ -858,8 +858,8 @@ begin
       (chain_iff_pairwise.1 h) a (mem_cons_self a _) a (mem_cons_self a _)).elim }
 end
 
-theorem not_chain_of_well_founded [i : is_well_founded α r] (h : chain r s) : s = nil :=
-not_chain_of_trans_of_irrefl $ h.imp $ λ _ _, relation.trans_gen.single
+theorem chain.eq_nil_of_well_founded [is_well_founded α r] (h : chain r s) : s = nil :=
+chain.eq_nil_of_irrefl $ h.imp $ λ _ _, relation.trans_gen.single
 
 theorem forall_eq_of_chain [is_trans α r] [is_antisymm α r]
   (hs : chain r s) {a b : α} (ha : a ∈ s) (hb : b ∈ s) : a = b :=

--- a/src/data/list/cycle.lean
+++ b/src/data/list/cycle.lean
@@ -854,7 +854,7 @@ theorem chain.eq_nil_of_irrefl [is_trans α r] [is_irrefl α r] (h : chain r s) 
 begin
   induction s using cycle.induction_on with a l _ h,
   { refl },
-  { have ha := mem_cons_self a _,
+  { have ha := mem_cons_self a l,
     exact (irrefl_of r a $ chain_iff_pairwise.1 h a ha a ha).elim }
 end
 

--- a/src/data/list/cycle.lean
+++ b/src/data/list/cycle.lean
@@ -854,8 +854,8 @@ theorem chain.eq_nil_of_irrefl [is_trans α r] [is_irrefl α r] (h : chain r s) 
 begin
   induction s using cycle.induction_on with a l _ h,
   { refl },
-  { exact (irrefl_of r a $
-      (chain_iff_pairwise.1 h) a (mem_cons_self a _) a (mem_cons_self a _)).elim }
+  { have ha := mem_cons_self a _,
+    exact (irrefl_of r a $ chain_iff_pairwise.1 h a ha a ha).elim }
 end
 
 theorem chain.eq_nil_of_well_founded [is_well_founded α r] (h : chain r s) : s = nil :=

--- a/src/data/list/cycle.lean
+++ b/src/data/list/cycle.lean
@@ -801,6 +801,15 @@ by rw [range_succ, ←coe_cons_eq_coe_append, chain_coe_cons, ←range_succ, cha
 
 variables {r : α → α → Prop} {s : cycle α}
 
+theorem chain.imp {r₁ r₂ : α → α → Prop} (H : ∀ a b, r₁ a b → r₂ a b) (p : chain r₁ s) :
+  chain r₂ s :=
+begin
+  induction s using cycle.induction_on,
+  { triv },
+  { rw chain_coe_cons at ⊢ p,
+    exact p.imp H }
+end
+
 theorem chain_of_pairwise : (∀ (a ∈ s) (b ∈ s), r a b) → chain r s :=
 begin
   induction s using cycle.induction_on with a l _,
@@ -840,6 +849,17 @@ theorem chain_iff_pairwise [is_trans α r] : chain r s ↔ ∀ (a ∈ s) (b ∈ 
   { exact hs.2.2 b hb },
   { exact trans (hs.2.2 b hb) (hs.1 c (or.inl hc)) }
 end, cycle.chain_of_pairwise⟩
+
+theorem not_chain_of_trans_of_irrefl [is_trans α r] [is_irrefl α r] (h : chain r s) : s = nil :=
+begin
+  induction s using cycle.induction_on with a l _ h,
+  { refl },
+  { exact (irrefl_of r a $
+      (chain_iff_pairwise.1 h) a (mem_cons_self a _) a (mem_cons_self a _)).elim }
+end
+
+theorem not_chain_of_well_founded [i : is_well_founded α r] (h : chain r s) : s = nil :=
+not_chain_of_trans_of_irrefl $ h.imp $ λ _ _, relation.trans_gen.single
 
 theorem forall_eq_of_chain [is_trans α r] [is_antisymm α r]
   (hs : chain r s) {a b : α} (ha : a ∈ s) (hb : b ∈ s) : a = b :=

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -3,8 +3,9 @@ Copyright (c) 2020 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro, Yury G. Kudryashov
 -/
-import order.basic
 import logic.is_empty
+import logic.relation
+import order.basic
 
 /-!
 # Unbundled relation classes
@@ -246,6 +247,9 @@ instance is_well_founded.is_asymm (r : α → α → Prop) [is_well_founded α r
 @[priority 100] -- see Note [lower instance priority]
 instance is_well_founded.is_irrefl (r : α → α → Prop) [is_well_founded α r] : is_irrefl α r :=
 is_asymm.is_irrefl
+
+instance (r : α → α → Prop) [i : is_well_founded α r] : is_well_founded α (relation.trans_gen r) :=
+⟨i.wf.trans_gen⟩
 
 /-- A class for a well founded relation `<`. -/
 @[reducible] def well_founded_lt (α : Type*) [has_lt α] : Prop := is_well_founded α (<)


### PR DESCRIPTION
Since `simp` can prove statements such as `cycle r [a, b, c] ↔ r a b ∧ r b c ∧ r c a`, this gives us a nice generalization of asymmetry.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
