### PR TITLE
[Merged by Bors] - feat(measure_theory/function/l1_space): Hölder's inequality specialized to integrable functions

### DIFF
--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -643,6 +643,27 @@ begin
     exact ennreal.mul_lt_top ennreal.coe_ne_top (ne_of_lt hint.2) },
 end
 
+/-
+theorem measure_theory.snorm_smul_le_mul_snorm {α : Type u_1} {E : Type u_2}
+  {m0 : measurable_space α} {μ : measure_theory.measure α} [normed_add_comm_group E]
+  {𝕜 : Type u_5} [normed_field 𝕜] [normed_space 𝕜 E] {p q r : ennreal} {f : α → E}
+  (hf : measure_theory.ae_strongly_measurable f μ) {φ : α → 𝕜}
+  (hφ : measure_theory.ae_strongly_measurable φ μ) (hpqr : 1 / p = 1 / q + 1 / r) :
+measure_theory.snorm (φ • f) p μ ≤ measure_theory.snorm φ q μ * measure_theory.snorm f r μ
+
+-/
+
+lemma integrable.mul_ℒ_infinity  {G : Type*} {E : Type*} [normed_ring E] [normed_algebra ℝ E]
+  [measurable_space E] [borel_space E] [has_measurable_mul₂ E] [measurable_space G]
+  {μ : measure G}
+  (f : G → E)
+  (f_ℒ_1 : integrable f μ)
+  (g : G → E)
+  (g_measurable : ae_strongly_measurable g μ)
+  (g_ℒ_infinity : ess_sup (λ x, (‖g x‖₊ : ℝ≥0∞)) μ < ∞) :
+  integrable (λ (x : G), f x * g x) μ :=
+sorry
+
 lemma integrable_norm_iff {f : α → β} (hf : ae_strongly_measurable f μ) :
   integrable (λa, ‖f a‖) μ ↔ integrable f μ :=
 by simp_rw [integrable, and_iff_right hf, and_iff_right hf.norm, has_finite_integral_norm_iff]

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -647,32 +647,32 @@ end
 vector-valued function by a scalar function with finite essential supremum is integrable. -/
 lemma integrable.ess_sup_smul {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β] {f : α → β}
   (hf : integrable f μ) {g : α → 𝕜} (g_ae_strongly_measurable : ae_strongly_measurable g μ)
-  (ess_sup_g : ess_sup (λ x, (‖g x‖₊ : ℝ≥0∞)) μ < ∞) :
+  (ess_sup_g : ess_sup (λ x, (‖g x‖₊ : ℝ≥0∞)) μ ≠ ∞) :
   integrable (λ (x : α), g x • f x) μ :=
 begin
   rw ← mem_ℒp_one_iff_integrable at *,
   refine ⟨g_ae_strongly_measurable.smul hf.1, _⟩,
   have h : (1:ℝ≥0∞) / 1 = 1 / ∞ + 1 / 1 := by norm_num,
-  have hg' : snorm g ∞ μ < ∞ := by rwa snorm_exponent_top,
+  have hg' : snorm g ∞ μ ≠ ∞ := by rwa snorm_exponent_top,
   calc snorm (λ (x : α), g x • f x) 1 μ
       ≤ _ : measure_theory.snorm_smul_le_mul_snorm hf.1 g_ae_strongly_measurable h
-  ... < ∞ : ennreal.mul_lt_top hg'.ne hf.2.ne,
+  ... < ∞ : ennreal.mul_lt_top hg' hf.2.ne,
 end
 
 /-- Hölder's inequality for integrable functions: the scalar multiplication of an integrable
 scalar-valued function by a vector-value function with finite essential supremum is integrable. -/
 lemma integrable.smul_ess_sup {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β] {f : α → 𝕜}
   (hf : integrable f μ) {g : α → β} (g_ae_strongly_measurable : ae_strongly_measurable g μ)
-  (ess_sup_g : ess_sup (λ x, (‖g x‖₊ : ℝ≥0∞)) μ < ∞) :
+  (ess_sup_g : ess_sup (λ x, (‖g x‖₊ : ℝ≥0∞)) μ ≠ ∞) :
   integrable (λ (x : α), f x • g x) μ :=
 begin
   rw ← mem_ℒp_one_iff_integrable at *,
   refine ⟨hf.1.smul g_ae_strongly_measurable, _⟩,
   have h : (1:ℝ≥0∞) / 1 = 1 / 1 + 1 / ∞ := by norm_num,
-  have hg' : snorm g ∞ μ < ∞ := by rwa snorm_exponent_top,
+  have hg' : snorm g ∞ μ ≠ ∞ := by rwa snorm_exponent_top,
   calc snorm (λ (x : α), f x • g x) 1 μ
       ≤ _ : measure_theory.snorm_smul_le_mul_snorm g_ae_strongly_measurable hf.1 h
-  ... < ∞ : ennreal.mul_lt_top hf.2.ne hg'.ne,
+  ... < ∞ : ennreal.mul_lt_top hf.2.ne hg',
 end
 
 lemma integrable_norm_iff {f : α → β} (hf : ae_strongly_measurable f μ) :

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -643,26 +643,37 @@ begin
     exact ennreal.mul_lt_top ennreal.coe_ne_top (ne_of_lt hint.2) },
 end
 
-/-
-theorem measure_theory.snorm_smul_le_mul_snorm {α : Type u_1} {E : Type u_2}
-  {m0 : measurable_space α} {μ : measure_theory.measure α} [normed_add_comm_group E]
-  {𝕜 : Type u_5} [normed_field 𝕜] [normed_space 𝕜 E] {p q r : ennreal} {f : α → E}
-  (hf : measure_theory.ae_strongly_measurable f μ) {φ : α → 𝕜}
-  (hφ : measure_theory.ae_strongly_measurable φ μ) (hpqr : 1 / p = 1 / q + 1 / r) :
-measure_theory.snorm (φ • f) p μ ≤ measure_theory.snorm φ q μ * measure_theory.snorm f r μ
+/-- Hölder's inequality for integrable functions: the scalar multiplication of an integrable
+vector-valued function by a scalar function with finite essential supremum is integrable. -/
+lemma integrable.ess_sup_smul {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β] {f : α → β}
+  (hf : integrable f μ) {g : α → 𝕜} (g_ae_strongly_measurable : ae_strongly_measurable g μ)
+  (ess_sup_g : ess_sup (λ x, (‖g x‖₊ : ℝ≥0∞)) μ < ∞) :
+  integrable (λ (x : α), g x • f x) μ :=
+begin
+  rw ← mem_ℒp_one_iff_integrable at *,
+  refine ⟨g_ae_strongly_measurable.smul hf.1, _⟩,
+  have h : (1:ℝ≥0∞) / 1 = 1 / ∞ + 1 / 1 := by norm_num,
+  have hg' : snorm g ∞ μ < ∞ := by rwa snorm_exponent_top,
+  calc snorm (λ (x : α), g x • f x) 1 μ
+      ≤ _ : measure_theory.snorm_smul_le_mul_snorm hf.1 g_ae_strongly_measurable h
+  ... < ∞ : ennreal.mul_lt_top hg'.ne hf.2.ne,
+end
 
--/
-
-lemma integrable.mul_ℒ_infinity  {G : Type*} {E : Type*} [normed_ring E] [normed_algebra ℝ E]
-  [measurable_space E] [borel_space E] [has_measurable_mul₂ E] [measurable_space G]
-  {μ : measure G}
-  (f : G → E)
-  (f_ℒ_1 : integrable f μ)
-  (g : G → E)
-  (g_measurable : ae_strongly_measurable g μ)
-  (g_ℒ_infinity : ess_sup (λ x, (‖g x‖₊ : ℝ≥0∞)) μ < ∞) :
-  integrable (λ (x : G), f x * g x) μ :=
-sorry
+/-- Hölder's inequality for integrable functions: the scalar multiplication of an integrable
+scalar-valued function by a vector-value function with finite essential supremum is integrable. -/
+lemma integrable.smul_ess_sup {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 β] {f : α → 𝕜}
+  (hf : integrable f μ) {g : α → β} (g_ae_strongly_measurable : ae_strongly_measurable g μ)
+  (ess_sup_g : ess_sup (λ x, (‖g x‖₊ : ℝ≥0∞)) μ < ∞) :
+  integrable (λ (x : α), f x • g x) μ :=
+begin
+  rw ← mem_ℒp_one_iff_integrable at *,
+  refine ⟨hf.1.smul g_ae_strongly_measurable, _⟩,
+  have h : (1:ℝ≥0∞) / 1 = 1 / 1 + 1 / ∞ := by norm_num,
+  have hg' : snorm g ∞ μ < ∞ := by rwa snorm_exponent_top,
+  calc snorm (λ (x : α), f x • g x) 1 μ
+      ≤ _ : measure_theory.snorm_smul_le_mul_snorm g_ae_strongly_measurable hf.1 h
+  ... < ∞ : ennreal.mul_lt_top hf.2.ne hg'.ne,
+end
 
 lemma integrable_norm_iff {f : α → β} (hf : ae_strongly_measurable f μ) :
   integrable (λa, ‖f a‖) μ ↔ integrable f μ :=


### PR DESCRIPTION
Specialize Hölder's inequality for scalar product of an integrable and a finite-essential-supremum function.

Co-authored-by: Alex Kontorovich <58564076+AlexKontorovich@users.noreply.github.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
