### PR TITLE
[Merged by Bors] - feat(ring_theory/hahn_series): add lemma neg_order

### DIFF
--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -395,7 +395,8 @@ lemma sub_coeff {x y : hahn_series Γ R} {a : Γ} :
   (x - y).coeff a = x.coeff a - y.coeff a := by simp
 
 lemma order_neg [has_zero Γ] {f : hahn_series Γ R} : (- f).order = f.order :=
-  by { by_cases hf : f = 0, { simp only [hf, neg_zero] }, simp only [order, support_neg, neg_eq_zero] }
+  by { by_cases hf : f = 0, { simp only [hf, neg_zero] },
+    simp only [order, support_neg, neg_eq_zero] }
 
 end add_group
 

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -395,7 +395,7 @@ lemma sub_coeff {x y : hahn_series Γ R} {a : Γ} :
   (x - y).coeff a = x.coeff a - y.coeff a := by simp
 
 lemma neg_order [has_zero Γ] {f : hahn_series Γ R} : (- f).order = f.order :=
-  by {by_cases hf : f = 0, simp only [hf, neg_zero], simp only [order, support_neg, neg_eq_zero]}
+  by { by_cases hf : f = 0, { simp only [hf, neg_zero] }, simp only [order, support_neg, neg_eq_zero] }
 
 end add_group
 

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -394,7 +394,7 @@ lemma sub_coeff' {x y : hahn_series Γ R} :
 lemma sub_coeff {x y : hahn_series Γ R} {a : Γ} :
   (x - y).coeff a = x.coeff a - y.coeff a := by simp
 
-lemma neg_order [has_zero Γ] {f : hahn_series Γ R} : (- f).order = f.order :=
+lemma order_neg [has_zero Γ] {f : hahn_series Γ R} : (- f).order = f.order :=
   by { by_cases hf : f = 0, { simp only [hf, neg_zero] }, simp only [order, support_neg, neg_eq_zero] }
 
 end add_group

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -394,7 +394,7 @@ lemma sub_coeff' {x y : hahn_series Γ R} :
 lemma sub_coeff {x y : hahn_series Γ R} {a : Γ} :
   (x - y).coeff a = x.coeff a - y.coeff a := by simp
 
-lemma order_neg [has_zero Γ] {f : hahn_series Γ R} : (- f).order = f.order :=
+@[simp] lemma order_neg [has_zero Γ] {f : hahn_series Γ R} : (- f).order = f.order :=
   by { by_cases hf : f = 0, { simp only [hf, neg_zero] },
     simp only [order, support_neg, neg_eq_zero] }
 

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -395,7 +395,7 @@ lemma sub_coeff {x y : hahn_series Γ R} {a : Γ} :
   (x - y).coeff a = x.coeff a - y.coeff a := by simp
 
 @[simp] lemma order_neg [has_zero Γ] {f : hahn_series Γ R} : (- f).order = f.order :=
-  by { by_cases hf : f = 0, { simp only [hf, neg_zero] },
+by { by_cases hf : f = 0, { simp only [hf, neg_zero] },
     simp only [order, support_neg, neg_eq_zero] }
 
 end add_group

--- a/src/ring_theory/hahn_series.lean
+++ b/src/ring_theory/hahn_series.lean
@@ -394,6 +394,9 @@ lemma sub_coeff' {x y : hahn_series Γ R} :
 lemma sub_coeff {x y : hahn_series Γ R} {a : Γ} :
   (x - y).coeff a = x.coeff a - y.coeff a := by simp
 
+lemma neg_order [has_zero Γ] {f : hahn_series Γ R} : (- f).order = f.order :=
+  by {by_cases hf : f = 0, simp only [hf, neg_zero], simp only [order, support_neg, neg_eq_zero]}
+
 end add_group
 
 instance [add_comm_group R] : add_comm_group (hahn_series Γ R) :=


### PR DESCRIPTION
added lemma `neg_order` stating that the order of the opposite of a Hahn series (with coefficients in an `add_group`) is the same of the order of the series itself.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
