### PR TITLE
[Merged by Bors] - chore(analysis/inner_product_space): rename `_sym` to `_symm`

### DIFF
--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -70,7 +70,7 @@ by { simp only [adjoint_aux_apply, to_dual_symm_apply, to_sesq_form_apply_coe, c
                 innerSL_apply_coe]}
 
 lemma adjoint_aux_inner_right (A : E →L[𝕜] F) (x : E) (y : F) : ⟪x, adjoint_aux A y⟫ = ⟪A x, y⟫ :=
-by rw [←inner_conj_sym, adjoint_aux_inner_left, inner_conj_sym]
+by rw [←inner_conj_symm, adjoint_aux_inner_left, inner_conj_symm]
 
 variables [complete_space F]
 

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -102,7 +102,7 @@ To construct a norm from an inner product, see `inner_product_space.of_core`.
 class inner_product_space (𝕜 : Type*) (E : Type*) [is_R_or_C 𝕜]
   extends normed_add_comm_group E, normed_space 𝕜 E, has_inner 𝕜 E :=
 (norm_sq_eq_inner : ∀ (x : E), ‖x‖^2 = re (inner x x))
-(conj_sym  : ∀ x y, conj (inner y x) = inner x y)
+(conj_symm : ∀ x y, conj (inner y x) = inner x y)
 (add_left  : ∀ x y z, inner (x + y) z = inner x z + inner y z)
 (smul_left : ∀ x y r, inner (r • x) y = (conj r) * inner x y)
 
@@ -134,7 +134,7 @@ structure inner_product_space.core
   (𝕜 : Type*) (F : Type*)
   [is_R_or_C 𝕜] [add_comm_group F] [module 𝕜 F] :=
 (inner     : F → F → 𝕜)
-(conj_sym  : ∀ x y, conj (inner y x) = inner x y)
+(conj_symm : ∀ x y, conj (inner y x) = inner x y)
 (nonneg_re : ∀ x, 0 ≤ re (inner x x))
 (definite  : ∀ x, inner x x = 0 → x = 0)
 (add_left  : ∀ x y z, inner (x + y) z = inner x z + inner y z)
@@ -166,12 +166,12 @@ def norm_sq (x : F) := reK ⟪x, x⟫
 
 local notation `norm_sqF` := @norm_sq 𝕜 F _ _ _ _
 
-lemma inner_conj_sym (x y : F) : ⟪y, x⟫† = ⟪x, y⟫ := c.conj_sym x y
+lemma inner_conj_symm (x y : F) : ⟪y, x⟫† = ⟪x, y⟫ := c.conj_symm x y
 
 lemma inner_self_nonneg {x : F} : 0 ≤ re ⟪x, x⟫ := c.nonneg_re _
 
 lemma inner_self_nonneg_im (x : F) : im ⟪x, x⟫ = 0 :=
-by rw [← @of_real_inj 𝕜, im_eq_conj_sub]; simp [inner_conj_sym]
+by rw [← @of_real_inj 𝕜, im_eq_conj_sub]; simp [inner_conj_symm]
 
 lemma inner_self_im_zero (x : F) : im ⟪x, x⟫ = 0 :=
 inner_self_nonneg_im _
@@ -180,7 +180,7 @@ lemma inner_add_left (x y z : F) : ⟪x + y, z⟫ = ⟪x, z⟫ + ⟪y, z⟫ :=
 c.add_left _ _ _
 
 lemma inner_add_right (x y z : F) : ⟪x, y + z⟫ = ⟪x, y⟫ + ⟪x, z⟫ :=
-by rw [←inner_conj_sym, inner_add_left, ring_hom.map_add]; simp only [inner_conj_sym]
+by rw [←inner_conj_symm, inner_add_left, ring_hom.map_add]; simp only [inner_conj_symm]
 
 lemma inner_norm_sq_eq_inner_self (x : F) : (norm_sqF x : 𝕜) = ⟪x, x⟫ :=
 begin
@@ -189,22 +189,22 @@ begin
 end
 
 lemma inner_re_symm (x y : F) : re ⟪x, y⟫ = re ⟪y, x⟫ :=
-by rw [←inner_conj_sym, conj_re]
+by rw [←inner_conj_symm, conj_re]
 
 lemma inner_im_symm (x y : F) : im ⟪x, y⟫ = -im ⟪y, x⟫ :=
-by rw [←inner_conj_sym, conj_im]
+by rw [←inner_conj_symm, conj_im]
 
 lemma inner_smul_left (x y : F) {r : 𝕜} : ⟪r • x, y⟫ = r† * ⟪x, y⟫ :=
 c.smul_left _ _ _
 
 lemma inner_smul_right (x y : F) {r : 𝕜} : ⟪x, r • y⟫ = r * ⟪x, y⟫ :=
-by rw [←inner_conj_sym, inner_smul_left]; simp only [conj_conj, inner_conj_sym, ring_hom.map_mul]
+by rw [←inner_conj_symm, inner_smul_left]; simp only [conj_conj, inner_conj_symm, ring_hom.map_mul]
 
 lemma inner_zero_left (x : F) : ⟪0, x⟫ = 0 :=
 by rw [←zero_smul 𝕜 (0 : F), inner_smul_left]; simp only [zero_mul, ring_hom.map_zero]
 
 lemma inner_zero_right (x : F) : ⟪x, 0⟫ = 0 :=
-by rw [←inner_conj_sym, inner_zero_left]; simp only [ring_hom.map_zero]
+by rw [←inner_conj_symm, inner_zero_left]; simp only [ring_hom.map_zero]
 
 lemma inner_self_eq_zero {x : F} : ⟪x, x⟫ = 0 ↔ x = 0 :=
 iff.intro (c.definite _) (by { rintro rfl, exact inner_zero_left _ })
@@ -212,14 +212,14 @@ iff.intro (c.definite _) (by { rintro rfl, exact inner_zero_left _ })
 lemma inner_self_re_to_K (x : F) : (re ⟪x, x⟫ : 𝕜) = ⟪x, x⟫ :=
 by norm_num [ext_iff, inner_self_nonneg_im]
 
-lemma inner_abs_conj_sym (x y : F) : abs ⟪x, y⟫ = abs ⟪y, x⟫ :=
-by rw [←inner_conj_sym, abs_conj]
+lemma inner_abs_conj_symm (x y : F) : abs ⟪x, y⟫ = abs ⟪y, x⟫ :=
+by rw [←inner_conj_symm, abs_conj]
 
 lemma inner_neg_left (x y : F) : ⟪-x, y⟫ = -⟪x, y⟫ :=
 by { rw [← neg_one_smul 𝕜 x, inner_smul_left], simp }
 
 lemma inner_neg_right (x y : F) : ⟪x, -y⟫ = -⟪x, y⟫ :=
-by rw [←inner_conj_sym, inner_neg_left]; simp only [ring_hom.map_neg, inner_conj_sym]
+by rw [←inner_conj_symm, inner_neg_left]; simp only [ring_hom.map_neg, inner_conj_symm]
 
 lemma inner_sub_left (x y z : F) : ⟪x - y, z⟫ = ⟪x, z⟫ - ⟪y, z⟫ :=
 by { simp [sub_eq_add_neg, inner_add_left, inner_neg_left] }
@@ -228,7 +228,7 @@ lemma inner_sub_right (x y z : F) : ⟪x, y - z⟫ = ⟪x, y⟫ - ⟪x, z⟫ :=
 by { simp [sub_eq_add_neg, inner_add_right, inner_neg_right] }
 
 lemma inner_mul_conj_re_abs (x y : F) : re (⟪x, y⟫ * ⟪y, x⟫) = abs (⟪x, y⟫ * ⟪y, x⟫) :=
-by { rw [←inner_conj_sym, mul_comm], exact re_eq_abs_of_mul_conj (inner y x), }
+by { rw [←inner_conj_symm, mul_comm], exact re_eq_abs_of_mul_conj (inner y x), }
 
 /-- Expand `inner (x + y) (x + y)` -/
 lemma inner_add_add_self (x y : F) : ⟪x + y, x + y⟫ = ⟪x, x⟫ + ⟪x, y⟫ + ⟪y, x⟫ + ⟪y, y⟫ :=
@@ -276,7 +276,7 @@ begin
       ... = re ⟪x, x⟫ - re (T† * ⟪y, x⟫) - re (T * ⟪x, y⟫) + re (T * T† * ⟪y, y⟫)
                   : by simp only [inner_smul_left, inner_smul_right, mul_assoc]
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ / ⟪y, y⟫ * ⟪y, x⟫)
-                  : by field_simp [-mul_re, inner_conj_sym, hT, map_div₀, h₁, h₃]
+                  : by field_simp [-mul_re, inner_conj_symm, hT, map_div₀, h₁, h₃]
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ * ⟪y, x⟫ / ⟪y, y⟫)
                   : by rw ←mul_div_right_comm
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ * ⟪y, x⟫ / re ⟪y, y⟫)
@@ -316,7 +316,7 @@ begin
   rw H,
   conv
   begin
-    to_lhs, congr, rw [inner_abs_conj_sym],
+    to_lhs, congr, rw [inner_abs_conj_symm],
   end,
   exact inner_mul_inner_self_le y x,
 end
@@ -331,7 +331,7 @@ add_group_norm.to_normed_add_comm_group
     have h₁ : abs ⟪x, y⟫ ≤ ‖x‖ * ‖y‖ := abs_inner_le_norm _ _,
     have h₂ : re ⟪x, y⟫ ≤ abs ⟪x, y⟫ := re_le_abs _,
     have h₃ : re ⟪x, y⟫ ≤ ‖x‖ * ‖y‖ := by linarith,
-    have h₄ : re ⟪y, x⟫ ≤ ‖x‖ * ‖y‖ := by rwa [←inner_conj_sym, conj_re],
+    have h₄ : re ⟪y, x⟫ ≤ ‖x‖ * ‖y‖ := by rwa [←inner_conj_symm, conj_re],
     have : ‖x + y‖ * ‖x + y‖ ≤ (‖x‖ + ‖y‖) * (‖x‖ + ‖y‖),
     { simp only [←inner_self_eq_norm_mul_norm, inner_add_add_self, mul_add, mul_comm, map_add],
       linarith },
@@ -389,11 +389,11 @@ export inner_product_space (norm_sq_eq_inner)
 
 section basic_properties
 
-@[simp] lemma inner_conj_sym (x y : E) : ⟪y, x⟫† = ⟪x, y⟫ := inner_product_space.conj_sym _ _
-lemma real_inner_comm (x y : F) : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := @inner_conj_sym ℝ _ _ _ x y
+@[simp] lemma inner_conj_symm (x y : E) : ⟪y, x⟫† = ⟪x, y⟫ := inner_product_space.conj_symm _ _
+lemma real_inner_comm (x y : F) : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := @inner_conj_symm ℝ _ _ _ x y
 
-lemma inner_eq_zero_sym {x y : E} : ⟪x, y⟫ = 0 ↔ ⟪y, x⟫ = 0 :=
-⟨λ h, by simp [←inner_conj_sym, h], λ h, by simp [←inner_conj_sym, h]⟩
+lemma inner_eq_zero_symm {x y : E} : ⟪x, y⟫ = 0 ↔ ⟪y, x⟫ = 0 :=
+⟨λ h, by simp [←inner_conj_symm, h], λ h, by simp [←inner_conj_symm, h]⟩
 
 @[simp] lemma inner_self_nonneg_im (x : E) : im ⟪x, x⟫ = 0 :=
 by rw [← @of_real_inj 𝕜, im_eq_conj_sub]; simp
@@ -404,13 +404,13 @@ lemma inner_add_left (x y z : E) : ⟪x + y, z⟫ = ⟪x, z⟫ + ⟪y, z⟫ :=
 inner_product_space.add_left _ _ _
 
 lemma inner_add_right (x y z : E) : ⟪x, y + z⟫ = ⟪x, y⟫ + ⟪x, z⟫ :=
-by { rw [←inner_conj_sym, inner_add_left, ring_hom.map_add], simp only [inner_conj_sym] }
+by { rw [←inner_conj_symm, inner_add_left, ring_hom.map_add], simp only [inner_conj_symm] }
 
 lemma inner_re_symm (x y : E) : re ⟪x, y⟫ = re ⟪y, x⟫ :=
-by rw [←inner_conj_sym, conj_re]
+by rw [←inner_conj_symm, conj_re]
 
 lemma inner_im_symm (x y : E) : im ⟪x, y⟫ = -im ⟪y, x⟫ :=
-by rw [←inner_conj_sym, conj_im]
+by rw [←inner_conj_symm, conj_im]
 
 lemma inner_smul_left (x y : E) (r : 𝕜) : ⟪r • x, y⟫ = r† * ⟪x, y⟫ :=
 inner_product_space.smul_left _ _ _
@@ -420,7 +420,7 @@ lemma inner_smul_real_left (x y : E) (r : ℝ) : ⟪(r : 𝕜) • x, y⟫ = r �
 by { rw [inner_smul_left, conj_of_real, algebra.smul_def], refl }
 
 lemma inner_smul_right (x y : E) (r : 𝕜) : ⟪x, r • y⟫ = r * ⟪x, y⟫ :=
-by rw [←inner_conj_sym, inner_smul_left, ring_hom.map_mul, conj_conj, inner_conj_sym]
+by rw [←inner_conj_symm, inner_smul_left, ring_hom.map_mul, conj_conj, inner_conj_symm]
 lemma real_inner_smul_right (x y : F) (r : ℝ) : ⟪x, r • y⟫_ℝ = r * ⟪x, y⟫_ℝ :=
 inner_smul_right _ _ _
 
@@ -488,7 +488,7 @@ lemma inner_re_zero_left (x : E) : re ⟪0, x⟫ = 0 :=
 by simp only [inner_zero_left, add_monoid_hom.map_zero]
 
 @[simp] lemma inner_zero_right (x : E) : ⟪x, 0⟫ = 0 :=
-by rw [←inner_conj_sym, inner_zero_left, ring_hom.map_zero]
+by rw [←inner_conj_symm, inner_zero_left, ring_hom.map_zero]
 
 lemma inner_re_zero_right (x : E) : re ⟪x, 0⟫ = 0 :=
 by simp only [inner_zero_right, add_monoid_hom.map_zero]
@@ -549,14 +549,14 @@ by { rw [←inner_self_re_abs], exact inner_self_re_to_K _ }
 lemma real_inner_self_abs (x : F) : absR ⟪x, x⟫_ℝ = ⟪x, x⟫_ℝ :=
 by { have h := @inner_self_abs_to_K ℝ F _ _ x, simpa using h }
 
-lemma inner_abs_conj_sym (x y : E) : abs ⟪x, y⟫ = abs ⟪y, x⟫ :=
-by rw [←inner_conj_sym, abs_conj]
+lemma inner_abs_conj_symm (x y : E) : abs ⟪x, y⟫ = abs ⟪y, x⟫ :=
+by rw [←inner_conj_symm, abs_conj]
 
 @[simp] lemma inner_neg_left (x y : E) : ⟪-x, y⟫ = -⟪x, y⟫ :=
 by { rw [← neg_one_smul 𝕜 x, inner_smul_left], simp }
 
 @[simp] lemma inner_neg_right (x y : E) : ⟪x, -y⟫ = -⟪x, y⟫ :=
-by rw [←inner_conj_sym, inner_neg_left]; simp only [ring_hom.map_neg, inner_conj_sym]
+by rw [←inner_conj_symm, inner_neg_left]; simp only [ring_hom.map_neg, inner_conj_symm]
 
 lemma inner_neg_neg (x y : E) : ⟪-x, -y⟫ = ⟪x, y⟫ := by simp
 
@@ -570,7 +570,7 @@ lemma inner_sub_right (x y z : E) : ⟪x, y - z⟫ = ⟪x, y⟫ - ⟪x, z⟫ :=
 by { simp [sub_eq_add_neg, inner_add_right] }
 
 lemma inner_mul_conj_re_abs (x y : E) : re (⟪x, y⟫ * ⟪y, x⟫) = abs (⟪x, y⟫ * ⟪y, x⟫) :=
-by { rw [←inner_conj_sym, mul_comm], exact re_eq_abs_of_mul_conj (inner y x), }
+by { rw [←inner_conj_symm, mul_comm], exact re_eq_abs_of_mul_conj (inner y x), }
 
 /-- Expand `⟪x + y, x + y⟫` -/
 lemma inner_add_add_self (x y : E) : ⟪x + y, x + y⟫ = ⟪x, x⟫ + ⟪x, y⟫ + ⟪y, x⟫ + ⟪y, y⟫ :=
@@ -579,7 +579,7 @@ by simp only [inner_add_left, inner_add_right]; ring
 /-- Expand `⟪x + y, x + y⟫_ℝ` -/
 lemma real_inner_add_add_self (x y : F) : ⟪x + y, x + y⟫_ℝ = ⟪x, x⟫_ℝ + 2 * ⟪x, y⟫_ℝ + ⟪y, y⟫_ℝ :=
 begin
-  have : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := by rw [←inner_conj_sym]; refl,
+  have : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := by rw [←inner_conj_symm]; refl,
   simp only [inner_add_add_self, this, add_left_inj],
   ring,
 end
@@ -591,7 +591,7 @@ by simp only [inner_sub_left, inner_sub_right]; ring
 /-- Expand `⟪x - y, x - y⟫_ℝ` -/
 lemma real_inner_sub_sub_self (x y : F) : ⟪x - y, x - y⟫_ℝ = ⟪x, x⟫_ℝ - 2 * ⟪x, y⟫_ℝ + ⟪y, y⟫_ℝ :=
 begin
-  have : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := by rw [←inner_conj_sym]; refl,
+  have : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := by rw [←inner_conj_symm]; refl,
   simp only [inner_sub_sub_self, this, add_left_inj],
   ring,
 end
@@ -646,7 +646,7 @@ begin
       ... = re ⟪x, x⟫ - re (T† * ⟪y, x⟫) - re (T * ⟪x, y⟫) + re (T * T† * ⟪y, y⟫)
                   : by simp only [inner_smul_left, inner_smul_right, mul_assoc]
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ / ⟪y, y⟫ * ⟪y, x⟫)
-                  : by simp only [map_div₀, h₃, inner_conj_sym, sub_add_cancel]
+                  : by simp only [map_div₀, h₃, inner_conj_symm, sub_add_cancel]
                     with field_simps {discharger := tactic.field_simp.ne_zero}
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ * ⟪y, x⟫ / ⟪y, y⟫)
                   : by rw ←mul_div_right_comm
@@ -666,7 +666,7 @@ end
 /-- Cauchy–Schwarz inequality for real inner products. -/
 lemma real_inner_mul_inner_self_le (x y : F) : ⟪x, y⟫_ℝ * ⟪x, y⟫_ℝ ≤ ⟪x, x⟫_ℝ * ⟪y, y⟫_ℝ :=
 begin
-  have h₁ : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := by rw [←inner_conj_sym]; refl,
+  have h₁ : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := by rw [←inner_conj_symm]; refl,
   have h₂ := @inner_mul_inner_self_le ℝ F _ _ x y,
   dsimp at h₂,
   have h₃ := abs_mul_abs_self ⟪x, y⟫_ℝ,
@@ -772,7 +772,7 @@ hv.inner_right_sum l (finset.mem_univ _)
 vectors picks out the coefficient of that vector. -/
 lemma orthonormal.inner_left_finsupp {v : ι → E} (hv : orthonormal 𝕜 v) (l : ι →₀ 𝕜) (i : ι) :
   ⟪finsupp.total ι E 𝕜 v l, v i⟫ = conj (l i) :=
-by rw [← inner_conj_sym, hv.inner_right_finsupp]
+by rw [← inner_conj_symm, hv.inner_right_finsupp]
 
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
 vectors picks out the coefficient of that vector. -/
@@ -979,7 +979,7 @@ begin
   repeat {rw [sq, ←inner_self_eq_norm_mul_norm]},
   rw [inner_add_add_self, two_mul],
   simp only [add_assoc, add_left_inj, add_right_inj, add_monoid_hom.map_add],
-  rw [←inner_conj_sym, conj_re],
+  rw [←inner_conj_symm, conj_re],
 end
 
 alias norm_add_sq ← norm_add_pow_two
@@ -1007,7 +1007,7 @@ begin
     re (⟪x, x⟫ - ⟪x, y⟫ - ⟪y, x⟫ + ⟪y, y⟫)
         = re ⟪x, x⟫ - re ⟪x, y⟫ - re ⟪y, x⟫ + re ⟪y, y⟫  : by simp only [map_add, map_sub]
     ... = -re ⟪y, x⟫ - re ⟪x, y⟫ + re ⟪x, x⟫ + re ⟪y, y⟫  : by ring
-    ... = -re (⟪x, y⟫†) - re ⟪x, y⟫ + re ⟪x, x⟫ + re ⟪y, y⟫ : by rw [inner_conj_sym]
+    ... = -re (⟪x, y⟫†) - re ⟪x, y⟫ + re ⟪x, x⟫ + re ⟪y, y⟫ : by rw [inner_conj_symm]
     ... = -re ⟪x, y⟫ - re ⟪x, y⟫ + re ⟪x, x⟫ + re ⟪y, y⟫ : by rw [conj_re]
     ... = re ⟪x, x⟫ - 2*re ⟪x, y⟫ + re ⟪y, y⟫ : by ring
 end
@@ -1035,7 +1035,7 @@ begin
   have : ‖x‖ * ‖y‖ * (‖x‖ * ‖y‖) = (re ⟪x, x⟫) * (re ⟪y, y⟫),
     simp only [inner_self_eq_norm_mul_norm], ring,
   rw this,
-  conv_lhs { congr, skip, rw [inner_abs_conj_sym] },
+  conv_lhs { congr, skip, rw [inner_abs_conj_symm] },
   exact inner_mul_inner_self_le _ _
 end
 
@@ -1531,7 +1531,7 @@ begin
       exact h2' },
     conv at h2 in ⟪r • x, t⟫ { rw [inner_smul_left, ht0, mul_zero] },
     symmetry' at h2,
-    have h₁ : ⟪t, r • x⟫ = 0 := by { rw [inner_smul_right, ←inner_conj_sym, ht0], simp },
+    have h₁ : ⟪t, r • x⟫ = 0 := by { rw [inner_smul_right, ←inner_conj_symm, ht0], simp },
     rw [add_zero, h₁, add_left_eq_self, add_zero, inner_self_eq_zero] at h2,
     rw h2 at ht,
     exact eq_of_sub_eq_zero ht.symm },
@@ -1801,8 +1801,8 @@ begin
     simp only [norm_nonneg, pow_nonneg], },
   rw [norm_sub_sq, sub_add],
   simp only [inner_product_space.norm_sq_eq_inner, inner_sum],
-  simp only [sum_inner, two_mul, inner_smul_right, inner_conj_sym, ←mul_assoc, h₂, ←h₃,
-  inner_conj_sym, add_monoid_hom.map_sum, finset.mul_sum, ←finset.sum_sub_distrib, inner_smul_left,
+  simp only [sum_inner, two_mul, inner_smul_right, inner_conj_symm, ←mul_assoc, h₂, ←h₃,
+  inner_conj_symm, add_monoid_hom.map_sum, finset.mul_sum, ←finset.sum_sub_distrib, inner_smul_left,
   add_sub_cancel'],
 end
 
@@ -1835,7 +1835,7 @@ instance is_R_or_C.inner_product_space : inner_product_space 𝕜 𝕜 :=
   inner := λ x y, conj x * y,
   norm_sq_eq_inner := λ x,
     by { unfold inner, rw [mul_comm, mul_conj, of_real_re, norm_sq_eq_def'] },
-  conj_sym := λ x y, by simp only [mul_comm, map_mul, star_ring_end_self_apply],
+  conj_symm := λ x y, by simp only [mul_comm, map_mul, star_ring_end_self_apply],
   add_left := λ x y z, by simp only [add_mul, map_add],
   smul_left := λ x y z, by simp only [mul_assoc, smul_eq_mul, map_mul] }
 
@@ -1847,7 +1847,7 @@ instance is_R_or_C.inner_product_space : inner_product_space 𝕜 𝕜 :=
 instance submodule.inner_product_space (W : submodule 𝕜 E) : inner_product_space 𝕜 W :=
 { to_normed_add_comm_group := submodule.normed_add_comm_group _,
   inner             := λ x y, ⟪(x:E), (y:E)⟫,
-  conj_sym          := λ _ _, inner_conj_sym _ _ ,
+  conj_symm         := λ _ _, inner_conj_symm _ _ ,
   norm_sq_eq_inner  := λ _, norm_sq_eq_inner _,
   add_left          := λ _ _ _, inner_add_left _ _ _,
   smul_left         := λ _ _ _, inner_smul_left _ _ _,
@@ -2103,7 +2103,7 @@ structure. -/
 def inner_product_space.is_R_or_C_to_real : inner_product_space ℝ E :=
 { to_normed_add_comm_group := inner_product_space.to_normed_add_comm_group 𝕜,
   norm_sq_eq_inner := norm_sq_eq_inner,
-  conj_sym := λ x y, inner_re_symm _ _,
+  conj_symm := λ x y, inner_re_symm _ _,
   add_left := λ x y z, by
   { change re ⟪x + y, z⟫ = re ⟪x, z⟫ + re ⟪y, z⟫,
     simp only [inner_add_left, map_add] },
@@ -2221,7 +2221,7 @@ lemma submodule.mem_orthogonal (v : E) : v ∈ Kᗮ ↔ ∀ u ∈ K, ⟪u, v⟫ 
 /-- When a vector is in `Kᗮ`, with the inner product the
 other way round. -/
 lemma submodule.mem_orthogonal' (v : E) : v ∈ Kᗮ ↔ ∀ u ∈ K, ⟪v, u⟫ = 0 :=
-by simp_rw [submodule.mem_orthogonal, inner_eq_zero_sym]
+by simp_rw [submodule.mem_orthogonal, inner_eq_zero_symm]
 
 variables {K}
 
@@ -2231,7 +2231,7 @@ lemma submodule.inner_right_of_mem_orthogonal {u v : E} (hu : u ∈ K) (hv : v �
 
 /-- A vector in `Kᗮ` is orthogonal to one in `K`. -/
 lemma submodule.inner_left_of_mem_orthogonal {u v : E} (hu : u ∈ K) (hv : v ∈ Kᗮ) : ⟪v, u⟫ = 0 :=
-by rw [inner_eq_zero_sym]; exact submodule.inner_right_of_mem_orthogonal hu hv
+by rw [inner_eq_zero_symm]; exact submodule.inner_right_of_mem_orthogonal hu hv
 
 /-- A vector is in `(𝕜 ∙ u)ᗮ` iff it is orthogonal to `u`. -/
 lemma submodule.mem_orthogonal_singleton_iff_inner_right {u v : E} : v ∈ (𝕜 ∙ u)ᗮ ↔ ⟪u, v⟫ = 0 :=
@@ -2245,7 +2245,7 @@ end
 
 /-- A vector in `(𝕜 ∙ u)ᗮ` is orthogonal to `u`. -/
 lemma submodule.mem_orthogonal_singleton_iff_inner_left {u v : E} : v ∈ (𝕜 ∙ u)ᗮ ↔ ⟪v, u⟫ = 0 :=
-by rw [submodule.mem_orthogonal_singleton_iff_inner_right, inner_eq_zero_sym]
+by rw [submodule.mem_orthogonal_singleton_iff_inner_right, inner_eq_zero_symm]
 
 lemma submodule.sub_mem_orthogonal_of_inner_left {x y : E}
   (h : ∀ (v : K), ⟪x, v⟫ = ⟪y, v⟫) : x - y ∈ Kᗮ :=
@@ -2414,11 +2414,11 @@ instance : inner_product_space 𝕜 (completion E) :=
       (continuous_norm.pow 2)
       (continuous_re.comp (continuous.inner continuous_id' continuous_id')))
     (λ a, by simp only [norm_coe, inner_coe, inner_self_eq_norm_sq]),
-  conj_sym := λ x y, completion.induction_on₂ x y
+  conj_symm := λ x y, completion.induction_on₂ x y
     (is_closed_eq
       (continuous_conj.comp (continuous.inner continuous_snd continuous_fst))
       (continuous.inner continuous_fst continuous_snd))
-    (λ a b, by simp only [inner_coe, inner_conj_sym]),
+    (λ a b, by simp only [inner_coe, inner_conj_symm]),
   add_left := λ x y z, completion.induction_on₃ x y z
     (is_closed_eq
       (continuous.inner (continuous_fst.add (continuous_fst.comp continuous_snd))

--- a/src/analysis/inner_product_space/dual.lean
+++ b/src/analysis/inner_product_space/dual.lean
@@ -74,8 +74,8 @@ begin
   refine (function.injective.eq_iff continuous_linear_map.coe_injective).mp (basis.ext b _),
   intro i,
   simp only [to_dual_map_apply, continuous_linear_map.coe_coe],
-  rw [←inner_conj_sym],
-  nth_rewrite_rhs 0 [←inner_conj_sym],
+  rw [←inner_conj_symm],
+  nth_rewrite_rhs 0 [←inner_conj_symm],
   exact congr_arg conj (h i)
 end
 
@@ -83,8 +83,8 @@ lemma ext_inner_right_basis {ι : Type*} {x y : E} (b : basis ι 𝕜 E)
   (h : ∀ i : ι, ⟪x, b i⟫ = ⟪y, b i⟫) : x = y :=
 begin
   refine ext_inner_left_basis b (λ i, _),
-  rw [←inner_conj_sym],
-  nth_rewrite_rhs 0 [←inner_conj_sym],
+  rw [←inner_conj_symm],
+  nth_rewrite_rhs 0 [←inner_conj_symm],
   exact congr_arg conj (h i)
 end
 

--- a/src/analysis/inner_product_space/gram_schmidt_ortho.lean
+++ b/src/analysis/inner_product_space/gram_schmidt_ortho.lean
@@ -83,7 +83,7 @@ begin
   suffices : ∀ a b : ι, a < b → ⟪gram_schmidt 𝕜 f a, gram_schmidt 𝕜 f b⟫ = 0,
   { cases h₀.lt_or_lt with ha hb,
     { exact this _ _ ha, },
-    { rw inner_eq_zero_sym,
+    { rw inner_eq_zero_symm,
       exact this _ _ hb, }, },
   clear h₀ a b,
   intros a b h₀,
@@ -101,7 +101,7 @@ begin
   simp only [mul_eq_zero, div_eq_zero_iff, inner_self_eq_zero],
   right,
   cases hia.lt_or_lt with hia₁ hia₂,
-  { rw inner_eq_zero_sym,
+  { rw inner_eq_zero_symm,
     exact ih a h₀ i hia₁ },
   { exact ih i (mem_Iio.1 hi) a hia₂ }
 end

--- a/src/analysis/inner_product_space/l2_space.lean
+++ b/src/analysis/inner_product_space/l2_space.lean
@@ -117,10 +117,10 @@ instance : inner_product_space 𝕜 (lp G 2) :=
     { norm_num },
     { exact summable_inner f f },
   end,
-  conj_sym := λ f g, begin
+  conj_symm := λ f g, begin
     calc conj _ = conj ∑' i, ⟪g i, f i⟫ : by congr
     ... = ∑' i, conj ⟪g i, f i⟫ : is_R_or_C.conj_cle.map_tsum
-    ... = ∑' i, ⟪f i, g i⟫ : by simp only [inner_conj_sym]
+    ... = ∑' i, ⟪f i, g i⟫ : by simp only [inner_conj_symm]
     ... = _ : by congr,
   end,
   add_left := λ f₁ f₂ g, begin
@@ -160,7 +160,7 @@ begin
 end
 
 lemma inner_single_right (i : ι) (a : G i) (f : lp G 2) : ⟪f, lp.single 2 i a⟫ = ⟪f i, a⟫ :=
-by simpa [inner_conj_sym] using congr_arg conj (inner_single_left i a f)
+by simpa [inner_conj_symm] using congr_arg conj (inner_single_left i a f)
 
 end lp
 

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -74,14 +74,14 @@ instance pi_Lp.inner_product_space {ι : Type*} [fintype ι] (f : ι → Type*)
   inner := λ x y, ∑ i, inner (x i) (y i),
   norm_sq_eq_inner := λ x,
     by simp only [pi_Lp.norm_sq_eq_of_L2, add_monoid_hom.map_sum, ← norm_sq_eq_inner, one_div],
-  conj_sym :=
+  conj_symm :=
   begin
     intros x y,
     unfold inner,
     rw ring_hom.map_sum,
     apply finset.sum_congr rfl,
     rintros z -,
-    apply inner_conj_sym,
+    apply inner_conj_symm,
   end,
   add_left := λ x y z,
     show ∑ i, inner (x i + y i) (z i) = ∑ i, inner (x i) (z i) + ∑ i, inner (y i) (z i),

--- a/src/analysis/inner_product_space/projection.lean
+++ b/src/analysis/inner_product_space/projection.lean
@@ -456,7 +456,7 @@ orthogonal_projection_fn_inner_eq_zero v
   v - orthogonal_projection K v ∈ Kᗮ :=
 begin
   intros w hw,
-  rw inner_eq_zero_sym,
+  rw inner_eq_zero_symm,
   exact orthogonal_projection_inner_eq_zero _ _ hw
 end
 
@@ -556,7 +556,7 @@ begin
     obtain ⟨c, rfl⟩ := submodule.mem_span_singleton.mp hx,
     have hv : ↑‖v‖ ^ 2 = ⟪v, v⟫ := by { norm_cast, simp [norm_sq_eq_inner] },
     simp [inner_sub_left, inner_smul_left, inner_smul_right, map_div₀, mul_comm, hv,
-      inner_product_space.conj_sym, hv] }
+      inner_product_space.conj_symm, hv] }
 end
 
 /-- Formula for orthogonal projection onto a single vector. -/
@@ -719,11 +719,11 @@ begin
   { obtain ⟨y, hy, z, hz, rfl⟩ := K.exists_sum_mem_mem_orthogonal v,
     intros hv,
     have hz' : z = 0,
-    { have hyz : ⟪z, y⟫ = 0 := by simp [hz y hy, inner_eq_zero_sym],
+    { have hyz : ⟪z, y⟫ = 0 := by simp [hz y hy, inner_eq_zero_symm],
       simpa [inner_add_right, hyz] using hv z hz },
     simp [hy, hz'] },
   { intros hv w hw,
-    rw inner_eq_zero_sym,
+    rw inner_eq_zero_symm,
     exact hw v hv }
 end
 
@@ -758,7 +758,7 @@ orthogonal projection. -/
 lemma eq_orthogonal_projection_of_mem_orthogonal
   [complete_space K] {u v : E} (hv : v ∈ K) (hvo : u - v ∈ Kᗮ) :
   (orthogonal_projection K u : E) = v :=
-eq_orthogonal_projection_fn_of_mem_of_inner_eq_zero hv (λ w, inner_eq_zero_sym.mp ∘ (hvo w))
+eq_orthogonal_projection_fn_of_mem_of_inner_eq_zero hv (λ w, inner_eq_zero_symm.mp ∘ (hvo w))
 
 /-- A point in `K` with the orthogonality property (here characterized in terms of `Kᗮ`) must be the
 orthogonal projection. -/
@@ -977,7 +977,7 @@ calc ⟪orthogonal_projection K v, u⟫
 
 @[simp] lemma inner_orthogonal_projection_eq_of_mem_left [complete_space K] (u : K) (v : E) :
   ⟪u, orthogonal_projection K v⟫ = ⟪(u : E), v⟫ :=
-by rw [← inner_conj_sym, ← inner_conj_sym (u : E), inner_orthogonal_projection_eq_of_mem_right]
+by rw [← inner_conj_symm, ← inner_conj_symm (u : E), inner_orthogonal_projection_eq_of_mem_right]
 
 /-- The orthogonal projection is self-adjoint. -/
 lemma inner_orthogonal_projection_left_eq_right
@@ -1224,7 +1224,7 @@ begin
           intros hbe',
           apply hab',
           simp [ha, hbe'] },
-        rw inner_eq_zero_sym,
+        rw inner_eq_zero_symm,
         simpa [ha] using h_end b hb },
       rintros ⟨b, hb'⟩ hab',
       cases eq_or_mem_of_mem_insert hb' with hb hb,

--- a/src/analysis/inner_product_space/symmetric.lean
+++ b/src/analysis/inner_product_space/symmetric.lean
@@ -62,7 +62,7 @@ end real
 
 lemma is_symmetric.conj_inner_sym {T : E →ₗ[𝕜] E} (hT : is_symmetric T) (x y : E) :
   conj ⟪T x, y⟫ = ⟪T y, x⟫ :=
-by rw [hT x y, inner_conj_sym]
+by rw [hT x y, inner_conj_symm]
 
 @[simp] lemma is_symmetric.apply_clm {T : E →L[𝕜] E} (hT : is_symmetric (T : E →ₗ[𝕜] E))
   (x y : E) : ⟪T x, y⟫ = ⟪x, T y⟫ :=
@@ -139,7 +139,7 @@ begin
   { intros hT v,
     apply is_symmetric.conj_inner_sym hT },
   { intros h x y,
-    nth_rewrite 1 ← inner_conj_sym,
+    nth_rewrite 1 ← inner_conj_symm,
     nth_rewrite 1 inner_map_polarization,
     simp only [star_ring_end_apply, star_div', star_sub, star_add, star_mul],
     simp only [← star_ring_end_apply],

--- a/src/analysis/quaternion.lean
+++ b/src/analysis/quaternion.lean
@@ -44,7 +44,7 @@ lemma inner_def (a b : ℍ) : ⟪a, b⟫ = (a * b.conj).re := rfl
 noncomputable instance : inner_product_space ℝ ℍ :=
 inner_product_space.of_core
 { inner := has_inner.inner,
-  conj_sym := λ x y, by simp [inner_def, mul_comm],
+  conj_symm := λ x y, by simp [inner_def, mul_comm],
   nonneg_re := λ x, norm_sq_nonneg,
   definite := λ x, norm_sq_eq_zero.1,
   add_left := λ x y z, by simp only [inner_def, add_mul, add_re],

--- a/src/linear_algebra/matrix/ldl.lean
+++ b/src/linear_algebra/matrix/ldl.lean
@@ -93,7 +93,7 @@ begin
   { simp only [LDL.diag, hij, diagonal_apply_ne, ne.def, not_false_iff, mul_mul_apply],
     rw [conj_transpose, transpose_map, transpose_transpose, dot_product_mul_vec,
       (LDL.lower_inv_orthogonal hS (λ h : j = i, hij h.symm)).symm,
-      ← inner_conj_sym, mul_vec_transpose, euclidean_space.inner_eq_star_dot_product,
+      ← inner_conj_symm, mul_vec_transpose, euclidean_space.inner_eq_star_dot_product,
       ← is_R_or_C.star_def, ← star_dot_product_star, dot_product_comm, star_star],
     refl }
 end

--- a/src/linear_algebra/matrix/pos_def.lean
+++ b/src/linear_algebra/matrix/pos_def.lean
@@ -144,7 +144,7 @@ noncomputable def inner_product_space.of_matrix
   {M : matrix n n 𝕜} (hM : M.pos_def) : inner_product_space 𝕜 (n → 𝕜) :=
 inner_product_space.of_core
 { inner := λ x y, dot_product (star x) (M.mul_vec y),
-  conj_sym := λ x y, by
+  conj_symm := λ x y, by
     rw [star_dot_product, star_ring_end_apply, star_star, star_mul_vec,
       dot_product_mul_vec, hM.is_hermitian.eq],
   nonneg_re := λ x,

--- a/src/measure_theory/function/l2_space.lean
+++ b/src/measure_theory/function/l2_space.lean
@@ -158,7 +158,7 @@ end
 
 instance inner_product_space : inner_product_space 𝕜 (α →₂[μ] E) :=
 { norm_sq_eq_inner := norm_sq_eq_inner',
-  conj_sym := λ _ _, by simp_rw [inner_def, ← integral_conj, inner_conj_sym],
+  conj_symm := λ _ _, by simp_rw [inner_def, ← integral_conj, inner_conj_symm],
   add_left := add_left',
   smul_left := smul_left', }
 


### PR DESCRIPTION
This is the preferred spelling of `symmetric` in mathlib. `sym` refers to the type of unordered pairs.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #18579 (to avoid conflicts)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
