### PR TITLE
[Merged by Bors] - feat(linear_algebra/free_module/pid): rename module.free_of_finite_type_torsion_free

### DIFF
--- a/src/algebra/module/pid.lean
+++ b/src/algebra/module/pid.lean
@@ -234,7 +234,7 @@ begin
   haveI := is_noetherian_submodule' (torsion R N),
   haveI := module.finite.of_surjective _ (torsion R N).mkq_surjective,
   obtain ⟨I, fI, p, hp, e, ⟨h⟩⟩ := equiv_direct_sum_of_is_torsion (@torsion_is_torsion R N _ _ _),
-  obtain ⟨n, ⟨g⟩⟩ := @module.free_of_finite_type_torsion_free' R _ _ _ (N ⧸ torsion R N) _ _ _ _,
+  obtain ⟨n, ⟨g⟩⟩ := @module.basis_of_finite_type_torsion_free' R _ _ _ (N ⧸ torsion R N) _ _ _ _,
   haveI : module.projective R (N ⧸ torsion R N) := module.projective_of_basis ⟨g⟩,
   obtain ⟨f, hf⟩ := module.projective_lifting_property _ linear_map.id (torsion R N).mkq_surjective,
   refine ⟨n, I, fI, p, hp, e,

--- a/src/linear_algebra/free_module/pid.lean
+++ b/src/linear_algebra/free_module/pid.lean
@@ -5,6 +5,7 @@ Authors: Anne Baanen
 -/
 
 import linear_algebra.dimension
+import linear_algebra.free_module.basic
 import ring_theory.principal_ideal_domain
 import ring_theory.finiteness
 
@@ -348,8 +349,8 @@ submodule.basis_of_pid_of_le le (basis.span hb)
 
 variable {M}
 
-/-- A finite type torsion free module over a PID is free. -/
-noncomputable def module.free_of_finite_type_torsion_free [fintype ι] {s : ι → M}
+/-- A finite type torsion free module over a PID admits a basis. -/
+noncomputable def module.basis_of_finite_type_torsion_free [fintype ι] {s : ι → M}
   (hs : span R (range s) = ⊤) [no_zero_smul_divisors R M] :
   Σ (n : ℕ), basis (fin n) R M :=
 begin
@@ -396,11 +397,27 @@ begin
   exact ⟨n, b.map ψ.symm⟩
 end
 
-/-- A finite type torsion free module over a PID is free. -/
-noncomputable def module.free_of_finite_type_torsion_free' [module.finite R M]
+lemma module.free_of_finite_type_torsion_free [fintype ι] {s : ι → M}
+  (hs : span R (range s) = ⊤) [no_zero_smul_divisors R M] :
+  module.free R M :=
+begin
+  obtain ⟨n, b⟩ : Σ n, basis (fin n) R M := module.basis_of_finite_type_torsion_free hs,
+  exact module.free.of_basis b,
+end
+
+/-- A finite type torsion free module over a PID admits a basis. -/
+noncomputable def module.basis_of_finite_type_torsion_free' [module.finite R M]
   [no_zero_smul_divisors R M] :
   Σ (n : ℕ), basis (fin n) R M :=
-module.free_of_finite_type_torsion_free module.finite.exists_fin.some_spec.some_spec
+module.basis_of_finite_type_torsion_free module.finite.exists_fin.some_spec.some_spec
+
+lemma module.free_of_finite_type_torsion_free' [module.finite R M]
+  [no_zero_smul_divisors R M] :
+  module.free R M :=
+begin
+  obtain ⟨n, b⟩ : Σ n, basis (fin n) R M := module.basis_of_finite_type_torsion_free',
+  exact module.free.of_basis b,
+end
 
 section smith_normal
 

--- a/src/linear_algebra/free_module/pid.lean
+++ b/src/linear_algebra/free_module/pid.lean
@@ -397,10 +397,11 @@ begin
   exact ⟨n, b.map ψ.symm⟩
 end
 
-lemma module.free_of_finite_type_torsion_free [fintype ι] {s : ι → M}
+lemma module.free_of_finite_type_torsion_free [finite ι] {s : ι → M}
   (hs : span R (range s) = ⊤) [no_zero_smul_divisors R M] :
   module.free R M :=
 begin
+  casesI nonempty_fintype ι,
   obtain ⟨n, b⟩ : Σ n, basis (fin n) R M := module.basis_of_finite_type_torsion_free hs,
   exact module.free.of_basis b,
 end


### PR DESCRIPTION
See https://github.com/leanprover-community/mathlib/pull/18474#discussion_r1122802316

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
