### PR TITLE
[Merged by Bors] - feat(number_theory/pell): group structure

### DIFF
--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -228,6 +228,10 @@ lemma x_mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (mk x y rel).x = x := rfl
 lemma y_mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (mk x y rel).y = y := rfl
 
 @[simp]
+lemma coe_mk  (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (↑(mk x y rel) : ℤ√d) = ⟨x,y⟩ :=
+zsqrtd.ext.mpr ⟨x_mk x y rel, y_mk x y rel⟩
+
+@[simp]
 lemma x_one : (1 : solution₁ d).x = 1 := rfl
 
 @[simp]

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -57,15 +57,7 @@ end
 
 /-- The kernel of the norm map on `ℤ√d` equals the submonoid of unitary elements. -/
 lemma mker_norm_eq_unitary : (@norm_monoid_hom d).mker = unitary ℤ√d :=
-submonoid.ext (λ x, (monoid_hom.mem_mker _).trans norm_eq_one_iff_mem_unitary)
-
-/-- An element of `ℤ√d` has norm one (i.e., `a.re^2 - d*a.im^2 = 1`) if and only if
-it is contained in the submonoid of unitary elements.
-
-TODO: merge this result with `pell.is_pell_iff_mem_unitary`. -/
-lemma is_pell_solution_iff_mem_unitary {a : ℤ√d} :
-  a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary ℤ√d :=
-by rw [← norm_eq_one_iff_mem_unitary, norm_def, sq, sq, ← mul_assoc]
+submonoid.ext (λ x, norm_eq_one_iff_mem_unitary)
 
 end zsqrtd
 
@@ -185,6 +177,16 @@ the "commutative group with distributive negation" structure from `↥(unitary (
 We then set up an API for `pell.solution₁ d`.
 -/
 
+open zsqrtd
+
+/-- An element of `ℤ√d` has norm one (i.e., `a.re^2 - d*a.im^2 = 1`) if and only if
+it is contained in the submonoid of unitary elements.
+
+TODO: merge this result with `pell.is_pell_iff_mem_unitary`. -/
+lemma is_pell_solution_iff_mem_unitary {d : ℤ} {a : ℤ√d} :
+  a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary ℤ√d :=
+by rw [← norm_eq_one_iff_mem_unitary, norm_def, sq, sq, ← mul_assoc]
+
 -- We use `solution₁ d` to allow for a more general structure `solution d m` that
 -- encodes solutions to `x^2 - d*y^2 = m` to be added later.
 
@@ -195,8 +197,6 @@ We define this in terms of elements of `ℤ√d` of norm one.
 def solution₁ (d : ℤ) : Type := ↥(unitary ℤ√d)
 
 namespace solution₁
-
-open zsqrtd
 
 variables {d : ℤ}
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -184,7 +184,7 @@ run_cmd mk_simp_attr `pell_simp
 instance : has_one (solution₁ d) :=
 { one := { x := 1, y := 0, rel := by simp } }
 
-instance (d : ℤ) : inhabited (solution₁ d) := ⟨1⟩
+instance : inhabited (solution₁ d) := ⟨1⟩
 
 @[simp, pell_simp]
 lemma x_one : (1 : solution₁ d).x = 1 := rfl

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -202,6 +202,7 @@ lemma rel_y (a : solution₁ d) : d * a.y ^ 2 = a.x ^ 2 - 1 := by {rw ← a.rel,
 lemma ext {a b : solution₁ d} (hx : a.x = b.x) (hy : a.y = b.y) : a = b :=
 by {ext, exact ext.mpr ⟨hx, hy⟩}
 
+/-- Construct a solution from `x`, `y` and a proof that the equation is satisfied. -/
 def mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : solution₁ d :=
 { val := ⟨x, y⟩,
   property := norm_eq_one_iff_mem_unitary.mp rel }

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -174,8 +174,7 @@ lemma ext {a b : solution₁ d} (hx : a.x = b.x) (hy : a.y = b.y) : a = b :=
 begin
   cases a,
   cases b,
-  dsimp at hx hy,
-  simp only [hx, hy, eq_self_iff_true, and_self],
+  congr; assumption,
 end
 
 /-- We use `1` to denote the trivial solution `(1, 0)`. -/

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -40,6 +40,18 @@ Pell's equation
 * Connect solutions to the continued fraction expansion of `√d`.
 -/
 
+namespace zsqrtd
+
+lemma norm_eq_one_iff_mem_unitary {d : ℤ} {a : zsqrtd d} :
+  a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary (zsqrtd d) :=
+begin
+  rw [unitary.mem_iff, ← norm_eq_mul_conj, mul_comm _ a, ← norm_eq_mul_conj, and_self, norm_def,
+      sq, sq, ← mul_assoc],
+  norm_cast,
+end
+
+end zsqrtd
+
 namespace pell
 
 section existence

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -50,8 +50,7 @@ it is contained in the submonoid of unitary elements. -/
 lemma norm_eq_one_iff_mem_unitary {d : ℤ} {a : zsqrtd d} :
   a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary (zsqrtd d) :=
 begin
-  rw [unitary.mem_iff, ← norm_eq_mul_conj, mul_comm _ a, ← norm_eq_mul_conj, and_self, norm_def,
-      sq, sq, ← mul_assoc],
+  rw [unitary.mem_iff_self_mul_star, ← norm_eq_mul_conj, norm_def, sq, sq, ← mul_assoc],
   norm_cast,
 end
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -185,10 +185,10 @@ instance : has_one (solution₁ d) :=
 { one := { x := 1, y := 0, rel := by simp } }
 
 @[simp, pell_simp]
-lemma one.x : (1 : solution₁ d).x = 1 := rfl
+lemma x_one : (1 : solution₁ d).x = 1 := rfl
 
 @[simp, pell_simp]
-lemma one.y : (1 : solution₁ d).y = 0 := rfl
+lemma y_one : (1 : solution₁ d).y = 0 := rfl
 
 /-- We can multiply two solutions. -/
 instance : has_mul (solution₁ d) :=
@@ -198,30 +198,30 @@ instance : has_mul (solution₁ d) :=
     rel := by {conv_rhs {rw ← mul_one (1 : ℤ), congr, rw ← a.rel, skip, rw ← b.rel}, ring} } }
 
 @[simp, pell_simp]
-lemma mul.x (a b : solution₁ d) : (a * b).x = a.x * b.x + d * (a.y * b.y) := rfl
+lemma x_mul (a b : solution₁ d) : (a * b).x = a.x * b.x + d * (a.y * b.y) := rfl
 
 @[simp, pell_simp]
-lemma mul.y (a b : solution₁ d) : (a * b).y = a.x * b.y + a.y * b.x := rfl
+lemma y_mul (a b : solution₁ d) : (a * b).y = a.x * b.y + a.y * b.x := rfl
 
 /-- We obtain the inverse of a solution by changing the sign of `y`. -/
 instance : has_inv (solution₁ d) :=
 { inv := λ a, { x := a.x, y := -a.y, rel := by simp [a.rel] } }
 
 @[simp, pell_simp]
-lemma inv.x (a : solution₁ d) : a⁻¹.x = a.x := rfl
+lemma x_inv (a : solution₁ d) : a⁻¹.x = a.x := rfl
 
 @[simp, pell_simp]
-lemma inv.y (a : solution₁ d) : a⁻¹.y = -a.y := rfl
+lemma y_inv (a : solution₁ d) : a⁻¹.y = -a.y := rfl
 
 /-- We define the negative of a solution by negating both `x` and `y`. -/
 instance : has_neg (solution₁ d) :=
 { neg := λ a, { x := -a.x, y := -a.y, rel := by simp [a.rel] } }
 
 @[simp, pell_simp]
-lemma neg.x (a : solution₁ d) : (-a).x = -a.x := rfl
+lemma x_neg (a : solution₁ d) : (-a).x = -a.x := rfl
 
 @[simp, pell_simp]
-lemma neg.y (a : solution₁ d) : (-a).y = -a.y := rfl
+lemma y_neg (a : solution₁ d) : (-a).y = -a.y := rfl
 
 /-- Set up a tactic that discharges the computational goals below. -/
 meta def pell_tac : tactic unit :=

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -42,8 +42,8 @@ Pell's equation
 
 namespace zsqrtd
 
--- Note: We put this here to avoid having to import `algebra.star.unitary`
---       into `number_theory.zsqrtd.basic` just for this one result.
+-- Note: We put these here to avoid having to import `algebra.star.unitary`
+--       into `number_theory.zsqrtd.basic` just for these two results.
 
 /-- An element of `ℤ√d` has norm equal to `1` if and only if it is contained in the submonoid
 of unitary elements. -/

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -200,11 +200,7 @@ lemma rel_y (a : solution₁ d) : d * a.y ^ 2 = a.x ^ 2 - 1 := by {rw ← a.rel,
 /-- Two solutions are equal if their `x` and `y` components are equal. -/
 @[ext]
 lemma ext {a b : solution₁ d} (hx : a.x = b.x) (hy : a.y = b.y) : a = b :=
-begin
-  ext,
-  refine ext.mpr _,
-  split; assumption,
-end
+by {ext, exact ext.mpr ⟨hx, hy⟩}
 
 def mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : solution₁ d :=
 { val := ⟨x, y⟩,

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -184,6 +184,8 @@ run_cmd mk_simp_attr `pell_simp
 instance : has_one (solution₁ d) :=
 { one := { x := 1, y := 0, rel := by simp } }
 
+instance (d : ℤ) : inhabited (solution₁ d) := ⟨1⟩
+
 @[simp, pell_simp]
 lemma x_one : (1 : solution₁ d).x = 1 := rfl
 
@@ -238,8 +240,6 @@ instance : comm_group (solution₁ d) :=
   inv := has_inv.inv,
   mul_left_inv := λ a, by {pell_tac, rw a.rel_x, ring},
   .. }
-
-instance (d : ℤ) : inhabited (solution₁ d) := ⟨1⟩
 
 /-- The negation of solutions is compatible with the multiplicative structure. -/
 instance : has_distrib_neg (solution₁ d) :=

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -168,7 +168,7 @@ The multiplication is given by `(x, y) * (x', y') = (x*y' + d*y*y', x*y' + y*x')
 -- encodes solutions to `x^2 - d*y^2 = m` to be added later.
 
 /-- `pell.solution₁ d` is the type of solutions to the Pell equation `x^2 - d*y^2 = 1`.
-This is a structure containing two integers `x` and `y` and a proof `rel` that the equation holds.
+We define this in terms of elements of `ℤ√d` of norm one.
 -/
 @[derive [comm_group, has_distrib_neg, inhabited]]
 def solution₁ (d : ℤ) : Type := ↥(unitary (zsqrtd d))
@@ -237,8 +237,6 @@ lemma x_neg (a : solution₁ d) : (-a).x = -a.x := rfl
 
 @[simp]
 lemma y_neg (a : solution₁ d) : (-a).y = -a.y := rfl
-
-
 
 end solution₁
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -141,7 +141,7 @@ end existence
 ### Group structure of the solution set
 
 We define a structure of a commutative multiplicative group with distributive negation
-on the set of all solutions to the Pell equation `x^2 - d*^2 = 1`.
+on the set of all solutions to the Pell equation `x^2 - d*y^2 = 1`.
 
 The type of such solutions is `pell.solution₁ d`. It contains integers `x` and `y` and
 a proof that `(x, y)` is indeed a solution.

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -45,14 +45,20 @@ namespace zsqrtd
 -- Note: We put this here to avoid having to import `algebra.star.unitary`
 --       into `number_theory.zsqrtd.basic` just for this one result.
 
-/-- An element of `ℤ√d` has norm one (i.e., `a.re^2 - d*a.im^2 = 1`) if and only if
-it is contained in the submonoid of unitary elements. -/
+/-- An element of `ℤ√d` has norm equal to `1` if and only if it is contained in the submonoid
+of unitary elements. -/
 lemma norm_eq_one_iff_mem_unitary {d : ℤ} {a : zsqrtd d} :
-  a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary (zsqrtd d) :=
+  a.norm = 1 ↔ a ∈ unitary (zsqrtd d) :=
 begin
-  rw [unitary.mem_iff_self_mul_star, ← norm_eq_mul_conj, norm_def, sq, sq, ← mul_assoc],
+  rw [unitary.mem_iff_self_mul_star, ← norm_eq_mul_conj],
   norm_cast,
 end
+
+/-- An element of `ℤ√d` has norm one (i.e., `a.re^2 - d*a.im^2 = 1`) if and only if
+it is contained in the submonoid of unitary elements. -/
+lemma norm_eq_one_iff_mem_unitary' {d : ℤ} {a : zsqrtd d} :
+  a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary (zsqrtd d) :=
+by rw [← norm_eq_one_iff_mem_unitary, norm_def, sq, sq, ← mul_assoc]
 
 end zsqrtd
 
@@ -197,7 +203,7 @@ def y (a : solution₁ d) : ℤ := (a : ℤ√d).im
 
 /-- The proof that `a` is a solution to the Pell equation `x^2 - d*y^2 = 1` -/
 lemma rel (a : solution₁ d) : a.x ^ 2 - d * a.y ^ 2 = 1 :=
-norm_eq_one_iff_mem_unitary.mpr a.property
+norm_eq_one_iff_mem_unitary'.mpr a.property
 
 /-- An alternative form of the relation, suitable for rewriting `x^2`. -/
 lemma rel_x (a : solution₁ d) : a.x ^ 2 = 1 + d * a.y ^ 2 := by {rw ← a.rel, ring}
@@ -213,7 +219,7 @@ by {ext, exact ext.mpr ⟨hx, hy⟩}
 /-- Construct a solution from `x`, `y` and a proof that the equation is satisfied. -/
 def mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : solution₁ d :=
 { val := ⟨x, y⟩,
-  property := norm_eq_one_iff_mem_unitary.mp rel }
+  property := norm_eq_one_iff_mem_unitary'.mp rel }
 
 @[simp]
 lemma x_mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (mk x y rel).x = x := rfl

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -179,12 +179,15 @@ open zsqrtd
 
 variables {d : ℤ}
 
-instance : has_coe (solution₁ d) (zsqrtd d) := { coe := subtype.val }
+instance : has_coe (solution₁ d) (ℤ√d) := { coe := subtype.val }
 
-def x (a : solution₁ d) : ℤ := (a : zsqrtd d).re
+/-- The `x` component of a solution to the Pell equation `x^2 - d*y^2 = 1` -/
+def x (a : solution₁ d) : ℤ := (a : ℤ√d).re
 
-def y (a : solution₁ d) : ℤ := (a : zsqrtd d).im
+/-- The `y` component of a solution to the Pell equation `x^2 - d*y^2 = 1` -/
+def y (a : solution₁ d) : ℤ := (a : ℤ√d).im
 
+/-- The proof that `a` is a solution to the Pell equation `x^2 - d*y^2 = 1` -/
 lemma rel (a : solution₁ d) : a.x ^ 2 - d * a.y ^ 2 = 1 :=
 norm_eq_one_iff_mem_unitary.mpr a.property
 
@@ -205,7 +208,7 @@ end
 
 def mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : solution₁ d :=
 { val := ⟨x, y⟩,
-  property := zsqrtd.norm_eq_one_iff_mem_unitary.mp rel }
+  property := norm_eq_one_iff_mem_unitary.mp rel }
 
 @[simp]
 lemma x_mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (mk x y rel).x = x := rfl

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -42,6 +42,11 @@ Pell's equation
 
 namespace zsqrtd
 
+-- Note: We put this here to avoid having to import `algebra.star.unitary`
+--       into `number_theory.zsqrtd.basic` just for this one result.
+
+/-- An element of `ℤ√d` has norm one (i.e., `a.re^2 - d*a.im^2 = 1`) if and only if
+it is contained in the submonoid of unitary elements. -/
 lemma norm_eq_one_iff_mem_unitary {d : ℤ} {a : zsqrtd d} :
   a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary (zsqrtd d) :=
 begin

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -202,7 +202,8 @@ lemma x_one : (1 : solution₁ d).x = 1 := rfl
 lemma y_one : (1 : solution₁ d).y = 0 := rfl
 
 @[simp]
-lemma x_mul (a b : solution₁ d) : (a * b).x = a.x * b.x + d * (a.y * b.y) := rfl
+lemma x_mul (a b : solution₁ d) : (a * b).x = a.x * b.x + d * (a.y * b.y) :=
+by {rw ← mul_assoc, refl}
 
 @[simp]
 lemma y_mul (a b : solution₁ d) : (a * b).y = a.x * b.y + a.y * b.x := rfl

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -157,11 +157,15 @@ end existence
 We define a structure of a commutative multiplicative group with distributive negation
 on the set of all solutions to the Pell equation `x^2 - d*y^2 = 1`.
 
-The type of such solutions is `pell.solution₁ d`. It contains integers `x` and `y` and
-a proof that `(x, y)` is indeed a solution.
+The type of such solutions is `pell.solution₁ d`. It corresponds to a pair of integers `x` and `y`
+and a proof that `(x, y)` is indeed a solution.
 
-The multiplication is given by `(x, y) * (x', y') = (x*y' + d*y*y', x*y' + y*x')`
-(this is obtained by mapping `(x, y)` to `x + y*√d` and multiplying the results).
+The multiplication is given by `(x, y) * (x', y') = (x*y' + d*y*y', x*y' + y*x')`.
+This is obtained by mapping `(x, y)` to `x + y*√d` and multiplying the results.
+In fact, we define `pell.solution₁ d` to be `↥(unitary (ℤ√d))` and transport
+the "commutative group with distributive negation" structure from `↥(unitary (ℤ√d))`.
+
+We then set up an API for `pell.solution₁ d`.
 -/
 
 -- We use `solution₁ d` to allow for a more general structure `solution d m` that
@@ -171,7 +175,7 @@ The multiplication is given by `(x, y) * (x', y') = (x*y' + d*y*y', x*y' + y*x')
 We define this in terms of elements of `ℤ√d` of norm one.
 -/
 @[derive [comm_group, has_distrib_neg, inhabited]]
-def solution₁ (d : ℤ) : Type := ↥(unitary (zsqrtd d))
+def solution₁ (d : ℤ) : Type := ↥(unitary (ℤ√d))
 
 namespace solution₁
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -55,7 +55,9 @@ begin
 end
 
 /-- An element of `ℤ√d` has norm one (i.e., `a.re^2 - d*a.im^2 = 1`) if and only if
-it is contained in the submonoid of unitary elements. -/
+it is contained in the submonoid of unitary elements.
+
+TODO: merge this result with `pell.is_pell_iff_mem_unitary`. -/
 lemma is_pell_solution_iff_mem_unitary {d : ℤ} {a : zsqrtd d} :
   a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary (zsqrtd d) :=
 by rw [← norm_eq_one_iff_mem_unitary, norm_def, sq, sq, ← mul_assoc]

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -214,7 +214,7 @@ lemma rel_y (a : solution₁ d) : d * a.y ^ 2 = a.x ^ 2 - 1 := by {rw ← a.rel,
 /-- Two solutions are equal if their `x` and `y` components are equal. -/
 @[ext]
 lemma ext {a b : solution₁ d} (hx : a.x = b.x) (hy : a.y = b.y) : a = b :=
-by {ext, exact ext.mpr ⟨hx, hy⟩}
+subtype.ext $ ext.mpr ⟨hx, hy⟩
 
 /-- Construct a solution from `x`, `y` and a proof that the equation is satisfied. -/
 def mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : solution₁ d :=

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -160,8 +160,6 @@ structure solution₁ (d : ℤ) := (x : ℤ) (y : ℤ) (rel : x ^ 2 - d * y ^ 2 
 
 namespace solution₁
 
-instance (d : ℤ) : inhabited (solution₁ d) := ⟨{x := 1, y := 0, rel := by simp}⟩
-
 variables {d : ℤ}
 
 /-- An alternative form of the relation, suitable for rewriting `x^2`. -/
@@ -208,6 +206,8 @@ instance : comm_group (solution₁ d) :=
     simp only [one, mul, inv, neg_mul, mul_neg, ← a.rel],
     split; ring },
   .. }
+
+instance (d : ℤ) : inhabited (solution₁ d) := ⟨1⟩
 
 /-- We define the negative of a solution by negating both `x` and `y`. -/
 def neg (a : solution₁ d) : solution₁ d :=

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -7,6 +7,8 @@ Authors: Michael Geißer, Michael Stoll
 import tactic.qify
 import data.zmod.basic
 import number_theory.diophantine_approximation
+import number_theory.zsqrtd.basic
+import algebra.star.unitary
 
 /-!
 # Pell's Equation
@@ -156,7 +158,8 @@ The multiplication is given by `(x, y) * (x', y') = (x*y' + d*y*y', x*y' + y*x')
 /-- `pell.solution₁ d` is the type of solutions to the Pell equation `x^2 - d*y^2 = 1`.
 This is a structure containing two integers `x` and `y` and a proof `rel` that the equation holds.
 -/
-structure solution₁ (d : ℤ) := (x : ℤ) (y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1)
+@[derive [comm_group, has_distrib_neg, inhabited]]
+def solution₁ (d : ℤ) : Type := ↥(unitary (zsqrtd d))
 
 namespace solution₁
 
@@ -179,6 +182,7 @@ end
 
 -- Define an attribute for a `simp` set to be used in `pell_tac`.
 run_cmd mk_simp_attr `pell_simp
+run_cmd tactic.add_doc_string `simp_attr.pell_simp "Simp set to be used in `pell_tac`"
 
 /-- We use `1` to denote the trivial solution `(1, 0)`. -/
 instance : has_one (solution₁ d) :=
@@ -251,3 +255,4 @@ instance : has_distrib_neg (solution₁ d) :=
 end solution₁
 
 end pell
+#lint

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -160,6 +160,8 @@ structure solution₁ (d : ℤ) := (x : ℤ) (y : ℤ) (rel : x ^ 2 - d * y ^ 2 
 
 namespace solution₁
 
+instance (d : ℤ) : inhabited (solution₁ d) := ⟨{x := 1, y := 0, rel := by simp}⟩
+
 variables {d : ℤ}
 
 /-- An alternative form of the relation, suitable for rewriting `x^2`. -/

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -195,24 +195,11 @@ begin
   split; assumption,
 end
 
-/-- We use `1` to denote the trivial solution `(1, 0)`. -/
-instance : has_one (solution₁ d) :=
-{ one := { x := 1, y := 0, rel := by simp } }
-
-instance : inhabited (solution₁ d) := ⟨1⟩
-
 @[simp]
 lemma x_one : (1 : solution₁ d).x = 1 := rfl
 
 @[simp]
 lemma y_one : (1 : solution₁ d).y = 0 := rfl
-
-/-- We can multiply two solutions. -/
-instance : has_mul (solution₁ d) :=
-{ mul := λ a b,
-  { x := a.x * b.x + d * (a.y * b.y),
-    y := a.x * b.y + a.y * b.x,
-    rel := by {conv_rhs {rw ← mul_one (1 : ℤ), congr, rw ← a.rel, skip, rw ← b.rel}, ring} } }
 
 @[simp]
 lemma x_mul (a b : solution₁ d) : (a * b).x = a.x * b.x + d * (a.y * b.y) := rfl
@@ -220,19 +207,11 @@ lemma x_mul (a b : solution₁ d) : (a * b).x = a.x * b.x + d * (a.y * b.y) := r
 @[simp]
 lemma y_mul (a b : solution₁ d) : (a * b).y = a.x * b.y + a.y * b.x := rfl
 
-/-- We obtain the inverse of a solution by changing the sign of `y`. -/
-instance : has_inv (solution₁ d) :=
-{ inv := λ a, { x := a.x, y := -a.y, rel := by simp [a.rel] } }
-
 @[simp]
 lemma x_inv (a : solution₁ d) : a⁻¹.x = a.x := rfl
 
 @[simp]
 lemma y_inv (a : solution₁ d) : a⁻¹.y = -a.y := rfl
-
-/-- We define the negative of a solution by negating both `x` and `y`. -/
-instance : has_neg (solution₁ d) :=
-{ neg := λ a, { x := -a.x, y := -a.y, rel := by simp [a.rel] } }
 
 @[simp]
 lemma x_neg (a : solution₁ d) : (-a).x = -a.x := rfl

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -195,6 +195,16 @@ begin
   split; assumption,
 end
 
+def mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : solution₁ d :=
+{ val := ⟨x, y⟩,
+  property := zsqrtd.norm_eq_one_iff_mem_unitary.mp rel }
+
+@[simp]
+lemma x_mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (mk x y rel).x = x := rfl
+
+@[simp]
+lemma y_mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (mk x y rel).y = y := rfl
+
 @[simp]
 lemma x_one : (1 : solution₁ d).x = 1 := rfl
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -186,11 +186,7 @@ def x (a : solution₁ d) : ℤ := (a : zsqrtd d).re
 def y (a : solution₁ d) : ℤ := (a : zsqrtd d).im
 
 lemma rel (a : solution₁ d) : a.x ^ 2 - d * a.y ^ 2 = 1 :=
-begin
-  have := a.property,
-  rwa [unitary.mem_iff, ← norm_eq_mul_conj, mul_comm, ← norm_eq_mul_conj, and_self, norm_def,
-       ← sq, mul_assoc, ← sq, ← int.cast_one, int.cast_inj] at this,
-end
+norm_eq_one_iff_mem_unitary.mpr a.property
 
 /-- An alternative form of the relation, suitable for rewriting `x^2`. -/
 lemma rel_x (a : solution₁ d) : a.x ^ 2 = 1 + d * a.y ^ 2 := by {rw ← a.rel, ring}

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -56,7 +56,7 @@ end
 
 /-- An element of `ℤ√d` has norm one (i.e., `a.re^2 - d*a.im^2 = 1`) if and only if
 it is contained in the submonoid of unitary elements. -/
-lemma norm_eq_one_iff_mem_unitary' {d : ℤ} {a : zsqrtd d} :
+lemma is_pell_solution_iff_mem_unitary {d : ℤ} {a : zsqrtd d} :
   a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary (zsqrtd d) :=
 by rw [← norm_eq_one_iff_mem_unitary, norm_def, sq, sq, ← mul_assoc]
 
@@ -203,7 +203,7 @@ def y (a : solution₁ d) : ℤ := (a : ℤ√d).im
 
 /-- The proof that `a` is a solution to the Pell equation `x^2 - d*y^2 = 1` -/
 lemma rel (a : solution₁ d) : a.x ^ 2 - d * a.y ^ 2 = 1 :=
-norm_eq_one_iff_mem_unitary'.mpr a.property
+is_pell_solution_iff_mem_unitary.mpr a.property
 
 /-- An alternative form of the relation, suitable for rewriting `x^2`. -/
 lemma rel_x (a : solution₁ d) : a.x ^ 2 = 1 + d * a.y ^ 2 := by {rw ← a.rel, ring}
@@ -219,7 +219,7 @@ subtype.ext $ ext.mpr ⟨hx, hy⟩
 /-- Construct a solution from `x`, `y` and a proof that the equation is satisfied. -/
 def mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : solution₁ d :=
 { val := ⟨x, y⟩,
-  property := norm_eq_one_iff_mem_unitary'.mp rel }
+  property := is_pell_solution_iff_mem_unitary.mp rel }
 
 @[simp]
 lemma x_mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (mk x y rel).x = x := rfl

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -54,6 +54,10 @@ begin
   norm_cast,
 end
 
+/-- The kernel of the norm map on `ℤ√d` equals the submonoid of unitary elements. -/
+lemma mker_norm_eq_unitary {d : ℤ} : (@norm_monoid_hom d).mker = unitary ℤ√d :=
+submonoid.ext (λ x, (monoid_hom.mem_mker _).trans norm_eq_one_iff_mem_unitary)
+
 /-- An element of `ℤ√d` has norm one (i.e., `a.re^2 - d*a.im^2 = 1`) if and only if
 it is contained in the submonoid of unitary elements.
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -8,7 +8,6 @@ import tactic.qify
 import data.zmod.basic
 import number_theory.diophantine_approximation
 import number_theory.zsqrtd.basic
-import algebra.star.unitary
 
 /-!
 # Pell's Equation
@@ -39,27 +38,6 @@ Pell's equation
   and furthermore also for `x ^ 2 - d * y ^ 2 = -1` and further generalizations.
 * Connect solutions to the continued fraction expansion of `√d`.
 -/
-
-namespace zsqrtd
-
-variables {d : ℤ}
-
--- Note: We put these here to avoid having to import `algebra.star.unitary`
---       into `number_theory.zsqrtd.basic` just for these three results.
-
-/-- An element of `ℤ√d` has norm equal to `1` if and only if it is contained in the submonoid
-of unitary elements. -/
-lemma norm_eq_one_iff_mem_unitary {a : ℤ√d} : a.norm = 1 ↔ a ∈ unitary ℤ√d :=
-begin
-  rw [unitary.mem_iff_self_mul_star, ← norm_eq_mul_conj],
-  norm_cast,
-end
-
-/-- The kernel of the norm map on `ℤ√d` equals the submonoid of unitary elements. -/
-lemma mker_norm_eq_unitary : (@norm_monoid_hom d).mker = unitary ℤ√d :=
-submonoid.ext (λ x, norm_eq_one_iff_mem_unitary)
-
-end zsqrtd
 
 namespace pell
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -163,7 +163,22 @@ def solution₁ (d : ℤ) : Type := ↥(unitary (zsqrtd d))
 
 namespace solution₁
 
+open zsqrtd
+
 variables {d : ℤ}
+
+instance : has_coe (solution₁ d) (zsqrtd d) := { coe := subtype.val }
+
+def x (a : solution₁ d) : ℤ := (a : zsqrtd d).re
+
+def y (a : solution₁ d) : ℤ := (a : zsqrtd d).im
+
+lemma rel (a : solution₁ d) : a.x ^ 2 - d * a.y ^ 2 = 1 :=
+begin
+  have := a.property,
+  rwa [unitary.mem_iff, ← norm_eq_mul_conj, mul_comm, ← norm_eq_mul_conj, and_self, norm_def,
+       ← sq, mul_assoc, ← sq, ← int.cast_one, int.cast_inj] at this,
+end
 
 /-- An alternative form of the relation, suitable for rewriting `x^2`. -/
 lemma rel_x (a : solution₁ d) : a.x ^ 2 = 1 + d * a.y ^ 2 := by {rw ← a.rel, ring}
@@ -175,9 +190,9 @@ lemma rel_y (a : solution₁ d) : d * a.y ^ 2 = a.x ^ 2 - 1 := by {rw ← a.rel,
 @[ext]
 lemma ext {a b : solution₁ d} (hx : a.x = b.x) (hy : a.y = b.y) : a = b :=
 begin
-  cases a,
-  cases b,
-  congr; assumption,
+  ext,
+  refine ext.mpr _,
+  split; assumption,
 end
 
 -- Define an attribute for a `simp` set to be used in `pell_tac`.

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -42,28 +42,29 @@ Pell's equation
 
 namespace zsqrtd
 
+variables {d : ℤ}
+
 -- Note: We put these here to avoid having to import `algebra.star.unitary`
---       into `number_theory.zsqrtd.basic` just for these two results.
+--       into `number_theory.zsqrtd.basic` just for these three results.
 
 /-- An element of `ℤ√d` has norm equal to `1` if and only if it is contained in the submonoid
 of unitary elements. -/
-lemma norm_eq_one_iff_mem_unitary {d : ℤ} {a : zsqrtd d} :
-  a.norm = 1 ↔ a ∈ unitary (zsqrtd d) :=
+lemma norm_eq_one_iff_mem_unitary {a : ℤ√d} : a.norm = 1 ↔ a ∈ unitary ℤ√d :=
 begin
   rw [unitary.mem_iff_self_mul_star, ← norm_eq_mul_conj],
   norm_cast,
 end
 
 /-- The kernel of the norm map on `ℤ√d` equals the submonoid of unitary elements. -/
-lemma mker_norm_eq_unitary {d : ℤ} : (@norm_monoid_hom d).mker = unitary ℤ√d :=
+lemma mker_norm_eq_unitary : (@norm_monoid_hom d).mker = unitary ℤ√d :=
 submonoid.ext (λ x, (monoid_hom.mem_mker _).trans norm_eq_one_iff_mem_unitary)
 
 /-- An element of `ℤ√d` has norm one (i.e., `a.re^2 - d*a.im^2 = 1`) if and only if
 it is contained in the submonoid of unitary elements.
 
 TODO: merge this result with `pell.is_pell_iff_mem_unitary`. -/
-lemma is_pell_solution_iff_mem_unitary {d : ℤ} {a : zsqrtd d} :
-  a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary (zsqrtd d) :=
+lemma is_pell_solution_iff_mem_unitary {a : ℤ√d} :
+  a.re ^ 2 - d * a.im ^ 2 = 1 ↔ a ∈ unitary ℤ√d :=
 by rw [← norm_eq_one_iff_mem_unitary, norm_def, sq, sq, ← mul_assoc]
 
 end zsqrtd
@@ -191,7 +192,7 @@ We then set up an API for `pell.solution₁ d`.
 We define this in terms of elements of `ℤ√d` of norm one.
 -/
 @[derive [comm_group, has_distrib_neg, inhabited]]
-def solution₁ (d : ℤ) : Type := ↥(unitary (ℤ√d))
+def solution₁ (d : ℤ) : Type := ↥(unitary ℤ√d)
 
 namespace solution₁
 
@@ -199,23 +200,23 @@ open zsqrtd
 
 variables {d : ℤ}
 
-instance : has_coe (solution₁ d) (ℤ√d) := { coe := subtype.val }
+instance : has_coe (solution₁ d) ℤ√d := { coe := subtype.val }
 
 /-- The `x` component of a solution to the Pell equation `x^2 - d*y^2 = 1` -/
-def x (a : solution₁ d) : ℤ := (a : ℤ√d).re
+protected def x (a : solution₁ d) : ℤ := (a : ℤ√d).re
 
 /-- The `y` component of a solution to the Pell equation `x^2 - d*y^2 = 1` -/
-def y (a : solution₁ d) : ℤ := (a : ℤ√d).im
+protected def y (a : solution₁ d) : ℤ := (a : ℤ√d).im
 
 /-- The proof that `a` is a solution to the Pell equation `x^2 - d*y^2 = 1` -/
-lemma rel (a : solution₁ d) : a.x ^ 2 - d * a.y ^ 2 = 1 :=
+lemma prop (a : solution₁ d) : a.x ^ 2 - d * a.y ^ 2 = 1 :=
 is_pell_solution_iff_mem_unitary.mpr a.property
 
-/-- An alternative form of the relation, suitable for rewriting `x^2`. -/
-lemma rel_x (a : solution₁ d) : a.x ^ 2 = 1 + d * a.y ^ 2 := by {rw ← a.rel, ring}
+/-- An alternative form of the equation, suitable for rewriting `x^2`. -/
+lemma prop_x (a : solution₁ d) : a.x ^ 2 = 1 + d * a.y ^ 2 := by {rw ← a.prop, ring}
 
-/-- An alternative form of the relation, suitable for rewriting `d * y^2`. -/
-lemma rel_y (a : solution₁ d) : d * a.y ^ 2 = a.x ^ 2 - 1 := by {rw ← a.rel, ring}
+/-- An alternative form of the equation, suitable for rewriting `d * y^2`. -/
+lemma prop_y (a : solution₁ d) : d * a.y ^ 2 = a.x ^ 2 - 1 := by {rw ← a.prop, ring}
 
 /-- Two solutions are equal if their `x` and `y` components are equal. -/
 @[ext]
@@ -223,19 +224,19 @@ lemma ext {a b : solution₁ d} (hx : a.x = b.x) (hy : a.y = b.y) : a = b :=
 subtype.ext $ ext.mpr ⟨hx, hy⟩
 
 /-- Construct a solution from `x`, `y` and a proof that the equation is satisfied. -/
-def mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : solution₁ d :=
+def mk (x y : ℤ) (prop : x ^ 2 - d * y ^ 2 = 1) : solution₁ d :=
 { val := ⟨x, y⟩,
-  property := is_pell_solution_iff_mem_unitary.mp rel }
+  property := is_pell_solution_iff_mem_unitary.mp prop }
 
 @[simp]
-lemma x_mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (mk x y rel).x = x := rfl
+lemma x_mk (x y : ℤ) (prop : x ^ 2 - d * y ^ 2 = 1) : (mk x y prop).x = x := rfl
 
 @[simp]
-lemma y_mk (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (mk x y rel).y = y := rfl
+lemma y_mk (x y : ℤ) (prop : x ^ 2 - d * y ^ 2 = 1) : (mk x y prop).y = y := rfl
 
 @[simp]
-lemma coe_mk  (x y : ℤ) (rel : x ^ 2 - d * y ^ 2 = 1) : (↑(mk x y rel) : ℤ√d) = ⟨x,y⟩ :=
-zsqrtd.ext.mpr ⟨x_mk x y rel, y_mk x y rel⟩
+lemma coe_mk  (x y : ℤ) (prop : x ^ 2 - d * y ^ 2 = 1) : (↑(mk x y prop) : ℤ√d) = ⟨x,y⟩ :=
+zsqrtd.ext.mpr ⟨x_mk x y prop, y_mk x y prop⟩
 
 @[simp]
 lemma x_one : (1 : solution₁ d).x = 1 := rfl

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -250,4 +250,3 @@ lemma y_neg (a : solution₁ d) : (-a).y = -a.y := rfl
 end solution₁
 
 end pell
-#lint

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -195,20 +195,16 @@ begin
   split; assumption,
 end
 
--- Define an attribute for a `simp` set to be used in `pell_tac`.
-run_cmd mk_simp_attr `pell_simp
-run_cmd tactic.add_doc_string `simp_attr.pell_simp "Simp set to be used in `pell_tac`"
-
 /-- We use `1` to denote the trivial solution `(1, 0)`. -/
 instance : has_one (solution₁ d) :=
 { one := { x := 1, y := 0, rel := by simp } }
 
 instance : inhabited (solution₁ d) := ⟨1⟩
 
-@[simp, pell_simp]
+@[simp]
 lemma x_one : (1 : solution₁ d).x = 1 := rfl
 
-@[simp, pell_simp]
+@[simp]
 lemma y_one : (1 : solution₁ d).y = 0 := rfl
 
 /-- We can multiply two solutions. -/
@@ -218,54 +214,33 @@ instance : has_mul (solution₁ d) :=
     y := a.x * b.y + a.y * b.x,
     rel := by {conv_rhs {rw ← mul_one (1 : ℤ), congr, rw ← a.rel, skip, rw ← b.rel}, ring} } }
 
-@[simp, pell_simp]
+@[simp]
 lemma x_mul (a b : solution₁ d) : (a * b).x = a.x * b.x + d * (a.y * b.y) := rfl
 
-@[simp, pell_simp]
+@[simp]
 lemma y_mul (a b : solution₁ d) : (a * b).y = a.x * b.y + a.y * b.x := rfl
 
 /-- We obtain the inverse of a solution by changing the sign of `y`. -/
 instance : has_inv (solution₁ d) :=
 { inv := λ a, { x := a.x, y := -a.y, rel := by simp [a.rel] } }
 
-@[simp, pell_simp]
+@[simp]
 lemma x_inv (a : solution₁ d) : a⁻¹.x = a.x := rfl
 
-@[simp, pell_simp]
+@[simp]
 lemma y_inv (a : solution₁ d) : a⁻¹.y = -a.y := rfl
 
 /-- We define the negative of a solution by negating both `x` and `y`. -/
 instance : has_neg (solution₁ d) :=
 { neg := λ a, { x := -a.x, y := -a.y, rel := by simp [a.rel] } }
 
-@[simp, pell_simp]
+@[simp]
 lemma x_neg (a : solution₁ d) : (-a).x = -a.x := rfl
 
-@[simp, pell_simp]
+@[simp]
 lemma y_neg (a : solution₁ d) : (-a).y = -a.y := rfl
 
-/-- Set up a tactic that discharges the computational goals below. -/
-meta def pell_tac : tactic unit :=
-`[ intros, ext; simp only with pell_simp; ring_nf ]
 
-/-- The solutions to the Pell equation `x^2 - d*y^2 = 1` form a commutative group. -/
-instance : comm_group (solution₁ d) :=
-{ mul := has_mul.mul,
-  mul_assoc := by pell_tac,
-  one := has_one.one,
-  one_mul := by pell_tac,
-  mul_one := by pell_tac,
-  mul_comm := by pell_tac,
-  inv := has_inv.inv,
-  mul_left_inv := λ a, by {pell_tac, rw a.rel_x, ring},
-  .. }
-
-/-- The negation of solutions is compatible with the multiplicative structure. -/
-instance : has_distrib_neg (solution₁ d) :=
-{ neg := has_neg.neg,
-  neg_neg := by pell_tac,
-  neg_mul := by pell_tac,
-  mul_neg := by pell_tac }
 
 end solution₁
 

--- a/src/number_theory/zsqrtd/basic.lean
+++ b/src/number_theory/zsqrtd/basic.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro
 import algebra.associated
 import ring_theory.int.basic
 import tactic.ring
+import algebra.star.unitary
 
 /-! # ℤ[√d]
 
@@ -758,5 +759,17 @@ begin
     rwa [← int.cast_zero, h_inj.eq_iff, norm_eq_zero hd] at this },
   rw [norm_eq_mul_conj, ring_hom.map_mul, ha, zero_mul]
 end
+
+/-- An element of `ℤ√d` has norm equal to `1` if and only if it is contained in the submonoid
+of unitary elements. -/
+lemma norm_eq_one_iff_mem_unitary {d : ℤ} {a : ℤ√d} : a.norm = 1 ↔ a ∈ unitary ℤ√d :=
+begin
+  rw [unitary.mem_iff_self_mul_star, ← norm_eq_mul_conj],
+  norm_cast,
+end
+
+/-- The kernel of the norm map on `ℤ√d` equals the submonoid of unitary elements. -/
+lemma mker_norm_eq_unitary {d : ℤ} : (@norm_monoid_hom d).mker = unitary ℤ√d :=
+submonoid.ext (λ x, norm_eq_one_iff_mem_unitary)
 
 end zsqrtd


### PR DESCRIPTION
This continues the sequence of PRs related to the Pell equation.
We define a type for the solutions of `x^2 - d*y^2 = 1` and give it the structure of a commutative mutiplicative group with compatible negation.

See [this thread on Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Proving.20Pell's.20equation.20is.20solvable/near/338175458).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
