### PR TITLE
refactor(set_theory/game/*): remove `relabelling`

### DIFF
--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -498,10 +498,28 @@ def mul_one_relabelling : Π (x : pgame.{u}), x * 1 ≡r x
   try { rintro (⟨i, ⟨ ⟩⟩ | ⟨i, ⟨ ⟩⟩) }; try { intro i };
   dsimp;
   apply (relabelling.sub_congr (relabelling.refl _) (mul_zero_relabelling _)).trans;
-  rw sub_zero;
+  rw sub_zero_eq_add_zero;
   exact (add_zero_relabelling _).trans (((mul_one_relabelling _).add_congr
     (mul_zero_relabelling _)).trans $ add_zero_relabelling _)
 end
+
+/-- `1 * x` has the same moves as `x`. -/
+def one_mul : Π (x : pgame.{u}), 1 * x ≡ x
+| ⟨xl, xr, xL, xR⟩ := begin
+  refine identical.ext (λ z, _) (λ z, _),
+  { simp_rw [memₗ_mul_iff], dsimp, simp_rw [is_empty.exists_iff, or_false, exists_const],
+    simp_rw [(((((pgame.zero_mul _).add (one_mul _)).trans (pgame.zero_add _)).sub
+      (xL _).zero_mul).trans (pgame.sub_zero _)).congr_right],
+    refl, },
+  { simp_rw [memᵣ_mul_iff], dsimp, simp_rw [is_empty.exists_iff, or_false, exists_const],
+    simp_rw [(((((pgame.zero_mul _).add (one_mul _)).trans (pgame.zero_add _)).sub
+      (xR _).zero_mul).trans (pgame.sub_zero _)).congr_right],
+    refl, },
+end
+using_well_founded { dec_tac := pgame_wf_tac }
+
+/-- `x * 1` has the same moves as `x`. -/
+def mul_one (x : pgame.{u}) : x * 1 ≡ x := (x.mul_comm _).trans x.one_mul
 
 @[simp] theorem quot_mul_one (x : pgame) : ⟦x * 1⟧ = ⟦x⟧ := quot.sound $ mul_one_relabelling x
 

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -343,7 +343,7 @@ instance is_empty_zero_mul_right_moves (x : pgame.{u}) : is_empty (0 * x).right_
 by { cases x, apply sum.is_empty }
 
 /-- `x * 0` has exactly the same moves as `0`. -/
-protected def mul_zero (x : pgame) : x * 0 ≡ 0 := identical_zero _
+protected lemma mul_zero (x : pgame) : x * 0 ≡ 0 := identical_zero _
 
 /-- `x * 0` has exactly the same moves as `0`. -/
 def mul_zero_relabelling (x : pgame) : x * 0 ≡r 0 := relabelling.is_empty _
@@ -355,7 +355,7 @@ theorem mul_zero_equiv (x : pgame) : x * 0 ≈ 0 := (mul_zero_relabelling x).equ
 @quotient.sound _ _ (x * 0) _ x.mul_zero_equiv
 
 /-- `0 * x` has exactly the same moves as `0`. -/
-protected def zero_mul (x : pgame) : 0 * x ≡ 0 := identical_zero _
+protected lemma zero_mul (x : pgame) : 0 * x ≡ 0 := identical_zero _
 
 /-- `0 * x` has exactly the same moves as `0`. -/
 def zero_mul_relabelling (x : pgame) : 0 * x ≡r 0 := relabelling.is_empty _
@@ -491,20 +491,6 @@ by { change ⟦(y + -z) * x⟧ = ⟦y * x⟧ + -⟦z * x⟧, rw [quot_right_dist
 
 /-- `x * 1` has the same moves as `x`. -/
 def mul_one_relabelling : Π (x : pgame.{u}), x * 1 ≡r x
-| ⟨xl, xr, xL, xR⟩ := begin
-  unfold has_one.one,
-  refine ⟨(equiv.sum_empty _ _).trans (equiv.prod_punit _),
-    (equiv.empty_sum _ _).trans (equiv.prod_punit _), _, _⟩;
-  try { rintro (⟨i, ⟨ ⟩⟩ | ⟨i, ⟨ ⟩⟩) }; try { intro i };
-  dsimp;
-  apply (relabelling.sub_congr (relabelling.refl _) (mul_zero_relabelling _)).trans;
-  rw sub_zero;
-  exact (add_zero_relabelling _).trans (((mul_one_relabelling _).add_congr
-    (mul_zero_relabelling _)).trans $ add_zero_relabelling _)
-end
-
-/-- `x * 1` has the same moves as `x`. -/
-def mul_one : Π (x : pgame.{u}), x * 1 ≡ x
 | ⟨xl, xr, xL, xR⟩ := begin
   unfold has_one.one,
   refine ⟨(equiv.sum_empty _ _).trans (equiv.prod_punit _),

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -146,7 +146,7 @@ but to prove their properties we need to use the abelian group structure of game
 Hence we define them here. -/
 
 /-- The product of `x = {xL | xR}` and `y = {yL | yR}` is
-`{xL*y + x*yL - xL*yL, xR*y + x*yR - xR*yR | xL*y + x*yR - xL*yR, xR*y + x*yL - xR*yL }`. -/
+`{xL*y + x*yL - xL*yL, xR*y + x*yR - xR*yR | xL*y + x*yR - xL*yR, xR*y + x*yL - xR*yL}`. -/
 instance : has_mul pgame.{u} :=
 ⟨λ x y, begin
   induction x with xl xr xL xR IHxl IHxr generalizing y,
@@ -662,6 +662,14 @@ theorem zero_lf_inv' : ∀ (x : pgame), 0 ⧏ inv' x
 | ⟨xl, xr, xL, xR⟩ := by { convert lf_mk _ _ inv_ty.zero, refl }
 
 /-- `inv' 0` has exactly the same moves as `1`. -/
+def inv'_zero' : inv' 0 ≡ 1 :=
+begin
+  refine ⟨_, _⟩,
+  { simp_rw [unique.forall_iff, unique.exists_iff, and_self, pgame.inv_val_is_empty], },
+  { simp_rw [is_empty.forall_iff, and_self], },
+end
+
+/-- `inv' 0` has exactly the same moves as `1`. -/
 def inv'_zero : inv' 0 ≡r 1 :=
 begin
   change mk _ _ _ _ ≡r 1,
@@ -676,6 +684,17 @@ begin
 end
 
 theorem inv'_zero_equiv : inv' 0 ≈ 1 := inv'_zero.equiv
+
+/-- `inv' 1` has exactly the same moves as `1`. -/
+def inv'_one' : inv' 1 ≡ (1 : pgame.{u}) :=
+begin
+  haveI inst : is_empty {i : punit.{u+1} // (0 : pgame.{u}) < 0},
+  { rw lt_self_iff_false, apply_instance },
+  refine ⟨_, _⟩,
+  { simp_rw [unique.forall_iff, unique.exists_iff, pgame.inv_val_is_empty, and_self], },
+  { simp_rw [is_empty.forall_iff, and_true, is_empty.exists_iff],
+    exact (@inv_ty.is_empty _ _ inst _).elim, },
+end
 
 /-- `inv' 1` has exactly the same moves as `1`. -/
 def inv'_one : inv' 1 ≡r (1 : pgame.{u}) :=
@@ -709,6 +728,10 @@ by { classical, exact (if_neg h.lf.not_equiv').trans (if_pos h) }
 
 theorem inv_eq_of_lf_zero {x : pgame} (h : x ⧏ 0) : x⁻¹ = -inv' (-x) :=
 by { classical, exact (if_neg h.not_equiv).trans (if_neg h.not_gt) }
+
+/-- `1⁻¹` has exactly the same moves as `1`. -/
+def inv_one' : 1⁻¹ ≡ 1 :=
+by { rw inv_eq_of_pos pgame.zero_lt_one, exact inv'_one' }
 
 /-- `1⁻¹` has exactly the same moves as `1`. -/
 def inv_one : 1⁻¹ ≡r 1 :=

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -314,20 +314,8 @@ protected lemma mul_comm : Π (x y : pgame.{u}), x * y ≡ y * x
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-/-- `x * y` and `y * x` have the same moves. -/
-def mul_comm_relabelling : Π (x y : pgame.{u}), x * y ≡r y * x
-| ⟨xl, xr, xL, xR⟩ ⟨yl, yr, yL, yR⟩ := begin
-  refine ⟨equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _),
-    (equiv.sum_comm _ _).trans (equiv.sum_congr (equiv.prod_comm _ _) (equiv.prod_comm _ _)), _, _⟩;
-  rintro (⟨i, j⟩ | ⟨i, j⟩);
-  dsimp;
-  exact ((add_comm_relabelling _ _).trans $ (mul_comm_relabelling _ _).add_congr
-    (mul_comm_relabelling _ _)).sub_congr (mul_comm_relabelling _ _)
-end
-using_well_founded { dec_tac := pgame_wf_tac }
-
 theorem quot_mul_comm (x y : pgame.{u}) : ⟦x * y⟧ = ⟦y * x⟧ :=
-quot.sound (mul_comm_relabelling x y).equiv
+quot.sound (x.mul_comm y).equiv
 
 /-- `x * y` is equivalent to `y * x`. -/
 theorem mul_comm_equiv (x y : pgame) : x * y ≈ y * x :=
@@ -345,11 +333,8 @@ by { cases x, apply sum.is_empty }
 /-- `x * 0` has exactly the same moves as `0`. -/
 protected lemma mul_zero (x : pgame) : x * 0 ≡ 0 := identical_zero _
 
-/-- `x * 0` has exactly the same moves as `0`. -/
-def mul_zero_relabelling (x : pgame) : x * 0 ≡r 0 := relabelling.is_empty _
-
 /-- `x * 0` is equivalent to `0`. -/
-theorem mul_zero_equiv (x : pgame) : x * 0 ≈ 0 := (mul_zero_relabelling x).equiv
+theorem mul_zero_equiv (x : pgame) : x * 0 ≈ 0 := x.mul_zero.equiv
 
 @[simp] theorem quot_mul_zero (x : pgame) : ⟦x * 0⟧ = ⟦0⟧ :=
 @quotient.sound _ _ (x * 0) _ x.mul_zero_equiv
@@ -357,26 +342,11 @@ theorem mul_zero_equiv (x : pgame) : x * 0 ≈ 0 := (mul_zero_relabelling x).equ
 /-- `0 * x` has exactly the same moves as `0`. -/
 protected lemma zero_mul (x : pgame) : 0 * x ≡ 0 := identical_zero _
 
-/-- `0 * x` has exactly the same moves as `0`. -/
-def zero_mul_relabelling (x : pgame) : 0 * x ≡r 0 := relabelling.is_empty _
-
 /-- `0 * x` is equivalent to `0`. -/
-theorem zero_mul_equiv (x : pgame) : 0 * x ≈ 0 := (zero_mul_relabelling x).equiv
+theorem zero_mul_equiv (x : pgame) : 0 * x ≈ 0 := x.zero_mul.equiv
 
 @[simp] theorem quot_zero_mul (x : pgame) : ⟦0 * x⟧ = ⟦0⟧ :=
 @quotient.sound _ _ (0 * x) _ x.zero_mul_equiv
-
-/-- `-x * y` and `-(x * y)` have the same moves. -/
-def neg_mul_relabelling : Π (x y : pgame.{u}), -x * y ≡r -(x * y)
-| ⟨xl, xr, xL, xR⟩ ⟨yl, yr, yL, yR⟩ := begin
-  refine ⟨equiv.sum_comm _ _, equiv.sum_comm _ _, _, _⟩;
-  rintro (⟨i, j⟩ | ⟨i, j⟩);
-  dsimp;
-  apply ((neg_add_relabelling _ _).trans _).symm;
-  apply ((neg_add_relabelling _ _).trans (relabelling.add_congr _ _)).sub_congr;
-  exact (neg_mul_relabelling _ _).symm
-end
-using_well_founded { dec_tac := pgame_wf_tac }
 
 /-- `x * -y` and `-(x * y)` have the same moves. -/
 lemma mul_neg : Π (x y : pgame.{u}), x * -y = -(x * y)
@@ -412,15 +382,10 @@ def neg_mul (x y : pgame.{u}) : -x * y ≡ -(x * y) :=
 ((pgame.mul_comm _ _).trans (of_eq (mul_neg _ _))).trans (pgame.mul_comm _ _).neg
 
 @[simp] theorem quot_neg_mul (x y : pgame) : ⟦-x * y⟧ = -⟦x * y⟧ :=
-quot.sound (neg_mul_relabelling x y).equiv
-
-/-- `x * -y` and `-(x * y)` have the same moves. -/
-def mul_neg_relabelling (x y : pgame) : x * -y ≡r -(x * y) :=
-(mul_comm_relabelling x _).trans $
-  (neg_mul_relabelling _ x).trans (mul_comm_relabelling y x).neg_congr
+quot.sound (neg_mul x y).equiv
 
 @[simp] theorem quot_mul_neg (x y : pgame) : ⟦x * -y⟧ = -⟦x * y⟧ :=
-quot.sound (mul_neg_relabelling x y).equiv
+quot.sound (of_eq (mul_neg x y))
 
 @[simp] theorem quot_left_distrib : Π (x y z : pgame), ⟦x * (y + z)⟧ = ⟦x * y⟧ + ⟦x * z⟧
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) :=
@@ -489,20 +454,6 @@ quotient.exact $ quot_right_distrib _ _ _
 @[simp] theorem quot_right_distrib_sub (x y z : pgame) : ⟦(y - z) * x⟧ = ⟦y * x⟧ - ⟦z * x⟧ :=
 by { change ⟦(y + -z) * x⟧ = ⟦y * x⟧ + -⟦z * x⟧, rw [quot_right_distrib, quot_neg_mul] }
 
-/-- `x * 1` has the same moves as `x`. -/
-def mul_one_relabelling : Π (x : pgame.{u}), x * 1 ≡r x
-| ⟨xl, xr, xL, xR⟩ := begin
-  unfold has_one.one,
-  refine ⟨(equiv.sum_empty _ _).trans (equiv.prod_punit _),
-    (equiv.empty_sum _ _).trans (equiv.prod_punit _), _, _⟩;
-  try { rintro (⟨i, ⟨ ⟩⟩ | ⟨i, ⟨ ⟩⟩) }; try { intro i };
-  dsimp;
-  apply (relabelling.sub_congr (relabelling.refl _) (mul_zero_relabelling _)).trans;
-  rw sub_zero_eq_add_zero;
-  exact (add_zero_relabelling _).trans (((mul_one_relabelling _).add_congr
-    (mul_zero_relabelling _)).trans $ add_zero_relabelling _)
-end
-
 /-- `1 * x` has the same moves as `x`. -/
 lemma one_mul : Π (x : pgame.{u}), 1 * x ≡ x
 | ⟨xl, xr, xL, xR⟩ := begin
@@ -518,22 +469,18 @@ lemma one_mul : Π (x : pgame.{u}), 1 * x ≡ x
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-/-- `x * 1` has the same moves as `x`. -/
-lemma mul_one (x : pgame.{u}) : x * 1 ≡ x := (x.mul_comm _).trans x.one_mul
-
-@[simp] theorem quot_mul_one (x : pgame) : ⟦x * 1⟧ = ⟦x⟧ := quot.sound $ mul_one_relabelling x
-
-/-- `x * 1` is equivalent to `x`. -/
-theorem mul_one_equiv (x : pgame) : x * 1 ≈ x := quotient.exact $ quot_mul_one x
-
-/-- `1 * x` has the same moves as `x`. -/
-def one_mul_relabelling (x : pgame) : 1 * x ≡r x :=
-(mul_comm_relabelling 1 x).trans $ mul_one_relabelling x
-
-@[simp] theorem quot_one_mul (x : pgame) : ⟦1 * x⟧ = ⟦x⟧ := quot.sound $ one_mul_relabelling x
+@[simp] theorem quot_one_mul (x : pgame) : ⟦1 * x⟧ = ⟦x⟧ := quot.sound $ (one_mul x).equiv
 
 /-- `1 * x` is equivalent to `x`. -/
 theorem one_mul_equiv (x : pgame) : 1 * x ≈ x := quotient.exact $ quot_one_mul x
+
+/-- `x * 1` has the same moves as `x`. -/
+lemma mul_one (x : pgame.{u}) : x * 1 ≡ x := (x.mul_comm _).trans x.one_mul
+
+@[simp] theorem quot_mul_one (x : pgame) : ⟦x * 1⟧ = ⟦x⟧ := quot.sound $ (mul_one x).equiv
+
+/-- `x * 1` is equivalent to `x`. -/
+theorem mul_one_equiv (x : pgame) : x * 1 ≈ x := quotient.exact $ quot_mul_one x
 
 theorem quot_mul_assoc : Π (x y z : pgame), ⟦x * y * z⟧ = ⟦x * (y * z)⟧
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) :=
@@ -662,31 +609,17 @@ theorem zero_lf_inv' : ∀ (x : pgame), 0 ⧏ inv' x
 | ⟨xl, xr, xL, xR⟩ := by { convert lf_mk _ _ inv_ty.zero, refl }
 
 /-- `inv' 0` has exactly the same moves as `1`. -/
-def inv'_zero' : inv' 0 ≡ 1 :=
+def inv'_zero : inv' 0 ≡ 1 :=
 begin
   refine ⟨_, _⟩,
   { simp_rw [unique.forall_iff, unique.exists_iff, and_self, pgame.inv_val_is_empty], },
   { simp_rw [is_empty.forall_iff, and_self], },
 end
 
-/-- `inv' 0` has exactly the same moves as `1`. -/
-def inv'_zero : inv' 0 ≡r 1 :=
-begin
-  change mk _ _ _ _ ≡r 1,
-  refine ⟨_, _, λ i, _, is_empty.elim _⟩,
-  { apply equiv.equiv_punit (inv_ty _ _ _),
-    apply_instance },
-  { apply equiv.equiv_pempty (inv_ty _ _ _),
-    apply_instance },
-  { simp },
-  { dsimp,
-    apply_instance }
-end
-
 theorem inv'_zero_equiv : inv' 0 ≈ 1 := inv'_zero.equiv
 
 /-- `inv' 1` has exactly the same moves as `1`. -/
-def inv'_one' : inv' 1 ≡ (1 : pgame.{u}) :=
+def inv'_one : inv' 1 ≡ (1 : pgame.{u}) :=
 begin
   haveI inst : is_empty {i : punit.{u+1} // (0 : pgame.{u}) < 0},
   { rw lt_self_iff_false, apply_instance },
@@ -694,19 +627,6 @@ begin
   { simp_rw [unique.forall_iff, unique.exists_iff, pgame.inv_val_is_empty, and_self], },
   { simp_rw [is_empty.forall_iff, and_true, is_empty.exists_iff],
     exact (@inv_ty.is_empty _ _ inst _).elim, },
-end
-
-/-- `inv' 1` has exactly the same moves as `1`. -/
-def inv'_one : inv' 1 ≡r (1 : pgame.{u}) :=
-begin
-  change relabelling (mk _ _ _ _) 1,
-  haveI : is_empty {i : punit.{u+1} // (0 : pgame.{u}) < 0},
-  { rw lt_self_iff_false, apply_instance },
-  refine ⟨_, _, λ i, _, is_empty.elim _⟩; dsimp,
-  { apply equiv.equiv_punit },
-  { apply equiv.equiv_of_is_empty },
-  { simp },
-  { apply_instance }
 end
 
 theorem inv'_one_equiv : inv' 1 ≈ 1 := inv'_one.equiv
@@ -730,11 +650,7 @@ theorem inv_eq_of_lf_zero {x : pgame} (h : x ⧏ 0) : x⁻¹ = -inv' (-x) :=
 by { classical, exact (if_neg h.not_equiv).trans (if_neg h.not_gt) }
 
 /-- `1⁻¹` has exactly the same moves as `1`. -/
-def inv_one' : 1⁻¹ ≡ 1 :=
-by { rw inv_eq_of_pos pgame.zero_lt_one, exact inv'_one' }
-
-/-- `1⁻¹` has exactly the same moves as `1`. -/
-def inv_one : 1⁻¹ ≡r 1 :=
+def inv_one : 1⁻¹ ≡ 1 :=
 by { rw inv_eq_of_pos pgame.zero_lt_one, exact inv'_one }
 
 theorem inv_one_equiv : 1⁻¹ ≈ 1 := inv_one.equiv

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -504,7 +504,7 @@ def mul_one_relabelling : Π (x : pgame.{u}), x * 1 ≡r x
 end
 
 /-- `1 * x` has the same moves as `x`. -/
-def one_mul : Π (x : pgame.{u}), 1 * x ≡ x
+lemma one_mul : Π (x : pgame.{u}), 1 * x ≡ x
 | ⟨xl, xr, xL, xR⟩ := begin
   refine identical.ext (λ z, _) (λ z, _),
   { simp_rw [memₗ_mul_iff], dsimp, simp_rw [is_empty.exists_iff, or_false, exists_const],
@@ -519,7 +519,7 @@ end
 using_well_founded { dec_tac := pgame_wf_tac }
 
 /-- `x * 1` has the same moves as `x`. -/
-def mul_one (x : pgame.{u}) : x * 1 ≡ x := (x.mul_comm _).trans x.one_mul
+lemma mul_one (x : pgame.{u}) : x * 1 ≡ x := (x.mul_comm _).trans x.one_mul
 
 @[simp] theorem quot_mul_one (x : pgame) : ⟦x * 1⟧ = ⟦x⟧ := quot.sound $ mul_one_relabelling x
 

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -146,7 +146,7 @@ but to prove their properties we need to use the abelian group structure of game
 Hence we define them here. -/
 
 /-- The product of `x = {xL | xR}` and `y = {yL | yR}` is
-`{xL*y + x*yL - xL*yL, xR*y + x*yR - xR*yR | xL*y + x*yR - xL*yR, x*yL + xR*y - xR*yL }`. -/
+`{xL*y + x*yL - xL*yL, xR*y + x*yR - xR*yR | xL*y + x*yR - xL*yR, xR*y + x*yL - xR*yL }`. -/
 instance : has_mul pgame.{u} :=
 ⟨λ x y, begin
   induction x with xl xr xL xR IHxl IHxr generalizing y,
@@ -282,6 +282,23 @@ lemma memᵣ_mul_iff : Π {x y₁ y₂ : pgame},
   { rintros ⟨(⟨i, j⟩ | ⟨i, j⟩), hi⟩, exacts [or.inl ⟨_, _, hi⟩, or.inr ⟨_, _, hi⟩], },
   { rintros (⟨i, j, h⟩ | ⟨i, j, h⟩), exacts [⟨sum.inl (i, j), h⟩, ⟨sum.inr (i, j), h⟩], },
 end
+
+/-- `x * y` and `y * x` have the same moves. -/
+protected def mul_comm : Π (x y : pgame.{u}), x * y ≡ y * x
+| ⟨xl, xr, xL, xR⟩ ⟨yl, yr, yL, yR⟩ := begin
+  refine identical.ext (λ z, _) (λ z, _),
+  { simp_rw [memₗ_mul_iff], dsimp, rw [@exists_comm xl, @exists_comm xr],
+    simp_rw [((((mul_comm _ _).add (mul_comm _ _)).trans ((_ * xL _).add_comm _)).sub
+        (mul_comm _ _)).congr_right,
+      ((((mul_comm _ _).add (mul_comm _ _)).trans ((_ * xR _).add_comm _)).sub
+        (mul_comm _ _)).congr_right], },
+  { simp_rw [memᵣ_mul_iff], dsimp, rw [@exists_comm xl, @exists_comm xr, or.comm],
+    simp_rw [((((mul_comm _ _).add (mul_comm _ _)).trans ((_ * xL _).add_comm _)).sub
+        (mul_comm _ _)).congr_right,
+      ((((mul_comm _ _).add (mul_comm _ _)).trans ((_ * xR _).add_comm _)).sub
+        (mul_comm _ _)).congr_right], },
+end
+using_well_founded { dec_tac := pgame_wf_tac }
 
 /-- `x * y` and `y * x` have the same moves. -/
 def mul_comm_relabelling : Π (x y : pgame.{u}), x * y ≡r y * x

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -263,6 +263,26 @@ begin
   { apply hr }
 end
 
+lemma memₗ_mul_iff : Π {x y₁ y₂ : pgame},
+  x ∈ₗ y₁ * y₂ ↔
+    (∃ i j, x ≡ y₁.move_left i * y₂ + y₁ * y₂.move_left j - y₁.move_left i * y₂.move_left j) ∨
+    (∃ i j, x ≡ y₁.move_right i * y₂ + y₁ * y₂.move_right j - y₁.move_right i * y₂.move_right j)
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
+  constructor,
+  { rintros ⟨(⟨i, j⟩ | ⟨i, j⟩), hi⟩, exacts [or.inl ⟨_, _, hi⟩, or.inr ⟨_, _, hi⟩], },
+  { rintros (⟨i, j, h⟩ | ⟨i, j, h⟩), exacts [⟨sum.inl (i, j), h⟩, ⟨sum.inr (i, j), h⟩], },
+end
+
+lemma memᵣ_mul_iff : Π {x y₁ y₂ : pgame},
+  x ∈ᵣ y₁ * y₂ ↔
+    (∃ i j, x ≡ y₁.move_left i * y₂ + y₁ * y₂.move_right j - y₁.move_left i * y₂.move_right j) ∨
+    (∃ i j, x ≡ y₁.move_right i * y₂ + y₁ * y₂.move_left j - y₁.move_right i * y₂.move_left j)
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
+  constructor,
+  { rintros ⟨(⟨i, j⟩ | ⟨i, j⟩), hi⟩, exacts [or.inl ⟨_, _, hi⟩, or.inr ⟨_, _, hi⟩], },
+  { rintros (⟨i, j, h⟩ | ⟨i, j, h⟩), exacts [⟨sum.inl (i, j), h⟩, ⟨sum.inr (i, j), h⟩], },
+end
+
 /-- `x * y` and `y * x` have the same moves. -/
 def mul_comm_relabelling : Π (x y : pgame.{u}), x * y ≡r y * x
 | ⟨xl, xr, xL, xR⟩ ⟨yl, yr, yL, yR⟩ := begin

--- a/src/set_theory/game/birthday.lean
+++ b/src/set_theory/game/birthday.lean
@@ -69,7 +69,7 @@ begin
     { exact hi.trans_lt (birthday_move_right_lt i) } }
 end
 
-theorem relabelling.birthday_congr : ∀ {x y : pgame.{u}}, x ≡r y → birthday x = birthday y
+theorem identical.birthday_congr : ∀ {x y : pgame.{u}}, x ≡ y → birthday x = birthday y
 | ⟨xl, xr, xL, xR⟩ ⟨yl, yr, yL, yR⟩ r := begin
   unfold birthday,
   congr' 1,
@@ -77,10 +77,10 @@ theorem relabelling.birthday_congr : ∀ {x y : pgame.{u}}, x ≡r y → birthda
   { apply lsub_eq_of_range_eq.{u u u},
     ext i, split },
   all_goals { rintro ⟨j, rfl⟩ },
-  { exact ⟨_, (r.move_left j).birthday_congr.symm⟩ },
-  { exact ⟨_, (r.move_left_symm j).birthday_congr⟩ },
-  { exact ⟨_, (r.move_right j).birthday_congr.symm⟩ },
-  { exact ⟨_, (r.move_right_symm j).birthday_congr⟩ }
+  { exact (r.move_left j).imp (λ i hi, hi.birthday_congr.symm) },
+  { exact (r.move_left_symm j).imp (λ i hi, hi.birthday_congr) },
+  { exact (r.move_right j).imp (λ i hi, hi.birthday_congr.symm) },
+  { exact (r.move_right_symm j).imp (λ i hi, hi.birthday_congr) },
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 

--- a/src/set_theory/game/impartial.lean
+++ b/src/set_theory/game/impartial.lean
@@ -62,7 +62,7 @@ instance move_right_impartial {G : pgame} [h : G.impartial] (j : G.right_moves) 
   (G.move_right j).impartial :=
 (impartial_def.1 h).2.2 j
 
-theorem impartial_congr : ∀ {G H : pgame} (e : G ≡r H) [G.impartial], H.impartial
+theorem identical_congr : ∀ {G H : pgame} (e : G ≡ H) [G.impartial], H.impartial
 | G H := λ e, begin
   introI h,
   exact impartial_def.2
@@ -77,7 +77,7 @@ begin
   introsI hG hH,
   rw impartial_def,
   refine ⟨(add_congr (neg_equiv_self _) (neg_equiv_self _)).trans
-    (neg_add_relabelling _ _).equiv.symm, λ k, _, λ k, _⟩,
+    (equiv_of_eq (pgame.neg_add _ _)).symm, λ k, _, λ k, _⟩,
   { apply left_moves_add_cases k,
     all_goals
     { intro i, simp only [add_move_left_inl, add_move_left_inr],

--- a/src/set_theory/game/nim.lean
+++ b/src/set_theory/game/nim.lean
@@ -113,7 +113,7 @@ instance is_empty_nim_zero_right_moves : is_empty (nim 0).right_moves :=
 by { rw nim_def, exact ordinal.is_empty_out_zero }
 
 /-- `nim 0` has exactly the same moves as `0`. -/
-def nim_zero_relabelling : nim 0 ≡r 0 := relabelling.is_empty _
+lemma nim_zero_identical : nim 0 ≡ 0 := identical_zero _
 
 theorem nim_zero_equiv : nim 0 ≈ 0 := equiv.is_empty _
 
@@ -146,15 +146,18 @@ theorem nim_one_move_right (x) : (nim 1).move_right x = nim 0 :=
 by simp
 
 /-- `nim 1` has exactly the same moves as `star`. -/
-def nim_one_relabelling : nim 1 ≡r star :=
+lemma nim_one_identical : nim.{u} 1 ≡ star.{u} :=
 begin
-  rw nim_def,
-  refine ⟨_, _, λ i, _, λ j, _⟩,
-  any_goals { dsimp, apply equiv.equiv_of_unique },
-  all_goals { simp, exact nim_zero_relabelling }
+  refine identical.ext (λ z, _) (λ z, _),
+  { unfold memₗ,
+    simp_rw [nim_one_move_left, unique.exists_iff, star_move_left],
+    exact identical.congr_right nim_zero_identical, },
+  { unfold memᵣ,
+    simp_rw [nim_one_move_right, unique.exists_iff, star_move_right],
+    exact identical.congr_right nim_zero_identical, },
 end
 
-theorem nim_one_equiv : nim 1 ≈ star := nim_one_relabelling.equiv
+theorem nim_one_equiv : nim 1 ≈ star := nim_one_identical.equiv
 
 @[simp] lemma nim_birthday (o : ordinal) : (nim o).birthday = o :=
 begin

--- a/src/set_theory/game/ordinal.lean
+++ b/src/set_theory/game/ordinal.lean
@@ -73,8 +73,8 @@ theorem to_pgame_move_left {o : ordinal} (i) :
 by simp
 
 /-- `0.to_pgame` has the same moves as `0`. -/
-noncomputable def zero_to_pgame_relabelling : to_pgame 0 ≡r 0 :=
-relabelling.is_empty _
+lemma zero_to_pgame : to_pgame 0 ≡ 0 :=
+identical_zero _
 
 noncomputable instance unique_one_to_pgame_left_moves : unique (to_pgame 1).left_moves :=
 (equiv.cast $ to_pgame_left_moves 1).unique
@@ -91,9 +91,14 @@ theorem one_to_pgame_move_left (x) : (to_pgame 1).move_left x = to_pgame 0 :=
 by simp
 
 /-- `1.to_pgame` has the same moves as `1`. -/
-noncomputable def one_to_pgame_relabelling : to_pgame 1 ≡r 1 :=
-⟨equiv.equiv_of_unique _ _, equiv.equiv_of_is_empty _ _,
-  λ i, by simpa using zero_to_pgame_relabelling, is_empty_elim⟩
+lemma one_to_pgame : to_pgame.{u} 1 ≡ (1 : pgame.{u}) :=
+begin
+  refine identical.ext (λ z, _) (λ z, _),
+  { unfold memₗ,
+    simp_rw [one_to_pgame_move_left, unique.exists_iff],
+    exact identical.congr_right zero_to_pgame, },
+  { unfold memᵣ, simp, },
+end
 
 theorem to_pgame_lf {a b : ordinal} (h : a < b) : a.to_pgame ⧏ b.to_pgame :=
 by { convert move_left_lf (to_left_moves_to_pgame ⟨a, h⟩), rw to_pgame_move_left }
@@ -109,7 +114,7 @@ theorem to_pgame_lt {a b : ordinal} (h : a < b) : a.to_pgame < b.to_pgame :=
 ⟨to_pgame_le h.le, to_pgame_lf h⟩
 
 theorem to_pgame_nonneg (a : ordinal) : 0 ≤ a.to_pgame :=
-zero_to_pgame_relabelling.ge.trans $ to_pgame_le $ ordinal.zero_le a
+zero_to_pgame.symm.le.trans $ to_pgame_le $ ordinal.zero_le a
 
 @[simp] theorem to_pgame_lf_iff {a b : ordinal} : a.to_pgame ⧏ b.to_pgame ↔ a < b :=
 ⟨by { contrapose, rw [not_lt, not_lf], exact to_pgame_le }, to_pgame_lf⟩

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1298,7 +1298,7 @@ end
 
 lemma memₗ_add_iff : Π {x y₁ y₂ : pgame},
   x ∈ₗ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_left i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_left i))
-| (mk x₁l x₁r x₁L x₁R) (mk x₂l x₂r x₂L x₂R) (mk yl yr yL yR) := begin
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
   constructor,
   { rintros ⟨(i | i), hi⟩, exacts [or.inl ⟨_, hi⟩, or.inr ⟨_, hi⟩], },
   { rintros (⟨i, h⟩ | ⟨i, h⟩), exacts [⟨sum.inl i, h⟩, ⟨sum.inr i, h⟩], },
@@ -1306,7 +1306,7 @@ end
 
 lemma memᵣ_add_iff : Π {x y₁ y₂ : pgame},
   x ∈ᵣ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_right i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_right i))
-| (mk x₁l x₁r x₁L x₁R) (mk x₂l x₂r x₂L x₂R) (mk yl yr yL yR) := begin
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
   constructor,
   { rintros ⟨(i | i), hi⟩, exacts [or.inl ⟨_, hi⟩, or.inr ⟨_, hi⟩], },
   { rintros (⟨i, h⟩ | ⟨i, h⟩), exacts [⟨sum.inl i, h⟩, ⟨sum.inr i, h⟩], },

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -710,6 +710,11 @@ end forall_exists_rel
 namespace pgame
 open_locale pgame
 
+/-! ### Identity -/
+
+/-- Two pre-games are identical if their left and right sets are identical.
+That is, `identical x y` if every left move of `x` is identical to some left move of `y`,
+every right move of `x` is identical to some right move of `y`, and vice versa. -/
 def identical : Π (x y : pgame), Prop
 | (mk _ _ xL xR) (mk _ _ yL yR) :=
   ((∀ i, ∃ j, identical (xL i) (yL j)) ∧ (∀ j, ∃ i, identical (xL i) (yL j))) ∧
@@ -717,7 +722,10 @@ def identical : Π (x y : pgame), Prop
 
 localized "infix (name := pgame.identical) ` ≡ `:50 := pgame.identical" in pgame
 
+/-- `x ∈ₗ y` if `x` is identical to some left move of `y`. -/
 def memₗ (x y : pgame.{u}) : Prop := ∃ b, x ≡ (y.move_left b)
+
+/-- `x ∈ᵣ y` if `x` is identical to some right move of `y`. -/
 def memᵣ (x y : pgame.{u}) : Prop := ∃ b, x ≡ (y.move_right b)
 
 localized "infix (name := pgame.memₗ) ` ∈ₗ `:50 := pgame.memₗ" in pgame
@@ -1304,7 +1312,7 @@ lemma memᵣ_add_iff : Π {x y₁ y₂ : pgame},
   { rintros (⟨i, h⟩ | ⟨i, h⟩), exacts [⟨sum.inl i, h⟩, ⟨sum.inr i, h⟩], },
 end
 
-lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
+protected lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
 | (mk xl xr xL xR) (mk yl yr yL yR) := begin
   refine identical.ext (λ z, _) (λ z, _),
   { simp_rw [memₗ_add_iff], rw [or.comm], dsimp,
@@ -1334,7 +1342,7 @@ begin
   { rintros (⟨i, hi⟩ | ⟨i, hi⟩), exacts [⟨_, hi⟩, ⟨_, hi⟩], }
 end
 
-lemma add_assoc : Π (x y z : pgame.{u}), x + y + z ≡ x + (y + z)
+protected lemma add_assoc : Π (x y z : pgame.{u}), x + y + z ≡ x + (y + z)
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) := begin
   refine identical.ext (λ z, _) (λ z, _),
   { simp_rw [memₗ_add_iff, exists_left_moves_add, or.assoc,
@@ -1344,7 +1352,7 @@ lemma add_assoc : Π (x y z : pgame.{u}), x + y + z ≡ x + (y + z)
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-lemma add_zero : Π (x : pgame), x + 0 ≡ x
+protected lemma add_zero : Π (x : pgame), x + 0 ≡ x
 | (mk xl xr xL xR) := begin
   refine identical.ext (λ z, _) (λ z, _),
   { simp_rw [memₗ_add_iff, is_empty.exists_iff, or_false, (add_zero _).congr_right], refl },
@@ -1352,10 +1360,10 @@ lemma add_zero : Π (x : pgame), x + 0 ≡ x
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-lemma zero_add (x : pgame) : 0 + x ≡ x :=
-(add_comm _ _).trans (add_zero _)
+protected lemma zero_add (x : pgame) : 0 + x ≡ x :=
+(pgame.add_comm _ _).trans x.add_zero
 
-lemma neg_add_rev : Π (x y : pgame.{u}), -(x + y) ≡ -y + -x
+protected lemma neg_add_rev : Π (x y : pgame.{u}), -(x + y) ≡ -y + -x
 | (mk xl xr xL xR) (mk yl yr yL yR) := begin
   refine identical.ext (λ z, _) (λ z, _),
   { simp_rw [memₗ_add_iff, memₗ_neg_iff, exists_right_moves_add,
@@ -1365,8 +1373,8 @@ lemma neg_add_rev : Π (x y : pgame.{u}), -(x + y) ≡ -y + -x
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-lemma neg_add (x y : pgame.{u}) : -(x + y) ≡ -x + -y :=
-(neg_add_rev _ _).trans (add_comm _ _)
+protected lemma neg_add (x y : pgame.{u}) : -(x + y) ≡ -x + -y :=
+(x.neg_add_rev y).trans (pgame.add_comm _ _)
 
 lemma identical_zero_iff : Π (x : pgame.{u}),
   x ≡ 0 ↔ is_empty x.left_moves ∧ is_empty x.right_moves
@@ -1397,7 +1405,7 @@ end
 using_well_founded { dec_tac := pgame_wf_tac }
 
 lemma identical.add_left {x y₁ y₂} (hy : y₁ ≡ y₂) : x + y₁ ≡ x + y₂ :=
-(add_comm _ _).trans (hy.add_right.trans (add_comm _ _))
+(x.add_comm y₁).trans (hy.add_right.trans (y₂.add_comm x))
 
 lemma identical.add {x₁ x₂ y₁ y₂ : pgame.{u}} (hx : x₁ ≡ x₂) (hy : y₁ ≡ y₂) : x₁ + y₁ ≡ x₂ + y₂ :=
 hx.add_right.trans hy.add_left

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1315,9 +1315,9 @@ end
 protected lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
 | (mk xl xr xL xR) (mk yl yr yL yR) := begin
   refine identical.ext (λ z, _) (λ z, _),
-  { simp_rw [memₗ_add_iff], rw [or.comm], dsimp,
+  { simp_rw [memₗ_add_iff], dsimp, rw [or.comm],
     simp_rw [(add_comm (xL _) _).congr_right, (add_comm _ (yL _)).congr_right], },
-  { simp_rw [memᵣ_add_iff], rw [or.comm], dsimp,
+  { simp_rw [memᵣ_add_iff], dsimp, rw [or.comm],
     simp_rw [(add_comm (xR _) _).congr_right, (add_comm _ (yR _)).congr_right], },
 end
 using_well_founded { dec_tac := pgame_wf_tac }

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1296,32 +1296,6 @@ instance is_empty_nat_right_moves : ∀ n : ℕ, is_empty (right_moves n)
   apply_instance
 end
 
-lemma memₗ_add_iff : Π {x y₁ y₂ : pgame},
-  x ∈ₗ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_left i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_left i))
-| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
-  constructor,
-  { rintros ⟨(i | i), hi⟩, exacts [or.inl ⟨_, hi⟩, or.inr ⟨_, hi⟩], },
-  { rintros (⟨i, h⟩ | ⟨i, h⟩), exacts [⟨sum.inl i, h⟩, ⟨sum.inr i, h⟩], },
-end
-
-lemma memᵣ_add_iff : Π {x y₁ y₂ : pgame},
-  x ∈ᵣ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_right i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_right i))
-| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := begin
-  constructor,
-  { rintros ⟨(i | i), hi⟩, exacts [or.inl ⟨_, hi⟩, or.inr ⟨_, hi⟩], },
-  { rintros (⟨i, h⟩ | ⟨i, h⟩), exacts [⟨sum.inl i, h⟩, ⟨sum.inr i, h⟩], },
-end
-
-protected lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
-| (mk xl xr xL xR) (mk yl yr yL yR) := begin
-  refine identical.ext (λ z, _) (λ z, _),
-  { simp_rw [memₗ_add_iff], dsimp, rw [or.comm],
-    simp_rw [(add_comm (xL _) _).congr_right, (add_comm _ (yL _)).congr_right], },
-  { simp_rw [memᵣ_add_iff], dsimp, rw [or.comm],
-    simp_rw [(add_comm (xR _) _).congr_right, (add_comm _ (yR _)).congr_right], },
-end
-using_well_founded { dec_tac := pgame_wf_tac }
-
 lemma exists_left_moves_add {x y : pgame.{u}} {p : (x + y).left_moves → Prop} :
   (∃ i, p i) ↔
     (∃ i, p (to_left_moves_add (sum.inl i))) ∨ (∃ i, p (to_left_moves_add (sum.inr i))) :=
@@ -1341,6 +1315,24 @@ begin
   { rintros ⟨(i | i), hi⟩, exacts [or.inl ⟨i, hi⟩, or.inr ⟨i, hi⟩], },
   { rintros (⟨i, hi⟩ | ⟨i, hi⟩), exacts [⟨_, hi⟩, ⟨_, hi⟩], }
 end
+
+lemma memₗ_add_iff : Π {x y₁ y₂ : pgame},
+  x ∈ₗ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_left i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_left i))
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := exists_left_moves_add
+
+lemma memᵣ_add_iff : Π {x y₁ y₂ : pgame},
+  x ∈ᵣ y₁ + y₂ ↔ (∃ i, x ≡ (y₁.move_right i) + y₂) ∨ (∃ i, x ≡ y₁ + (y₂.move_right i))
+| (mk xl xr xL xR) (mk y₁l y₁r y₁L y₁R) (mk y₂l y₂r y₂L y₂R) := exists_right_moves_add
+
+protected lemma add_comm : Π (x y : pgame.{u}), x + y ≡ y + x
+| (mk xl xr xL xR) (mk yl yr yL yR) := begin
+  refine identical.ext (λ z, _) (λ z, _),
+  { simp_rw [memₗ_add_iff], dsimp, rw [or.comm],
+    simp_rw [(add_comm (xL _) _).congr_right, (add_comm _ (yL _)).congr_right], },
+  { simp_rw [memᵣ_add_iff], dsimp, rw [or.comm],
+    simp_rw [(add_comm (xR _) _).congr_right, (add_comm _ (yR _)).congr_right], },
+end
+using_well_founded { dec_tac := pgame_wf_tac }
 
 protected lemma add_assoc : Π (x y z : pgame.{u}), x + y + z ≡ x + (y + z)
 | (mk xl xr xL xR) (mk yl yr yL yR) (mk zl zr zL zR) := begin

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1460,8 +1460,11 @@ using_well_founded { dec_tac := pgame_wf_tac }
 
 instance : has_sub pgame := ⟨λ x y, x + -y⟩
 
-@[simp] theorem sub_zero (x : pgame) : x - 0 = x + 0 :=
+@[simp] theorem sub_zero_eq_add_zero (x : pgame) : x - 0 = x + 0 :=
 show x + -0 = x + 0, by rw neg_zero
+
+lemma sub_zero (x : pgame) : x - 0 ≡ x :=
+trans (of_eq x.sub_zero_eq_add_zero) x.add_zero
 
 /-- Use the same name convention as global lemmas. -/
 lemma neg_sub' (x y : pgame.{u}) : -(x - y) = -x - -y := pgame.neg_add _ _

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1386,6 +1386,10 @@ lemma identical_zero_iff : Π (x : pgame.{u}),
   { rintros ⟨h₁, h₂⟩, exactI identical_of_is_empty _ _, },
 end
 
+/-- Any game without left or right moves is identival to 0. -/
+def identical_zero (x : pgame) [is_empty x.left_moves] [is_empty x.right_moves] : x ≡ 0 :=
+x.identical_zero_iff.mpr ⟨by apply_instance, by apply_instance⟩
+
 lemma add_eq_zero_iff : Π (x y : pgame.{u}), x + y ≡ 0 ↔ x ≡ 0 ∧ y ≡ 0
 | (mk xl xr xL xR) (mk yl yr yL yR) :=
 by { simp_rw [identical_zero_iff, left_moves_add, right_moves_add, is_empty_sum], tauto, }
@@ -1443,6 +1447,9 @@ instance : has_sub pgame := ⟨λ x y, x + -y⟩
 
 @[simp] theorem sub_zero (x : pgame) : x - 0 = x + 0 :=
 show x + -0 = x + 0, by rw neg_zero
+
+lemma identical.sub {x₁ x₂ y₁ y₂ : pgame.{u}} (hx : x₁ ≡ x₂) (hy : y₁ ≡ y₂) : x₁ - y₁ ≡ x₂ - y₂ :=
+hx.add hy.neg
 
 /-- If `w` has the same moves as `x` and `y` has the same moves as `z`,
 then `w - y` has the same moves as `x - z`. -/

--- a/src/set_theory/game/short.lean
+++ b/src/set_theory/game/short.lean
@@ -140,16 +140,11 @@ instance short_of_lists : Π (L R : list pgame) [list_short L] [list_short R],
   { intros, apply_instance },
   { intros, apply pgame.list_short_nth_le /- where does the subtype.val come from? -/ } }
 
-/-- If `x` is a short game, and `y` is a relabelling of `x`, then `y` is also short. -/
-def short_of_relabelling : Π {x y : pgame.{u}} (R : relabelling x y) (S : short x), short y
+/-- If `x` is a short game, and `y` is identical of `x`, then `y` is also short. -/
+def short_of_identical : Π {x y : pgame.{u}} (R : identical x y) (S : short x), short y
 | x y ⟨L, R, rL, rR⟩ S :=
 begin
-  resetI,
-  haveI := fintype.of_equiv _ L,
-  haveI := fintype.of_equiv _ R,
-  exact short.mk'
-    (λ i, by { rw ←(L.right_inv i), apply short_of_relabelling (rL (L.symm i)) infer_instance, })
-    (λ j, by simpa using short_of_relabelling (rR (R.symm j)) infer_instance)
+  sorry
 end
 
 instance short_neg : Π (x : pgame.{u}) [short x], short (-x)

--- a/src/set_theory/game/state.lean
+++ b/src/set_theory/game/state.lean
@@ -24,6 +24,7 @@ See `set_theory/game/domineering` for an example using this construction.
 universe u
 
 namespace pgame
+open_locale pgame
 
 /--
 `pgame_state S` describes how to interpret `s : S` as a state of a combinatorial game.
@@ -80,43 +81,29 @@ def of_state_aux : Π (n : ℕ) (s : S) (h : turn_bound s ≤ n), pgame
     (λ t, of_state_aux n t (turn_bound_of_right t.2 n h))
 
 /-- Two different (valid) turn bounds give equivalent games. -/
-def of_state_aux_relabelling : Π (s : S) (n m : ℕ) (hn : turn_bound s ≤ n) (hm : turn_bound s ≤ m),
-  relabelling (of_state_aux n s hn) (of_state_aux m s hm)
-| s 0 0 hn hm :=
-  begin
-    dsimp [pgame.of_state_aux],
-    fsplit, refl, refl,
-    { intro i, dsimp at i, exfalso,
-      exact turn_bound_ne_zero_of_left_move i.2 (nonpos_iff_eq_zero.mp hn) },
-    { intro j, dsimp at j, exfalso,
-      exact turn_bound_ne_zero_of_right_move j.2 (nonpos_iff_eq_zero.mp hm) }
-  end
+def of_state_aux_identical : Π (s : S) (n m : ℕ) (hn : turn_bound s ≤ n) (hm : turn_bound s ≤ m),
+  identical (of_state_aux n s hn) (of_state_aux m s hm)
+| s 0 0 hn hm := by apply identical.ext; simp
 | s 0 (m+1) hn hm :=
   begin
-    dsimp [pgame.of_state_aux],
-    fsplit, refl, refl,
-    { intro i, dsimp at i, exfalso,
-      exact turn_bound_ne_zero_of_left_move i.2 (nonpos_iff_eq_zero.mp hn) },
-    { intro j, dsimp at j, exfalso,
-      exact turn_bound_ne_zero_of_right_move j.2 (nonpos_iff_eq_zero.mp hn) }
+    refine identical.ext (λ z, ⟨λ h, _, λ h, _⟩) (λ z, ⟨λ h, _, λ h, _⟩);
+    obtain ⟨⟨i, hi⟩, h⟩ := h; exfalso;
+    exact turn_bound_ne_zero_of_left_move hi (nonpos_iff_eq_zero.mp hn) <|>
+    exact turn_bound_ne_zero_of_right_move hi (nonpos_iff_eq_zero.mp hn),
   end
 | s (n+1) 0 hn hm :=
   begin
-    dsimp [pgame.of_state_aux],
-    fsplit, refl, refl,
-    { intro i, dsimp at i, exfalso,
-      exact turn_bound_ne_zero_of_left_move i.2 (nonpos_iff_eq_zero.mp hm) },
-    { intro j, dsimp at j, exfalso,
-      exact turn_bound_ne_zero_of_right_move j.2 (nonpos_iff_eq_zero.mp hm) }
+    refine identical.ext (λ z, ⟨λ h, _, λ h, _⟩) (λ z, ⟨λ h, _, λ h, _⟩);
+    obtain ⟨⟨i, hi⟩, h⟩ := h; exfalso;
+    exact turn_bound_ne_zero_of_left_move hi (nonpos_iff_eq_zero.mp hm) <|>
+    exact turn_bound_ne_zero_of_right_move hi (nonpos_iff_eq_zero.mp hm),
   end
 | s (n+1) (m+1) hn hm :=
   begin
-    dsimp [pgame.of_state_aux],
-    fsplit, refl, refl,
-    { intro i,
-      apply of_state_aux_relabelling, },
-    { intro j,
-      apply of_state_aux_relabelling, }
+    refine identical.ext (λ z, ⟨λ h, _, λ h, _⟩) (λ z, ⟨λ h, _, λ h, _⟩);
+    obtain ⟨i, h⟩ := h;
+    exact ⟨i, h.trans (of_state_aux_identical _ n m _ _).symm⟩ <|>
+    exact ⟨i, h.trans (of_state_aux_identical _ n m _ _)⟩,
   end
 
 /-- Construct a combinatorial `pgame` from a state. -/
@@ -144,12 +131,12 @@ def right_moves_of_state (s : S) : right_moves (of_state s) ≃ {t // t ∈ R s}
 right_moves_of_state_aux _ _
 
 /--
-The relabelling showing `move_left` applied to a game constructed using `of_state_aux`
+The identity showing `move_left` applied to a game constructed using `of_state_aux`
 has itself been constructed using `of_state_aux`.
 -/
-def relabelling_move_left_aux (n : ℕ) {s : S} (h : turn_bound s ≤ n)
+def identical_move_left_aux (n : ℕ) {s : S} (h : turn_bound s ≤ n)
   (t : left_moves (of_state_aux n s h)) :
-  relabelling
+  identical
     (move_left (of_state_aux n s h) t)
     (of_state_aux (n-1) (((left_moves_of_state_aux n h) t) : S)
       ((turn_bound_of_left ((left_moves_of_state_aux n h) t).2 (n-1)
@@ -161,25 +148,25 @@ begin
   { refl },
 end
 /--
-The relabelling showing `move_left` applied to a game constructed using `of`
+The identity showing `move_left` applied to a game constructed using `of`
 has itself been constructed using `of`.
 -/
-def relabelling_move_left (s : S) (t : left_moves (of_state s)) :
-  relabelling
+def identical_move_left (s : S) (t : left_moves (of_state s)) :
+  identical
     (move_left (of_state s) t)
     (of_state (((left_moves_of_state s).to_fun t) : S)) :=
 begin
   transitivity,
-  apply relabelling_move_left_aux,
-  apply of_state_aux_relabelling,
+  apply identical_move_left_aux,
+  apply of_state_aux_identical,
 end
 /--
-The relabelling showing `move_right` applied to a game constructed using `of_state_aux`
+The identity showing `move_right` applied to a game constructed using `of_state_aux`
 has itself been constructed using `of_state_aux`.
 -/
-def relabelling_move_right_aux (n : ℕ) {s : S} (h : turn_bound s ≤ n)
+def identical_move_right_aux (n : ℕ) {s : S} (h : turn_bound s ≤ n)
   (t : right_moves (of_state_aux n s h)) :
-  relabelling
+  identical
     (move_right (of_state_aux n s h) t)
     (of_state_aux (n-1) (((right_moves_of_state_aux n h) t) : S)
       ((turn_bound_of_right ((right_moves_of_state_aux n h) t).2 (n-1)
@@ -191,17 +178,17 @@ begin
   { refl },
 end
 /--
-The relabelling showing `move_right` applied to a game constructed using `of`
+The identity showing `move_right` applied to a game constructed using `of`
 has itself been constructed using `of`.
 -/
-def relabelling_move_right (s : S) (t : right_moves (of_state s)) :
-  relabelling
+def identical_move_right (s : S) (t : right_moves (of_state s)) :
+  identical
     (move_right (of_state s) t)
     (of_state (((right_moves_of_state s).to_fun t) : S)) :=
 begin
   transitivity,
-  apply relabelling_move_right_aux,
-  apply of_state_aux_relabelling,
+  apply identical_move_right_aux,
+  apply of_state_aux_identical,
 end
 
 instance fintype_left_moves_of_state_aux (n : ℕ) (s : S) (h : turn_bound s ≤ n) :
@@ -232,8 +219,8 @@ instance short_of_state_aux : Π (n : ℕ) {s : S} (h : turn_bound s ≤ n), sho
   end)
 | (n+1) s h :=
   short.mk'
-  (λ i, short_of_relabelling (relabelling_move_left_aux (n+1) h i).symm (short_of_state_aux n _))
-  (λ j, short_of_relabelling (relabelling_move_right_aux (n+1) h j).symm (short_of_state_aux n _))
+  (λ i, short_of_identical (identical_move_left_aux (n+1) h i).symm (short_of_state_aux n _))
+  (λ j, short_of_identical (identical_move_right_aux (n+1) h j).symm (short_of_state_aux n _))
 
 instance short_of_state (s : S) : short (of_state s) :=
 begin

--- a/src/set_theory/surreal/basic.lean
+++ b/src/set_theory/surreal/basic.lean
@@ -95,18 +95,17 @@ theorem numeric_rec {C : pgame → Prop}
 | ⟨l, r, L, R⟩ ⟨h, hl, hr⟩ :=
   H _ _ _ _ h hl hr (λ i, numeric_rec _ (hl i)) (λ i, numeric_rec _ (hr i))
 
-theorem relabelling.numeric_imp {x y : pgame} (r : x ≡r y) (ox : numeric x) : numeric y :=
+theorem identical.numeric_imp {x y : pgame.{u}} (r : x ≡ y) (ox : numeric x) : numeric y :=
 begin
   induction x using pgame.move_rec_on with x IHl IHr generalizing y,
   apply numeric.mk (λ i j, _) (λ i, _) (λ j, _),
-  { rw ←lt_congr (r.move_left_symm i).equiv (r.move_right_symm j).equiv,
+  { rw ←lt_congr (r.move_left_symm i).some_spec.equiv (r.move_right_symm j).some_spec.equiv,
     apply ox.left_lt_right },
-  { exact IHl _ (ox.move_left _) (r.move_left_symm i) },
-  { exact IHr _ (ox.move_right _) (r.move_right_symm j) }
+  { exact IHl _ (ox.move_left _) (r.move_left_symm i).some_spec },
+  { exact IHr _ (ox.move_right _) (r.move_right_symm j).some_spec }
 end
 
-/-- Relabellings preserve being numeric. -/
-theorem relabelling.numeric_congr {x y : pgame} (r : x ≡r y) : numeric x ↔ numeric y :=
+theorem identical.numeric_congr {x y : pgame.{u}} (r : x ≡ y) : numeric x ↔ numeric y :=
 ⟨r.numeric_imp, r.symm.numeric_imp⟩
 
 theorem lf_asymm {x y : pgame} (ox : numeric x) (oy : numeric y) : x ⧏ y → ¬ y ⧏ x :=


### PR DESCRIPTION
This PR removes `pgame.relabelling`, which is only for implementing things in lean and not the real identity of games.

This PR is still waiting to redefine `pgame.short`.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Well-founded.20recursion.20for.20pgames/near/338664567)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #18515

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
