### PR TITLE
[Merged by Bors] - feat(number_theory/pell): add exists_pos_of_not_is_square

### DIFF
--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -122,6 +122,23 @@ begin
   simpa [mul_self_pos.mp h₀, sub_eq_add_neg, eq_neg_self_iff] using int.eq_of_mul_eq_one hxy,
 end
 
+/-- If `d` is a positive integer that is not a square, then there exists a solution
+to the Pell equation `x^2 - d*y^2 = 1` with `x > 1` and `y > 0`. -/
+lemma exists_pos_of_not_is_square {d : ℤ} (h₀ : 0 < d) (hd : ¬ is_square d) :
+  ∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ 1 < x ∧ 0 < y :=
+begin
+  obtain ⟨x', y', h, hy₀⟩ := exists_of_not_is_square h₀ hd,
+  refine ⟨|x'|, |y'|, by rw [sq_abs, sq_abs, h], _, abs_pos.mpr hy₀⟩,
+  by_contra' hf,
+  cases eq_or_gt_of_le (abs_nonneg x') with H H,
+  { rw [abs_eq_zero.mp H, pow_two, zero_mul, zero_sub, neg_eq_iff_add_eq_zero] at h,
+    exact (by positivity : d * y' ^ 2 + 1 ≠ 0) h, },
+  { change 1 ≤ |x'| at H,
+    rw [← sq_abs, ge_antisymm H hf, one_pow, sub_eq_iff_eq_add, ← sub_eq_iff_eq_add', sub_self,
+        zero_eq_mul, pow_eq_zero_iff'] at h,
+    exact hy₀ (h.resolve_left h₀.ne').1, }
+end
+
 end existence
 
 end pell

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -42,11 +42,13 @@ namespace pell
 
 section existence
 
+variables {d : ℤ}
+
 open set real
 
 /-- If `d` is a positive integer that is not a square, then there is a nontrivial solution
 to the Pell equation `x^2 - d*y^2 = 1`. -/
-theorem exists_of_not_is_square {d : ℤ} (h₀ : 0 < d) (hd : ¬ is_square d) :
+theorem exists_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
   ∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ y ≠ 0 :=
 begin
   let ξ : ℝ := sqrt d,
@@ -113,7 +115,7 @@ end
 
 /-- If `d` is a positive integer, then there is a nontrivial solution
 to the Pell equation `x^2 - d*y^2 = 1` if and only if `d` is not a square. -/
-theorem exists_iff_not_is_square {d : ℤ} (h₀ : 0 < d) :
+theorem exists_iff_not_is_square (h₀ : 0 < d) :
   (∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ y ≠ 0) ↔ ¬ is_square d :=
 begin
   refine ⟨_, exists_of_not_is_square h₀⟩,
@@ -124,7 +126,7 @@ end
 
 /-- If `d` is a positive integer that is not a square, then there exists a solution
 to the Pell equation `x^2 - d*y^2 = 1` with `x > 1` and `y > 0`. -/
-lemma exists_pos_of_not_is_square {d : ℤ} (h₀ : 0 < d) (hd : ¬ is_square d) :
+lemma exists_pos_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
   ∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ 1 < x ∧ 0 < y :=
 begin
   obtain ⟨x', y', h, hy₀⟩ := exists_of_not_is_square h₀ hd,

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -129,16 +129,10 @@ to the Pell equation `x^2 - d*y^2 = 1` with `x > 1` and `y > 0`. -/
 lemma exists_pos_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
   ∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ 1 < x ∧ 0 < y :=
 begin
-  obtain ⟨x', y', h, hy₀⟩ := exists_of_not_is_square h₀ hd,
-  refine ⟨|x'|, |y'|, by rw [sq_abs, sq_abs, h], _, abs_pos.mpr hy₀⟩,
-  by_contra' hf,
-  cases eq_or_gt_of_le (abs_nonneg x') with H H,
-  { rw [abs_eq_zero.mp H, pow_two, zero_mul, zero_sub, neg_eq_iff_add_eq_zero] at h,
-    exact (by positivity : d * y' ^ 2 + 1 ≠ 0) h, },
-  { change 1 ≤ |x'| at H,
-    rw [← sq_abs, ge_antisymm H hf, one_pow, sub_eq_iff_eq_add, ← sub_eq_iff_eq_add', sub_self,
-        zero_eq_mul, pow_eq_zero_iff'] at h,
-    exact hy₀ (h.resolve_left h₀.ne').1, }
+  obtain ⟨x, y, h, hy⟩ := exists_of_not_is_square h₀ hd,
+  refine ⟨|x|, |y|, by rwa [sq_abs, sq_abs], _, abs_pos.mpr hy⟩,
+  rw [← one_lt_sq_iff_one_lt_abs, eq_add_of_sub_eq h, lt_add_iff_pos_right],
+  exact mul_pos h₀ (sq_pos_of_ne_zero y hy),
 end
 
 end existence


### PR DESCRIPTION
This PR continues work on the theory of the Pell equation for general (nonsquare and positive) `d`.
In preparation for proving statements on the structure of the solution set, this adds
```lean
lemma exists_pos_of_not_is_square {d : ℤ} (h₀ : 0 < d) (hd : ¬ is_square d) :
  ∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ 1 < x ∧ 0 < y := ...
```
as a prerequisite for defining the fundamental solution as the solution with smallest `x > 1` and positive `y`.
See [this thread on Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Proving.20Pell's.20equation.20is.20solvable/near/338175458).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
