### PR TITLE
[Merged by Bors] - chore(number_theory/pell_matiyasevic): generalize `is_pell` to arbitary `d`

### DIFF
--- a/src/number_theory/pell_matiyasevic.lean
+++ b/src/number_theory/pell_matiyasevic.lean
@@ -53,6 +53,27 @@ namespace pell
 open nat
 
 section
+variables {d : ℤ}
+
+/-- The property of being a solution to the Pell equation, expressed
+  as a property of elements of `ℤ√d`. -/
+def is_pell : ℤ√d → Prop | ⟨x, y⟩ := x*x - d*y*y = 1
+
+theorem is_pell_norm : Π {b : ℤ√d}, is_pell b ↔ b * star b = 1
+| ⟨x, y⟩ := by simp [zsqrtd.ext, is_pell, mul_comm]; ring_nf
+
+theorem is_pell_iff_mem_unitary : Π {b : ℤ√d}, is_pell b ↔ b ∈ unitary ℤ√d
+| ⟨x, y⟩ := by rw [unitary.mem_iff, is_pell_norm, mul_comm (star _), and_self]
+
+theorem is_pell_mul {b c : ℤ√d} (hb : is_pell b) (hc : is_pell c) : is_pell (b * c) :=
+is_pell_norm.2 (by simp [mul_comm, mul_left_comm, star_mul, is_pell_norm.1 hb, is_pell_norm.1 hc])
+
+theorem is_pell_star : ∀ {b : ℤ√d}, is_pell b ↔ is_pell (star b) | ⟨x, y⟩ :=
+by simp [is_pell, zsqrtd.star_mk]
+
+end
+
+section
 parameters {a : ℕ} (a1 : 1 < a)
 
 include a1
@@ -112,33 +133,16 @@ def pell_zd (n : ℕ) : ℤ√d := ⟨xn n, yn n⟩
 @[simp] theorem pell_zd_re (n : ℕ) : (pell_zd n).re = xn n := rfl
 @[simp] theorem pell_zd_im (n : ℕ) : (pell_zd n).im = yn n := rfl
 
-/-- The property of being a solution to the Pell equation, expressed
-  as a property of elements of `ℤ√d`. -/
-def is_pell : ℤ√d → Prop | ⟨x, y⟩ := x*x - d*y*y = 1
-
-theorem is_pell_nat {x y : ℕ} : is_pell ⟨x, y⟩ ↔ x*x - d*y*y = 1 :=
+theorem is_pell_nat {x y : ℕ} : is_pell (⟨x, y⟩ : ℤ√d) ↔ x*x - d*y*y = 1 :=
 ⟨λh, int.coe_nat_inj
   (by rw int.coe_nat_sub (int.le_of_coe_nat_le_coe_nat $ int.le.intro_sub h); exact h),
 λh, show ((x*x : ℕ) - (d*y*y:ℕ) : ℤ) = 1,
   by rw [← int.coe_nat_sub $ le_of_lt $ nat.lt_of_sub_eq_succ h, h]; refl⟩
 
-theorem is_pell_norm : Π {b : ℤ√d}, is_pell b ↔ b * star b = 1
-| ⟨x, y⟩ := by simp [zsqrtd.ext, is_pell, mul_comm]; ring_nf
-
-theorem is_pell_iff_mem_unitary : Π {b : ℤ√d}, is_pell b ↔ b ∈ unitary ℤ√d
-| ⟨x, y⟩ := by rw [unitary.mem_iff, is_pell_norm, mul_comm (star _), and_self]
-
-theorem is_pell_mul {b c : ℤ√d} (hb : is_pell b) (hc : is_pell c) : is_pell (b * c) :=
-is_pell_norm.2 (by simp [mul_comm, mul_left_comm,
-  star_mul, pell.is_pell_norm.1 hb, pell.is_pell_norm.1 hc])
-
-theorem is_pell_star : ∀ {b : ℤ√d}, is_pell b ↔ is_pell (star b) | ⟨x, y⟩ :=
-by simp [is_pell, zsqrtd.star_mk]
-
 @[simp] theorem pell_zd_succ (n : ℕ) : pell_zd (n+1) = pell_zd n * ⟨a, 1⟩ :=
 by simp [zsqrtd.ext]
 
-theorem is_pell_one : is_pell ⟨a, 1⟩ :=
+theorem is_pell_one : is_pell (⟨a, 1⟩ : ℤ√d) :=
 show az*az-d*1*1=1, by simp [dz_val]; ring
 
 theorem is_pell_pell_zd : ∀ (n : ℕ), is_pell (pell_zd n)
@@ -252,7 +256,7 @@ by injection (pell_zd_add _ m n) with _ h;
 theorem pell_zd_sub {m n} (h : n ≤ m) : pell_zd (m - n) = pell_zd m * star (pell_zd n) :=
 let t := pell_zd_add n (m - n) in
 by rw [add_tsub_cancel_of_le h] at t;
-    rw [t, mul_comm (pell_zd _ n) _, mul_assoc, (is_pell_norm _).1 (is_pell_pell_zd _ _), mul_one]
+    rw [t, mul_comm (pell_zd _ n) _, mul_assoc, is_pell_norm.1 (is_pell_pell_zd _ _), mul_one]
 
 theorem xz_sub {m n} (h : n ≤ m) : xz (m - n) = xz m * xz n - d * yz m * yz n :=
 by { rw [sub_eq_add_neg, ←mul_neg], exact congr_arg zsqrtd.re (pell_zd_sub a1 h) }


### PR DESCRIPTION
Not much else in the file generalizes, but we may as well generalize the definition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
