### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/*exponential): more results about `star`

### DIFF
--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -378,8 +378,8 @@ end skew_adjoint
 
 /-- Scalar multiplication of a self-adjoint element by a skew-adjoint element produces a
 skew-adjoint element. -/
-lemma is_self_adjoint.smul_mem_skew_adjoint
-  [ring R] [add_comm_group A] [module R A] [star_add_monoid R] [star_add_monoid A] [star_module R A] {r : R}
+lemma is_self_adjoint.smul_mem_skew_adjoint [ring R] [add_comm_group A] [module R A]
+  [star_add_monoid R] [star_add_monoid A] [star_module R A] {r : R}
   (hr : r ∈ skew_adjoint R) {a : A} (ha : is_self_adjoint a) :
   r • a ∈ skew_adjoint A :=
 (star_smul _ _).trans $ (congr_arg2 _ hr ha).trans $ neg_smul _ _

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -34,6 +34,7 @@ We also define `is_star_normal R`, a `Prop` that states that an element `x` sati
 
 ## TODO
 
+* Define `is_skew_adjoint` to match `is_self_adjoint`.
 * Define `λ z x, z * x * star z` (i.e. conjugation by `z`) as a monoid action of `R` on `R`
   (similar to the existing `conj_act` for groups), and then state the fact that `self_adjoint R` is
   invariant under it.

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -376,6 +376,14 @@ end has_smul
 
 end skew_adjoint
 
+/-- Scalar multiplication of a self-adjoint element by a skew-adjoint element produces a
+skew-adjoint element. -/
+lemma is_self_adjoint.smul_mem_skew_adjoint
+  [ring R] [add_comm_group A] [module R A] [star_add_monoid R] [star_add_monoid A] [star_module R A] {r : R}
+  (hr : r ∈ skew_adjoint R) {a : A} (ha : is_self_adjoint a) :
+  r • a ∈ skew_adjoint A :=
+(star_smul _ _).trans $ (congr_arg2 _ hr ha).trans $ neg_smul _ _
+
 instance is_star_normal_zero [semiring R] [star_ring R] : is_star_normal (0 : R) :=
 ⟨by simp only [star_comm_self, star_zero]⟩
 

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -384,6 +384,14 @@ lemma is_self_adjoint.smul_mem_skew_adjoint [ring R] [add_comm_group A] [module 
   r • a ∈ skew_adjoint A :=
 (star_smul _ _).trans $ (congr_arg2 _ hr ha).trans $ neg_smul _ _
 
+/-- Scalar multiplication of a skew-adjoint element by a skew-adjoint element produces a
+self-adjoint element. -/
+lemma is_self_adjoint_smul_of_mem_skew_adjoint [ring R] [add_comm_group A] [module R A]
+  [star_add_monoid R] [star_add_monoid A] [star_module R A] {r : R}
+  (hr : r ∈ skew_adjoint R) {a : A} (ha : a ∈ skew_adjoint A) :
+  is_self_adjoint (r • a) :=
+(star_smul _ _).trans $ (congr_arg2 _ hr ha).trans $ neg_smul_neg _ _
+
 instance is_star_normal_zero [semiring R] [star_ring R] : is_star_normal (0 : R) :=
 ⟨by simp only [star_comm_self, star_zero]⟩
 

--- a/src/analysis/normed_space/exponential.lean
+++ b/src/analysis/normed_space/exponential.lean
@@ -125,6 +125,11 @@ by simp_rw [exp_eq_tsum, ←star_pow, ←star_inv_nat_cast_smul, ←tsum_star]
 
 variables (𝕂)
 
+lemma is_self_adjoint.exp [t2_space 𝔸] [star_ring 𝔸] [has_continuous_star 𝔸] {x : 𝔸}
+  (h : is_self_adjoint x) :
+  is_self_adjoint (exp 𝕂 x) :=
+(star_exp x).trans $ h.symm ▸ rfl
+
 lemma commute.exp_right [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute x (exp 𝕂 y) :=
 begin
   rw exp_eq_tsum,
@@ -446,6 +451,13 @@ begin
   letI := invertible_exp 𝕂 x,
   exact ring.inverse_invertible _,
 end
+
+lemma exp_mem_unitary_of_mem_skew_adjoint [star_ring 𝔸] [has_continuous_star 𝔸] {x : 𝔸}
+  (h : x ∈ skew_adjoint 𝔸) :
+  exp 𝕂 x ∈ unitary 𝔸 :=
+by rw [unitary.mem_iff, star_exp, skew_adjoint.mem_iff.mp h,
+  ←exp_add_of_commute (commute.refl x).neg_left, ←exp_add_of_commute (commute.refl x).neg_right,
+  add_left_neg, add_right_neg, exp_zero, and_self]
 
 end
 

--- a/src/analysis/normed_space/matrix_exponential.lean
+++ b/src/analysis/normed_space/matrix_exponential.lean
@@ -7,6 +7,8 @@ Authors: Eric Wieser
 import analysis.normed_space.exponential
 import analysis.matrix
 import linear_algebra.matrix.zpow
+import linear_algebra.matrix.hermitian
+import linear_algebra.matrix.symmetric
 import topology.uniform_space.matrix
 
 /-!
@@ -118,6 +120,10 @@ lemma exp_conj_transpose [star_ring 𝔸] [has_continuous_star 𝔸] (A : matrix
   exp 𝕂 Aᴴ = (exp 𝕂 A)ᴴ :=
 (star_exp A).symm
 
+lemma is_hermitian.exp [star_ring 𝔸] [has_continuous_star 𝔸] {A : matrix m m 𝔸}
+  (h : A.is_hermitian) : (exp 𝕂 A).is_hermitian :=
+(exp_conj_transpose _ _).symm.trans $ congr_arg _ h
+
 end ring
 
 section comm_ring
@@ -126,6 +132,9 @@ variables [fintype m] [decidable_eq m] [field 𝕂]
 
 lemma exp_transpose (A : matrix m m 𝔸) : exp 𝕂 Aᵀ = (exp 𝕂 A)ᵀ :=
 by simp_rw [exp_eq_tsum, transpose_tsum, transpose_smul, transpose_pow]
+
+lemma is_symm.exp {A : matrix m m 𝔸} (h : A.is_symm) : (exp 𝕂 A).is_symm :=
+(exp_transpose _ _).symm.trans $ congr_arg _ h
 
 end comm_ring
 

--- a/src/analysis/normed_space/star/exponential.lean
+++ b/src/analysis/normed_space/star/exponential.lean
@@ -26,21 +26,15 @@ variables {A : Type*}
 
 open complex
 
-lemma is_self_adjoint.exp_i_smul_unitary {a : A} (ha : is_self_adjoint a) :
-  exp ℂ (I • a) ∈ unitary A :=
-begin
-  rw [unitary.mem_iff, star_exp],
-  simp only [star_smul, is_R_or_C.star_def, self_adjoint.mem_iff.mp ha, conj_I, neg_smul],
-  rw ←@exp_add_of_commute ℂ A _ _ _ _ _ _ ((commute.refl (I • a)).neg_left),
-  rw ←@exp_add_of_commute ℂ A _ _ _ _ _ _ ((commute.refl (I • a)).neg_right),
-  simpa only [add_right_neg, add_left_neg, and_self] using (exp_zero : exp ℂ (0 : A) = 1),
-end
+lemma is_self_adjoint.I_smul_mem_skew_adjoint {a : A} (ha : is_self_adjoint a) :
+  (I • a) ∈ skew_adjoint A :=
+by rw [skew_adjoint.mem_iff, star_smul, is_R_or_C.star_def, conj_I, ha.star_eq, neg_smul]
 
 /-- The map from the selfadjoint real subspace to the unitary group. This map only makes sense
 over ℂ. -/
 @[simps]
 noncomputable def self_adjoint.exp_unitary (a : self_adjoint A) : unitary A :=
-⟨exp ℂ (I • a), a.prop.exp_i_smul_unitary⟩
+⟨exp ℂ (I • a), exp_mem_unitary_of_mem_skew_adjoint _ a.prop.I_smul_mem_skew_adjoint⟩
 
 open self_adjoint
 

--- a/src/analysis/normed_space/star/exponential.lean
+++ b/src/analysis/normed_space/star/exponential.lean
@@ -26,15 +26,11 @@ variables {A : Type*}
 
 open complex
 
-lemma is_self_adjoint.I_smul_mem_skew_adjoint {a : A} (ha : is_self_adjoint a) :
-  (I • a) ∈ skew_adjoint A :=
-by rw [skew_adjoint.mem_iff, star_smul, is_R_or_C.star_def, conj_I, ha.star_eq, neg_smul]
-
 /-- The map from the selfadjoint real subspace to the unitary group. This map only makes sense
 over ℂ. -/
 @[simps]
 noncomputable def self_adjoint.exp_unitary (a : self_adjoint A) : unitary A :=
-⟨exp ℂ (I • a), exp_mem_unitary_of_mem_skew_adjoint _ a.prop.I_smul_mem_skew_adjoint⟩
+⟨exp ℂ (I • a), exp_mem_unitary_of_mem_skew_adjoint _ (a.prop.smul_mem_skew_adjoint conj_I)⟩
 
 open self_adjoint
 

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -10,7 +10,7 @@ import analysis.special_functions.exponential
 import algebra.star.star_alg_hom
 
 /-! # Spectral properties in C⋆-algebras
-In this file, we establish various propreties related to the spectrum of elements in C⋆-algebras.
+In this file, we establish various properties related to the spectrum of elements in C⋆-algebras.
 -/
 
 local postfix `⋆`:std.prec.max_plus := star

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -90,6 +90,7 @@ end
 theorem is_self_adjoint.mem_spectrum_eq_re [star_module ℂ A] {a : A}
   (ha : is_self_adjoint a) {z : ℂ} (hz : z ∈ spectrum ℂ a) : z = z.re :=
 begin
+  have hu := exp_mem_unitary_of_mem_skew_adjoint ℂ (ha.smul_mem_skew_adjoint conj_I),
   let Iu := units.mk0 I I_ne_zero,
   have : exp ℂ (I • z) ∈ spectrum ℂ (exp ℂ (I • a)),
     by simpa only [units.smul_def, units.coe_mk0]
@@ -97,7 +98,7 @@ begin
   exact complex.ext (of_real_re _)
     (by simpa only [←complex.exp_eq_exp_ℂ, mem_sphere_zero_iff_norm, norm_eq_abs, abs_exp,
       real.exp_eq_one_iff, smul_eq_mul, I_mul, neg_eq_zero]
-      using spectrum.subset_circle_of_unitary ha.exp_i_smul_unitary this),
+      using spectrum.subset_circle_of_unitary hu this),
 end
 
 /-- Any element of the spectrum of a selfadjoint is real. -/


### PR DESCRIPTION
These are trivial consequences of existing results.

It turns out we already had a proof about `exp _ x` belonging to `unitary X`; this weakens the conditions.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
