### PR TITLE
[Merged by Bors] - chore(algebra/algebra/restrict_scalars): replace `restrict_scalars_smul_def` with version that does not commit defeq-abuse.

### DIFF
--- a/src/algebra/algebra/restrict_scalars.lean
+++ b/src/algebra/algebra/restrict_scalars.lean
@@ -153,6 +153,11 @@ variables [comm_semiring R] [semiring S] [algebra R S] [module S M]
   = (algebra_map R S c) • restrict_scalars.add_equiv R S M x :=
 rfl
 
+lemma restrict_scalars.smul_def (c : R) (x : restrict_scalars R S M) :
+  c • x = (restrict_scalars.add_equiv R S M).symm
+    (algebra_map R S c • restrict_scalars.add_equiv R S M x) :=
+rfl
+
 lemma restrict_scalars.add_equiv_symm_map_algebra_map_smul (r : R) (x : M) :
   (restrict_scalars.add_equiv R S M).symm (algebra_map R S r • x)
   = r • (restrict_scalars.add_equiv R S M).symm x :=

--- a/src/algebra/algebra/restrict_scalars.lean
+++ b/src/algebra/algebra/restrict_scalars.lean
@@ -148,14 +148,6 @@ add_equiv.refl M
 
 variables [comm_semiring R] [semiring S] [algebra R S] [module S M]
 
-/--
-Note that this lemma relies on the definitional equality `restrict_scalars R S M = M`,
-so usage may result in instance leakage.
-`restrict_scalars.add_equiv_map_smul` is the "hygienic" version.
--/
-lemma restrict_scalars_smul_def (c : R) (x : restrict_scalars R S M) :
-  c • x = ((algebra_map R S c) • x : M) := rfl
-
 @[simp] lemma restrict_scalars.add_equiv_map_smul (c : R) (x : restrict_scalars R S M) :
   restrict_scalars.add_equiv R S M (c • x)
   = (algebra_map R S c) • restrict_scalars.add_equiv R S M x :=

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -211,8 +211,7 @@ by rw [← finite_dimensional.finrank_mul_finrank ℝ ℂ E, complex.finrank_rea
 @[priority 900]
 instance star_module.complex_to_real {E : Type*} [add_comm_group E] [has_star E] [module ℂ E]
   [star_module ℂ E] : star_module ℝ E :=
-⟨λ r a, by rw [← one_smul ℂ (star a), ← smul_assoc, ← star_one, ← star_smul, ← star_smul,
-    smul_assoc, one_smul]⟩
+⟨λ r a, by rw [←smul_one_smul ℂ r a, star_smul, star_smul, star_one, smul_one_smul]⟩
 
 namespace complex
 

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -211,8 +211,8 @@ by rw [← finite_dimensional.finrank_mul_finrank ℝ ℂ E, complex.finrank_rea
 @[priority 900]
 instance star_module.complex_to_real {E : Type*} [add_comm_group E] [has_star E] [module ℂ E]
   [star_module ℂ E] : star_module ℝ E :=
-⟨λ r a, by rw [star_trivial r, restrict_scalars_smul_def, restrict_scalars_smul_def, star_smul,
-  complex.coe_algebra_map, complex.star_def, complex.conj_of_real]⟩
+⟨λ r a, by rw [← one_smul ℂ (star a), ← smul_assoc, ← star_one, ← star_smul, ← star_smul,
+    smul_assoc, one_smul]⟩
 
 namespace complex
 


### PR DESCRIPTION
This lemma abuses definitional equality and I think we are better without it. My immediate motivation is the trouble it is causing in the Mathlib4 porting PR: https://github.com/leanprover-community/mathlib4/pull/2563

Note that it was only used in one place and there is a better proof.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
