### PR TITLE
[Merged by Bors] - fix(algebra/algebra/operations): add missing `set_semiring.down` casts

### DIFF
--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -461,12 +461,13 @@ by rw [←comap_equiv_eq_map_symm, ←comap_equiv_eq_map_symm, comap_op_pow]
 
 /-- `span` is a semiring homomorphism (recall multiplication is pointwise multiplication of subsets
 on either side). -/
+@[simps]
 def span.ring_hom : set_semiring A →+* submodule R A :=
-{ to_fun := submodule.span R,
+{ to_fun := λ s, submodule.span R s.down,
   map_zero' := span_empty,
   map_one' := one_eq_span.symm,
   map_add' := span_union,
-  map_mul' := λ s t, by erw [span_mul_span, ← image_mul_prod] }
+  map_mul' := λ s t, by rw [set_semiring.down_mul, span_mul_span, ← image_mul_prod] }
 
 section
 variables {α : Type*} [monoid α] [mul_semiring_action α A] [smul_comm_class α R A]
@@ -523,22 +524,23 @@ variables (R A)
 
 /-- R-submodules of the R-algebra A are a module over `set A`. -/
 instance module_set : module (set_semiring A) (submodule R A) :=
-{ smul := λ s P, span R s * P,
+{ smul := λ s P, span R s.down * P,
   smul_add := λ _ _ _, mul_add _ _ _,
-  add_smul := λ s t P, show span R (s ⊔ t) * P = _, by { erw [span_union, right_distrib] },
-  mul_smul := λ s t P, show _ = _ * (_ * _),
-    by { rw [← mul_assoc, span_mul_span, ← image_mul_prod] },
-  one_smul := λ P, show span R {(1 : A)} * P = _,
-    by { conv_lhs {erw ← span_eq P}, erw [span_mul_span, one_mul, span_eq] },
-  zero_smul := λ P, show span R ∅ * P = ⊥, by erw [span_empty, bot_mul],
+  add_smul := λ s t P,
+    by simp_rw [has_smul.smul, set_semiring.down_add, span_union, sup_mul, add_eq_sup],
+  mul_smul := λ s t P,
+    by simp_rw [has_smul.smul, set_semiring.down_mul, ← mul_assoc, span_mul_span],
+  one_smul := λ P,
+    by simp_rw [has_smul.smul, set_semiring.down_one, ←one_eq_span_one_set, one_mul],
+  zero_smul := λ P,
+    by simp_rw [has_smul.smul, set_semiring.down_zero, span_empty, bot_mul, bot_eq_zero],
   smul_zero := λ _, mul_bot _ }
-
 
 variables {R A}
 
-lemma smul_def {s : set_semiring A} {P : submodule R A} : s • P = span R s * P := rfl
+lemma smul_def (s : set_semiring A) (P : submodule R A) : s • P = span R s.down * P := rfl
 
-lemma smul_le_smul {s t : set_semiring A} {M N : submodule R A} (h₁ : s.down ≤ t.down)
+lemma smul_le_smul {s t : set_semiring A} {M N : submodule R A} (h₁ : s.down ⊆ t.down)
   (h₂ : M ≤ N) : s • M ≤ t • N :=
 mul_le_mul (span_mono h₁) h₂
 

--- a/src/data/set/semiring.lean
+++ b/src/data/set/semiring.lean
@@ -147,10 +147,13 @@ def image_hom [mul_one_class α] [mul_one_class β] (f : α →* β) :
   map_add' := image_union _,
   map_mul' := λ _ _, image_mul f }
 
+lemma down_image_def [mul_one_class α] [mul_one_class β] (f : α →* β) (s : set_semiring α) :
+  image_hom f s = (image f s.down).up := rfl
+
 @[simp] lemma down_image_hom [mul_one_class α] [mul_one_class β] (f : α →* β) (s : set_semiring α) :
   (image_hom f s).down = f '' s.down := rfl
 
-@[simp] lemma image_hom_up [mul_one_class α] [mul_one_class β] (f : α →* β) (s : set α) :
-  image_hom f s.up = (f '' s).up := rfl
+@[simp] lemma _root_.set.up_image [mul_one_class α] [mul_one_class β] (f : α →* β) (s : set α) :
+  (f '' s).up = image_hom f s.up := rfl
 
 end set_semiring

--- a/src/data/set/semiring.lean
+++ b/src/data/set/semiring.lean
@@ -83,7 +83,7 @@ instance : non_unital_non_assoc_semiring (set_semiring α) :=
 
 lemma mul_def (s t : set_semiring α) : s * t = (s.down * t.down).up := rfl
 
-@[simp] lemma down_mul (s t : set_semiring α) : (s + t).down = s.down ∪ t.down := rfl
+@[simp] lemma down_mul (s t : set_semiring α) : (s * t).down = s.down * t.down := rfl
 
 @[simp] lemma _root_.set.up_mul (s t : set α) : (s * t).up = s.up * t.up := rfl
 

--- a/src/data/set/semiring.lean
+++ b/src/data/set/semiring.lean
@@ -141,10 +141,16 @@ instance [comm_monoid α] : canonically_ordered_comm_semiring (set_semiring α) 
 with respect to the pointwise operations on sets. -/
 def image_hom [mul_one_class α] [mul_one_class β] (f : α →* β) :
   set_semiring α →+* set_semiring β :=
-{ to_fun := image f,
+{ to_fun := λ s, (image f s.down).up,
   map_zero' := image_empty _,
-  map_one' := by rw [image_one, map_one, singleton_one],
+  map_one' := by rw [down_one, image_one, map_one, singleton_one, set.up_one],
   map_add' := image_union _,
   map_mul' := λ _ _, image_mul f }
+
+@[simp] lemma down_image_hom [mul_one_class α] [mul_one_class β] (f : α →* β) (s : set_semiring α) :
+  (image_hom f s).down = f '' s.down := rfl
+
+@[simp] lemma image_hom_up [mul_one_class α] [mul_one_class β] (f : α →* β) (s : set α) :
+  image_hom f s.up = (f '' s).up := rfl
 
 end set_semiring


### PR DESCRIPTION
Previously this was abusing the defeq of the types, resulting in lemmas stated in weird ways.

This also fixes a type in #18449, and adds three missing lemmas about `image_hom`.

Forward port of `set_semiring` will be included in https://github.com/leanprover-community/mathlib4/pull/2518

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
