### PR TITLE
[Merged by Bors] - refactor(topology/uniform_space/basic): review API

### DIFF
--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -837,7 +837,7 @@ by simp [metric.mem_closure_iff, dist_eq_norm_div]
 @[to_additive norm_le_zero_iff'] lemma norm_le_zero_iff''' [t0_space E] {a : E} : ‖a‖ ≤ 0 ↔ a = 1 :=
 begin
   letI : normed_group E :=
-    { to_metric_space := metric.of_t0_pseudo_metric_space E, ..‹seminormed_group E› },
+    { to_metric_space := metric_space..of_t0_pseudo_metric_space E, ..‹seminormed_group E› },
   rw [←dist_one_right, dist_le_zero],
 end
 

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -837,7 +837,7 @@ by simp [metric.mem_closure_iff, dist_eq_norm_div]
 @[to_additive norm_le_zero_iff'] lemma norm_le_zero_iff''' [t0_space E] {a : E} : ‖a‖ ≤ 0 ↔ a = 1 :=
 begin
   letI : normed_group E :=
-    { to_metric_space := metric_space..of_t0_pseudo_metric_space E, ..‹seminormed_group E› },
+    { to_metric_space := metric_space.of_t0_pseudo_metric_space E, ..‹seminormed_group E› },
   rw [←dist_one_right, dist_le_zero],
 end
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -263,29 +263,36 @@ instance submodule.normed_space {𝕜 R : Type*} [has_smul 𝕜 R] [normed_field
 /-- If there is a scalar `c` with `‖c‖>1`, then any element with nonzero norm can be
 moved by scalar multiplication to any shell of width `‖c‖`. Also recap information on the norm of
 the rescaling element that shows up in applications. -/
-lemma rescale_to_shell_semi_normed {c : α} (hc : 1 < ‖c‖) {ε : ℝ} (εpos : 0 < ε) {x : E}
-  (hx : ‖x‖ ≠ 0) : ∃d:α, d ≠ 0 ∧ ‖d • x‖ < ε ∧ (ε/‖c‖ ≤ ‖d • x‖) ∧ (‖d‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
+lemma rescale_to_shell_semi_normed_zpow {c : α} (hc : 1 < ‖c‖) {ε : ℝ} (εpos : 0 < ε) {x : E}
+  (hx : ‖x‖ ≠ 0) :
+  ∃ n : ℤ, c ^ n ≠ 0 ∧ ‖c ^ n • x‖ < ε ∧ (ε / ‖c‖ ≤ ‖c ^ n • x‖) ∧ (‖c ^ n‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
 begin
   have xεpos : 0 < ‖x‖/ε := div_pos ((ne.symm hx).le_iff_lt.1 (norm_nonneg x)) εpos,
   rcases exists_mem_Ico_zpow xεpos hc with ⟨n, hn⟩,
   have cpos : 0 < ‖c‖ := lt_trans (zero_lt_one : (0 :ℝ) < 1) hc,
   have cnpos : 0 < ‖c^(n+1)‖ := by { rw norm_zpow, exact lt_trans xεpos hn.2 },
-  refine ⟨(c^(n+1))⁻¹, _, _, _, _⟩,
-  show (c ^ (n + 1))⁻¹  ≠ 0,
-    by rwa [ne.def, inv_eq_zero, ← ne.def, ← norm_pos_iff],
-  show ‖(c ^ (n + 1))⁻¹ • x‖ < ε,
-  { rw [norm_smul, norm_inv, ← div_eq_inv_mul, div_lt_iff cnpos, mul_comm, norm_zpow],
+  refine ⟨-(n+1), _, _, _, _⟩,
+  show c ^ (-(n + 1)) ≠ 0, from zpow_ne_zero _ (norm_pos_iff.1 cpos),
+  show ‖c ^ (-(n + 1)) • x‖ < ε,
+  { rw [norm_smul, zpow_neg, norm_inv, ← div_eq_inv_mul, div_lt_iff cnpos, mul_comm, norm_zpow],
     exact (div_lt_iff εpos).1 (hn.2) },
-  show ε / ‖c‖ ≤ ‖(c ^ (n + 1))⁻¹ • x‖,
-  { rw [div_le_iff cpos, norm_smul, norm_inv, norm_zpow, zpow_add₀ (ne_of_gt cpos),
+  show ε / ‖c‖ ≤ ‖c ^ (-(n + 1)) • x‖,
+  { rw [zpow_neg, div_le_iff cpos, norm_smul, norm_inv, norm_zpow, zpow_add₀ (ne_of_gt cpos),
         zpow_one, mul_inv_rev, mul_comm, ← mul_assoc, ← mul_assoc, mul_inv_cancel (ne_of_gt cpos),
         one_mul, ← div_eq_inv_mul, le_div_iff (zpow_pos_of_pos cpos _), mul_comm],
     exact (le_div_iff εpos).1 hn.1 },
-  show ‖(c ^ (n + 1))⁻¹‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖,
-  { have : ε⁻¹ * ‖c‖ * ‖x‖ = ε⁻¹ * ‖x‖ * ‖c‖, by ring,
-    rw [norm_inv, inv_inv, norm_zpow, zpow_add₀ (ne_of_gt cpos), zpow_one, this, ← div_eq_inv_mul],
+  show ‖c ^ (-(n + 1))‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖,
+  { rw [zpow_neg, norm_inv, inv_inv, norm_zpow, zpow_add₀ cpos.ne', zpow_one, mul_right_comm,
+      ← div_eq_inv_mul],
     exact mul_le_mul_of_nonneg_right hn.1 (norm_nonneg _) }
 end
+
+/-- If there is a scalar `c` with `‖c‖>1`, then any element with nonzero norm can be
+moved by scalar multiplication to any shell of width `‖c‖`. Also recap information on the norm of
+the rescaling element that shows up in applications. -/
+lemma rescale_to_shell_semi_normed {c : α} (hc : 1 < ‖c‖) {ε : ℝ} (εpos : 0 < ε) {x : E}
+  (hx : ‖x‖ ≠ 0) : ∃d:α, d ≠ 0 ∧ ‖d • x‖ < ε ∧ (ε/‖c‖ ≤ ‖d • x‖) ∧ (‖d‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
+let ⟨n, hn⟩ := rescale_to_shell_semi_normed_zpow hc εpos hx in ⟨_, hn⟩
 
 end seminormed_add_comm_group
 
@@ -369,12 +376,16 @@ by rw [frontier, closure_closed_ball, interior_closed_ball' x r, closed_ball_dif
 
 variables {α}
 
+lemma rescale_to_shell_zpow {c : α} (hc : 1 < ‖c‖) {ε : ℝ} (εpos : 0 < ε) {x : E} (hx : x ≠ 0) :
+  ∃ n : ℤ, c ^ n ≠ 0 ∧ ‖c ^ n • x‖ < ε ∧ (ε / ‖c‖ ≤ ‖c ^ n • x‖) ∧ (‖c ^ n‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
+rescale_to_shell_semi_normed_zpow hc εpos (mt norm_eq_zero.1 hx)
+
 /-- If there is a scalar `c` with `‖c‖>1`, then any element can be moved by scalar multiplication to
 any shell of width `‖c‖`. Also recap information on the norm of the rescaling element that shows
 up in applications. -/
 lemma rescale_to_shell {c : α} (hc : 1 < ‖c‖) {ε : ℝ} (εpos : 0 < ε) {x : E} (hx : x ≠ 0) :
   ∃d:α, d ≠ 0 ∧ ‖d • x‖ < ε ∧ (ε/‖c‖ ≤ ‖d • x‖) ∧ (‖d‖⁻¹ ≤ ε⁻¹ * ‖c‖ * ‖x‖) :=
-rescale_to_shell_semi_normed hc εpos (ne_of_lt (norm_pos_iff.2 hx)).symm
+rescale_to_shell_semi_normed hc εpos (mt norm_eq_zero.1 hx)
 
 end normed_add_comm_group
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -1137,9 +1137,10 @@ variables [nontrivially_normed_field 𝕜] [nontrivially_normed_field 𝕜₂]
   {σ₁₂ : 𝕜 →+* 𝕜₂} {σ₂₃ : 𝕜₂ →+* 𝕜₃}
   (f g : E →SL[σ₁₂] F) (x y z : E)
 
-lemma linear_map.bound_of_shell [ring_hom_isometric σ₁₂] (f : E →ₛₗ[σ₁₂] F) {ε C : ℝ}
-  (ε_pos : 0 < ε) {c : 𝕜} (hc : 1 < ‖c‖)
-  (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) (x : E) :
+namespace linear_map
+
+lemma bound_of_shell [ring_hom_isometric σ₁₂] (f : E →ₛₗ[σ₁₂] F) {ε C : ℝ} (ε_pos : 0 < ε) {c : 𝕜}
+  (hc : 1 < ‖c‖) (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) (x : E) :
   ‖f x‖ ≤ C * ‖x‖ :=
 begin
   by_cases hx : x = 0, { simp [hx] },
@@ -1151,14 +1152,14 @@ end
 `linear_map.bound_of_ball_bound'` is a version of this lemma over a field satisfying `is_R_or_C`
 that produces a concrete bound.
 -/
-lemma linear_map.bound_of_ball_bound {r : ℝ} (r_pos : 0 < r) (c : ℝ) (f : E →ₗ[𝕜] Fₗ)
+lemma bound_of_ball_bound {r : ℝ} (r_pos : 0 < r) (c : ℝ) (f : E →ₗ[𝕜] Fₗ)
   (h : ∀ z ∈ metric.ball (0 : E) r, ‖f z‖ ≤ c) :
   ∃ C, ∀ (z : E), ‖f z‖ ≤ C * ‖z‖ :=
 begin
   cases @nontrivially_normed_field.non_trivial 𝕜 _ with k hk,
   use c * (‖k‖ / r),
   intro z,
-  refine linear_map.bound_of_shell _ r_pos hk (λ x hko hxo, _) _,
+  refine bound_of_shell _ r_pos hk (λ x hko hxo, _) _,
   calc ‖f x‖ ≤ c : h _ (mem_ball_zero_iff.mpr hxo)
          ... ≤ c * ((‖x‖ * ‖k‖) / r) : le_mul_of_one_le_right _ _
          ... = _ : by ring,
@@ -1166,6 +1167,33 @@ begin
   { rw [div_le_iff (zero_lt_one.trans hk)] at hko,
     exact (one_le_div r_pos).mpr hko }
 end
+
+lemma antilipschitz_of_comap_nhds_le [h : ring_hom_isometric σ₁₂] (f : E →ₛₗ[σ₁₂] F)
+  (hf : (𝓝 0).comap f ≤ 𝓝 0) : ∃ K, antilipschitz_with K f :=
+begin
+  rcases ((nhds_basis_ball.comap _).le_basis_iff nhds_basis_ball).1 hf 1 one_pos
+    with ⟨ε, ε0, hε⟩,
+  simp only [set.subset_def, set.mem_preimage, mem_ball_zero_iff] at hε,
+  lift ε to ℝ≥0 using ε0.le,
+  rcases normed_field.exists_one_lt_norm 𝕜 with ⟨c, hc⟩,
+  refine ⟨ε⁻¹ * ‖c‖₊, add_monoid_hom_class.antilipschitz_of_bound f $ λ x, _⟩,
+  by_cases hx : f x = 0,
+  { rw [← hx] at hf,
+    obtain rfl : x = 0 := specializes.eq (specializes_iff_pure.2 $
+      ((filter.tendsto_pure_pure _ _).mono_right (pure_le_nhds _)).le_comap.trans hf),
+    exact norm_zero.trans_le (mul_nonneg (nnreal.coe_nonneg _) (norm_nonneg _)) },
+  have hc₀ : c ≠ 0 := norm_pos_iff.1 (one_pos.trans hc),
+  rw [← h.1] at hc,
+  rcases rescale_to_shell_zpow hc ε0 hx with ⟨n, -, hlt, -, hle⟩,
+  simp only [← map_zpow₀, h.1, ← map_smulₛₗ] at hlt hle,
+  calc ‖x‖ = ‖c ^ n‖⁻¹ * ‖c ^ n • x‖ :
+    by rwa [← norm_inv, ← norm_smul, inv_smul_smul₀ (zpow_ne_zero _ _)]
+  ... ≤ ‖c ^ n‖⁻¹ * 1 :
+    mul_le_mul_of_nonneg_left (hε _ hlt).le (inv_nonneg.2 (norm_nonneg _))
+  ... ≤ ε⁻¹ * ‖c‖ * ‖f x‖ : by rwa [mul_one]
+end
+
+end linear_map
 
 namespace continuous_linear_map
 
@@ -1214,39 +1242,11 @@ end
 
 variable (f)
 
-/-- If a continuous linear map is a uniform embedding, then it is expands the distances
+/-- If a continuous linear map is a topology embedding, then it is expands the distances
 by a positive factor.-/
-theorem antilipschitz_of_uniform_embedding (f : E →L[𝕜] Fₗ) (hf : uniform_embedding f) :
+theorem antilipschitz_of_embedding (f : E →L[𝕜] Fₗ) (hf : embedding f) :
   ∃ K, antilipschitz_with K f :=
-begin
-  obtain ⟨ε, εpos, hε⟩ : ∃ (ε : ℝ) (H : ε > 0), ∀ {x y : E}, dist (f x) (f y) < ε → dist x y < 1,
-    from (uniform_embedding_iff.1 hf).2.2 1 zero_lt_one,
-  let δ := ε/2,
-  have δ_pos : δ > 0 := half_pos εpos,
-  have H : ∀{x}, ‖f x‖ ≤ δ → ‖x‖ ≤ 1,
-  { assume x hx,
-    have : dist x 0 ≤ 1,
-    { refine (hε _).le,
-      rw [f.map_zero, dist_zero_right],
-      exact hx.trans_lt (half_lt_self εpos) },
-    simpa using this },
-  rcases normed_field.exists_one_lt_norm 𝕜 with ⟨c, hc⟩,
-  refine ⟨⟨δ⁻¹, _⟩ * ‖c‖₊, add_monoid_hom_class.antilipschitz_of_bound f $ λx, _⟩,
-  exact inv_nonneg.2 (le_of_lt δ_pos),
-  by_cases hx : f x = 0,
-  { have : f x = f 0, by { simp [hx] },
-    have : x = 0 := (uniform_embedding_iff.1 hf).1 this,
-    simp [this] },
-  { rcases rescale_to_shell hc δ_pos hx with ⟨d, hd, dxlt, ledx, dinv⟩,
-    rw [← f.map_smul d] at dxlt,
-    have : ‖d • x‖ ≤ 1 := H dxlt.le,
-    calc ‖x‖ = ‖d‖⁻¹ * ‖d • x‖ :
-      by rwa [← norm_inv, ← norm_smul, ← mul_smul, inv_mul_cancel, one_smul]
-    ... ≤ ‖d‖⁻¹ * 1 :
-      mul_le_mul_of_nonneg_left this (inv_nonneg.2 (norm_nonneg _))
-    ... ≤ δ⁻¹ * ‖c‖ * ‖f x‖ :
-      by rwa [mul_one] }
-end
+f.to_linear_map.antilipschitz_of_comap_nhds_le $ map_zero f ▸ (hf.nhds_eq_comap 0).ge
 
 section completeness
 

--- a/src/analysis/normed_space/pi_Lp.lean
+++ b/src/analysis/normed_space/pi_Lp.lean
@@ -424,7 +424,7 @@ instance [Π i, pseudo_emetric_space (β i)] : pseudo_emetric_space (pi_Lp p β)
 /-- emetric space instance on the product of finitely many emetric spaces, using the `L^p`
 edistance, and having as uniformity the product uniformity. -/
 instance [Π i, emetric_space (α i)] : emetric_space (pi_Lp p α) :=
-@emetric.of_t0_pseudo_emetric_space (pi_Lp p α) _ pi.t0_space
+@emetric_space.of_t0_pseudo_emetric_space (pi_Lp p α) _ pi.t0_space
 
 /-- pseudometric space instance on the product of finitely many psuedometric spaces, using the
 `L^p` distance, and having as uniformity the product uniformity. -/
@@ -435,7 +435,7 @@ instance [Π i, pseudo_metric_space (β i)] : pseudo_metric_space (pi_Lp p β) :
 /-- metric space instance on the product of finitely many metric spaces, using the `L^p` distance,
 and having as uniformity the product uniformity. -/
 instance [Π i, metric_space (α i)] : metric_space (pi_Lp p α) :=
-metric.of_t0_pseudo_metric_space _
+metric_space.of_t0_pseudo_metric_space _
 
 lemma nndist_eq_sum {p : ℝ≥0∞} [fact (1 ≤ p)] {β : ι → Type*}
   [Π i, pseudo_metric_space (β i)] (hp : p ≠ ∞) (x y : pi_Lp p β) :

--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -83,7 +83,7 @@ equiv.plift.symm.pprod_prod equiv.plift.symm
 
 /-- Product of two equivalences. If `α₁ ≃ α₂` and `β₁ ≃ β₂`, then `α₁ × β₁ ≃ α₂ × β₂`. This is
 `prod.map` as an equivalence. -/
-@[congr, simps apply]
+@[congr, simps apply { fully_applied := ff }]
 def prod_congr {α₁ β₁ α₂ β₂ : Type*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ :=
 ⟨prod.map e₁ e₂, prod.map e₁.symm e₂.symm, λ ⟨a, b⟩, by simp, λ ⟨a, b⟩, by simp⟩
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -727,12 +727,10 @@ metric.uniformity_basis_dist_le.uniform_continuous_on_iff metric.uniformity_basi
 theorem uniform_embedding_iff [pseudo_metric_space β] {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ uniform_continuous f ∧
     ∀ δ > 0, ∃ ε > 0, ∀ {a b : α}, dist (f a) (f b) < ε → dist a b < δ :=
-uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
-⟨λ H δ δ0, let ⟨t, tu, ht⟩ := H _ (dist_mem_uniformity δ0),
-               ⟨ε, ε0, hε⟩ := mem_uniformity_dist.1 tu in
-  ⟨ε, ε0, λ a b h, ht _ _ (hε h)⟩,
- λ H s su, let ⟨δ, δ0, hδ⟩ := mem_uniformity_dist.1 su, ⟨ε, ε0, hε⟩ := H _ δ0 in
-  ⟨_, dist_mem_uniformity ε0, λ a b h, hδ (hε h)⟩⟩
+begin
+  simp only [uniformity_basis_dist.uniform_embedding_iff uniformity_basis_dist, exists_prop],
+  refl
+end
 
 /-- If a map between pseudometric spaces is a uniform embedding then the distance between `f x`
 and `f y` is controlled in terms of the distance between `x` and `y`. -/
@@ -2672,42 +2670,32 @@ end
 lemma subsingleton_sphere (x : γ) {r : ℝ} (hr : r ≤ 0) : (sphere x r).subsingleton :=
 (subsingleton_closed_ball x hr).anti sphere_subset_closed_ball
 
-/-- A map between metric spaces is a uniform embedding if and only if the distance between `f x`
-and `f y` is controlled in terms of the distance between `x` and `y` and conversely. -/
-theorem uniform_embedding_iff' [metric_space β] {f : γ → β} :
-  uniform_embedding f ↔
-  (∀ ε > 0, ∃ δ > 0, ∀ {a b : γ}, dist a b < δ → dist (f a) (f b) < ε) ∧
-  (∀ δ > 0, ∃ ε > 0, ∀ {a b : γ}, dist (f a) (f b) < ε → dist a b < δ) :=
-begin
-  split,
-  { assume h,
-    exact ⟨uniform_continuous_iff.1 (uniform_embedding_iff.1 h).2.1,
-          (uniform_embedding_iff.1 h).2.2⟩ },
-  { rintros ⟨h₁, h₂⟩,
-    refine uniform_embedding_iff.2 ⟨_, uniform_continuous_iff.2 h₁, h₂⟩,
-    assume x y hxy,
-    have : dist x y ≤ 0,
-    { refine le_of_forall_lt' (λδ δpos, _),
-      rcases h₂ δ δpos with ⟨ε, εpos, hε⟩,
-      have : dist (f x) (f y) < ε, by simpa [hxy],
-      exact hε this },
-    simpa using this }
-end
-
 @[priority 100] -- see Note [lower instance priority]
 instance _root_.metric_space.to_separated : separated_space γ :=
 separated_def.2 $ λ x y h, eq_of_forall_dist_le $
   λ ε ε0, le_of_lt (h _ (dist_mem_uniformity ε0))
 
+/-- A map between metric spaces is a uniform embedding if and only if the distance between `f x`
+and `f y` is controlled in terms of the distance between `x` and `y` and conversely. -/
+theorem uniform_embedding_iff' [metric_space β] {f : γ → β} :
+  uniform_embedding f ↔
+    (∀ ε > 0, ∃ δ > 0, ∀ {a b : γ}, dist a b < δ → dist (f a) (f b) < ε) ∧
+    (∀ δ > 0, ∃ ε > 0, ∀ {a b : γ}, dist (f a) (f b) < ε → dist a b < δ) :=
+begin
+  simp only [uniform_embedding_iff_uniform_inducing,
+    uniformity_basis_dist.uniform_inducing_iff uniformity_basis_dist, exists_prop],
+  refl
+end
+
 /-- If a `pseudo_metric_space` is a T₀ space, then it is a `metric_space`. -/
-def of_t0_pseudo_metric_space (α : Type*) [pseudo_metric_space α] [t0_space α] :
+def _root_.metric_space.of_t0_pseudo_metric_space (α : Type*) [pseudo_metric_space α] [t0_space α] :
   metric_space α :=
 { eq_of_dist_eq_zero := λ x y hdist, inseparable.eq $ metric.inseparable_iff.2 hdist,
   ..‹pseudo_metric_space α› }
 
 /-- A metric space induces an emetric space -/
 @[priority 100] -- see Note [lower instance priority]
-instance metric_space.to_emetric_space : emetric_space γ :=
+instance _root_.metric_space.to_emetric_space : emetric_space γ :=
 emetric.of_t0_pseudo_emetric_space γ
 
 lemma is_closed_of_pairwise_le_dist {s : set γ} {ε : ℝ} (hε : 0 < ε)
@@ -2766,17 +2754,15 @@ def emetric_space.to_metric_space_of_dist {α : Type u} [e : emetric_space α]
   (edist_ne_top : ∀x y: α, edist x y ≠ ⊤)
   (h : ∀x y, dist x y = ennreal.to_real (edist x y)) :
   metric_space α :=
-{ dist := dist,
-  eq_of_dist_eq_zero := λx y hxy,
-    by simpa [h, ennreal.to_real_eq_zero_iff, edist_ne_top x y] using hxy,
-  ..pseudo_emetric_space.to_pseudo_metric_space_of_dist dist edist_ne_top h, }
+@metric_space.of_t0_pseudo_metric_space α
+  (pseudo_emetric_space.to_pseudo_metric_space_of_dist dist edist_ne_top h) _
 
 /-- One gets a metric space from an emetric space if the edistance
 is everywhere finite, by pushing the edistance to reals. We set it up so that the edist and the
 uniformity are defeq in the metric space and the emetric space. -/
-def emetric_space.to_metric_space {α : Type u} [e : emetric_space α] (h : ∀x y: α, edist x y ≠ ⊤) :
+def emetric_space.to_metric_space {α : Type u} [emetric_space α] (h : ∀ x y : α, edist x y ≠ ⊤) :
   metric_space α :=
-emetric_space.to_metric_space_of_dist (λx y, ennreal.to_real (edist x y)) h (λx y, rfl)
+emetric_space.to_metric_space_of_dist (λx y, ennreal.to_real (edist x y)) h (λ x y, rfl)
 
 /-- Build a new metric space from an old one where the bundled bornology structure is provably
 (but typically non-definitionaly) equal to some given bornology structure.
@@ -2829,6 +2815,7 @@ instance : metric_space empty :=
 { dist := λ _ _, 0,
   dist_self := λ _, rfl,
   dist_comm := λ _ _, rfl,
+  edist := λ _ _, 0,
   eq_of_dist_eq_zero := λ _ _ _, subsingleton.elim _ _,
   dist_triangle := λ _ _ _, show (0:ℝ) ≤ 0 + 0, by rw add_zero,
   to_uniform_space := empty.uniform_space,
@@ -2838,6 +2825,7 @@ instance : metric_space punit.{u + 1} :=
 { dist := λ _ _, 0,
   dist_self := λ _, rfl,
   dist_comm := λ _ _, rfl,
+  edist := λ _ _, 0,
   eq_of_dist_eq_zero := λ _ _ _, subsingleton.elim _ _,
   dist_triangle := λ _ _ _, show (0:ℝ) ≤ 0 + 0, by rw add_zero,
   to_uniform_space := punit.uniform_space,

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -2696,7 +2696,7 @@ def _root_.metric_space.of_t0_pseudo_metric_space (α : Type*) [pseudo_metric_sp
 /-- A metric space induces an emetric space -/
 @[priority 100] -- see Note [lower instance priority]
 instance _root_.metric_space.to_emetric_space : emetric_space γ :=
-emetric.of_t0_pseudo_emetric_space γ
+emetric_space.of_t0_pseudo_emetric_space γ
 
 lemma is_closed_of_pairwise_le_dist {s : set γ} {ε : ℝ} (hε : 0 < ε)
   (hs : s.pairwise (λ x y, ε ≤ dist x y)) : is_closed s :=

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -268,12 +268,10 @@ uniformity_basis_edist.uniform_continuous_iff uniformity_basis_edist
 theorem uniform_embedding_iff [pseudo_emetric_space β] {f : α → β} :
   uniform_embedding f ↔ function.injective f ∧ uniform_continuous f ∧
     ∀ δ > 0, ∃ ε > 0, ∀ {a b : α}, edist (f a) (f b) < ε → edist a b < δ :=
-uniform_embedding_def'.trans $ and_congr iff.rfl $ and_congr iff.rfl
-⟨λ H δ δ0, let ⟨t, tu, ht⟩ := H _ (edist_mem_uniformity δ0),
-               ⟨ε, ε0, hε⟩ := mem_uniformity_edist.1 tu in
-  ⟨ε, ε0, λ a b h, ht _ _ (hε h)⟩,
- λ H s su, let ⟨δ, δ0, hδ⟩ := mem_uniformity_edist.1 su, ⟨ε, ε0, hε⟩ := H _ δ0 in
-  ⟨_, edist_mem_uniformity ε0, λ a b h, hδ (hε h)⟩⟩
+begin
+  simp only [uniformity_basis_edist.uniform_embedding_iff uniformity_basis_edist, exists_prop],
+  refl
+end
 
 /-- If a map between pseudoemetric spaces is a uniform embedding then the edistance between `f x`
 and `f y` is controlled in terms of the distance between `x` and `y`. -/
@@ -281,11 +279,7 @@ theorem controlled_of_uniform_embedding [pseudo_emetric_space β] {f : α → β
   uniform_embedding f →
   (∀ ε > 0, ∃ δ > 0, ∀ {a b : α}, edist a b < δ → edist (f a) (f b) < ε) ∧
   (∀ δ > 0, ∃ ε > 0, ∀ {a b : α}, edist (f a) (f b) < ε → edist a b < δ) :=
-begin
-  assume h,
-    exact ⟨uniform_continuous_iff.1 (uniform_embedding_iff.1 h).2.1,
-          (uniform_embedding_iff.1 h).2.2⟩,
-end
+λ h, ⟨uniform_continuous_iff.1 (uniform_embedding_iff.1 h).2.1, (uniform_embedding_iff.1 h).2.2⟩
 
 /-- ε-δ characterization of Cauchy sequences on pseudoemetric spaces -/
 protected lemma cauchy_iff {f : filter α} :
@@ -888,38 +882,28 @@ nonpos_iff_eq_zero.trans edist_eq_zero
 theorem eq_of_forall_edist_le {x y : γ} (h : ∀ε > 0, edist x y ≤ ε) : x = y :=
 eq_of_edist_eq_zero (eq_of_le_of_forall_le_of_dense bot_le h)
 
-/-- A map between emetric spaces is a uniform embedding if and only if the edistance between `f x`
-and `f y` is controlled in terms of the distance between `x` and `y` and conversely. -/
-theorem uniform_embedding_iff' [emetric_space β] {f : γ → β} :
-  uniform_embedding f ↔
-  (∀ ε > 0, ∃ δ > 0, ∀ {a b : γ}, edist a b < δ → edist (f a) (f b) < ε) ∧
-  (∀ δ > 0, ∃ ε > 0, ∀ {a b : γ}, edist (f a) (f b) < ε → edist a b < δ) :=
-begin
-  split,
-  { assume h,
-    exact ⟨emetric.uniform_continuous_iff.1 (uniform_embedding_iff.1 h).2.1,
-          (uniform_embedding_iff.1 h).2.2⟩ },
-  { rintros ⟨h₁, h₂⟩,
-    refine uniform_embedding_iff.2 ⟨_, emetric.uniform_continuous_iff.2 h₁, h₂⟩,
-    assume x y hxy,
-    have : edist x y ≤ 0,
-    { refine le_of_forall_lt' (λδ δpos, _),
-      rcases h₂ δ δpos with ⟨ε, εpos, hε⟩,
-      have : edist (f x) (f y) < ε, by simpa [hxy],
-      exact hε this },
-    simpa using this }
-end
-
 /-- An emetric space is separated -/
 @[priority 100] -- see Note [lower instance priority]
 instance to_separated : separated_space γ :=
 separated_def.2 $ λ x y h, eq_of_forall_edist_le $
 λ ε ε0, le_of_lt (h _ (edist_mem_uniformity ε0))
 
+/-- A map between emetric spaces is a uniform embedding if and only if the edistance between `f x`
+and `f y` is controlled in terms of the distance between `x` and `y` and conversely. -/
+theorem emetric.uniform_embedding_iff' [emetric_space β] {f : γ → β} :
+  uniform_embedding f ↔
+    (∀ ε > 0, ∃ δ > 0, ∀ {a b : γ}, edist a b < δ → edist (f a) (f b) < ε) ∧
+    (∀ δ > 0, ∃ ε > 0, ∀ {a b : γ}, edist (f a) (f b) < ε → edist a b < δ) :=
+begin
+  simp only [uniform_embedding_iff_uniform_inducing,
+    uniformity_basis_edist.uniform_inducing_iff uniformity_basis_edist, exists_prop],
+  refl
+end
+
 /-- If a `pseudo_emetric_space` is a T₀ space, then it is an `emetric_space`. -/
 def emetric.of_t0_pseudo_emetric_space (α : Type*) [pseudo_emetric_space α] [t0_space α] :
   emetric_space α :=
-{ eq_of_edist_eq_zero := λ x y hdist, inseparable.eq $ emetric.inseparable_iff.2 hdist,
+{ eq_of_edist_eq_zero := λ x y hdist, (emetric.inseparable_iff.2 hdist).eq,
   ..‹pseudo_emetric_space α› }
 
 /-- Auxiliary function to replace the uniformity on an emetric space with

--- a/src/topology/metric_space/emetric_space.lean
+++ b/src/topology/metric_space/emetric_space.lean
@@ -901,7 +901,7 @@ begin
 end
 
 /-- If a `pseudo_emetric_space` is a T₀ space, then it is an `emetric_space`. -/
-def emetric.of_t0_pseudo_emetric_space (α : Type*) [pseudo_emetric_space α] [t0_space α] :
+def emetric_space.of_t0_pseudo_emetric_space (α : Type*) [pseudo_emetric_space α] [t0_space α] :
   emetric_space α :=
 { eq_of_edist_eq_zero := λ x y hdist, (emetric.inseparable_iff.2 hdist).eq,
   ..‹pseudo_emetric_space α› }
@@ -1023,7 +1023,7 @@ instance [pseudo_emetric_space X] : has_edist (uniform_space.separation_quotient
 rfl
 
 instance [pseudo_emetric_space X] : emetric_space (uniform_space.separation_quotient X) :=
-@emetric.of_t0_pseudo_emetric_space (uniform_space.separation_quotient X)
+@emetric_space.of_t0_pseudo_emetric_space (uniform_space.separation_quotient X)
   { edist_self := λ x, quotient.induction_on' x edist_self,
     edist_comm := λ x y, quotient.induction_on₂' x y edist_comm,
     edist_triangle := λ x y z, quotient.induction_on₃' x y z edist_triangle,

--- a/src/topology/metric_space/metrizable_uniformity.lean
+++ b/src/topology/metric_space/metrizable_uniformity.lean
@@ -241,7 +241,7 @@ protected noncomputable def uniform_space.pseudo_metric_space (X : Type*) [unifo
 /-- A `metric_space` instance compatible with a given `uniform_space` structure. -/
 protected noncomputable def uniform_space.metric_space (X : Type*) [uniform_space X]
   [is_countably_generated (𝓤 X)] [t0_space X] : metric_space X :=
-@of_t0_pseudo_metric_space X (uniform_space.pseudo_metric_space X) _
+@metric_space.of_t0_pseudo_metric_space X (uniform_space.pseudo_metric_space X) _
 
 /-- A uniform space with countably generated `𝓤 X` is pseudo metrizable. -/
 @[priority 100]

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -168,6 +168,18 @@ by simp only [t0_space_iff_inseparable, ne.def, not_imp_not]
 lemma inseparable.eq [t0_space α] {x y : α} (h : inseparable x y) : x = y :=
 t0_space.t0 h
 
+protected lemma inducing.injective [topological_space β] [t0_space α] {f : α → β}
+  (hf : inducing f) : injective f :=
+λ x y h, inseparable.eq $ hf.inseparable_iff.1 $ h ▸ inseparable.refl _
+
+protected lemma inducing.embedding [topological_space β] [t0_space α] {f : α → β}
+  (hf : inducing f) : embedding f :=
+⟨hf, hf.injective⟩
+
+lemma embedding_iff_inducing [topological_space β] [t0_space α] {f : α → β} :
+  embedding f ↔ inducing f :=
+⟨embedding.to_inducing, inducing.embedding⟩
+
 lemma t0_space_iff_nhds_injective (α : Type u) [topological_space α] :
   t0_space α ↔ injective (𝓝 : α → filter α) :=
 t0_space_iff_inseparable α

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -1016,14 +1016,14 @@ lemma uniform_continuous.comp [uniform_space β] [uniform_space γ] {g : β → 
   (hg : uniform_continuous g) (hf : uniform_continuous f) : uniform_continuous (g ∘ f) :=
 hg.comp hf
 
-lemma filter.has_basis.uniform_continuous_iff [uniform_space β] {p : γ → Prop} {s : γ → set (α×α)}
-  (ha : (𝓤 α).has_basis p s) {q : δ → Prop} {t : δ → set (β×β)} (hb : (𝓤 β).has_basis q t)
-  {f : α → β} :
+lemma filter.has_basis.uniform_continuous_iff {ι'} [uniform_space β] {p : ι → Prop}
+  {s : ι → set (α×α)} (ha : (𝓤 α).has_basis p s) {q : ι' → Prop} {t : ι' → set (β×β)}
+  (hb : (𝓤 β).has_basis q t) {f : α → β} :
   uniform_continuous f ↔ ∀ i (hi : q i), ∃ j (hj : p j), ∀ x y, (x, y) ∈ s j → (f x, f y) ∈ t i :=
 (ha.tendsto_iff hb).trans $ by simp only [prod.forall]
 
-lemma filter.has_basis.uniform_continuous_on_iff [uniform_space β] {p : γ → Prop}
-  {s : γ → set (α×α)} (ha : (𝓤 α).has_basis p s) {q : δ → Prop} {t : δ → set (β×β)}
+lemma filter.has_basis.uniform_continuous_on_iff {ι'} [uniform_space β] {p : ι → Prop}
+  {s : ι → set (α×α)} (ha : (𝓤 α).has_basis p s) {q : ι' → Prop} {t : ι' → set (β×β)}
   (hb : (𝓤 β).has_basis q t) {f : α → β} {S : set α} :
   uniform_continuous_on f S ↔
     ∀ i (hi : q i), ∃ j (hj : p j), ∀ x y ∈ S, (x, y) ∈ s j → (f x, f y) ∈ t i :=

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -16,7 +16,7 @@ import topology.dense_embedding
 Extension of uniform continuous functions.
 -/
 
-open filter topological_space set classical
+open filter topological_space set function classical
 open_locale classical uniformity topology filter
 
 section
@@ -24,11 +24,32 @@ variables {α : Type*} {β : Type*} {γ : Type*}
           [uniform_space α] [uniform_space β] [uniform_space γ]
 universes u v
 
+/-!
+### Uniform inducing maps
+-/
+
 /-- A map `f : α → β` between uniform spaces is called *uniform inducing* if the uniformity filter
 on `α` is the pullback of the uniformity filter on `β` under `prod.map f f`. If `α` is a separated
 space, then this implies that `f` is injective, hence it is a `uniform_embedding`. -/
+@[mk_iff]
 structure uniform_inducing (f : α → β) : Prop :=
 (comap_uniformity : comap (λx:α×α, (f x.1, f x.2)) (𝓤 β) = 𝓤 α)
+
+protected lemma uniform_inducing.comap_uniform_space {f : α → β} (hf : uniform_inducing f) :
+  ‹uniform_space β›.comap f = ‹uniform_space α› :=
+uniform_space_eq hf.1
+
+lemma uniform_inducing_iff' {f : α → β} :
+  uniform_inducing f ↔ uniform_continuous f ∧ comap (prod.map f f) (𝓤 β) ≤ 𝓤 α :=
+by rw [uniform_inducing_iff, uniform_continuous, tendsto_iff_comap, le_antisymm_iff, and_comm]; refl
+
+protected lemma filter.has_basis.uniform_inducing_iff {ι ι'} {p : ι → Prop} {p' : ι' → Prop} {s s'}
+  (h : (𝓤 α).has_basis p s) (h' : (𝓤 β).has_basis p' s') {f : α → β} :
+  uniform_inducing f ↔
+    (∀ i, p' i → ∃ j, p j ∧ ∀ x y, (x, y) ∈ s j → (f x, f y) ∈ s' i) ∧
+      (∀ j, p j → ∃ i, p' i ∧ ∀ x y, (f x, f y) ∈ s' i → (x, y) ∈ s j) :=
+by simp [uniform_inducing_iff', h.uniform_continuous_iff h', (h'.comap _).le_basis_iff h,
+  subset_def]
 
 lemma uniform_inducing.mk' {f : α → β} (h : ∀ s, s ∈ 𝓤 α ↔
     ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s) : uniform_inducing f :=
@@ -39,9 +60,7 @@ lemma uniform_inducing_id : uniform_inducing (@id α) :=
 
 lemma uniform_inducing.comp {g : β → γ} (hg : uniform_inducing g)
   {f : α → β} (hf : uniform_inducing f) : uniform_inducing (g ∘ f) :=
-⟨ by rw [show (λ (x : α × α), ((g ∘ f) x.1, (g ∘ f) x.2)) =
-         (λ y : β × β, (g y.1, g y.2)) ∘ (λ x : α × α, (f x.1, f x.2)), by ext ; simp,
-        ← filter.comap_comap, hg.1, hf.1]⟩
+⟨by rw [← hf.1, ← hg.1, comap_comap]⟩
 
 lemma uniform_inducing.basis_uniformity {f : α → β} (hf : uniform_inducing f)
   {ι : Sort*} {p : ι → Prop} {s : ι → set (β × β)} (H : (𝓤 β).has_basis p s) :
@@ -61,10 +80,59 @@ begin
   exact comap_mono hg.le_comap
 end
 
+lemma uniform_inducing.uniform_continuous {f : α → β}
+  (hf : uniform_inducing f) : uniform_continuous f :=
+(uniform_inducing_iff'.1 hf).1
+
+lemma uniform_inducing.uniform_continuous_iff {f : α → β} {g : β → γ} (hg : uniform_inducing g) :
+  uniform_continuous f ↔ uniform_continuous (g ∘ f) :=
+by { dsimp only [uniform_continuous, tendsto],
+  rw [← hg.comap_uniformity, ← map_le_iff_le_comap, filter.map_map] }
+
+protected lemma uniform_inducing.inducing {f : α → β} (h : uniform_inducing f) : inducing f :=
+begin
+  unfreezingI { obtain rfl := h.comap_uniform_space },
+  letI := uniform_space.comap f _,
+  exact ⟨rfl⟩
+end
+
+lemma uniform_inducing.prod {α' : Type*} {β' : Type*} [uniform_space α'] [uniform_space β']
+  {e₁ : α → α'} {e₂ : β → β'} (h₁ : uniform_inducing e₁) (h₂ : uniform_inducing e₂) :
+  uniform_inducing (λp:α×β, (e₁ p.1, e₂ p.2)) :=
+⟨by simp [(∘), uniformity_prod, h₁.comap_uniformity.symm, h₂.comap_uniformity.symm,
+           comap_inf, comap_comap]⟩
+
+lemma uniform_inducing.dense_inducing {f : α → β} (h : uniform_inducing f) (hd : dense_range f) :
+  dense_inducing f :=
+{ dense   := hd,
+  induced := h.inducing.induced }
+
+protected lemma uniform_inducing.injective [t0_space α] {f : α → β} (h : uniform_inducing f) :
+  injective f :=
+h.inducing.injective
+
 /-- A map `f : α → β` between uniform spaces is a *uniform embedding* if it is uniform inducing and
 injective. If `α` is a separated space, then the latter assumption follows from the former. -/
+@[mk_iff]
 structure uniform_embedding (f : α → β) extends uniform_inducing f : Prop :=
 (inj : function.injective f)
+
+theorem uniform_embedding_iff' {f : α → β} :
+  uniform_embedding f ↔ injective f ∧ uniform_continuous f ∧ comap (prod.map f f) (𝓤 β) ≤ 𝓤 α :=
+by rw [uniform_embedding_iff, and_comm, uniform_inducing_iff']
+
+theorem filter.has_basis.uniform_embedding_iff' {ι ι'} {p : ι → Prop} {p' : ι' → Prop} {s s'}
+  (h : (𝓤 α).has_basis p s) (h' : (𝓤 β).has_basis p' s') {f : α → β} :
+  uniform_embedding f ↔ injective f ∧
+    (∀ i, p' i → ∃ j, p j ∧ ∀ x y, (x, y) ∈ s j → (f x, f y) ∈ s' i) ∧
+      (∀ j, p j → ∃ i, p' i ∧ ∀ x y, (f x, f y) ∈ s' i → (x, y) ∈ s j) :=
+by rw [uniform_embedding_iff, and_comm, h.uniform_inducing_iff h']
+
+theorem filter.has_basis.uniform_embedding_iff {ι ι'} {p : ι → Prop} {p' : ι' → Prop} {s s'}
+  (h : (𝓤 α).has_basis p s) (h' : (𝓤 β).has_basis p' s') {f : α → β} :
+  uniform_embedding f ↔ injective f ∧ uniform_continuous f ∧
+      (∀ j, p j → ∃ i, p' i ∧ ∀ x y, (f x, f y) ∈ s' i → (x, y) ∈ s j) :=
+by simp only [h.uniform_embedding_iff' h', h.uniform_continuous_iff h', exists_prop]
 
 lemma uniform_embedding_subtype_val {p : α → Prop} :
   uniform_embedding (subtype.val : subtype p → α) :=
@@ -86,79 +154,38 @@ lemma uniform_embedding.comp {g : β → γ} (hg : uniform_embedding g)
 { inj := hg.inj.comp hf.inj,
   ..hg.to_uniform_inducing.comp hf.to_uniform_inducing }
 
-theorem uniform_embedding_def {f : α → β} :
-  uniform_embedding f ↔ function.injective f ∧ ∀ s, s ∈ 𝓤 α ↔
-    ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
-begin
-  split,
-  { rintro ⟨⟨h⟩, h'⟩,
-    rw [eq_comm, filter.ext_iff] at h,
-    simp [*, subset_def] },
-  { rintro ⟨h, h'⟩,
-    refine uniform_embedding.mk ⟨_⟩ h,
-    rw [eq_comm, filter.ext_iff],
-    simp [*, subset_def] }
-end
-
-theorem uniform_embedding_def' {f : α → β} :
-  uniform_embedding f ↔ function.injective f ∧ uniform_continuous f ∧
-    ∀ s, s ∈ 𝓤 α →
-      ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s :=
-by simp only [uniform_embedding_def, uniform_continuous_def]; exact
-⟨λ ⟨I, H⟩, ⟨I, λ s su, (H _).2 ⟨s, su, λ x y, id⟩, λ s, (H s).1⟩,
- λ ⟨I, H₁, H₂⟩, ⟨I, λ s, ⟨H₂ s,
-   λ ⟨t, tu, h⟩, mem_of_superset (H₁ t tu) (λ ⟨a, b⟩, h a b)⟩⟩⟩
-
 lemma equiv.uniform_embedding {α β : Type*} [uniform_space α] [uniform_space β] (f : α ≃ β)
   (h₁ : uniform_continuous f) (h₂ : uniform_continuous f.symm) : uniform_embedding f :=
-{ comap_uniformity :=
-  begin
-    refine le_antisymm _ _,
-    { change comap (f.prod_congr f) _ ≤ _,
-      rw ← map_equiv_symm (f.prod_congr f),
-      exact h₂ },
-    { rw ← map_le_iff_le_comap,
-      exact h₁ }
-  end,
-  inj := f.injective }
+uniform_embedding_iff'.2 ⟨f.injective, h₁, by rwa [← equiv.prod_congr_apply, ← map_equiv_symm]⟩
 
 theorem uniform_embedding_inl : uniform_embedding (sum.inl : α → α ⊕ β) :=
 begin
-  apply uniform_embedding_def.2 ⟨sum.inl_injective, λ s, ⟨_, _⟩⟩,
-  { assume hs,
-    refine ⟨(λ p : α × α, (sum.inl p.1, sum.inl p.2)) '' s ∪
-      (λ p : β × β, (sum.inr p.1, sum.inr p.2)) '' univ, _, _⟩,
-    { exact union_mem_uniformity_sum hs univ_mem },
-    { simp } },
-  { rintros ⟨t, ht, h't⟩,
-    simp only [sum.uniformity, mem_sup, mem_map] at ht,
-    apply filter.mem_of_superset ht.1,
-    rintros ⟨x, y⟩ hx,
-    exact h't _ _ hx }
+  refine ⟨⟨_⟩, sum.inl_injective⟩,
+  rw [sum.uniformity, comap_sup, comap_map, comap_eq_bot_iff_compl_range.2 _, sup_bot_eq],
+  { refine mem_map.2 (univ_mem' _),
+    simp },
+  { exact sum.inl_injective.prod_map sum.inl_injective }
 end
 
 theorem uniform_embedding_inr : uniform_embedding (sum.inr : β → α ⊕ β) :=
 begin
-  apply uniform_embedding_def.2 ⟨sum.inr_injective, λ s, ⟨_, _⟩⟩,
-  { assume hs,
-    refine ⟨(λ p : α × α, (sum.inl p.1, sum.inl p.2)) '' univ ∪
-      (λ p : β × β, (sum.inr p.1, sum.inr p.2)) '' s, _, _⟩,
-    { exact union_mem_uniformity_sum univ_mem hs },
-    { simp } },
-  { rintros ⟨t, ht, h't⟩,
-    simp only [sum.uniformity, mem_sup, mem_map] at ht,
-    apply filter.mem_of_superset ht.2,
-    rintros ⟨x, y⟩ hx,
-    exact h't _ _ hx }
+  refine ⟨⟨_⟩, sum.inr_injective⟩,
+  rw [sum.uniformity, comap_sup, comap_eq_bot_iff_compl_range.2 _, comap_map, bot_sup_eq],
+  { exact sum.inr_injective.prod_map sum.inr_injective },
+  { refine mem_map.2 (univ_mem' _),
+    simp },
 end
 
 /-- If the domain of a `uniform_inducing` map `f` is a `separated_space`, then `f` is injective,
 hence it is a `uniform_embedding`. -/
-protected theorem uniform_inducing.uniform_embedding [separated_space α] {f : α → β}
+protected theorem uniform_inducing.uniform_embedding [t0_space α] {f : α → β}
   (hf : uniform_inducing f) :
   uniform_embedding f :=
-⟨hf, λ x y h, eq_of_uniformity_basis (hf.basis_uniformity (𝓤 β).basis_sets) $
-  λ s hs, mem_preimage.2 $ mem_uniformity_of_eq hs h⟩
+⟨hf, hf.injective⟩
+
+theorem uniform_embedding_iff_uniform_inducing [t0_space α] {f : α → β} :
+  uniform_embedding f ↔ uniform_inducing f :=
+⟨uniform_embedding.to_uniform_inducing, uniform_inducing.uniform_embedding⟩
 
 /-- If a map `f : α → β` sends any two distinct points to point that are **not** related by a fixed
 `s ∈ 𝓤 β`, then `f` is uniform inducing with respect to the discrete uniformity on `α`:
@@ -186,35 +213,7 @@ begin
   exact uniform_inducing.uniform_embedding ⟨comap_uniformity_of_spaced_out hs hf⟩
 end
 
-lemma uniform_inducing.uniform_continuous {f : α → β}
-  (hf : uniform_inducing f) : uniform_continuous f :=
-by simp [uniform_continuous, hf.comap_uniformity.symm, tendsto_comap]
-
-lemma uniform_inducing.uniform_continuous_iff {f : α → β} {g : β → γ} (hg : uniform_inducing g) :
-  uniform_continuous f ↔ uniform_continuous (g ∘ f) :=
-by { dsimp only [uniform_continuous, tendsto],
-  rw [← hg.comap_uniformity, ← map_le_iff_le_comap, filter.map_map] }
-
-lemma uniform_inducing.inducing {f : α → β} (h : uniform_inducing f) : inducing f :=
-begin
-  refine ⟨eq_of_nhds_eq_nhds $ assume a, _ ⟩,
-  rw [nhds_induced, nhds_eq_uniformity, nhds_eq_uniformity, ← h.comap_uniformity,
-    comap_lift'_eq, comap_lift'_eq2],
-  exacts [rfl, monotone_preimage]
-end
-
-lemma uniform_inducing.prod {α' : Type*} {β' : Type*} [uniform_space α'] [uniform_space β']
-  {e₁ : α → α'} {e₂ : β → β'} (h₁ : uniform_inducing e₁) (h₂ : uniform_inducing e₂) :
-  uniform_inducing (λp:α×β, (e₁ p.1, e₂ p.2)) :=
-⟨by simp [(∘), uniformity_prod, h₁.comap_uniformity.symm, h₂.comap_uniformity.symm,
-           comap_inf, comap_comap]⟩
-
-lemma uniform_inducing.dense_inducing {f : α → β} (h : uniform_inducing f) (hd : dense_range f) :
-  dense_inducing f :=
-{ dense   := hd,
-  induced := h.inducing.induced }
-
-lemma uniform_embedding.embedding {f : α → β} (h : uniform_embedding f) : embedding f :=
+protected lemma uniform_embedding.embedding {f : α → β} (h : uniform_embedding f) : embedding f :=
 { induced := h.to_uniform_inducing.inducing.induced,
   inj := h.inj }
 
@@ -237,7 +236,7 @@ end
 lemma closure_image_mem_nhds_of_uniform_inducing
   {s : set (α×α)} {e : α → β} (b : β)
   (he₁ : uniform_inducing e) (he₂ : dense_inducing e) (hs : s ∈ 𝓤 α) :
-  ∃a, closure (e '' {a' | (a, a') ∈ s}) ∈ 𝓝 b :=
+  ∃ a, closure (e '' {a' | (a, a') ∈ s}) ∈ 𝓝 b :=
 have s ∈ comap (λp:α×α, (e p.1, e p.2)) (𝓤 β),
   from he₁.comap_uniformity.symm ▸ hs,
 let ⟨t₁, ht₁u, ht₁⟩ := this in


### PR DESCRIPTION
### API about uniform embeddings

* Add `mk_iff` to `uniform_inducing` and `uniform_embedding`.
* Move lemmas about `uniform_inducing` up.
* Add `uniform_inducing.comap_uniform_space`, `uniform_inducing_iff'`, and `filter.has_basis.uniform_inducing_iff`.
* Add `uniform_embedding_iff'`, `filter.has_basis.uniform_embedding_iff'`, and `filter.has_basis.uniform_embedding_iff`.
* Drop `uniform_embedding_def` and `uniform_embedding_def'`.
* Add `uniform_embedding_iff_uniform_inducing`.

### Other changes

* Add `rescale_to_shell_semi_normed_zpow` and `rescale_to_shell_zpow`.
* Generalize `continuous_linear_map.antilipschitz_of_uniform_embedding` to `continuous_linear_map.antilipschitz_of_embedding`, add an even more general version `linear_map.antilipschitz_of_comap_nhds_le`.
* Use `fully_applied := ff` to generate `equiv.prod_congr_apply`.
* Use `edist := λ _ _, 0` in `metric_space` instances for `empty` and `punit`.
* Add `inducing.injective`, `inducing.embedding`, and `embedding_iff_inducing`
* Allow `Sort*`s in `filter.has_basis.uniform_continuous_iff` and `filter.has_basis.uniform_continuous_on_iff`.
* Rename
  *  `metric.of_t0_pseudo_metric_space` to `metric_space.of_t0_pseudo_metric_space`;
  * `emetric.of_t0_pseudo_emetric_space` to `emetric_space.of_t0_pseudo_emetric_space`;
  * `metric.metric_space.to_emetric_space` to `metric_space.to_emetric_space`;
  * `uniform_embedding_iff'` to `emetric.uniform_embedding_iff'`



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
