### PR TITLE
feat(algebra/big_operators/finsupp): add some lemmas about `finsupp.indicator`

### DIFF
--- a/src/algebra/big_operators/finsupp.lean
+++ b/src/algebra/big_operators/finsupp.lean
@@ -488,7 +488,7 @@ begin
   exact h2,
 end
 
-lemma indicator_eq_sum_single [add_comm_monoid M] {s : finset α} (f : Π a ∈ s, M) :
+lemma indicator_eq_sum_attach_single [add_comm_monoid M] {s : finset α} (f : Π a ∈ s, M) :
   indicator s f = ∑ x in s.attach, single x (f x x.2) :=
 begin
   rw [← sum_single (indicator s f), sum, sum_subset (support_indicator_subset _ _), ← sum_attach],
@@ -498,12 +498,12 @@ begin
   rw [not_mem_support_iff.mp hi, single_zero],
 end
 
-lemma indicator_const_eq_sum_single [add_comm_monoid M] (s : finset α) (m : M) :
-  indicator s (λ _ _, m) = ∑ x in s, single x m :=
-(indicator_eq_sum_single _).trans $ @sum_attach _ _ _ _ (λ i, single i m)
+lemma indicator_eq_sum_single [add_comm_monoid M] (s : finset α) (f : α → M) :
+  indicator s (λ x _, f x) = ∑ x in s, single x (f x) :=
+(indicator_eq_sum_attach_single _).trans $ @sum_attach _ _ _ _ (λ x, single x (f x))
 
 @[simp, to_additive]
-lemma prod_indicator_index [has_zero M] [comm_monoid N]
+lemma prod_indicator_index_eq_prod_attach [has_zero M] [comm_monoid N]
   {s : finset α} (f : Π a ∈ s, M) {h : α → M → N} (h_zero : ∀ a ∈ s, h a 0 = 1) :
   (indicator s f).prod h = ∏ x in s.attach, h x (f x x.2) :=
 begin
@@ -513,10 +513,10 @@ begin
 end
 
 @[simp, to_additive]
-lemma prod_indicator_const_index [has_zero M] [comm_monoid N]
-  {s : finset α} (m : M) {h : α → M → N} (h_zero : ∀ a ∈ s, h a 0 = 1) :
-  (indicator s (λ _ _, m)).prod h = ∏ x in s, h x m :=
-(prod_indicator_index _ h_zero).trans $ @prod_attach _ _ _ _ (λ i, h i m)
+lemma prod_indicator_index [has_zero M] [comm_monoid N]
+  {s : finset α} (f : α → M) {h : α → M → N} (h_zero : ∀ a ∈ s, h a 0 = 1) :
+  (indicator s (λ x _, f x)).prod h = ∏ x in s, h x (f x) :=
+(prod_indicator_index_eq_prod_attach _ h_zero).trans $ @prod_attach _ _ _ _ (λ x, h x (f x))
 
 end finsupp
 

--- a/src/algebra/big_operators/finsupp.lean
+++ b/src/algebra/big_operators/finsupp.lean
@@ -488,7 +488,7 @@ begin
   exact h2,
 end
 
-lemma indicator_eq_sum_single [add_comm_monoid M] (s : finset α) (f : Π a ∈ s, M) :
+lemma indicator_eq_sum_single [add_comm_monoid M] {s : finset α} (f : Π a ∈ s, M) :
   indicator s f = ∑ x in s.attach, single x (f x x.2) :=
 begin
   rw [← sum_single (indicator s f), sum, sum_subset (support_indicator_subset _ _), ← sum_attach],
@@ -497,6 +497,10 @@ begin
   intros i _ hi,
   rw [not_mem_support_iff.mp hi, single_zero],
 end
+
+lemma indicator_const_eq_sum_single [add_comm_monoid M] (s : finset α) (m : M) :
+  indicator s (λ _ _, m) = ∑ x in s, single x m :=
+(indicator_eq_sum_single _).trans $ @sum_attach _ _ _ _ (λ i, single i m)
 
 @[simp, to_additive]
 lemma prod_indicator_index [has_zero M] [comm_monoid N]
@@ -507,6 +511,12 @@ begin
   refine finset.prod_congr rfl (λ x hx, _),
   rw [indicator_of_mem],
 end
+
+@[simp, to_additive]
+lemma prod_indicator_const_index [has_zero M] [comm_monoid N]
+  (s : finset α) (m : M) {h : α → M → N} (h_zero : ∀ a ∈ s, h a 0 = 1) :
+  (indicator s (λ _ _, m)).prod h = ∏ x in s, h x m :=
+(prod_indicator_index _ h_zero).trans $ @prod_attach _ _ _ _ (λ i, h i m)
 
 end finsupp
 

--- a/src/algebra/big_operators/finsupp.lean
+++ b/src/algebra/big_operators/finsupp.lean
@@ -514,7 +514,7 @@ end
 
 @[simp, to_additive]
 lemma prod_indicator_const_index [has_zero M] [comm_monoid N]
-  (s : finset α) (m : M) {h : α → M → N} (h_zero : ∀ a ∈ s, h a 0 = 1) :
+  {s : finset α} (m : M) {h : α → M → N} (h_zero : ∀ a ∈ s, h a 0 = 1) :
   (indicator s (λ _ _, m)).prod h = ∏ x in s, h x m :=
 (prod_indicator_index _ h_zero).trans $ @prod_attach _ _ _ _ (λ i, h i m)
 


### PR DESCRIPTION
It's hard to rewrite after using `indicator_eq_sum_single` and `prod_indicator_index`, so I add these two lemmas.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
