### PR TITLE
[Merged by Bors] - feat(algebra/star/self_adjoint): add and generalize trivial lemmas

### DIFF
--- a/src/algebra/star/module.lean
+++ b/src/algebra/star/module.lean
@@ -72,7 +72,7 @@ variables (R : Type*) (A : Type*)
 
 /-- The self-adjoint elements of a star module, as a submodule. -/
 def self_adjoint.submodule : submodule R A :=
-{ smul_mem' := is_self_adjoint.smul,
+{ smul_mem' := λ r, (is_self_adjoint.all _).smul,
   ..self_adjoint A }
 
 /-- The skew-adjoint elements of a star module, as a submodule. -/

--- a/src/algebra/star/module.lean
+++ b/src/algebra/star/module.lean
@@ -72,7 +72,7 @@ variables (R : Type*) (A : Type*)
 
 /-- The self-adjoint elements of a star module, as a submodule. -/
 def self_adjoint.submodule : submodule R A :=
-{ smul_mem' := λ r, (is_self_adjoint.all _).smul,
+{ smul_mem' := λ r x, (is_self_adjoint.all _).smul,
   ..self_adjoint A }
 
 /-- The skew-adjoint elements of a star module, as a submodule. -/

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -200,6 +200,21 @@ by { rw [←add_subgroup.mem_carrier], exact iff.rfl }
 
 instance : inhabited (self_adjoint R) := ⟨0⟩
 
+/-- The (trivial) star operator on `self_adjoint R` inherited from `R`. -/
+instance : star_add_monoid (self_adjoint R) :=
+{ star := λ x, ⟨star x, is_self_adjoint.star_iff.mpr x.prop⟩,
+  star_involutive := λ x, subtype.ext $ star_star _,
+  star_add := λ x y, subtype.ext $ star_add _ _ }
+
+lemma coe_star (x : self_adjoint R) : ↑(star x) = star (x : R) := rfl
+
+instance : has_trivial_star (self_adjoint R) :=
+{ star_trivial := λ x, subtype.ext $ x.prop }
+
+/-- When the `star` operation is trivial, `self_adjoint R` is just `⊤`. -/
+@[simp] lemma eq_top [has_trivial_star R] : self_adjoint R = ⊤ :=
+(add_subgroup.eq_top_iff' _).mpr is_self_adjoint.all
+
 end add_group
 
 section ring
@@ -336,6 +351,17 @@ instance : inhabited (skew_adjoint R) := ⟨0⟩
 
 lemma bit0_mem {x : R} (hx : x ∈ skew_adjoint R) : bit0 x ∈ skew_adjoint R :=
 by rw [mem_iff, star_bit0, mem_iff.mp hx, bit0, bit0, neg_add]
+
+/-- The star operator on `skew_adjoint R` inherited from `R`. -/
+instance : star_add_monoid (skew_adjoint R) :=
+{ star := λ x, ⟨star x, (star_star _).trans $ eq_neg_of_eq_neg x.prop⟩,
+  star_involutive := λ x, subtype.ext $ star_star _,
+  star_add := λ x y, subtype.ext $ star_add _ _ }
+
+lemma coe_star (x : skew_adjoint R) : ↑(star x) = star (x : R) := rfl
+
+@[simp] lemma star_eq_neg : (star : skew_adjoint R → skew_adjoint R) = has_neg.neg :=
+funext $ λ x, subtype.ext $ x.prop
 
 end add_group
 

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -82,8 +82,8 @@ lemma star_hom_apply {F R S : Type*} [has_star R] [has_star S] [star_hom_class F
   {x : R} (hx : is_self_adjoint x) (f : F) : is_self_adjoint (f x) :=
 show star (f x) = f x, from map_star f x ▸ congr_arg f hx
 
-section add_group
-variables [add_group R] [star_add_monoid R]
+section add_monoid
+variables [add_monoid R] [star_add_monoid R]
 
 variables (R)
 
@@ -94,19 +94,27 @@ variables {R}
 lemma add {x y : R} (hx : is_self_adjoint x) (hy : is_self_adjoint y) : is_self_adjoint (x + y) :=
 by simp only [is_self_adjoint_iff, star_add, hx.star_eq, hy.star_eq]
 
+lemma bit0 {x : R} (hx : is_self_adjoint x) : is_self_adjoint (bit0 x) :=
+by simp only [is_self_adjoint_iff, star_bit0, hx.star_eq]
+
+end add_monoid
+
+section add_group
+variables [add_group R] [star_add_monoid R]
+
 lemma neg {x : R} (hx : is_self_adjoint x) : is_self_adjoint (-x) :=
 by simp only [is_self_adjoint_iff, star_neg, hx.star_eq]
 
 lemma sub {x y : R} (hx : is_self_adjoint x) (hy : is_self_adjoint y) : is_self_adjoint (x - y) :=
 by simp only [is_self_adjoint_iff, star_sub, hx.star_eq, hy.star_eq]
 
-lemma bit0 {x : R} (hx : is_self_adjoint x) : is_self_adjoint (bit0 x) :=
-by simp only [is_self_adjoint_iff, star_bit0, hx.star_eq]
-
 end add_group
 
-section non_unital_semiring
-variables [non_unital_semiring R] [star_ring R]
+section semigroup
+variables [semigroup R] [star_semigroup R]
+
+lemma is_star_normal {x : R} (hx : is_self_adjoint x) : is_star_normal x :=
+⟨by simp only [hx.star_eq]⟩
 
 lemma conjugate {x : R} (hx : is_self_adjoint x) (z : R) : is_self_adjoint (z * x * star z) :=
 by simp only [is_self_adjoint_iff, star_mul, star_star, mul_assoc, hx.star_eq]
@@ -114,13 +122,10 @@ by simp only [is_self_adjoint_iff, star_mul, star_star, mul_assoc, hx.star_eq]
 lemma conjugate' {x : R} (hx : is_self_adjoint x) (z : R) : is_self_adjoint (star z * x * z) :=
 by simp only [is_self_adjoint_iff, star_mul, star_star, mul_assoc, hx.star_eq]
 
-lemma is_star_normal {x : R} (hx : is_self_adjoint x) : is_star_normal x :=
-⟨by simp only [hx.star_eq]⟩
+end semigroup
 
-end non_unital_semiring
-
-section ring
-variables [ring R] [star_ring R]
+section monoid
+variables [monoid R] [star_semigroup R]
 
 variables (R)
 
@@ -128,33 +133,57 @@ lemma _root_.is_self_adjoint_one : is_self_adjoint (1 : R) := star_one R
 
 variables {R}
 
-lemma bit1 {x : R} (hx : is_self_adjoint x) : is_self_adjoint (bit1 x) :=
-by simp only [is_self_adjoint_iff, star_bit1, hx.star_eq]
-
 lemma pow {x : R} (hx : is_self_adjoint x) (n : ℕ) : is_self_adjoint (x ^ n):=
 by simp only [is_self_adjoint_iff, star_pow, hx.star_eq]
 
-end ring
+end monoid
 
-section non_unital_comm_ring
-variables [non_unital_comm_ring R] [star_ring R]
+section semiring
+variables [semiring R] [star_ring R]
+
+lemma bit1 {x : R} (hx : is_self_adjoint x) : is_self_adjoint (bit1 x) :=
+by simp only [is_self_adjoint_iff, star_bit1, hx.star_eq]
+
+@[simp] lemma _root_.is_self_adjoint_nat_cast (n : ℕ) : is_self_adjoint (n : R) :=
+star_nat_cast _
+
+end semiring
+
+section comm_semigroup
+variables [comm_semigroup R] [star_semigroup R]
 
 lemma mul {x y : R} (hx : is_self_adjoint x) (hy : is_self_adjoint y) : is_self_adjoint (x * y) :=
 by simp only [is_self_adjoint_iff, star_mul', hx.star_eq, hy.star_eq]
 
-end non_unital_comm_ring
+end comm_semigroup
 
-section field
-variables [field R] [star_ring R]
+section ring
+variables [ring R] [star_ring R]
+
+@[simp] lemma _root_.is_self_adjoint_int_cast (z : ℤ) : is_self_adjoint (z : R) :=
+star_int_cast _
+
+end ring
+
+section division_ring
+variables [division_ring R] [star_ring R]
 
 lemma inv {x : R} (hx : is_self_adjoint x) : is_self_adjoint x⁻¹ :=
 by simp only [is_self_adjoint_iff, star_inv', hx.star_eq]
 
-lemma div {x y : R} (hx : is_self_adjoint x) (hy : is_self_adjoint y) : is_self_adjoint (x / y) :=
-by simp only [is_self_adjoint_iff, star_div', hx.star_eq, hy.star_eq]
-
 lemma zpow {x : R} (hx : is_self_adjoint x) (n : ℤ) : is_self_adjoint (x ^ n):=
 by simp only [is_self_adjoint_iff, star_zpow₀, hx.star_eq]
+
+lemma _root_.is_self_adjoint_rat_cast (x : ℚ) : is_self_adjoint (x : R) :=
+star_rat_cast _
+
+end division_ring
+
+section field
+variables [field R] [star_ring R]
+
+lemma div {x y : R} (hx : is_self_adjoint x) (hy : is_self_adjoint y) : is_self_adjoint (x / y) :=
+by simp only [is_self_adjoint_iff, star_div', hx.star_eq, hy.star_eq]
 
 end field
 
@@ -227,16 +256,10 @@ instance : has_one (self_adjoint R) := ⟨⟨1, is_self_adjoint_one R⟩⟩
 instance [nontrivial R] : nontrivial (self_adjoint R) := ⟨⟨0, 1, subtype.ne_of_val_ne zero_ne_one⟩⟩
 
 instance : has_nat_cast (self_adjoint R) :=
-⟨λ n, ⟨n, nat.rec_on n (by simp [zero_mem])
-  (λ k hk, (@nat.cast_succ R _ k).symm ▸ add_mem hk (is_self_adjoint_one R))⟩⟩
+⟨λ n, ⟨n, is_self_adjoint_nat_cast _⟩⟩
 
 instance : has_int_cast (self_adjoint R) :=
-⟨λ n, ⟨n,
-  begin
-    cases n;
-    simp [show ↑n ∈ self_adjoint R, from (n : self_adjoint R).2],
-    refine add_mem (is_self_adjoint_one R).neg (n : self_adjoint R).2.neg,
-  end ⟩ ⟩
+⟨λ n, ⟨n, is_self_adjoint_int_cast _⟩ ⟩
 
 instance : has_pow (self_adjoint R) ℕ :=
 ⟨λ x n, ⟨(x : R) ^ n, x.prop.pow n⟩⟩
@@ -285,18 +308,14 @@ instance : has_pow (self_adjoint R) ℤ :=
 
 @[simp, norm_cast] lemma coe_zpow (x : self_adjoint R) (z : ℤ) : ↑(x ^ z) = (x : R) ^ z := rfl
 
-lemma rat_cast_mem : ∀ (x : ℚ), is_self_adjoint (x : R)
-| ⟨a, b, h1, h2⟩ :=
-  by rw [is_self_adjoint, rat.cast_mk', star_mul', star_inv', star_nat_cast, star_int_cast]
-
 instance : has_rat_cast (self_adjoint R) :=
-⟨λ n, ⟨n, rat_cast_mem n⟩⟩
+⟨λ n, ⟨n, is_self_adjoint_rat_cast n⟩⟩
 
 @[simp, norm_cast] lemma coe_rat_cast (x : ℚ) : ↑(x : self_adjoint R) = (x : R) :=
 rfl
 
 instance has_qsmul : has_smul ℚ (self_adjoint R) :=
-⟨λ a x, ⟨a • x, by rw rat.smul_def; exact (rat_cast_mem a).mul x.prop⟩⟩
+⟨λ a x, ⟨a • x, by rw rat.smul_def; exact is_self_adjoint.mul (is_self_adjoint_rat_cast a) x.prop⟩⟩
 
 @[simp, norm_cast] lemma coe_rat_smul (x : self_adjoint R) (a : ℚ) : ↑(a • x) = a • (x : R) :=
 rfl

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -113,14 +113,14 @@ end add_group
 section semigroup
 variables [semigroup R] [star_semigroup R]
 
-lemma is_star_normal {x : R} (hx : is_self_adjoint x) : is_star_normal x :=
-⟨by simp only [hx.star_eq]⟩
-
 lemma conjugate {x : R} (hx : is_self_adjoint x) (z : R) : is_self_adjoint (z * x * star z) :=
 by simp only [is_self_adjoint_iff, star_mul, star_star, mul_assoc, hx.star_eq]
 
 lemma conjugate' {x : R} (hx : is_self_adjoint x) (z : R) : is_self_adjoint (star z * x * z) :=
 by simp only [is_self_adjoint_iff, star_mul, star_star, mul_assoc, hx.star_eq]
+
+lemma is_star_normal {x : R} (hx : is_self_adjoint x) : is_star_normal x :=
+⟨by simp only [hx.star_eq]⟩
 
 end semigroup
 

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -163,7 +163,7 @@ variables [has_star R] [add_monoid A] [star_add_monoid A] [has_smul R A] [star_m
 
 lemma smul {r : R} (hr : is_self_adjoint r) {x : A} (hx : is_self_adjoint x) :
   is_self_adjoint (r • x) :=
-by simp only [is_self_adjoint_iff, star_smul, star_trivial, hx.star_eq, hr.star_eq]
+by simp only [is_self_adjoint_iff, star_smul, hr.star_eq, hx.star_eq]
 
 end has_smul
 

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -58,6 +58,7 @@ is_star_normal.star_comm_self
 namespace is_self_adjoint
 
 -- named to match `commute.all`
+/-- All elements are self-adjoint when `star` is trivial. -/
 lemma all [has_star R] [has_trivial_star R] (r : R) : is_self_adjoint r := star_trivial _
 
 lemma star_eq [has_star R] {x : R} (hx : is_self_adjoint x) : star x = x := hx

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -57,6 +57,9 @@ is_star_normal.star_comm_self
 
 namespace is_self_adjoint
 
+-- named to match `commute.all`
+lemma all [has_star R] [has_trivial_star R] (r : R) : is_self_adjoint r := star_trivial _
+
 lemma star_eq [has_star R] {x : R} (hx : is_self_adjoint x) : star x = x := hx
 
 lemma _root_.is_self_adjoint_iff [has_star R] {x : R} : is_self_adjoint x ↔ star x = x := iff.rfl
@@ -155,11 +158,11 @@ by simp only [is_self_adjoint_iff, star_zpow₀, hx.star_eq]
 end field
 
 section has_smul
-variables [has_star R] [has_trivial_star R] [add_group A] [star_add_monoid A]
+variables [has_star R] [add_monoid A] [star_add_monoid A] [has_smul R A] [star_module R A]
 
-lemma smul [has_smul R A] [star_module R A] (r : R) {x : A} (hx : is_self_adjoint x) :
+lemma smul {r : R} (hr : is_self_adjoint r) {x : A} (hx : is_self_adjoint x) :
   is_self_adjoint (r • x) :=
-by simp only [is_self_adjoint_iff, star_smul, star_trivial, hx.star_eq]
+by simp only [is_self_adjoint_iff, star_smul, star_trivial, hx.star_eq, hr.star_eq]
 
 end has_smul
 
@@ -294,7 +297,7 @@ section has_smul
 variables [has_star R] [has_trivial_star R] [add_group A] [star_add_monoid A]
 
 instance [has_smul R A] [star_module R A] : has_smul R (self_adjoint A) :=
-⟨λ r x, ⟨r • x, x.prop.smul r⟩⟩
+⟨λ r x, ⟨r • x, (is_self_adjoint.all _).smul x.prop⟩⟩
 
 @[simp, norm_cast] lemma coe_smul [has_smul R A] [star_module R A] (r : R) (x : self_adjoint A) :
   ↑(r • x) = r • (x : A) := rfl

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -229,21 +229,6 @@ by { rw [←add_subgroup.mem_carrier], exact iff.rfl }
 
 instance : inhabited (self_adjoint R) := ⟨0⟩
 
-/-- The (trivial) star operator on `self_adjoint R` inherited from `R`. -/
-instance : star_add_monoid (self_adjoint R) :=
-{ star := λ x, ⟨star x, is_self_adjoint.star_iff.mpr x.prop⟩,
-  star_involutive := λ x, subtype.ext $ star_star _,
-  star_add := λ x y, subtype.ext $ star_add _ _ }
-
-lemma coe_star (x : self_adjoint R) : ↑(star x) = star (x : R) := rfl
-
-instance : has_trivial_star (self_adjoint R) :=
-{ star_trivial := λ x, subtype.ext $ x.prop }
-
-/-- When the `star` operation is trivial, `self_adjoint R` is just `⊤`. -/
-@[simp] lemma eq_top [has_trivial_star R] : self_adjoint R = ⊤ :=
-(add_subgroup.eq_top_iff' _).mpr is_self_adjoint.all
-
 end add_group
 
 section ring
@@ -370,17 +355,6 @@ instance : inhabited (skew_adjoint R) := ⟨0⟩
 
 lemma bit0_mem {x : R} (hx : x ∈ skew_adjoint R) : bit0 x ∈ skew_adjoint R :=
 by rw [mem_iff, star_bit0, mem_iff.mp hx, bit0, bit0, neg_add]
-
-/-- The star operator on `skew_adjoint R` inherited from `R`. -/
-instance : star_add_monoid (skew_adjoint R) :=
-{ star := λ x, ⟨star x, (star_star _).trans $ eq_neg_of_eq_neg x.prop⟩,
-  star_involutive := λ x, subtype.ext $ star_star _,
-  star_add := λ x y, subtype.ext $ star_add _ _ }
-
-lemma coe_star (x : skew_adjoint R) : ↑(star x) = star (x : R) := rfl
-
-@[simp] lemma star_eq_neg : (star : skew_adjoint R → skew_adjoint R) = has_neg.neg :=
-funext $ λ x, subtype.ext $ x.prop
 
 end add_group
 


### PR DESCRIPTION
This:
* Generalizes `is_self_adjoint.smul`, which makes it easier to show that `0.5 • x` is self-adjoint when `x` is, even if `0.5` is a complex number.
* Generalizes `is_self_adjoint.add` to match `matrix.is_hermitian.add` (for a later refactor), along with many other lemmas.
* Removes re-proofs of `star_nat_cast` and `star_int_cast`.

The first is motivated by showing that `exp K m` for some matrix `m` is positive definite if `is_self_adjoint m`.

Forward-ported at https://github.com/leanprover-community/mathlib4/pull/2719.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
