### PR TITLE
feat(set_theory/game/pgame): define `pgame.identical` `pgame.memₗ` `pgame.memᵣ`

### DIFF
--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -263,7 +263,7 @@ begin
   { apply hr }
 end
 
-lemma exists_left_moves_mul {x y : pgame.{u}} {p : (x * y).left_moves → Prop} :
+lemma left_moves_mul.exists {x y : pgame.{u}} {p : (x * y).left_moves → Prop} :
   (∃ i, p i) ↔
     (∃ i j, p (to_left_moves_mul (sum.inl (i, j)))) ∨
     (∃ i j, p (to_left_moves_mul (sum.inr (i, j)))) :=
@@ -274,7 +274,7 @@ begin
   { rintros (⟨i, j, h⟩ | ⟨i, j, h⟩), exacts [⟨_, h⟩, ⟨_, h⟩], },
 end
 
-lemma exists_right_moves_mul {x y : pgame.{u}} {p : (x * y).right_moves → Prop} :
+lemma right_moves_mul.exists {x y : pgame.{u}} {p : (x * y).right_moves → Prop} :
   (∃ i, p i) ↔
     (∃ i j, p (to_right_moves_mul (sum.inl (i, j)))) ∨
     (∃ i j, p (to_right_moves_mul (sum.inr (i, j)))) :=
@@ -289,13 +289,13 @@ lemma memₗ_mul_iff : Π {x y₁ y₂ : pgame},
   x ∈ₗ y₁ * y₂ ↔
     (∃ i j, x ≡ y₁.move_left i * y₂ + y₁ * y₂.move_left j - y₁.move_left i * y₂.move_left j) ∨
     (∃ i j, x ≡ y₁.move_right i * y₂ + y₁ * y₂.move_right j - y₁.move_right i * y₂.move_right j)
-| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := exists_left_moves_mul
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := left_moves_mul.exists
 
 lemma memᵣ_mul_iff : Π {x y₁ y₂ : pgame},
   x ∈ᵣ y₁ * y₂ ↔
     (∃ i j, x ≡ y₁.move_left i * y₂ + y₁ * y₂.move_right j - y₁.move_left i * y₂.move_right j) ∨
     (∃ i j, x ≡ y₁.move_right i * y₂ + y₁ * y₂.move_left j - y₁.move_right i * y₂.move_left j)
-| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := exists_right_moves_mul
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := right_moves_mul.exists
 
 /-- `x * y` and `y * x` have the same moves. -/
 protected lemma mul_comm : Π (x y : pgame.{u}), x * y ≡ y * x

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -408,7 +408,7 @@ end
 using_well_founded { dec_tac := pgame_wf_tac }
 
 /-- `-x * y` and `-(x * y)` have the same moves. -/
-def neg_mul (x y : pgame.{u}) : -x * y ≡ -(x * y) :=
+lemma neg_mul (x y : pgame.{u}) : -x * y ≡ -(x * y) :=
 ((pgame.mul_comm _ _).trans (of_eq (mul_neg _ _))).trans (pgame.mul_comm _ _).neg
 
 @[simp] theorem quot_neg_mul (x y : pgame) : ⟦-x * y⟧ = -⟦x * y⟧ :=
@@ -662,7 +662,7 @@ theorem zero_lf_inv' : ∀ (x : pgame), 0 ⧏ inv' x
 | ⟨xl, xr, xL, xR⟩ := by { convert lf_mk _ _ inv_ty.zero, refl }
 
 /-- `inv' 0` has exactly the same moves as `1`. -/
-def inv'_zero' : inv' 0 ≡ 1 :=
+lemma inv'_zero' : inv' 0 ≡ 1 :=
 begin
   refine ⟨_, _⟩,
   { simp_rw [unique.forall_iff, unique.exists_iff, and_self, pgame.inv_val_is_empty], },
@@ -686,7 +686,7 @@ end
 theorem inv'_zero_equiv : inv' 0 ≈ 1 := inv'_zero.equiv
 
 /-- `inv' 1` has exactly the same moves as `1`. -/
-def inv'_one' : inv' 1 ≡ (1 : pgame.{u}) :=
+lemma inv'_one' : inv' 1 ≡ (1 : pgame.{u}) :=
 begin
   haveI inst : is_empty {i : punit.{u+1} // (0 : pgame.{u}) < 0},
   { rw lt_self_iff_false, apply_instance },
@@ -730,7 +730,7 @@ theorem inv_eq_of_lf_zero {x : pgame} (h : x ⧏ 0) : x⁻¹ = -inv' (-x) :=
 by { classical, exact (if_neg h.not_equiv).trans (if_neg h.not_gt) }
 
 /-- `1⁻¹` has exactly the same moves as `1`. -/
-def inv_one' : 1⁻¹ ≡ 1 :=
+lemma inv_one' : 1⁻¹ ≡ 1 :=
 by { rw inv_eq_of_pos pgame.zero_lt_one, exact inv'_one' }
 
 /-- `1⁻¹` has exactly the same moves as `1`. -/

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -498,10 +498,28 @@ def mul_one_relabelling : Π (x : pgame.{u}), x * 1 ≡r x
   try { rintro (⟨i, ⟨ ⟩⟩ | ⟨i, ⟨ ⟩⟩) }; try { intro i };
   dsimp;
   apply (relabelling.sub_congr (relabelling.refl _) (mul_zero_relabelling _)).trans;
-  rw sub_zero;
+  rw sub_zero_eq_add_zero;
   exact (add_zero_relabelling _).trans (((mul_one_relabelling _).add_congr
     (mul_zero_relabelling _)).trans $ add_zero_relabelling _)
 end
+
+/-- `1 * x` has the same moves as `x`. -/
+def one_mul : Π (x : pgame.{u}), 1 * x ≡ x
+| ⟨xl, xr, xL, xR⟩ := begin
+  refine identical.ext (λ z, _) (λ z, _),
+  { simp_rw [memₗ_mul_iff], dsimp, simp_rw [is_empty.exists_iff, or_false, exists_const],
+    simp_rw [(((((pgame.zero_mul _).add (one_mul _)).trans (pgame.zero_add _)).sub
+      (xL _).zero_mul).trans (pgame.sub_zero _)).congr_right],
+    refl, },
+  { simp_rw [memᵣ_mul_iff], dsimp, simp_rw [is_empty.exists_iff, or_false, exists_const],
+    simp_rw [(((((pgame.zero_mul _).add (one_mul _)).trans (pgame.zero_add _)).sub
+      (xR _).zero_mul).trans (pgame.sub_zero _)).congr_right],
+    refl, },
+end
+using_well_founded { dec_tac := pgame_wf_tac }
+
+/-- `x * 1` has the same moves as `x`. -/
+def mul_one (x : pgame.{u}) : x * 1 ≡ x := (x.mul_comm _).trans x.one_mul
 
 @[simp] theorem quot_mul_one (x : pgame) : ⟦x * 1⟧ = ⟦x⟧ := quot.sound $ mul_one_relabelling x
 

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -343,7 +343,7 @@ instance is_empty_zero_mul_right_moves (x : pgame.{u}) : is_empty (0 * x).right_
 by { cases x, apply sum.is_empty }
 
 /-- `x * 0` has exactly the same moves as `0`. -/
-protected def mul_zero (x : pgame) : x * 0 ≡ 0 := identical_zero _
+protected lemma mul_zero (x : pgame) : x * 0 ≡ 0 := identical_zero _
 
 /-- `x * 0` has exactly the same moves as `0`. -/
 def mul_zero_relabelling (x : pgame) : x * 0 ≡r 0 := relabelling.is_empty _
@@ -355,7 +355,7 @@ theorem mul_zero_equiv (x : pgame) : x * 0 ≈ 0 := (mul_zero_relabelling x).equ
 @quotient.sound _ _ (x * 0) _ x.mul_zero_equiv
 
 /-- `0 * x` has exactly the same moves as `0`. -/
-protected def zero_mul (x : pgame) : 0 * x ≡ 0 := identical_zero _
+protected lemma zero_mul (x : pgame) : 0 * x ≡ 0 := identical_zero _
 
 /-- `0 * x` has exactly the same moves as `0`. -/
 def zero_mul_relabelling (x : pgame) : 0 * x ≡r 0 := relabelling.is_empty _
@@ -491,20 +491,6 @@ by { change ⟦(y + -z) * x⟧ = ⟦y * x⟧ + -⟦z * x⟧, rw [quot_right_dist
 
 /-- `x * 1` has the same moves as `x`. -/
 def mul_one_relabelling : Π (x : pgame.{u}), x * 1 ≡r x
-| ⟨xl, xr, xL, xR⟩ := begin
-  unfold has_one.one,
-  refine ⟨(equiv.sum_empty _ _).trans (equiv.prod_punit _),
-    (equiv.empty_sum _ _).trans (equiv.prod_punit _), _, _⟩;
-  try { rintro (⟨i, ⟨ ⟩⟩ | ⟨i, ⟨ ⟩⟩) }; try { intro i };
-  dsimp;
-  apply (relabelling.sub_congr (relabelling.refl _) (mul_zero_relabelling _)).trans;
-  rw sub_zero;
-  exact (add_zero_relabelling _).trans (((mul_one_relabelling _).add_congr
-    (mul_zero_relabelling _)).trans $ add_zero_relabelling _)
-end
-
-/-- `x * 1` has the same moves as `x`. -/
-def mul_one : Π (x : pgame.{u}), x * 1 ≡ x
 | ⟨xl, xr, xL, xR⟩ := begin
   unfold has_one.one,
   refine ⟨(equiv.sum_empty _ _).trans (equiv.prod_punit _),

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Scott Morrison, Apurva Nakade
+Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Scott Morrison, Apurva Nakade, Yuyang Zhao
 -/
 import set_theory.game.pgame
 import tactic.abel
@@ -662,10 +662,11 @@ theorem zero_lf_inv' : ∀ (x : pgame), 0 ⧏ inv' x
 | ⟨xl, xr, xL, xR⟩ := by { convert lf_mk _ _ inv_ty.zero, refl }
 
 /-- `inv' 0` has exactly the same moves as `1`. -/
-lemma inv'_zero' : inv' 0 ≡ 1 :=
+lemma inv'_zero' : inv' 0 ≡ (1 : pgame.{u}) :=
 begin
   refine ⟨_, _⟩,
-  { simp_rw [unique.forall_iff, unique.exists_iff, and_self, pgame.inv_val_is_empty], },
+  { simp_rw [unique.forall_iff, unique.exists_iff, and_self, pgame.inv_val_is_empty],
+    exact identical_zero _, },
   { simp_rw [is_empty.forall_iff, and_self], },
 end
 
@@ -685,15 +686,17 @@ end
 
 theorem inv'_zero_equiv : inv' 0 ≈ 1 := inv'_zero.equiv
 
+universe v
+
 /-- `inv' 1` has exactly the same moves as `1`. -/
-lemma inv'_one' : inv' 1 ≡ (1 : pgame.{u}) :=
+lemma inv'_one' : inv'.{u} 1 ≡ 1 :=
 begin
   haveI inst : is_empty {i : punit.{u+1} // (0 : pgame.{u}) < 0},
   { rw lt_self_iff_false, apply_instance },
   refine ⟨_, _⟩,
-  { simp_rw [unique.forall_iff, unique.exists_iff, pgame.inv_val_is_empty, and_self], },
-  { simp_rw [is_empty.forall_iff, and_true, is_empty.exists_iff],
-    exact (@inv_ty.is_empty _ _ inst _).elim, },
+  { simp_rw [unique.forall_iff, unique.exists_iff, pgame.inv_val_is_empty, and_self],
+    exact identical_zero _, },
+  { simp_rw [is_empty.forall_iff, and_true], },
 end
 
 /-- `inv' 1` has exactly the same moves as `1`. -/

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -146,7 +146,7 @@ but to prove their properties we need to use the abelian group structure of game
 Hence we define them here. -/
 
 /-- The product of `x = {xL | xR}` and `y = {yL | yR}` is
-`{xL*y + x*yL - xL*yL, xR*y + x*yR - xR*yR | xL*y + x*yR - xL*yR, xR*y + x*yL - xR*yL }`. -/
+`{xL*y + x*yL - xL*yL, xR*y + x*yR - xR*yR | xL*y + x*yR - xL*yR, xR*y + x*yL - xR*yL}`. -/
 instance : has_mul pgame.{u} :=
 ⟨λ x y, begin
   induction x with xl xr xL xR IHxl IHxr generalizing y,
@@ -662,6 +662,14 @@ theorem zero_lf_inv' : ∀ (x : pgame), 0 ⧏ inv' x
 | ⟨xl, xr, xL, xR⟩ := by { convert lf_mk _ _ inv_ty.zero, refl }
 
 /-- `inv' 0` has exactly the same moves as `1`. -/
+def inv'_zero' : inv' 0 ≡ 1 :=
+begin
+  refine ⟨_, _⟩,
+  { simp_rw [unique.forall_iff, unique.exists_iff, and_self, pgame.inv_val_is_empty], },
+  { simp_rw [is_empty.forall_iff, and_self], },
+end
+
+/-- `inv' 0` has exactly the same moves as `1`. -/
 def inv'_zero : inv' 0 ≡r 1 :=
 begin
   change mk _ _ _ _ ≡r 1,
@@ -676,6 +684,17 @@ begin
 end
 
 theorem inv'_zero_equiv : inv' 0 ≈ 1 := inv'_zero.equiv
+
+/-- `inv' 1` has exactly the same moves as `1`. -/
+def inv'_one' : inv' 1 ≡ (1 : pgame.{u}) :=
+begin
+  haveI inst : is_empty {i : punit.{u+1} // (0 : pgame.{u}) < 0},
+  { rw lt_self_iff_false, apply_instance },
+  refine ⟨_, _⟩,
+  { simp_rw [unique.forall_iff, unique.exists_iff, pgame.inv_val_is_empty, and_self], },
+  { simp_rw [is_empty.forall_iff, and_true, is_empty.exists_iff],
+    exact (@inv_ty.is_empty _ _ inst _).elim, },
+end
 
 /-- `inv' 1` has exactly the same moves as `1`. -/
 def inv'_one : inv' 1 ≡r (1 : pgame.{u}) :=
@@ -709,6 +728,10 @@ by { classical, exact (if_neg h.lf.not_equiv').trans (if_pos h) }
 
 theorem inv_eq_of_lf_zero {x : pgame} (h : x ⧏ 0) : x⁻¹ = -inv' (-x) :=
 by { classical, exact (if_neg h.not_equiv).trans (if_neg h.not_gt) }
+
+/-- `1⁻¹` has exactly the same moves as `1`. -/
+def inv_one' : 1⁻¹ ≡ 1 :=
+by { rw inv_eq_of_pos pgame.zero_lt_one, exact inv'_one' }
 
 /-- `1⁻¹` has exactly the same moves as `1`. -/
 def inv_one : 1⁻¹ ≡r 1 :=

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -504,7 +504,7 @@ def mul_one_relabelling : Π (x : pgame.{u}), x * 1 ≡r x
 end
 
 /-- `1 * x` has the same moves as `x`. -/
-def one_mul : Π (x : pgame.{u}), 1 * x ≡ x
+lemma one_mul : Π (x : pgame.{u}), 1 * x ≡ x
 | ⟨xl, xr, xL, xR⟩ := begin
   refine identical.ext (λ z, _) (λ z, _),
   { simp_rw [memₗ_mul_iff], dsimp, simp_rw [is_empty.exists_iff, or_false, exists_const],
@@ -519,7 +519,7 @@ end
 using_well_founded { dec_tac := pgame_wf_tac }
 
 /-- `x * 1` has the same moves as `x`. -/
-def mul_one (x : pgame.{u}) : x * 1 ≡ x := (x.mul_comm _).trans x.one_mul
+lemma mul_one (x : pgame.{u}) : x * 1 ≡ x := (x.mul_comm _).trans x.one_mul
 
 @[simp] theorem quot_mul_one (x : pgame) : ⟦x * 1⟧ = ⟦x⟧ := quot.sound $ mul_one_relabelling x
 

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -146,7 +146,7 @@ but to prove their properties we need to use the abelian group structure of game
 Hence we define them here. -/
 
 /-- The product of `x = {xL | xR}` and `y = {yL | yR}` is
-`{xL*y + x*yL - xL*yL, xR*y + x*yR - xR*yR | xL*y + x*yR - xL*yR, x*yL + xR*y - xR*yL }`. -/
+`{xL*y + x*yL - xL*yL, xR*y + x*yR - xR*yR | xL*y + x*yR - xL*yR, xR*y + x*yL - xR*yL }`. -/
 instance : has_mul pgame.{u} :=
 ⟨λ x y, begin
   induction x with xl xr xL xR IHxl IHxr generalizing y,
@@ -282,6 +282,23 @@ lemma memᵣ_mul_iff : Π {x y₁ y₂ : pgame},
   { rintros ⟨(⟨i, j⟩ | ⟨i, j⟩), hi⟩, exacts [or.inl ⟨_, _, hi⟩, or.inr ⟨_, _, hi⟩], },
   { rintros (⟨i, j, h⟩ | ⟨i, j, h⟩), exacts [⟨sum.inl (i, j), h⟩, ⟨sum.inr (i, j), h⟩], },
 end
+
+/-- `x * y` and `y * x` have the same moves. -/
+protected def mul_comm : Π (x y : pgame.{u}), x * y ≡ y * x
+| ⟨xl, xr, xL, xR⟩ ⟨yl, yr, yL, yR⟩ := begin
+  refine identical.ext (λ z, _) (λ z, _),
+  { simp_rw [memₗ_mul_iff], dsimp, rw [@exists_comm xl, @exists_comm xr],
+    simp_rw [((((mul_comm _ _).add (mul_comm _ _)).trans ((_ * xL _).add_comm _)).sub
+        (mul_comm _ _)).congr_right,
+      ((((mul_comm _ _).add (mul_comm _ _)).trans ((_ * xR _).add_comm _)).sub
+        (mul_comm _ _)).congr_right], },
+  { simp_rw [memᵣ_mul_iff], dsimp, rw [@exists_comm xl, @exists_comm xr, or.comm],
+    simp_rw [((((mul_comm _ _).add (mul_comm _ _)).trans ((_ * xL _).add_comm _)).sub
+        (mul_comm _ _)).congr_right,
+      ((((mul_comm _ _).add (mul_comm _ _)).trans ((_ * xR _).add_comm _)).sub
+        (mul_comm _ _)).congr_right], },
+end
+using_well_founded { dec_tac := pgame_wf_tac }
 
 /-- `x * y` and `y * x` have the same moves. -/
 def mul_comm_relabelling : Π (x y : pgame.{u}), x * y ≡r y * x

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -263,6 +263,26 @@ begin
   { apply hr }
 end
 
+lemma memₗ_mul_iff : Π {x y₁ y₂ : pgame},
+  x ∈ₗ y₁ * y₂ ↔
+    (∃ i j, x ≡ y₁.move_left i * y₂ + y₁ * y₂.move_left j - y₁.move_left i * y₂.move_left j) ∨
+    (∃ i j, x ≡ y₁.move_right i * y₂ + y₁ * y₂.move_right j - y₁.move_right i * y₂.move_right j)
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
+  constructor,
+  { rintros ⟨(⟨i, j⟩ | ⟨i, j⟩), hi⟩, exacts [or.inl ⟨_, _, hi⟩, or.inr ⟨_, _, hi⟩], },
+  { rintros (⟨i, j, h⟩ | ⟨i, j, h⟩), exacts [⟨sum.inl (i, j), h⟩, ⟨sum.inr (i, j), h⟩], },
+end
+
+lemma memᵣ_mul_iff : Π {x y₁ y₂ : pgame},
+  x ∈ᵣ y₁ * y₂ ↔
+    (∃ i j, x ≡ y₁.move_left i * y₂ + y₁ * y₂.move_right j - y₁.move_left i * y₂.move_right j) ∨
+    (∃ i j, x ≡ y₁.move_right i * y₂ + y₁ * y₂.move_left j - y₁.move_right i * y₂.move_left j)
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
+  constructor,
+  { rintros ⟨(⟨i, j⟩ | ⟨i, j⟩), hi⟩, exacts [or.inl ⟨_, _, hi⟩, or.inr ⟨_, _, hi⟩], },
+  { rintros (⟨i, j, h⟩ | ⟨i, j, h⟩), exacts [⟨sum.inl (i, j), h⟩, ⟨sum.inr (i, j), h⟩], },
+end
+
 /-- `x * y` and `y * x` have the same moves. -/
 def mul_comm_relabelling : Π (x y : pgame.{u}), x * y ≡r y * x
 | ⟨xl, xr, xL, xR⟩ ⟨yl, yr, yL, yR⟩ := begin

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -765,7 +765,7 @@ pgame.rec_on x $ λ xl xr xL xR IHL IHR y, pgame.cases_on y $ λ yl yr yL yR ⟨
 @[symm] protected theorem identical.symm {x y} : x ≡ y → y ≡ x :=
 (identical.refl y).euc
 
-protected theorem identical_comm {x y} : x ≡ y ↔ y ≡ x :=
+theorem identical_comm {x y} : x ≡ y ↔ y ≡ x :=
 ⟨identical.symm, identical.symm⟩
 
 @[trans] protected theorem identical.trans {x y z} (h₁ : x ≡ y) (h₂ : y ≡ z) : x ≡ z :=
@@ -799,7 +799,7 @@ theorem identical_iff : Π {x y : pgame}, x ≡ y ↔
     ((∀ i, (x.move_right i) ∈ᵣ y) ∧ (∀ j, (y.move_right j) ∈ᵣ x))
 | (mk _ _ _ _) (mk _ _ _ _) := begin
   convert identical_iff';
-  exact pi_congr (λ i, propext (exists_congr $ λ j, by rw [identical.comm])),
+  exact pi_congr (λ i, propext (exists_congr $ λ j, by rw [identical_comm])),
 end
 
 theorem memₗ.congr_right : Π {x y : pgame.{u}},

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1472,7 +1472,7 @@ lemma sub_zero (x : pgame) : x - 0 ≡ x :=
 trans (of_eq x.sub_zero_eq_add_zero) x.add_zero
 
 /-- Use the same name convention as global lemmas. -/
-lemma neg_sub' (x y : pgame.{u}) : -(x - y) = -x - -y := pgame.neg_add _ _
+protected lemma neg_sub' (x y : pgame.{u}) : -(x - y) = -x - -y := pgame.neg_add _ _
 
 /-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
 then `w - y` has the same moves as `x - z`. -/

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -687,7 +687,7 @@ end
 
 end pgame
 
--- This can also used to golf `pSet.equiv` lemmas, but I'm not sure where to put it.
+-- This can also be used to golf `pSet.equiv` lemmas, but I'm not sure where to put it.
 /-- An auxiliary definition for `pgame.identical`.
 
 `forall_exists_rel r s t` says that for every `s i` there is some `t j` such that `r (s i) (t j)`,

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1062,11 +1062,11 @@ lemma move_right_neg_symm' {x : pgame} (i) :
 by simp
 
 lemma memₗ_neg_iff : Π {x y : pgame},
-  x ∈ₗ -y ↔ (∃ i, x ≡ -(y.move_right i))
+  x ∈ₗ -y ↔ ∃ i, x ≡ -y.move_right i
 | (mk xl xr xL xR) (mk yl yr yL yR) := iff.rfl
 
 lemma memᵣ_neg_iff : Π {x y : pgame},
-  x ∈ᵣ -y ↔ (∃ i, x ≡ -(y.move_left i))
+  x ∈ᵣ -y ↔ ∃ i, x ≡ -y.move_left i
 | (mk xl xr xL xR) (mk yl yr yL yR) := iff.rfl
 
 /-- If `x` has the same moves as `y`, then `-x` has the sames moves as `-y`. -/
@@ -1077,12 +1077,12 @@ lemma identical.neg : Π {x₁ x₂ : pgame.{u}} (hx : x₁ ≡ x₂), -x₁ ≡
 using_well_founded { dec_tac := pgame_wf_tac }
 
 lemma memₗ_neg_iff' : Π {x y : pgame},
-  x ∈ₗ -y ↔ (∃ z ∈ᵣ y, x ≡ -z)
+  x ∈ₗ -y ↔ ∃ z ∈ᵣ y, x ≡ -z
 | (mk xl xr xL xR) (mk yl yr yL yR) := memₗ_neg_iff.trans
   ⟨λ ⟨i, hi⟩, ⟨_, ⟨_, refl _⟩, hi⟩, λ ⟨_, ⟨i, hi⟩, h⟩, ⟨i, h.trans hi.neg⟩⟩
 
 lemma memᵣ_neg_iff' : Π {x y : pgame},
-  x ∈ᵣ -y ↔ (∃ z ∈ₗ y, x ≡ -z)
+  x ∈ᵣ -y ↔ ∃ z ∈ₗ y, x ≡ -z
 | (mk xl xr xL xR) (mk yl yr yL yR) := memᵣ_neg_iff.trans
   ⟨λ ⟨i, hi⟩, ⟨_, ⟨_, refl _⟩, hi⟩, λ ⟨_, ⟨i, hi⟩, h⟩, ⟨i, h.trans hi.neg⟩⟩
 
@@ -1468,7 +1468,7 @@ instance : has_sub pgame := ⟨λ x y, x + -y⟩
 @[simp] theorem sub_zero_eq_add_zero (x : pgame) : x - 0 = x + 0 :=
 show x + -0 = x + 0, by rw neg_zero
 
-lemma sub_zero (x : pgame) : x - 0 ≡ x :=
+protected lemma sub_zero (x : pgame) : x - 0 ≡ x :=
 trans (of_eq x.sub_zero_eq_add_zero) x.add_zero
 
 /-- Use the same name convention as global lemmas. -/

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1314,7 +1314,7 @@ instance is_empty_nat_right_moves : ∀ n : ℕ, is_empty (right_moves n)
   apply_instance
 end
 
-lemma exists_left_moves_add {x y : pgame.{u}} {p : (x + y).left_moves → Prop} :
+lemma left_moves_add.exists {x y : pgame.{u}} {p : (x + y).left_moves → Prop} :
   (∃ i, p i) ↔
     (∃ i, p (to_left_moves_add (sum.inl i))) ∨ (∃ i, p (to_left_moves_add (sum.inr i))) :=
 begin
@@ -1324,7 +1324,7 @@ begin
   { rintros (⟨i, hi⟩ | ⟨i, hi⟩), exacts [⟨_, hi⟩, ⟨_, hi⟩], }
 end
 
-lemma exists_right_moves_add {x y : pgame.{u}} {p : (x + y).right_moves → Prop} :
+lemma right_moves_add.exists {x y : pgame.{u}} {p : (x + y).right_moves → Prop} :
   (∃ i, p i) ↔
     (∃ i, p (to_right_moves_add (sum.inl i))) ∨ (∃ i, p (to_right_moves_add (sum.inr i))) :=
 begin
@@ -1336,11 +1336,11 @@ end
 
 lemma memₗ_add_iff : Π {x y₁ y₂ : pgame},
   x ∈ₗ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_left i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_left i))
-| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := exists_left_moves_add
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := left_moves_add.exists
 
 lemma memᵣ_add_iff : Π {x y₁ y₂ : pgame},
   x ∈ᵣ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_right i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_right i))
-| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := exists_right_moves_add
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := right_moves_add.exists
 
 /-- `x + y` has exactly the same moves as `y + x`. -/
 protected lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
@@ -1357,9 +1357,9 @@ using_well_founded { dec_tac := pgame_wf_tac }
 protected lemma add_assoc : Π (x y z : pgame.{u}), x + y + z ≡ x + (y + z)
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) := begin
   refine identical.ext (λ z, _) (λ z, _),
-  { simp_rw [memₗ_add_iff, exists_left_moves_add, or.assoc,
+  { simp_rw [memₗ_add_iff, left_moves_add.exists, or.assoc,
       add_move_left_inl, add_move_left_inr, (add_assoc _ _ _).congr_right], },
-  { simp_rw [memᵣ_add_iff, exists_right_moves_add, or.assoc,
+  { simp_rw [memᵣ_add_iff, right_moves_add.exists, or.assoc,
       add_move_right_inl, add_move_right_inr, (add_assoc _ _ _).congr_right], },
 end
 using_well_founded { dec_tac := pgame_wf_tac }

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -21,7 +21,8 @@ types (thought of as indexing the possible moves for the players Left and Right)
 functions out of these types to `pgame` (thought of as describing the resulting game after making a
 move).
 
-Combinatorial games themselves, as a quotient of pregames, are constructed in `basic.lean`.
+Combinatorial games themselves, as a quotient of pregames, are constructed in
+`set_theory.game.basic`.
 
 ## Conway induction
 

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -765,7 +765,7 @@ pgame.rec_on x $ λ xl xr xL xR IHL IHR y, pgame.cases_on y $ λ yl yr yL yR ⟨
 @[symm] protected theorem identical.symm {x y} : x ≡ y → y ≡ x :=
 (identical.refl y).euc
 
-protected theorem identical.comm {x y} : x ≡ y ↔ y ≡ x :=
+protected theorem identical_comm {x y} : x ≡ y ↔ y ≡ x :=
 ⟨identical.symm, identical.symm⟩
 
 @[trans] protected theorem identical.trans {x y z} (h₁ : x ≡ y) (h₂ : y ≡ z) : x ≡ z :=

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -687,7 +687,10 @@ end
 end pgame
 
 -- This can also used for golf `Set.equiv` lemmas, but I'm not sure where to put it.
-/-- An auxiliary definition for `pgame.identical` -/
+/-- An auxiliary definition for `pgame.identical`.
+
+`forall_exists_rel r s t` says that for every `s i` there is some `t j` such that `r (s i) (t j)`,
+and for every `t j` there is some `s i` such that `r (s i) (t j)`. -/
 def forall_exists_rel {ι₁ ι₂ α₁ α₂ : Type*} (r : α₁ → α₂ → Prop) (s : ι₁ → α₁) (t : ι₂ → α₂) :=
   (∀ i, ∃ j, r (s i) (t j)) ∧ (∀ j, ∃ i, r (s i) (t j))
 

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -687,7 +687,7 @@ end
 
 end pgame
 
--- This can also used for golf `Set.equiv` lemmas, but I'm not sure where to put it.
+-- This can also used to golf `pSet.equiv` lemmas, but I'm not sure where to put it.
 /-- An auxiliary definition for `pgame.identical`.
 
 `forall_exists_rel r s t` says that for every `s i` there is some `t j` such that `r (s i) (t j)`,

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1298,7 +1298,7 @@ end
 
 lemma memₗ_add_iff : Π {x y₁ y₂ : pgame},
   x ∈ₗ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_left i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_left i))
-| (mk x₁l x₁r x₁L x₁R) (mk x₂l x₂r x₂L x₂R) (mk yl yr yL yR) := begin
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
   constructor,
   { rintros ⟨(i | i), hi⟩, exacts [or.inl ⟨_, hi⟩, or.inr ⟨_, hi⟩], },
   { rintros (⟨i, h⟩ | ⟨i, h⟩), exacts [⟨sum.inl i, h⟩, ⟨sum.inr i, h⟩], },
@@ -1306,7 +1306,7 @@ end
 
 lemma memᵣ_add_iff : Π {x y₁ y₂ : pgame},
   x ∈ᵣ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_right i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_right i))
-| (mk x₁l x₁r x₁L x₁R) (mk x₂l x₂r x₂L x₂R) (mk yl yr yL yR) := begin
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
   constructor,
   { rintros ⟨(i | i), hi⟩, exacts [or.inl ⟨_, hi⟩, or.inr ⟨_, hi⟩], },
   { rintros (⟨i, h⟩ | ⟨i, h⟩), exacts [⟨sum.inl i, h⟩, ⟨sum.inr i, h⟩], },

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -710,6 +710,11 @@ end forall_exists_rel
 namespace pgame
 open_locale pgame
 
+/-! ### Identity -/
+
+/-- Two pre-games are identical if their left and right sets are identical.
+That is, `identical x y` if every left move of `x` is identical to some left move of `y`,
+every right move of `x` is identical to some right move of `y`, and vice versa. -/
 def identical : Π (x y : pgame), Prop
 | (mk _ _ xL xR) (mk _ _ yL yR) :=
   ((∀ i, ∃ j, identical (xL i) (yL j)) ∧ (∀ j, ∃ i, identical (xL i) (yL j))) ∧
@@ -717,7 +722,10 @@ def identical : Π (x y : pgame), Prop
 
 localized "infix (name := pgame.identical) ` ≡ `:50 := pgame.identical" in pgame
 
+/-- `x ∈ₗ y` if `x` is identical to some left move of `y`. -/
 def memₗ (x y : pgame.{u}) : Prop := ∃ b, x ≡ (y.move_left b)
+
+/-- `x ∈ᵣ y` if `x` is identical to some right move of `y`. -/
 def memᵣ (x y : pgame.{u}) : Prop := ∃ b, x ≡ (y.move_right b)
 
 localized "infix (name := pgame.memₗ) ` ∈ₗ `:50 := pgame.memₗ" in pgame
@@ -1304,7 +1312,7 @@ lemma memᵣ_add_iff : Π {x y₁ y₂ : pgame},
   { rintros (⟨i, h⟩ | ⟨i, h⟩), exacts [⟨sum.inl i, h⟩, ⟨sum.inr i, h⟩], },
 end
 
-lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
+protected lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
 | (mk xl xr xL xR) (mk yl yr yL yR) := begin
   refine identical.ext (λ z, _) (λ z, _),
   { simp_rw [memₗ_add_iff], rw [or.comm], dsimp,
@@ -1334,7 +1342,7 @@ begin
   { rintros (⟨i, hi⟩ | ⟨i, hi⟩), exacts [⟨_, hi⟩, ⟨_, hi⟩], }
 end
 
-lemma add_assoc : Π (x y z : pgame.{u}), x + y + z ≡ x + (y + z)
+protected lemma add_assoc : Π (x y z : pgame.{u}), x + y + z ≡ x + (y + z)
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) := begin
   refine identical.ext (λ z, _) (λ z, _),
   { simp_rw [memₗ_add_iff, exists_left_moves_add, or.assoc,
@@ -1344,7 +1352,7 @@ lemma add_assoc : Π (x y z : pgame.{u}), x + y + z ≡ x + (y + z)
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-lemma add_zero : Π (x : pgame), x + 0 ≡ x
+protected lemma add_zero : Π (x : pgame), x + 0 ≡ x
 | (mk xl xr xL xR) := begin
   refine identical.ext (λ z, _) (λ z, _),
   { simp_rw [memₗ_add_iff, is_empty.exists_iff, or_false, (add_zero _).congr_right], refl },
@@ -1352,10 +1360,10 @@ lemma add_zero : Π (x : pgame), x + 0 ≡ x
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-lemma zero_add (x : pgame) : 0 + x ≡ x :=
-(add_comm _ _).trans (add_zero _)
+protected lemma zero_add (x : pgame) : 0 + x ≡ x :=
+(pgame.add_comm _ _).trans x.add_zero
 
-lemma neg_add_rev : Π (x y : pgame.{u}), -(x + y) ≡ -y + -x
+protected lemma neg_add_rev : Π (x y : pgame.{u}), -(x + y) ≡ -y + -x
 | (mk xl xr xL xR) (mk yl yr yL yR) := begin
   refine identical.ext (λ z, _) (λ z, _),
   { simp_rw [memₗ_add_iff, memₗ_neg_iff, exists_right_moves_add,
@@ -1365,8 +1373,8 @@ lemma neg_add_rev : Π (x y : pgame.{u}), -(x + y) ≡ -y + -x
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-lemma neg_add (x y : pgame.{u}) : -(x + y) ≡ -x + -y :=
-(neg_add_rev _ _).trans (add_comm _ _)
+protected lemma neg_add (x y : pgame.{u}) : -(x + y) ≡ -x + -y :=
+(x.neg_add_rev y).trans (pgame.add_comm _ _)
 
 lemma identical_zero_iff : Π (x : pgame.{u}),
   x ≡ 0 ↔ is_empty x.left_moves ∧ is_empty x.right_moves
@@ -1397,7 +1405,7 @@ end
 using_well_founded { dec_tac := pgame_wf_tac }
 
 lemma identical.add_left {x y₁ y₂} (hy : y₁ ≡ y₂) : x + y₁ ≡ x + y₂ :=
-(add_comm _ _).trans (hy.add_right.trans (add_comm _ _))
+(x.add_comm y₁).trans (hy.add_right.trans (y₂.add_comm x))
 
 lemma identical.add {x₁ x₂ y₁ y₂ : pgame.{u}} (hx : x₁ ≡ x₂) (hy : y₁ ≡ y₂) : x₁ + y₁ ≡ x₂ + y₂ :=
 hx.add_right.trans hy.add_left

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1315,9 +1315,9 @@ end
 protected lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
 | (mk xl xr xL xR) (mk yl yr yL yR) := begin
   refine identical.ext (λ z, _) (λ z, _),
-  { simp_rw [memₗ_add_iff], rw [or.comm], dsimp,
+  { simp_rw [memₗ_add_iff], dsimp, rw [or.comm],
     simp_rw [(add_comm (xL _) _).congr_right, (add_comm _ (yL _)).congr_right], },
-  { simp_rw [memᵣ_add_iff], rw [or.comm], dsimp,
+  { simp_rw [memᵣ_add_iff], dsimp, rw [or.comm],
     simp_rw [(add_comm (xR _) _).congr_right, (add_comm _ (yR _)).congr_right], },
 end
 using_well_founded { dec_tac := pgame_wf_tac }

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -772,6 +772,7 @@ theorem identical_of_is_empty (x y : pgame)
   [is_empty y.left_moves] [is_empty y.right_moves] : identical x y :=
 identical_iff'.2 $ by simp [forall_exists_rel]
 
+/-- `identical` as a `setoid`. -/
 def identical_setoid : setoid pgame :=
 ⟨identical, identical.refl, λ x y, identical.symm, λ x y z, identical.trans⟩
 

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Scott Morrison
+Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Scott Morrison, Yuyang Zhao
 -/
 import data.fin.basic
 import data.list.basic

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1296,32 +1296,6 @@ instance is_empty_nat_right_moves : ∀ n : ℕ, is_empty (right_moves n)
   apply_instance
 end
 
-lemma memₗ_add_iff : Π {x y₁ y₂ : pgame},
-  x ∈ₗ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_left i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_left i))
-| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
-  constructor,
-  { rintros ⟨(i | i), hi⟩, exacts [or.inl ⟨_, hi⟩, or.inr ⟨_, hi⟩], },
-  { rintros (⟨i, h⟩ | ⟨i, h⟩), exacts [⟨sum.inl i, h⟩, ⟨sum.inr i, h⟩], },
-end
-
-lemma memᵣ_add_iff : Π {x y₁ y₂ : pgame},
-  x ∈ᵣ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_right i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_right i))
-| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
-  constructor,
-  { rintros ⟨(i | i), hi⟩, exacts [or.inl ⟨_, hi⟩, or.inr ⟨_, hi⟩], },
-  { rintros (⟨i, h⟩ | ⟨i, h⟩), exacts [⟨sum.inl i, h⟩, ⟨sum.inr i, h⟩], },
-end
-
-protected lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
-| (mk xl xr xL xR) (mk yl yr yL yR) := begin
-  refine identical.ext (λ z, _) (λ z, _),
-  { simp_rw [memₗ_add_iff], dsimp, rw [or.comm],
-    simp_rw [(add_comm (xL _) _).congr_right, (add_comm _ (yL _)).congr_right], },
-  { simp_rw [memᵣ_add_iff], dsimp, rw [or.comm],
-    simp_rw [(add_comm (xR _) _).congr_right, (add_comm _ (yR _)).congr_right], },
-end
-using_well_founded { dec_tac := pgame_wf_tac }
-
 lemma exists_left_moves_add {x y : pgame.{u}} {p : (x + y).left_moves → Prop} :
   (∃ i, p i) ↔
     (∃ i, p (to_left_moves_add (sum.inl i))) ∨ (∃ i, p (to_left_moves_add (sum.inr i))) :=
@@ -1341,6 +1315,24 @@ begin
   { rintros ⟨(i | i), hi⟩, exacts [or.inl ⟨i, hi⟩, or.inr ⟨i, hi⟩], },
   { rintros (⟨i, hi⟩ | ⟨i, hi⟩), exacts [⟨_, hi⟩, ⟨_, hi⟩], }
 end
+
+lemma memₗ_add_iff : Π {x y₁ y₂ : pgame},
+  x ∈ₗ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_left i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_left i))
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := exists_left_moves_add
+
+lemma memᵣ_add_iff : Π {x y₁ y₂ : pgame},
+  x ∈ᵣ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_right i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_right i))
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := exists_right_moves_add
+
+protected lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
+| (mk xl xr xL xR) (mk yl yr yL yR) := begin
+  refine identical.ext (λ z, _) (λ z, _),
+  { simp_rw [memₗ_add_iff], dsimp, rw [or.comm],
+    simp_rw [(add_comm (xL _) _).congr_right, (add_comm _ (yL _)).congr_right], },
+  { simp_rw [memᵣ_add_iff], dsimp, rw [or.comm],
+    simp_rw [(add_comm (xR _) _).congr_right, (add_comm _ (yR _)).congr_right], },
+end
+using_well_founded { dec_tac := pgame_wf_tac }
 
 protected lemma add_assoc : Π (x y z : pgame.{u}), x + y + z ≡ x + (y + z)
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) := begin

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1460,8 +1460,11 @@ using_well_founded { dec_tac := pgame_wf_tac }
 
 instance : has_sub pgame := ⟨λ x y, x + -y⟩
 
-@[simp] theorem sub_zero (x : pgame) : x - 0 = x + 0 :=
+@[simp] theorem sub_zero_eq_add_zero (x : pgame) : x - 0 = x + 0 :=
 show x + -0 = x + 0, by rw neg_zero
+
+lemma sub_zero (x : pgame) : x - 0 ≡ x :=
+trans (of_eq x.sub_zero_eq_add_zero) x.add_zero
 
 /-- Use the same name convention as global lemmas. -/
 lemma neg_sub' (x y : pgame.{u}) : -(x - y) = -x - -y := pgame.neg_add _ _

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1386,6 +1386,10 @@ lemma identical_zero_iff : Π (x : pgame.{u}),
   { rintros ⟨h₁, h₂⟩, exactI identical_of_is_empty _ _, },
 end
 
+/-- Any game without left or right moves is identival to 0. -/
+def identical_zero (x : pgame) [is_empty x.left_moves] [is_empty x.right_moves] : x ≡ 0 :=
+x.identical_zero_iff.mpr ⟨by apply_instance, by apply_instance⟩
+
 lemma add_eq_zero_iff : Π (x y : pgame.{u}), x + y ≡ 0 ↔ x ≡ 0 ∧ y ≡ 0
 | (mk xl xr xL xR) (mk yl yr yL yR) :=
 by { simp_rw [identical_zero_iff, left_moves_add, right_moves_add, is_empty_sum], tauto, }
@@ -1443,6 +1447,9 @@ instance : has_sub pgame := ⟨λ x y, x + -y⟩
 
 @[simp] theorem sub_zero (x : pgame) : x - 0 = x + 0 :=
 show x + -0 = x + 0, by rw neg_zero
+
+lemma identical.sub {x₁ x₂ y₁ y₂ : pgame.{u}} (hx : x₁ ≡ x₂) (hy : y₁ ≡ y₂) : x₁ - y₁ ≡ x₂ - y₂ :=
+hx.add hy.neg
 
 /-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
 then `w - y` has the same moves as `x - z`. -/


### PR DESCRIPTION
This PR is the first step to remove `pgame.relabelling` (which is only for implementing things in lean and not real identity) and define games with identity as `eq`.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Well-founded.20recursion.20for.20pgames/near/338664567)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
