### PR TITLE
[Merged by Bors] - refactor(analysis/inner_product_space/basic): do not extend normed_add_comm_group

### DIFF
--- a/archive/100-theorems-list/57_herons_formula.lean
+++ b/archive/100-theorems-list/57_herons_formula.lean
@@ -23,8 +23,8 @@ open_locale real euclidean_geometry
 
 local notation `√` := real.sqrt
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-  [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 
 include V
 

--- a/archive/imo/imo2019_q2.lean
+++ b/archive/imo/imo2019_q2.lean
@@ -63,7 +63,8 @@ open_locale affine euclidean_geometry real
 
 local attribute [instance] fact_finite_dimensional_of_finrank_eq_succ
 
-variables (V : Type*) (Pt : Type*) [inner_product_space ℝ V] [metric_space Pt]
+variables (V : Type*) (Pt : Type*)
+variables [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space Pt]
 variables [normed_add_torsor V Pt] [hd2 : fact (finrank ℝ V = 2)]
 include hd2
 

--- a/src/analysis/calculus/bump_function_inner.lean
+++ b/src/analysis/calculus/bump_function_inner.lean
@@ -331,7 +331,7 @@ let e : cont_diff_bump_base E :=
       exact cont_diff_at_const.congr_of_eventually_eq this },
     { refine real.smooth_transition.cont_diff_at.comp _ _,
       refine cont_diff_at.div _ _ (sub_pos.2 hR).ne',
-      { exact cont_diff_at_fst.sub (cont_diff_at_snd.norm hx) },
+      { exact cont_diff_at_fst.sub (cont_diff_at_snd.norm _ hx) },
       { exact cont_diff_at_fst.sub cont_diff_at_const } }
   end,
   eq_one := λ R hR x hx, real.smooth_transition.one_of_one_le $

--- a/src/analysis/calculus/bump_function_inner.lean
+++ b/src/analysis/calculus/bump_function_inner.lean
@@ -306,7 +306,7 @@ nonempty.some hb.out
 
 /-- Any inner product space has smooth bump functions. -/
 @[priority 100] instance has_cont_diff_bump_of_inner_product_space
-  (E : Type*) [inner_product_space ℝ E] : has_cont_diff_bump E :=
+  (E : Type*) [normed_add_comm_group E] [inner_product_space ℝ E] : has_cont_diff_bump E :=
 let e : cont_diff_bump_base E :=
 { to_fun := λ R x, real.smooth_transition ((R - ‖x‖) / (R - 1)),
   mem_Icc := λ R x, ⟨real.smooth_transition.nonneg _, real.smooth_transition.le_one _⟩,
@@ -331,7 +331,7 @@ let e : cont_diff_bump_base E :=
       exact cont_diff_at_const.congr_of_eventually_eq this },
     { refine real.smooth_transition.cont_diff_at.comp _ _,
       refine cont_diff_at.div _ _ (sub_pos.2 hR).ne',
-      { exact cont_diff_at_fst.sub (cont_diff_at_snd.norm _ hx) },
+      { exact cont_diff_at_fst.sub (cont_diff_at_snd.norm ℝ hx) },
       { exact cont_diff_at_fst.sub cont_diff_at_const } }
   end,
   eq_one := λ R hR x hx, real.smooth_transition.one_of_one_le $

--- a/src/analysis/calculus/conformal/inner_product.lean
+++ b/src/analysis/calculus/conformal/inner_product.lean
@@ -15,7 +15,9 @@ is conformal at `x` iff the derivative preserves inner products up to a scalar m
 
 noncomputable theory
 
-variables {E F : Type*} [inner_product_space ℝ E] [inner_product_space ℝ F]
+variables {E F : Type*}
+variables [normed_add_comm_group E] [normed_add_comm_group F]
+variables [inner_product_space ℝ E] [inner_product_space ℝ F]
 
 open_locale real_inner_product_space
 

--- a/src/analysis/convex/cone/basic.lean
+++ b/src/analysis/convex/cone/basic.lean
@@ -717,7 +717,7 @@ end
 /-! ### The dual cone -/
 
 section dual
-variables {H : Type*} [inner_product_space ℝ H] (s t : set H)
+variables {H : Type*} [normed_add_comm_group H] [inner_product_space ℝ H] (s t : set H)
 open_locale real_inner_product_space
 
 /-- The dual cone is the cone consisting of all points `y` such that for

--- a/src/analysis/fourier/add_circle.lean
+++ b/src/analysis/fourier/add_circle.lean
@@ -426,7 +426,7 @@ begin
   { exact_mod_cast lp.norm_rpow_eq_tsum _ (fourier_basis.repr f),
     norm_num },
   have H₂ : ‖fourier_basis.repr f‖ ^ 2 = ‖f‖ ^ 2 := by simp,
-  have H₃ := congr_arg is_R_or_C.re (@L2.inner_def (add_circle T) ℂ ℂ _ _ _ _ f f),
+  have H₃ := congr_arg is_R_or_C.re (@L2.inner_def (add_circle T) ℂ ℂ _ _ _ _ _ f f),
   rw ← integral_re at H₃,
   { simp only [← norm_sq_eq_inner] at H₃,
     rw [← H₁, H₂, H₃], },

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -44,6 +44,7 @@ open is_R_or_C
 open_locale complex_conjugate
 
 variables {𝕜 E F G : Type*} [is_R_or_C 𝕜]
+variables [normed_add_comm_group E] [normed_add_comm_group F] [normed_add_comm_group G]
 variables [inner_product_space 𝕜 E] [inner_product_space 𝕜 F] [inner_product_space 𝕜 G]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
@@ -206,7 +207,9 @@ end⟩
 
 section real
 
-variables {E' : Type*} {F' : Type*} [inner_product_space ℝ E'] [inner_product_space ℝ F']
+variables {E' : Type*} {F' : Type*}
+variables [normed_add_comm_group E'] [normed_add_comm_group F']
+variables [inner_product_space ℝ E'] [inner_product_space ℝ F']
 variables [complete_space E'] [complete_space F']
 
 -- Todo: Generalize this to `is_R_or_C`.
@@ -402,7 +405,9 @@ by { rw [is_self_adjoint_iff', is_symmetric, ← linear_map.eq_adjoint_iff], exa
 
 section real
 
-variables {E' : Type*} {F' : Type*} [inner_product_space ℝ E'] [inner_product_space ℝ F']
+variables {E' : Type*} {F' : Type*}
+variables [normed_add_comm_group E'] [normed_add_comm_group F']
+variables [inner_product_space ℝ E'] [inner_product_space ℝ F']
 variables [finite_dimensional ℝ E'] [finite_dimensional ℝ F']
 
 -- Todo: Generalize this to `is_R_or_C`.

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -14,8 +14,8 @@ import linear_algebra.bilinear_form
 # Inner product space
 
 This file defines inner product spaces and proves the basic properties.  We do not formally
-define Hilbert spaces, but they can be obtained using the pair of assumptions
-`[inner_product_space 𝕜 E] [complete_space E]`.
+define Hilbert spaces, but they can be obtained using the set of assumptions
+`[normed_add_comm_group E] [inner_product_space 𝕜 E] [complete_space E]`.
 
 An inner product space is a vector space endowed with an inner product. It generalizes the notion of
 dot product in `ℝ^n` and provides the means of defining the length of a vector and the angle between
@@ -99,15 +99,12 @@ spaces.
 
 To construct a norm from an inner product, see `inner_product_space.of_core`.
 -/
-class inner_product_space (𝕜 : Type*) (E : Type*) [is_R_or_C 𝕜]
-  extends normed_add_comm_group E, normed_space 𝕜 E, has_inner 𝕜 E :=
+class inner_product_space (𝕜 : Type*) (E : Type*) [is_R_or_C 𝕜] [normed_add_comm_group E]
+  extends normed_space 𝕜 E, has_inner 𝕜 E :=
 (norm_sq_eq_inner : ∀ (x : E), ‖x‖^2 = re (inner x x))
 (conj_symm : ∀ x y, conj (inner y x) = inner x y)
 (add_left  : ∀ x y z, inner (x + y) z = inner x z + inner y z)
 (smul_left : ∀ x y r, inner (r • x) y = (conj r) * inner x y)
-
-attribute [nolint dangerous_instance] inner_product_space.to_normed_add_comm_group
--- note [is_R_or_C instance]
 
 /-!
 ### Constructing a normed space structure from an inner product
@@ -361,13 +358,15 @@ def to_normed_space : normed_space 𝕜 F :=
 
 end inner_product_space.of_core
 
+section
+local attribute [instance] inner_product_space.of_core.to_normed_add_comm_group
+
 /-- Given a `inner_product_space.core` structure on a space, one can use it to turn
-the space into an inner product space, constructing the norm out of the inner product -/
+the space into an inner product space. The `normed_add_comm_group` structure is expected
+to already be defined with `inner_product_space.of_core.to_normed_add_comm_group`. -/
 def inner_product_space.of_core [add_comm_group F] [module 𝕜 F]
   (c : inner_product_space.core 𝕜 F) : inner_product_space 𝕜 F :=
 begin
-  letI : normed_add_comm_group F :=
-    @inner_product_space.of_core.to_normed_add_comm_group 𝕜 F _ _ _ c,
   letI : normed_space 𝕜 F := @inner_product_space.of_core.to_normed_space 𝕜 F _ _ _ c,
   exact { norm_sq_eq_inner := λ x,
     begin
@@ -378,9 +377,12 @@ begin
     ..c }
 end
 
+end
+
 /-! ### Properties of inner product spaces -/
 
-variables [inner_product_space 𝕜 E] [inner_product_space ℝ F]
+variables [normed_add_comm_group E] [inner_product_space 𝕜 E]
+variables [normed_add_comm_group F] [inner_product_space ℝ F]
 variables [dec_E : decidable_eq E]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 local notation `IK` := @is_R_or_C.I 𝕜 _
@@ -393,7 +395,7 @@ export inner_product_space (norm_sq_eq_inner)
 section basic_properties
 
 @[simp] lemma inner_conj_symm (x y : E) : ⟪y, x⟫† = ⟪x, y⟫ := inner_product_space.conj_symm _ _
-lemma real_inner_comm (x y : F) : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := @inner_conj_symm ℝ _ _ _ x y
+lemma real_inner_comm (x y : F) : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := @inner_conj_symm ℝ _ _ _ _ x y
 
 lemma inner_eq_zero_symm {x y : E} : ⟪x, y⟫ = 0 ↔ ⟪y, x⟫ = 0 :=
 ⟨λ h, by simp [←inner_conj_symm, h], λ h, by simp [←inner_conj_symm, h]⟩
@@ -498,7 +500,7 @@ by simp only [inner_zero_right, add_monoid_hom.map_zero]
 
 lemma inner_self_nonneg {x : E} : 0 ≤ re ⟪x, x⟫ :=
 by rw [←norm_sq_eq_inner]; exact pow_nonneg (norm_nonneg x) 2
-lemma real_inner_self_nonneg {x : F} : 0 ≤ ⟪x, x⟫_ℝ := @inner_self_nonneg ℝ F _ _ x
+lemma real_inner_self_nonneg {x : F} : 0 ≤ ⟪x, x⟫_ℝ := @inner_self_nonneg ℝ F _ _ _ x
 
 @[simp] lemma inner_self_eq_zero {x : E} : ⟪x, x⟫ = 0 ↔ x = 0 :=
 begin
@@ -520,7 +522,7 @@ inner_self_eq_zero.not
 begin
   split,
   { intro h,
-    rw ←inner_self_eq_zero,
+    rw ←@inner_self_eq_zero 𝕜,
     have H₁ : re ⟪x, x⟫ ≥ 0, exact inner_self_nonneg,
     have H₂ : re ⟪x, x⟫ = 0, exact le_antisymm h H₁,
     rw is_R_or_C.ext_iff,
@@ -530,7 +532,7 @@ begin
 end
 
 lemma real_inner_self_nonpos {x : F} : ⟪x, x⟫_ℝ ≤ 0 ↔ x = 0 :=
-by { have h := @inner_self_nonpos ℝ F _ _ x, simpa using h }
+by { have h := @inner_self_nonpos ℝ F _ _ _ x, simpa using h }
 
 @[simp] lemma inner_self_re_to_K (x : E) : (re ⟪x, x⟫ : 𝕜) = ⟪x, x⟫ :=
 is_R_or_C.ext_iff.2 ⟨by simp only [of_real_re], by simp only [inner_self_nonneg_im, of_real_im]⟩
@@ -553,7 +555,7 @@ lemma inner_self_abs_to_K (x : E) : (absK ⟪x, x⟫ : 𝕜) = ⟪x, x⟫ :=
 by { rw [←inner_self_re_abs], exact inner_self_re_to_K _ }
 
 lemma real_inner_self_abs (x : F) : absR ⟪x, x⟫_ℝ = ⟪x, x⟫_ℝ :=
-by { have h := @inner_self_abs_to_K ℝ F _ _ x, simpa using h }
+by { have h := @inner_self_abs_to_K ℝ F _ _ _ x, simpa using h }
 
 lemma inner_abs_conj_symm (x y : E) : abs ⟪x, y⟫ = abs ⟪y, x⟫ :=
 by rw [←inner_conj_symm, abs_conj]
@@ -606,10 +608,10 @@ variable (𝕜)
 include 𝕜
 
 lemma ext_inner_left {x y : E} (h : ∀ v, ⟪v, x⟫ = ⟪v, y⟫) : x = y :=
-by rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_right, sub_eq_zero, h (x - y)]
+by rw [←sub_eq_zero, ←@inner_self_eq_zero 𝕜, inner_sub_right, sub_eq_zero, h (x - y)]
 
 lemma ext_inner_right {x y : E} (h : ∀ v, ⟪x, v⟫ = ⟪y, v⟫) : x = y :=
-by rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_left, sub_eq_zero, h (x - y)]
+by rw [←sub_eq_zero, ←@inner_self_eq_zero 𝕜, inner_sub_left, sub_eq_zero, h (x - y)]
 
 omit 𝕜
 variable {𝕜}
@@ -673,7 +675,7 @@ end
 lemma real_inner_mul_inner_self_le (x y : F) : ⟪x, y⟫_ℝ * ⟪x, y⟫_ℝ ≤ ⟪x, x⟫_ℝ * ⟪y, y⟫_ℝ :=
 begin
   have h₁ : ⟪y, x⟫_ℝ = ⟪x, y⟫_ℝ := by rw [←inner_conj_symm]; refl,
-  have h₂ := @inner_mul_inner_self_le ℝ F _ _ x y,
+  have h₂ := @inner_mul_inner_self_le ℝ F _ _ _ x y,
   dsimp at h₂,
   have h₃ := abs_mul_abs_self ⟪x, y⟫_ℝ,
   rw [h₁] at h₂,
@@ -727,7 +729,7 @@ begin
   { intros h,
     split,
     { intros i,
-      have h' : ‖v i‖ ^ 2 = 1 ^ 2 := by simp [norm_sq_eq_inner, h i i],
+      have h' : ‖v i‖ ^ 2 = 1 ^ 2 := by simp [@norm_sq_eq_inner 𝕜, h i i],
       have h₁ : 0 ≤ ‖v i‖ := norm_nonneg _,
       have h₂ : (0:ℝ) ≤ 1 := zero_le_one,
       rwa sq_eq_sq h₁ h₂ at h' },
@@ -964,25 +966,26 @@ calc ‖x‖ = sqrt (‖x‖ ^ 2) : (sqrt_sq (norm_nonneg _)).symm
 ... = sqrt (re ⟪x, x⟫) : congr_arg _ (norm_sq_eq_inner _)
 
 lemma norm_eq_sqrt_real_inner (x : F) : ‖x‖ = sqrt ⟪x, x⟫_ℝ :=
-by { have h := @norm_eq_sqrt_inner ℝ F _ _ x, simpa using h }
+by { have h := @norm_eq_sqrt_inner ℝ F _ _ _ x, simpa using h }
 
 lemma inner_self_eq_norm_mul_norm (x : E) : re ⟪x, x⟫ = ‖x‖ * ‖x‖ :=
-by rw [norm_eq_sqrt_inner, ←sqrt_mul inner_self_nonneg (re ⟪x, x⟫),
+by rw [@norm_eq_sqrt_inner 𝕜, ←sqrt_mul inner_self_nonneg (re ⟪x, x⟫),
   sqrt_mul_self inner_self_nonneg]
 
 lemma inner_self_eq_norm_sq (x : E) : re ⟪x, x⟫ = ‖x‖^2 :=
 by rw [pow_two, inner_self_eq_norm_mul_norm]
 
 lemma real_inner_self_eq_norm_mul_norm (x : F) : ⟪x, x⟫_ℝ = ‖x‖ * ‖x‖ :=
-by { have h := @inner_self_eq_norm_mul_norm ℝ F _ _ x, simpa using h }
+by { have h := @inner_self_eq_norm_mul_norm ℝ F _ _ _ x, simpa using h }
 
 lemma real_inner_self_eq_norm_sq (x : F) : ⟪x, x⟫_ℝ = ‖x‖^2 :=
 by rw [pow_two, real_inner_self_eq_norm_mul_norm]
 
+variables (𝕜)
 /-- Expand the square -/
 lemma norm_add_sq (x y : E) : ‖x + y‖^2 = ‖x‖^2 + 2 * (re ⟪x, y⟫) + ‖y‖^2 :=
 begin
-  repeat {rw [sq, ←inner_self_eq_norm_mul_norm]},
+  repeat {rw [sq, ←@inner_self_eq_norm_mul_norm 𝕜]},
   rw [inner_add_add_self, two_mul],
   simp only [add_assoc, add_left_inj, add_right_inj, add_monoid_hom.map_add],
   rw [←inner_conj_symm, conj_re],
@@ -992,7 +995,7 @@ alias norm_add_sq ← norm_add_pow_two
 
 /-- Expand the square -/
 lemma norm_add_sq_real (x y : F) : ‖x + y‖^2 = ‖x‖^2 + 2 * ⟪x, y⟫_ℝ + ‖y‖^2 :=
-by { have h := @norm_add_sq ℝ _ _ _ x y, simpa using h }
+by { have h := @norm_add_sq ℝ _ _ _ _ x y, simpa using h }
 
 alias norm_add_sq_real ← norm_add_pow_two_real
 
@@ -1002,12 +1005,12 @@ by { repeat {rw [← sq]}, exact norm_add_sq _ _ }
 
 /-- Expand the square -/
 lemma norm_add_mul_self_real (x y : F) : ‖x + y‖ * ‖x + y‖ = ‖x‖ * ‖x‖ + 2 * ⟪x, y⟫_ℝ + ‖y‖ * ‖y‖ :=
-by { have h := @norm_add_mul_self ℝ _ _ _ x y, simpa using h }
+by { have h := @norm_add_mul_self ℝ _ _ _ _ x y, simpa using h }
 
 /-- Expand the square -/
 lemma norm_sub_sq (x y : E) : ‖x - y‖^2 = ‖x‖^2 - 2 * (re ⟪x, y⟫) + ‖y‖^2 :=
 begin
-  repeat {rw [sq, ←inner_self_eq_norm_mul_norm]},
+  repeat {rw [sq, ←@inner_self_eq_norm_mul_norm 𝕜]},
   rw [inner_sub_sub_self],
   calc
     re (⟪x, x⟫ - ⟪x, y⟫ - ⟪y, x⟫ + ⟪y, y⟫)
@@ -1022,7 +1025,7 @@ alias norm_sub_sq ← norm_sub_pow_two
 
 /-- Expand the square -/
 lemma norm_sub_sq_real (x y : F) : ‖x - y‖^2 = ‖x‖^2 - 2 * ⟪x, y⟫_ℝ + ‖y‖^2 :=
-norm_sub_sq _ _
+@norm_sub_sq ℝ _ _ _ _ _ _
 
 alias norm_sub_sq_real ← norm_sub_pow_two_real
 
@@ -1032,7 +1035,7 @@ by { repeat {rw [← sq]}, exact norm_sub_sq _ _ }
 
 /-- Expand the square -/
 lemma norm_sub_mul_self_real (x y : F) : ‖x - y‖ * ‖x - y‖ = ‖x‖ * ‖x‖ - 2 * ⟪x, y⟫_ℝ + ‖y‖ * ‖y‖ :=
-by { have h := @norm_sub_mul_self ℝ _ _ _ x y, simpa using h }
+by { have h := @norm_sub_mul_self ℝ _ _ _ _ x y, simpa using h }
 
 /-- Cauchy–Schwarz inequality with norm -/
 lemma abs_inner_le_norm (x y : E) : abs ⟪x, y⟫ ≤ ‖x‖ * ‖y‖ :=
@@ -1056,46 +1059,47 @@ le_trans (re_le_abs (inner x y)) (abs_inner_le_norm x y)
 
 /-- Cauchy–Schwarz inequality with norm -/
 lemma abs_real_inner_le_norm (x y : F) : absR ⟪x, y⟫_ℝ ≤ ‖x‖ * ‖y‖ :=
-by { have h := @abs_inner_le_norm ℝ F _ _ x y, simpa using h }
+by { have h := @abs_inner_le_norm ℝ F _ _ _ x y, simpa using h }
 
 /-- Cauchy–Schwarz inequality with norm -/
 lemma real_inner_le_norm (x y : F) : ⟪x, y⟫_ℝ ≤ ‖x‖ * ‖y‖ :=
 le_trans (le_abs_self _) (abs_real_inner_le_norm _ _)
 
 include 𝕜
+variables (𝕜)
 lemma parallelogram_law_with_norm (x y : E) :
   ‖x + y‖ * ‖x + y‖ + ‖x - y‖ * ‖x - y‖ = 2 * (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖) :=
 begin
-  simp only [← inner_self_eq_norm_mul_norm],
+  simp only [← @inner_self_eq_norm_mul_norm 𝕜],
   rw [← re.map_add, parallelogram_law, two_mul, two_mul],
   simp only [re.map_add],
 end
 
 lemma parallelogram_law_with_nnnorm (x y : E) :
   ‖x + y‖₊ * ‖x + y‖₊ + ‖x - y‖₊ * ‖x - y‖₊ = 2 * (‖x‖₊ * ‖x‖₊ + ‖y‖₊ * ‖y‖₊) :=
-subtype.ext $ parallelogram_law_with_norm x y
-
+subtype.ext $ parallelogram_law_with_norm 𝕜 x y
+variables {𝕜}
 omit 𝕜
 
 /-- Polarization identity: The real part of the  inner product, in terms of the norm. -/
 lemma re_inner_eq_norm_add_mul_self_sub_norm_mul_self_sub_norm_mul_self_div_two (x y : E) :
   re ⟪x, y⟫ = (‖x + y‖ * ‖x + y‖ - ‖x‖ * ‖x‖ - ‖y‖ * ‖y‖) / 2 :=
-by { rw norm_add_mul_self, ring }
+by { rw @norm_add_mul_self 𝕜, ring }
 
 /-- Polarization identity: The real part of the  inner product, in terms of the norm. -/
 lemma re_inner_eq_norm_mul_self_add_norm_mul_self_sub_norm_sub_mul_self_div_two (x y : E) :
   re ⟪x, y⟫ = (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖ - ‖x - y‖ * ‖x - y‖) / 2 :=
-by { rw [norm_sub_mul_self], ring }
+by { rw [@norm_sub_mul_self 𝕜], ring }
 
 /-- Polarization identity: The real part of the  inner product, in terms of the norm. -/
 lemma re_inner_eq_norm_add_mul_self_sub_norm_sub_mul_self_div_four (x y : E) :
   re ⟪x, y⟫ = (‖x + y‖ * ‖x + y‖ - ‖x - y‖ * ‖x - y‖) / 4 :=
-by { rw [norm_add_mul_self, norm_sub_mul_self], ring }
+by { rw [@norm_add_mul_self 𝕜, @norm_sub_mul_self 𝕜], ring }
 
 /-- Polarization identity: The imaginary part of the inner product, in terms of the norm. -/
 lemma im_inner_eq_norm_sub_I_smul_mul_self_sub_norm_add_I_smul_mul_self_div_four (x y : E) :
   im ⟪x, y⟫ = (‖x - IK • y‖ * ‖x - IK • y‖ - ‖x + IK • y‖ * ‖x + IK • y‖) / 4 :=
-by { simp only [norm_add_mul_self, norm_sub_mul_self, inner_smul_right, I_mul_re], ring }
+by { simp only [@norm_add_mul_self 𝕜, @norm_sub_mul_self 𝕜, inner_smul_right, I_mul_re], ring }
 
 /-- Polarization identity: The inner product, in terms of the norm. -/
 lemma inner_eq_sum_norm_sq_div_four (x y : E) :
@@ -1132,15 +1136,14 @@ instance inner_product_space.to_uniform_convex_space : uniform_convex_space F :=
     exact pow_pos hε _ },
   rw sub_sub_cancel,
   refine le_sqrt_of_sq_le _,
-  rw [sq, eq_sub_iff_add_eq.2 (parallelogram_law_with_norm x y), ←sq (‖x - y‖), hx, hy],
+  rw [sq, eq_sub_iff_add_eq.2 (parallelogram_law_with_norm ℝ x y), ←sq (‖x - y‖), hx, hy],
   norm_num,
   exact pow_le_pow_of_le_left hε.le hxy _,
 end⟩
 
 section complex
 
-variables {V : Type*}
-[inner_product_space ℂ V]
+variables {V : Type*} [normed_add_comm_group V] [inner_product_space ℂ V]
 
 /--
 A complex polarization identity, with a linear map
@@ -1178,7 +1181,7 @@ begin
   split,
   { intro hT,
     ext x,
-    simp only [linear_map.zero_apply, ← inner_self_eq_zero, inner_map_polarization, hT],
+    simp only [linear_map.zero_apply, ← @inner_self_eq_zero ℂ, inner_map_polarization, hT],
     norm_num },
   { rintro rfl x,
     simp only [linear_map.zero_apply, inner_zero_left] }
@@ -1201,8 +1204,8 @@ end complex
 section
 
 variables {ι : Type*} {ι' : Type*} {ι'' : Type*}
-variables {E' : Type*} [inner_product_space 𝕜 E']
-variables {E'' : Type*} [inner_product_space 𝕜 E'']
+variables {E' : Type*} [normed_add_comm_group E'] [inner_product_space 𝕜 E']
+variables {E'' : Type*} [normed_add_comm_group E''] [inner_product_space 𝕜 E'']
 
 /-- A linear isometry preserves the inner product. -/
 @[simp] lemma linear_isometry.inner_map_map (f : E →ₗᵢ[𝕜] E') (x y : E) : ⟪f x, f y⟫ = ⟪x, y⟫ :=
@@ -1215,7 +1218,7 @@ f.to_linear_isometry.inner_map_map x y
 
 /-- A linear map that preserves the inner product is a linear isometry. -/
 def linear_map.isometry_of_inner (f : E →ₗ[𝕜] E') (h : ∀ x y, ⟪f x, f y⟫ = ⟪x, y⟫) : E →ₗᵢ[𝕜] E' :=
-⟨f, λ x, by simp only [norm_eq_sqrt_inner, h]⟩
+⟨f, λ x, by simp only [@norm_eq_sqrt_inner 𝕜, h]⟩
 
 @[simp] lemma linear_map.coe_isometry_of_inner (f : E →ₗ[𝕜] E') (h) :
   ⇑(f.isometry_of_inner h) = f := rfl
@@ -1355,7 +1358,7 @@ re_to_real.symm.trans $
 lemma norm_add_sq_eq_norm_sq_add_norm_sq_iff_real_inner_eq_zero (x y : F) :
   ‖x + y‖ * ‖x + y‖ = ‖x‖ * ‖x‖ + ‖y‖ * ‖y‖ ↔ ⟪x, y⟫_ℝ = 0 :=
 begin
-  rw [norm_add_mul_self, add_right_cancel_iff, add_right_eq_self, mul_eq_zero],
+  rw [@norm_add_mul_self ℝ, add_right_cancel_iff, add_right_eq_self, mul_eq_zero],
   norm_num
 end
 
@@ -1369,7 +1372,7 @@ by rw [←norm_add_sq_eq_norm_sq_add_norm_sq_iff_real_inner_eq_zero, eq_comm,
 lemma norm_add_sq_eq_norm_sq_add_norm_sq_of_inner_eq_zero (x y : E) (h : ⟪x, y⟫ = 0) :
   ‖x + y‖ * ‖x + y‖ = ‖x‖ * ‖x‖ + ‖y‖ * ‖y‖ :=
 begin
-  rw [norm_add_mul_self, add_right_cancel_iff, add_right_eq_self, mul_eq_zero],
+  rw [@norm_add_mul_self 𝕜, add_right_cancel_iff, add_right_eq_self, mul_eq_zero],
   apply or.inr,
   simp only [h, zero_re'],
 end
@@ -1384,7 +1387,7 @@ inner product form. -/
 lemma norm_sub_sq_eq_norm_sq_add_norm_sq_iff_real_inner_eq_zero (x y : F) :
   ‖x - y‖ * ‖x - y‖ = ‖x‖ * ‖x‖ + ‖y‖ * ‖y‖ ↔ ⟪x, y⟫_ℝ = 0 :=
 begin
-  rw [norm_sub_mul_self, add_right_cancel_iff, sub_eq_add_neg, add_right_eq_self, neg_eq_zero,
+  rw [@norm_sub_mul_self ℝ, add_right_cancel_iff, sub_eq_add_neg, add_right_eq_self, neg_eq_zero,
       mul_eq_zero],
   norm_num
 end
@@ -1407,7 +1410,7 @@ if they have the same norm. -/
 lemma real_inner_add_sub_eq_zero_iff (x y : F) : ⟪x + y, x - y⟫_ℝ = 0 ↔ ‖x‖ = ‖y‖ :=
 begin
   conv_rhs { rw ←mul_self_inj_of_nonneg (norm_nonneg _) (norm_nonneg _) },
-  simp only [←inner_self_eq_norm_mul_norm, inner_add_left, inner_sub_right,
+  simp only [←@inner_self_eq_norm_mul_norm ℝ, inner_add_left, inner_sub_right,
             real_inner_comm y x, sub_eq_zero, re_to_real],
   split,
   { intro h,
@@ -1421,7 +1424,8 @@ end
 lemma norm_sub_eq_norm_add {v w : E} (h : ⟪v, w⟫ = 0) : ‖w - v‖ = ‖w + v‖ :=
 begin
   rw ←mul_self_inj_of_nonneg (norm_nonneg _) (norm_nonneg _),
-  simp only [h, ←inner_self_eq_norm_mul_norm, sub_neg_eq_add, sub_zero, map_sub, zero_re', zero_sub,
+  simp only [h, ←@inner_self_eq_norm_mul_norm 𝕜, sub_neg_eq_add, sub_zero, map_sub, zero_re',
+    zero_sub,
     add_zero, map_add, inner_add_right, inner_sub_left, inner_sub_right, inner_re_symm, zero_add]
 end
 
@@ -1513,8 +1517,8 @@ begin
     have ht0 : ⟪x, t⟫ = 0,
     { rw [ht, inner_sub_right, inner_smul_right, hr],
       norm_cast,
-      rw [←inner_self_eq_norm_mul_norm, inner_self_re_to_K,
-          div_mul_cancel _ (λ h, hx0 (inner_self_eq_zero.1 h)), sub_self] },
+      rw [←@inner_self_eq_norm_mul_norm 𝕜, inner_self_re_to_K,
+          div_mul_cancel _ (λ h, hx0 ((@inner_self_eq_zero 𝕜 _ _ _ _ _).1 h)), sub_self] },
     replace h : ‖r • x‖ / ‖t + r • x‖ = 1,
     { rw [←sub_add_cancel y (r • x), ←ht, inner_add_right, ht0, zero_add, inner_smul_right,
         is_R_or_C.abs_div, is_R_or_C.abs_mul, ←inner_self_re_abs,
@@ -1531,7 +1535,7 @@ begin
     have h2 : ‖r • x‖ ^ 2 = ‖t + r • x‖ ^ 2,
     { rw [eq_of_div_eq_one h] },
     replace h2 : ⟪r • x, r • x⟫ = ⟪t, t⟫ + ⟪t, r • x⟫ + ⟪r • x, t⟫ + ⟪r • x, r • x⟫,
-    { rw [sq, sq, ←inner_self_eq_norm_mul_norm, ←inner_self_eq_norm_mul_norm ] at h2,
+    { rw [sq, sq, ←@inner_self_eq_norm_mul_norm 𝕜, ←@inner_self_eq_norm_mul_norm 𝕜] at h2,
       have h2' := congr_arg (λ z : ℝ, (z : 𝕜)) h2,
       simp_rw [inner_self_re_to_K, inner_add_add_self] at h2',
       exact h2' },
@@ -1555,7 +1559,7 @@ a multiple of the other. One form of equality case for Cauchy-Schwarz. -/
 lemma abs_real_inner_div_norm_mul_norm_eq_one_iff (x y : F) :
   absR (⟪x, y⟫_ℝ / (‖x‖ * ‖y‖)) = 1 ↔ (x ≠ 0 ∧ ∃ (r : ℝ), r ≠ 0 ∧ y = r • x) :=
 begin
-  have := @abs_inner_div_norm_mul_norm_eq_one_iff ℝ F _ _ x y,
+  have := @abs_inner_div_norm_mul_norm_eq_one_iff ℝ F _ _ _ x y,
   simpa [coe_real_eq_id] using this,
 end
 
@@ -1648,7 +1652,7 @@ begin
     by simp [h, show (2:ℝ) ≠ 0, by norm_num, sub_eq_zero]
   ... ↔ ‖(‖y‖:𝕜) • x - (‖x‖:𝕜) • y‖ * ‖(‖y‖:𝕜) • x - (‖x‖:𝕜) • y‖ = 0 :
   begin
-    simp only [norm_sub_mul_self, inner_smul_left, inner_smul_right, norm_smul, conj_of_real,
+    simp only [@norm_sub_mul_self 𝕜, inner_smul_left, inner_smul_right, norm_smul, conj_of_real,
       is_R_or_C.norm_eq_abs, abs_of_real, of_real_im, of_real_re, mul_re, abs_norm_eq_norm],
     refine eq.congr _ rfl,
     ring
@@ -1745,7 +1749,7 @@ variables {𝕜}
 
 namespace continuous_linear_map
 
-variables  {E' : Type*} [inner_product_space 𝕜 E']
+variables  {E' : Type*} [normed_add_comm_group E'] [inner_product_space 𝕜 E']
 
 /-- Given `f : E →L[𝕜] E'`, construct the continuous sesquilinear form `λ x y, ⟪x, A y⟫`, given
 as a continuous linear map. -/
@@ -1762,7 +1766,7 @@ begin
   refine op_norm_le_bound _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) _,
   intro x,
   have h₁ : ‖f x‖ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _,
-  have h₂ := @norm_inner_le_norm 𝕜 E' _ _ v (f x),
+  have h₂ := @norm_inner_le_norm 𝕜 E' _ _ _ v (f x),
   calc ‖⟪v, f x⟫‖ ≤ ‖v‖ * ‖f x‖       :  h₂
               ... ≤ ‖v‖ * (‖f‖ * ‖x‖)  : mul_le_mul_of_nonneg_left h₁ (norm_nonneg v)
               ... = ‖f‖ * ‖v‖ * ‖x‖    : by ring,
@@ -1809,8 +1813,8 @@ begin
   suffices hbf: ‖x -  ∑ i in s, ⟪v i, x⟫ • (v i)‖ ^ 2 = ‖x‖ ^ 2 - ∑ i in s, ‖⟪v i, x⟫‖ ^ 2,
   { rw [←sub_nonneg, ←hbf],
     simp only [norm_nonneg, pow_nonneg], },
-  rw [norm_sub_sq, sub_add],
-  simp only [inner_product_space.norm_sq_eq_inner, inner_sum],
+  rw [@norm_sub_sq 𝕜, sub_add],
+  simp only [@inner_product_space.norm_sq_eq_inner 𝕜, inner_sum],
   simp only [sum_inner, two_mul, inner_smul_right, inner_conj_symm, ←mul_assoc, h₂, ←h₃,
   inner_conj_symm, add_monoid_hom.map_sum, finset.mul_sum, ←finset.sum_sub_distrib, inner_smul_left,
   add_sub_cancel'],
@@ -1841,8 +1845,7 @@ end bessels_inequality
 
 /-- A field `𝕜` satisfying `is_R_or_C` is itself a `𝕜`-inner product space. -/
 instance is_R_or_C.inner_product_space : inner_product_space 𝕜 𝕜 :=
-{ to_normed_add_comm_group := non_unital_normed_ring.to_normed_add_comm_group,
-  inner := λ x y, conj x * y,
+{ inner := λ x y, conj x * y,
   norm_sq_eq_inner := λ x,
     by { unfold inner, rw [mul_comm, mul_conj, of_real_re, norm_sq_eq_def'] },
   conj_symm := λ x y, by simp only [mul_comm, map_mul, star_ring_end_self_apply],
@@ -1855,10 +1858,9 @@ instance is_R_or_C.inner_product_space : inner_product_space 𝕜 𝕜 :=
 
 /-- Induced inner product on a submodule. -/
 instance submodule.inner_product_space (W : submodule 𝕜 E) : inner_product_space 𝕜 W :=
-{ to_normed_add_comm_group := submodule.normed_add_comm_group _,
-  inner             := λ x y, ⟪(x:E), (y:E)⟫,
-  conj_symm         := λ _ _, inner_conj_symm _ _ ,
-  norm_sq_eq_inner  := λ _, norm_sq_eq_inner _,
+{ inner             := λ x y, ⟪(x:E), (y:E)⟫,
+  conj_symm         := λ _ _, inner_conj_symm _ _,
+  norm_sq_eq_inner  := λ x, norm_sq_eq_inner (x : E),
   add_left          := λ _ _ _, inner_add_left _ _ _,
   smul_left         := λ _ _ _, inner_smul_left _ _ _,
   ..submodule.normed_space W }
@@ -1868,11 +1870,11 @@ instance submodule.inner_product_space (W : submodule 𝕜 E) : inner_product_sp
 
 lemma orthonormal.cod_restrict {ι : Type*} {v : ι → E} (hv : orthonormal 𝕜 v)
   (s : submodule 𝕜 E) (hvs : ∀ i, v i ∈ s) :
-  @orthonormal 𝕜 s _ _ ι (set.cod_restrict v s hvs) :=
+  @orthonormal 𝕜 s _ _ _ ι (set.cod_restrict v s hvs) :=
 s.subtypeₗᵢ.orthonormal_comp_iff.mp hv
 
 lemma orthonormal_span {ι : Type*} {v : ι → E} (hv : orthonormal 𝕜 v) :
-  @orthonormal 𝕜 (submodule.span 𝕜 (set.range v)) _ _ ι
+  @orthonormal 𝕜 (submodule.span 𝕜 (set.range v)) _ _ _ ι
     (λ i : ι, ⟨v i, submodule.subset_span (set.mem_range_self i)⟩) :=
 hv.cod_restrict (submodule.span 𝕜 (set.range v))
   (λ i, submodule.subset_span (set.mem_range_self i))
@@ -1894,11 +1896,13 @@ product space structure on each of the submodules is important -- for example, w
 their Hilbert sum (`pi_lp V 2`).  For example, given an orthonormal set of vectors `v : ι → E`,
 we have an associated orthogonal family of one-dimensional subspaces of `E`, which it is convenient
 to be able to discuss using `ι → 𝕜` rather than `Π i : ι, span 𝕜 (v i)`. -/
-def orthogonal_family (G : ι → Type*) [Π i, inner_product_space 𝕜 (G i)] (V : Π i, G i →ₗᵢ[𝕜] E) :
+def orthogonal_family (G : ι → Type*)
+  [Π i, normed_add_comm_group (G i)] [Π i, inner_product_space 𝕜 (G i)] (V : Π i, G i →ₗᵢ[𝕜] E) :
   Prop :=
 ∀ ⦃i j⦄, i ≠ j → ∀ v : G i, ∀ w : G j, ⟪V i v, V j w⟫ = 0
 
-variables {𝕜} {G : ι → Type*} [Π i, inner_product_space 𝕜 (G i)] {V : Π i, G i →ₗᵢ[𝕜] E}
+variables {𝕜} {G : ι → Type*}
+  [Π i, normed_add_comm_group (G i)] [Π i, inner_product_space 𝕜 (G i)] {V : Π i, G i →ₗᵢ[𝕜] E}
   (hV : orthogonal_family 𝕜 G V) [dec_V : Π i (x : G i), decidable (x ≠ 0)]
 
 lemma orthonormal.orthogonal_family {v : ι → E} (hv : orthonormal 𝕜 v) :
@@ -2111,8 +2115,7 @@ registered as an instance since it creates problems with the case `𝕜 = ℝ`, 
 proof to obtain a real inner product space structure from a given `𝕜`-inner product space
 structure. -/
 def inner_product_space.is_R_or_C_to_real : inner_product_space ℝ E :=
-{ to_normed_add_comm_group := inner_product_space.to_normed_add_comm_group 𝕜,
-  norm_sq_eq_inner := norm_sq_eq_inner,
+{ norm_sq_eq_inner := norm_sq_eq_inner,
   conj_symm := λ x y, inner_re_symm _ _,
   add_left := λ x y z, by
   { change re ⟪x + y, z⟫ = re ⟪x, z⟫ + re ⟪y, z⟫,
@@ -2135,14 +2138,16 @@ by simp [real_inner_eq_re_inner, inner_smul_right]
 omit 𝕜
 
 /-- A complex inner product implies a real inner product -/
-instance inner_product_space.complex_to_real [inner_product_space ℂ G] : inner_product_space ℝ G :=
+instance inner_product_space.complex_to_real
+  [normed_add_comm_group G] [inner_product_space ℂ G] : inner_product_space ℝ G :=
 inner_product_space.is_R_or_C_to_real ℂ G
 
 @[simp] protected lemma complex.inner (w z : ℂ) : ⟪w, z⟫_ℝ = (conj w * z).re := rfl
 
 /-- The inner product on an inner product space of dimension 2 can be evaluated in terms
 of a complex-number representation of the space. -/
-lemma inner_map_complex [inner_product_space ℝ G] (f : G ≃ₗᵢ[ℝ] ℂ) (x y : G) :
+lemma inner_map_complex [normed_add_comm_group G] [inner_product_space ℝ G]
+  (f : G ≃ₗᵢ[ℝ] ℂ) (x y : G) :
   ⟪x, y⟫_ℝ = (conj (f x) * f y).re :=
 by rw [← complex.inner, f.inner_map_map]
 
@@ -2417,8 +2422,7 @@ protected lemma continuous.inner {α : Type*} [topological_space α]
 uniform_space.completion.continuous_inner.comp (hf.prod_mk hg : _)
 
 instance : inner_product_space 𝕜 (completion E) :=
-{ to_normed_add_comm_group := infer_instance,
-  norm_sq_eq_inner := λ x, completion.induction_on x
+{ norm_sq_eq_inner := λ x, completion.induction_on x
     (is_closed_eq
       (continuous_norm.pow 2)
       (continuous_re.comp (continuous.inner continuous_id' continuous_id')))

--- a/src/analysis/inner_product_space/calculus.lean
+++ b/src/analysis/inner_product_space/calculus.lean
@@ -34,13 +34,13 @@ variables {𝕜 E F : Type*} [is_R_or_C 𝕜]
 variables [inner_product_space 𝕜 E] [inner_product_space ℝ F]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
-variables [normed_space ℝ E]
+variables (𝕜) [normed_space ℝ E]
 
 /-- Derivative of the inner product. -/
 def fderiv_inner_clm (p : E × E) : E × E →L[ℝ] 𝕜 := is_bounded_bilinear_map_inner.deriv p
 
 @[simp] lemma fderiv_inner_clm_apply (p x : E × E) :
-  fderiv_inner_clm  p x = ⟪p.1, x.2⟫ + ⟪x.1, p.2⟫ := rfl
+  fderiv_inner_clm 𝕜 p x = ⟪p.1, x.2⟫ + ⟪x.1, p.2⟫ := rfl
 
 lemma cont_diff_inner {n} : cont_diff ℝ n (λ p : E × E, ⟪p.1, p.2⟫) :=
 is_bounded_bilinear_map_inner.cont_diff
@@ -65,11 +65,11 @@ cont_diff_at_inner.comp_cont_diff_within_at x (hf.prod hg)
 lemma cont_diff_at.inner (hf : cont_diff_at ℝ n f x)
   (hg : cont_diff_at ℝ n g x) :
   cont_diff_at ℝ n (λ x, ⟪f x, g x⟫) x :=
-hf.inner hg
+hf.inner 𝕜 hg
 
 lemma cont_diff_on.inner (hf : cont_diff_on ℝ n f s) (hg : cont_diff_on ℝ n g s) :
   cont_diff_on ℝ n (λ x, ⟪f x, g x⟫) s :=
-λ x hx, (hf x hx).inner (hg x hx)
+λ x hx, (hf x hx).inner 𝕜 (hg x hx)
 
 lemma cont_diff.inner (hf : cont_diff ℝ n f) (hg : cont_diff ℝ n g) :
   cont_diff ℝ n (λ x, ⟪f x, g x⟫) :=
@@ -77,27 +77,27 @@ cont_diff_inner.comp (hf.prod hg)
 
 lemma has_fderiv_within_at.inner (hf : has_fderiv_within_at f f' s x)
   (hg : has_fderiv_within_at g g' s x) :
-  has_fderiv_within_at (λ t, ⟪f t, g t⟫) ((fderiv_inner_clm (f x, g x)).comp $ f'.prod g') s x :=
+  has_fderiv_within_at (λ t, ⟪f t, g t⟫) ((fderiv_inner_clm 𝕜 (f x, g x)).comp $ f'.prod g') s x :=
 (is_bounded_bilinear_map_inner.has_fderiv_at (f x, g x)).comp_has_fderiv_within_at x (hf.prod hg)
 
 lemma has_strict_fderiv_at.inner (hf : has_strict_fderiv_at f f' x)
   (hg : has_strict_fderiv_at g g' x) :
-  has_strict_fderiv_at (λ t, ⟪f t, g t⟫) ((fderiv_inner_clm (f x, g x)).comp $ f'.prod g') x :=
+  has_strict_fderiv_at (λ t, ⟪f t, g t⟫) ((fderiv_inner_clm 𝕜 (f x, g x)).comp $ f'.prod g') x :=
 (is_bounded_bilinear_map_inner.has_strict_fderiv_at (f x, g x)).comp x (hf.prod hg)
 
 lemma has_fderiv_at.inner (hf : has_fderiv_at f f' x) (hg : has_fderiv_at g g' x) :
-  has_fderiv_at (λ t, ⟪f t, g t⟫) ((fderiv_inner_clm (f x, g x)).comp $ f'.prod g') x :=
+  has_fderiv_at (λ t, ⟪f t, g t⟫) ((fderiv_inner_clm 𝕜 (f x, g x)).comp $ f'.prod g') x :=
 (is_bounded_bilinear_map_inner.has_fderiv_at (f x, g x)).comp x (hf.prod hg)
 
 lemma has_deriv_within_at.inner {f g : ℝ → E} {f' g' : E} {s : set ℝ} {x : ℝ}
   (hf : has_deriv_within_at f f' s x) (hg : has_deriv_within_at g g' s x) :
   has_deriv_within_at (λ t, ⟪f t, g t⟫) (⟪f x, g'⟫ + ⟪f', g x⟫) s x :=
-by simpa using (hf.has_fderiv_within_at.inner hg.has_fderiv_within_at).has_deriv_within_at
+by simpa using (hf.has_fderiv_within_at.inner 𝕜 hg.has_fderiv_within_at).has_deriv_within_at
 
 lemma has_deriv_at.inner {f g : ℝ → E} {f' g' : E} {x : ℝ} :
   has_deriv_at f f' x →  has_deriv_at g g' x →
   has_deriv_at (λ t, ⟪f t, g t⟫) (⟪f x, g'⟫ + ⟪f', g x⟫) x :=
-by simpa only [← has_deriv_within_at_univ] using has_deriv_within_at.inner
+by simpa only [← has_deriv_within_at_univ] using has_deriv_within_at.inner 𝕜
 
 lemma differentiable_within_at.inner (hf : differentiable_within_at ℝ f s x)
   (hg : differentiable_within_at ℝ g s x) :
@@ -111,90 +111,90 @@ lemma differentiable_at.inner (hf : differentiable_at ℝ f x) (hg : differentia
 
 lemma differentiable_on.inner (hf : differentiable_on ℝ f s) (hg : differentiable_on ℝ g s) :
   differentiable_on ℝ (λ x, ⟪f x, g x⟫) s :=
-λ x hx, (hf x hx).inner (hg x hx)
+λ x hx, (hf x hx).inner 𝕜 (hg x hx)
 
 lemma differentiable.inner (hf : differentiable ℝ f) (hg : differentiable ℝ g) :
   differentiable ℝ (λ x, ⟪f x, g x⟫) :=
-λ x, (hf x).inner (hg x)
+λ x, (hf x).inner 𝕜 (hg x)
 
 lemma fderiv_inner_apply (hf : differentiable_at ℝ f x) (hg : differentiable_at ℝ g x) (y : G) :
   fderiv ℝ (λ t, ⟪f t, g t⟫) x y = ⟪f x, fderiv ℝ g x y⟫ + ⟪fderiv ℝ f x y, g x⟫ :=
-by { rw [(hf.has_fderiv_at.inner hg.has_fderiv_at).fderiv], refl }
+by { rw [(hf.has_fderiv_at.inner 𝕜 hg.has_fderiv_at).fderiv], refl }
 
 lemma deriv_inner_apply {f g : ℝ → E} {x : ℝ} (hf : differentiable_at ℝ f x)
   (hg : differentiable_at ℝ g x) :
   deriv (λ t, ⟪f t, g t⟫) x = ⟪f x, deriv g x⟫ + ⟪deriv f x, g x⟫ :=
-(hf.has_deriv_at.inner hg.has_deriv_at).deriv
+(hf.has_deriv_at.inner 𝕜 hg.has_deriv_at).deriv
 
 lemma cont_diff_norm_sq : cont_diff ℝ n (λ x : E, ‖x‖ ^ 2) :=
 begin
   simp only [sq, ← inner_self_eq_norm_mul_norm],
-  exact (re_clm : 𝕜 →L[ℝ] ℝ).cont_diff.comp (cont_diff_id.inner cont_diff_id)
+  exact (re_clm : 𝕜 →L[ℝ] ℝ).cont_diff.comp (cont_diff_id.inner 𝕜 cont_diff_id)
 end
 
 lemma cont_diff.norm_sq (hf : cont_diff ℝ n f) :
   cont_diff ℝ n (λ x, ‖f x‖ ^ 2) :=
-cont_diff_norm_sq.comp hf
+(cont_diff_norm_sq 𝕜).comp hf
 
 lemma cont_diff_within_at.norm_sq (hf : cont_diff_within_at ℝ n f s x) :
   cont_diff_within_at ℝ n (λ y, ‖f y‖ ^ 2) s x :=
-cont_diff_norm_sq.cont_diff_at.comp_cont_diff_within_at x hf
+(cont_diff_norm_sq 𝕜).cont_diff_at.comp_cont_diff_within_at x hf
 
 lemma cont_diff_at.norm_sq (hf : cont_diff_at ℝ n f x) :
   cont_diff_at ℝ n (λ y, ‖f y‖ ^ 2) x :=
-hf.norm_sq
+hf.norm_sq 𝕜
 
 lemma cont_diff_at_norm {x : E} (hx : x ≠ 0) : cont_diff_at ℝ n norm x :=
 have ‖id x‖ ^ 2 ≠ 0, from pow_ne_zero _ (norm_pos_iff.2 hx).ne',
-by simpa only [id, sqrt_sq, norm_nonneg] using cont_diff_at_id.norm_sq.sqrt this
+by simpa only [id, sqrt_sq, norm_nonneg] using (cont_diff_at_id.norm_sq 𝕜).sqrt this
 
 lemma cont_diff_at.norm (hf : cont_diff_at ℝ n f x) (h0 : f x ≠ 0) :
   cont_diff_at ℝ n (λ y, ‖f y‖) x :=
-(cont_diff_at_norm h0).comp x hf
+(cont_diff_at_norm 𝕜 h0).comp x hf
 
 lemma cont_diff_at.dist (hf : cont_diff_at ℝ n f x) (hg : cont_diff_at ℝ n g x)
   (hne : f x ≠ g x) :
   cont_diff_at ℝ n (λ y, dist (f y) (g y)) x :=
-by { simp only [dist_eq_norm], exact (hf.sub hg).norm (sub_ne_zero.2 hne) }
+by { simp only [dist_eq_norm], exact (hf.sub hg).norm 𝕜 (sub_ne_zero.2 hne) }
 
 lemma cont_diff_within_at.norm (hf : cont_diff_within_at ℝ n f s x) (h0 : f x ≠ 0) :
   cont_diff_within_at ℝ n (λ y, ‖f y‖) s x :=
-(cont_diff_at_norm h0).comp_cont_diff_within_at x hf
+(cont_diff_at_norm 𝕜 h0).comp_cont_diff_within_at x hf
 
 lemma cont_diff_within_at.dist (hf : cont_diff_within_at ℝ n f s x)
   (hg : cont_diff_within_at ℝ n g s x) (hne : f x ≠ g x) :
   cont_diff_within_at ℝ n (λ y, dist (f y) (g y)) s x :=
-by { simp only [dist_eq_norm], exact (hf.sub hg).norm (sub_ne_zero.2 hne) }
+by { simp only [dist_eq_norm], exact (hf.sub hg).norm 𝕜 (sub_ne_zero.2 hne) }
 
 lemma cont_diff_on.norm_sq (hf : cont_diff_on ℝ n f s) :
   cont_diff_on ℝ n (λ y, ‖f y‖ ^ 2) s :=
-(λ x hx, (hf x hx).norm_sq)
+(λ x hx, (hf x hx).norm_sq 𝕜)
 
 lemma cont_diff_on.norm (hf : cont_diff_on ℝ n f s) (h0 : ∀ x ∈ s, f x ≠ 0) :
   cont_diff_on ℝ n (λ y, ‖f y‖) s :=
-λ x hx, (hf x hx).norm (h0 x hx)
+λ x hx, (hf x hx).norm 𝕜 (h0 x hx)
 
 lemma cont_diff_on.dist (hf : cont_diff_on ℝ n f s)
   (hg : cont_diff_on ℝ n g s) (hne : ∀ x ∈ s, f x ≠ g x) :
   cont_diff_on ℝ n (λ y, dist (f y) (g y)) s :=
-λ x hx, (hf x hx).dist (hg x hx) (hne x hx)
+λ x hx, (hf x hx).dist 𝕜 (hg x hx) (hne x hx)
 
 lemma cont_diff.norm (hf : cont_diff ℝ n f) (h0 : ∀ x, f x ≠ 0) :
   cont_diff ℝ n (λ y, ‖f y‖) :=
-cont_diff_iff_cont_diff_at.2 $ λ x, hf.cont_diff_at.norm (h0 x)
+cont_diff_iff_cont_diff_at.2 $ λ x, hf.cont_diff_at.norm 𝕜 (h0 x)
 
 lemma cont_diff.dist (hf : cont_diff ℝ n f) (hg : cont_diff ℝ n g)
   (hne : ∀ x, f x ≠ g x) :
   cont_diff ℝ n (λ y, dist (f y) (g y)) :=
 cont_diff_iff_cont_diff_at.2 $
-  λ x, hf.cont_diff_at.dist hg.cont_diff_at (hne x)
+  λ x, hf.cont_diff_at.dist 𝕜 hg.cont_diff_at (hne x)
 
 omit 𝕜
 lemma has_strict_fderiv_at_norm_sq (x : F) :
   has_strict_fderiv_at (λ x, ‖x‖ ^ 2) (bit0 (innerSL ℝ x)) x :=
 begin
-  simp only [sq, ← inner_self_eq_norm_mul_norm],
-  convert (has_strict_fderiv_at_id x).inner (has_strict_fderiv_at_id x),
+  simp only [sq, ← @inner_self_eq_norm_mul_norm ℝ],
+  convert (has_strict_fderiv_at_id x).inner ℝ (has_strict_fderiv_at_id x),
   ext y,
   simp [bit0, real_inner_comm],
 end
@@ -202,54 +202,54 @@ include 𝕜
 
 lemma differentiable_at.norm_sq (hf : differentiable_at ℝ f x) :
   differentiable_at ℝ (λ y, ‖f y‖ ^ 2) x :=
-(cont_diff_at_id.norm_sq.differentiable_at le_rfl).comp x hf
+((cont_diff_at_id.norm_sq 𝕜).differentiable_at le_rfl).comp x hf
 
 lemma differentiable_at.norm (hf : differentiable_at ℝ f x) (h0 : f x ≠ 0) :
   differentiable_at ℝ (λ y, ‖f y‖) x :=
-((cont_diff_at_norm h0).differentiable_at le_rfl).comp x hf
+((cont_diff_at_norm 𝕜 h0).differentiable_at le_rfl).comp x hf
 
 lemma differentiable_at.dist (hf : differentiable_at ℝ f x) (hg : differentiable_at ℝ g x)
   (hne : f x ≠ g x) :
   differentiable_at ℝ (λ y, dist (f y) (g y)) x :=
-by { simp only [dist_eq_norm], exact (hf.sub hg).norm (sub_ne_zero.2 hne) }
+by { simp only [dist_eq_norm], exact (hf.sub hg).norm 𝕜 (sub_ne_zero.2 hne) }
 
 lemma differentiable.norm_sq (hf : differentiable ℝ f) : differentiable ℝ (λ y, ‖f y‖ ^ 2) :=
-λ x, (hf x).norm_sq
+λ x, (hf x).norm_sq 𝕜
 
 lemma differentiable.norm (hf : differentiable ℝ f) (h0 : ∀ x, f x ≠ 0) :
   differentiable ℝ (λ y, ‖f y‖) :=
-λ x, (hf x).norm (h0 x)
+λ x, (hf x).norm 𝕜 (h0 x)
 
 lemma differentiable.dist (hf : differentiable ℝ f) (hg : differentiable ℝ g)
   (hne : ∀ x, f x ≠ g x) :
   differentiable ℝ (λ y, dist (f y) (g y)) :=
-λ x, (hf x).dist (hg x) (hne x)
+λ x, (hf x).dist 𝕜 (hg x) (hne x)
 
 lemma differentiable_within_at.norm_sq (hf : differentiable_within_at ℝ f s x) :
   differentiable_within_at ℝ (λ y, ‖f y‖ ^ 2) s x :=
-(cont_diff_at_id.norm_sq.differentiable_at le_rfl).comp_differentiable_within_at x hf
+((cont_diff_at_id.norm_sq 𝕜).differentiable_at le_rfl).comp_differentiable_within_at x hf
 
 lemma differentiable_within_at.norm (hf : differentiable_within_at ℝ f s x) (h0 : f x ≠ 0) :
   differentiable_within_at ℝ (λ y, ‖f y‖) s x :=
-((cont_diff_at_id.norm h0).differentiable_at le_rfl).comp_differentiable_within_at x hf
+((cont_diff_at_id.norm 𝕜 h0).differentiable_at le_rfl).comp_differentiable_within_at x hf
 
 lemma differentiable_within_at.dist (hf : differentiable_within_at ℝ f s x)
   (hg : differentiable_within_at ℝ g s x) (hne : f x ≠ g x) :
   differentiable_within_at ℝ (λ y, dist (f y) (g y)) s x :=
-by { simp only [dist_eq_norm], exact (hf.sub hg).norm (sub_ne_zero.2 hne) }
+by { simp only [dist_eq_norm], exact (hf.sub hg).norm 𝕜 (sub_ne_zero.2 hne) }
 
 lemma differentiable_on.norm_sq (hf : differentiable_on ℝ f s) :
   differentiable_on ℝ (λ y, ‖f y‖ ^ 2) s :=
-λ x hx, (hf x hx).norm_sq
+λ x hx, (hf x hx).norm_sq 𝕜
 
 lemma differentiable_on.norm (hf : differentiable_on ℝ f s) (h0 : ∀ x ∈ s, f x ≠ 0) :
   differentiable_on ℝ (λ y, ‖f y‖) s :=
-λ x hx, (hf x hx).norm (h0 x hx)
+λ x hx, (hf x hx).norm 𝕜 (h0 x hx)
 
 lemma differentiable_on.dist (hf : differentiable_on ℝ f s) (hg : differentiable_on ℝ g s)
   (hne : ∀ x ∈ s, f x ≠ g x) :
   differentiable_on ℝ (λ y, dist (f y) (g y)) s :=
-λ x hx, (hf x hx).dist (hg x hx) (hne x hx)
+λ x hx, (hf x hx).dist 𝕜 (hg x hx) (hne x hx)
 
 end deriv_inner
 
@@ -346,7 +346,7 @@ begin
   suffices : cont_diff ℝ n (λ x, (1 + ‖x‖^2).sqrt⁻¹), { exact this.smul cont_diff_id, },
   have h : ∀ (x : E), 0 < 1 + ‖x‖ ^ 2 := λ x, by positivity,
   refine cont_diff.inv _ (λ x, real.sqrt_ne_zero'.mpr (h x)),
-  exact (cont_diff_const.add cont_diff_norm_sq).sqrt (λ x, (h x).ne.symm),
+  exact (cont_diff_const.add $ cont_diff_norm_sq ℝ).sqrt (λ x, (h x).ne.symm),
 end
 
 lemma cont_diff_on_homeomorph_unit_ball_symm
@@ -367,7 +367,7 @@ begin
     ← sq_lt_sq, one_pow, ← sub_pos] at hy,
   refine cont_diff_at.inv _ (real.sqrt_ne_zero'.mpr h),
   refine cont_diff_at.comp _ (cont_diff_at_sqrt h.ne.symm) _,
-  exact cont_diff_at_const.sub cont_diff_norm_sq.cont_diff_at,
+  exact cont_diff_at_const.sub (cont_diff_norm_sq ℝ).cont_diff_at,
 end
 
 end diffeomorph_unit_ball

--- a/src/analysis/inner_product_space/calculus.lean
+++ b/src/analysis/inner_product_space/calculus.lean
@@ -31,7 +31,8 @@ open_locale big_operators classical topology
 section deriv_inner
 
 variables {𝕜 E F : Type*} [is_R_or_C 𝕜]
-variables [inner_product_space 𝕜 E] [inner_product_space ℝ F]
+variables [normed_add_comm_group E] [inner_product_space 𝕜 E]
+variables [normed_add_comm_group F] [inner_product_space ℝ F]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
 variables (𝕜) [normed_space ℝ E]
@@ -128,7 +129,7 @@ lemma deriv_inner_apply {f g : ℝ → E} {x : ℝ} (hf : differentiable_at ℝ 
 
 lemma cont_diff_norm_sq : cont_diff ℝ n (λ x : E, ‖x‖ ^ 2) :=
 begin
-  simp only [sq, ← inner_self_eq_norm_mul_norm],
+  simp only [sq, ← @inner_self_eq_norm_mul_norm 𝕜],
   exact (re_clm : 𝕜 →L[ℝ] ℝ).cont_diff.comp (cont_diff_id.inner 𝕜 cont_diff_id)
 end
 
@@ -338,7 +339,7 @@ section diffeomorph_unit_ball
 
 open metric (hiding mem_nhds_iff)
 
-variables {n : ℕ∞} {E : Type*} [inner_product_space ℝ E]
+variables {n : ℕ∞} {E : Type*} [normed_add_comm_group E] [inner_product_space ℝ E]
 
 lemma cont_diff_homeomorph_unit_ball :
   cont_diff ℝ n $ λ (x : E), (homeomorph_unit_ball x : E) :=

--- a/src/analysis/inner_product_space/conformal_linear_map.lean
+++ b/src/analysis/inner_product_space/conformal_linear_map.lean
@@ -12,7 +12,9 @@ import analysis.inner_product_space.basic
 In an inner product space, a map is conformal iff it preserves inner products up to a scalar factor.
 -/
 
-variables {E F : Type*} [inner_product_space ℝ E] [inner_product_space ℝ F]
+variables {E F : Type*}
+variables [normed_add_comm_group E] [normed_add_comm_group F]
+variables [inner_product_space ℝ E] [inner_product_space ℝ F]
 
 open linear_isometry continuous_linear_map
 open_locale real_inner_product_space

--- a/src/analysis/inner_product_space/dual.lean
+++ b/src/analysis/inner_product_space/dual.lean
@@ -42,7 +42,7 @@ namespace inner_product_space
 open is_R_or_C continuous_linear_map
 
 variables (𝕜 : Type*)
-variables (E : Type*) [is_R_or_C 𝕜] [inner_product_space 𝕜 E]
+variables (E : Type*) [is_R_or_C 𝕜] [normed_add_comm_group E] [inner_product_space 𝕜 E]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 E _ x y
 local postfix `†`:90 := star_ring_end _
 

--- a/src/analysis/inner_product_space/gram_schmidt_ortho.lean
+++ b/src/analysis/inner_product_space/gram_schmidt_ortho.lean
@@ -38,7 +38,7 @@ and outputs a set of orthogonal vectors which have the same span.
 open_locale big_operators
 open finset submodule finite_dimensional
 
-variables (𝕜 : Type*) {E : Type*} [is_R_or_C 𝕜] [inner_product_space 𝕜 E]
+variables (𝕜 : Type*) {E : Type*} [is_R_or_C 𝕜] [normed_add_comm_group E] [inner_product_space 𝕜 E]
 variables {ι : Type*} [linear_order ι] [locally_finite_order_bot ι] [is_well_order ι (<)]
 
 local attribute [instance] is_well_order.to_has_well_founded

--- a/src/analysis/inner_product_space/l2_space.lean
+++ b/src/analysis/inner_product_space/l2_space.lean
@@ -85,8 +85,9 @@ open_locale big_operators nnreal ennreal classical complex_conjugate topology
 noncomputable theory
 
 variables {ι : Type*}
-variables {𝕜 : Type*} [is_R_or_C 𝕜] {E : Type*} [inner_product_space 𝕜 E] [cplt : complete_space E]
-variables {G : ι → Type*} [Π i, inner_product_space 𝕜 (G i)]
+variables {𝕜 : Type*} [is_R_or_C 𝕜] {E : Type*}
+variables [normed_add_comm_group E] [inner_product_space 𝕜 E] [cplt : complete_space E]
+variables {G : ι → Type*} [Π i, normed_add_comm_group (G i)] [Π i, inner_product_space 𝕜 (G i)]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
 notation `ℓ²(`ι`, `𝕜`)` := lp (λ i : ι, 𝕜) 2
@@ -111,7 +112,7 @@ instance : inner_product_space 𝕜 (lp G 2) :=
     calc ‖f‖ ^ 2 = ‖f‖ ^ (2:ℝ≥0∞).to_real : by norm_cast
     ... = ∑' i, ‖f i‖ ^ (2:ℝ≥0∞).to_real : lp.norm_rpow_eq_tsum _ f
     ... = ∑' i, ‖f i‖ ^ 2 : by norm_cast
-    ... = ∑' i, re ⟪f i, f i⟫ : by simp only [norm_sq_eq_inner]
+    ... = ∑' i, re ⟪f i, f i⟫ : by simp only [@norm_sq_eq_inner 𝕜]
     ... = re (∑' i, ⟪f i, f i⟫) : (is_R_or_C.re_clm.map_tsum _).symm
     ... = _ : by congr,
     { norm_num },
@@ -160,7 +161,7 @@ begin
 end
 
 lemma inner_single_right (i : ι) (a : G i) (f : lp G 2) : ⟪f, lp.single 2 i a⟫ = ⟪f i, a⟫ :=
-by simpa [inner_conj_symm] using congr_arg conj (inner_single_left i a f)
+by simpa [inner_conj_symm] using congr_arg conj (@inner_single_left _ 𝕜 _ _ _ _ i a f)
 
 end lp
 
@@ -425,6 +426,7 @@ begin
     exact (↑(b.repr.symm.to_continuous_linear_equiv) : ℓ²(ι, 𝕜) →L[𝕜] E).has_sum this },
   ext i,
   apply b.repr.injective,
+  letI : normed_space 𝕜 ↥(lp (λ i : ι, 𝕜) 2) := by apply_instance,
   have : lp.single 2 i (f i * 1) = f i • lp.single 2 i 1 := lp.single_smul 2 i (1:𝕜) (f i),
   rw mul_one at this,
   rw [linear_isometry_equiv.map_smul, b.repr_self, ← this,

--- a/src/analysis/inner_product_space/lax_milgram.lean
+++ b/src/analysis/inner_product_space/lax_milgram.lean
@@ -40,10 +40,10 @@ open_locale real_inner_product_space nnreal
 universe u
 
 namespace is_coercive
-variables {V : Type u} [inner_product_space ℝ V] [complete_space V]
+variables {V : Type u} [normed_add_comm_group V] [inner_product_space ℝ V] [complete_space V]
 variables {B : V →L[ℝ] V →L[ℝ] ℝ}
 
-local postfix `♯`:1025 := @continuous_linear_map_of_bilin ℝ V _ _ _
+local postfix `♯`:1025 := @continuous_linear_map_of_bilin ℝ V _ _ _ _
 
 lemma bounded_below (coercive : is_coercive B) :
   ∃ C, 0 < C ∧ ∀ v, C * ‖v‖ ≤ ‖B♯ v‖ :=

--- a/src/analysis/inner_product_space/orientation.lean
+++ b/src/analysis/inner_product_space/orientation.lean
@@ -35,7 +35,7 @@ This file provides definitions and proves lemmas about orientations of real inne
 
 noncomputable theory
 
-variables {E : Type*} [inner_product_space ℝ E]
+variables {E : Type*} [normed_add_comm_group E] [inner_product_space ℝ E]
 
 open finite_dimensional
 open_locale big_operators real_inner_product_space
@@ -317,7 +317,8 @@ lemma abs_volume_form_apply_of_orthonormal (v : orthonormal_basis (fin n) ℝ E)
   |o.volume_form v| = 1 :=
 by simpa [o.volume_form_robust' v v] using congr_arg abs v.to_basis.det_self
 
-lemma volume_form_map {F : Type*} [inner_product_space ℝ F] [fact (finrank ℝ F = n)]
+lemma volume_form_map {F : Type*}
+  [normed_add_comm_group F] [inner_product_space ℝ F] [fact (finrank ℝ F = n)]
   (φ : E ≃ₗᵢ[ℝ] F) (x : fin n → F) :
   (orientation.map (fin n) φ.to_linear_equiv o).volume_form x = o.volume_form (φ.symm ∘ x) :=
 begin

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -57,10 +57,11 @@ open_locale big_operators uniformity topology nnreal ennreal complex_conjugate d
 noncomputable theory
 
 variables {ι : Type*} {ι' : Type*}
-variables {𝕜 : Type*} [is_R_or_C 𝕜] {E : Type*} [inner_product_space 𝕜 E]
-variables {E' : Type*} [inner_product_space 𝕜 E']
-variables {F : Type*} [inner_product_space ℝ F]
-variables {F' : Type*} [inner_product_space ℝ F']
+variables {𝕜 : Type*} [is_R_or_C 𝕜]
+variables {E : Type*} [normed_add_comm_group E] [inner_product_space 𝕜 E]
+variables {E' : Type*} [normed_add_comm_group E'] [inner_product_space 𝕜 E']
+variables {F : Type*} [normed_add_comm_group F] [inner_product_space ℝ F]
+variables {F' : Type*} [normed_add_comm_group F'] [inner_product_space ℝ F']
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
 /-
@@ -69,9 +70,9 @@ then `Π i, f i` is an inner product space as well. Since `Π i, f i` is endowed
 we use instead `pi_Lp 2 f` for the product space, which is endowed with the `L^2` norm.
 -/
 instance pi_Lp.inner_product_space {ι : Type*} [fintype ι] (f : ι → Type*)
-  [Π i, inner_product_space 𝕜 (f i)] : inner_product_space 𝕜 (pi_Lp 2 f) :=
-{ to_normed_add_comm_group := infer_instance,
-  inner := λ x y, ∑ i, inner (x i) (y i),
+  [Π i, normed_add_comm_group (f i)] [Π i, inner_product_space 𝕜 (f i)] :
+  inner_product_space 𝕜 (pi_Lp 2 f) :=
+{ inner := λ x y, ∑ i, inner (x i) (y i),
   norm_sq_eq_inner := λ x,
     by simp only [pi_Lp.norm_sq_eq_of_L2, add_monoid_hom.map_sum, ← norm_sq_eq_inner, one_div],
   conj_symm :=
@@ -91,7 +92,7 @@ instance pi_Lp.inner_product_space {ι : Type*} [fintype ι] (f : ι → Type*)
     by simp only [finset.mul_sum, inner_smul_left] }
 
 @[simp] lemma pi_Lp.inner_apply {ι : Type*} [fintype ι] {f : ι → Type*}
-  [Π i, inner_product_space 𝕜 (f i)] (x y : pi_Lp 2 f) :
+  [Π i, normed_add_comm_group (f i)] [Π i, inner_product_space 𝕜 (f i)] (x y : pi_Lp 2 f) :
   ⟪x, y⟫ = ∑ i, ⟪x i, y i⟫ :=
 rfl
 
@@ -150,7 +151,7 @@ def direct_sum.is_internal.isometry_L2_of_orthogonal_family
 begin
   let e₁ := direct_sum.linear_equiv_fun_on_fintype 𝕜 ι (λ i, V i),
   let e₂ := linear_equiv.of_bijective (direct_sum.coe_linear_map V) hV,
-  refine (e₂.symm.trans e₁).isometry_of_inner _,
+  refine linear_equiv.isometry_of_inner (e₂.symm.trans e₁) _,
   suffices : ∀ v w, ⟪v, w⟫ = ⟪e₂ (e₁.symm v), e₂ (e₁.symm w)⟫,
   { intros v₀ w₀,
     convert this (e₁ (e₂.symm v₀)) (e₁ (e₂.symm w₀));
@@ -344,16 +345,17 @@ by simpa only [b.repr_apply_apply, inner_orthogonal_projection_eq_of_mem_left]
   using (b.sum_repr (orthogonal_projection U x)).symm
 
 /-- Mapping an orthonormal basis along a `linear_isometry_equiv`. -/
-protected def map {G : Type*} [inner_product_space 𝕜 G] (b : orthonormal_basis ι 𝕜 E)
+protected def map {G : Type*}
+  [normed_add_comm_group G] [inner_product_space 𝕜 G] (b : orthonormal_basis ι 𝕜 E)
   (L : E ≃ₗᵢ[𝕜] G) :
   orthonormal_basis ι 𝕜 G :=
 { repr := L.symm.trans b.repr }
 
-@[simp] protected lemma map_apply {G : Type*} [inner_product_space 𝕜 G]
+@[simp] protected lemma map_apply {G : Type*} [normed_add_comm_group G] [inner_product_space 𝕜 G]
   (b : orthonormal_basis ι 𝕜 E) (L : E ≃ₗᵢ[𝕜] G) (i : ι) :
   b.map L i = L (b i) := rfl
 
-@[simp] protected lemma to_basis_map {G : Type*} [inner_product_space 𝕜 G]
+@[simp] protected lemma to_basis_map {G : Type*} [normed_add_comm_group G] [inner_product_space 𝕜 G]
   (b : orthonormal_basis ι 𝕜 E) (L : E ≃ₗᵢ[𝕜] G) :
   (b.map L).to_basis = b.to_basis.map L.to_linear_equiv :=
 rfl
@@ -737,7 +739,7 @@ def orthonormal_basis.from_orthogonal_span_singleton
 
 section linear_isometry
 
-variables {V : Type*} [inner_product_space 𝕜 V] [finite_dimensional 𝕜 V]
+variables {V : Type*} [normed_add_comm_group V] [inner_product_space 𝕜 V] [finite_dimensional 𝕜 V]
 
 variables {S : submodule 𝕜 V} {L : S →ₗᵢ[𝕜] V}
 

--- a/src/analysis/inner_product_space/positive.lean
+++ b/src/analysis/inner_product_space/positive.lean
@@ -38,8 +38,10 @@ open_locale inner_product complex_conjugate
 
 namespace continuous_linear_map
 
-variables {𝕜 E F : Type*} [is_R_or_C 𝕜] [inner_product_space 𝕜 E] [inner_product_space 𝕜 F]
-  [complete_space E] [complete_space F]
+variables {𝕜 E F : Type*} [is_R_or_C 𝕜]
+variables [normed_add_comm_group E] [normed_add_comm_group F]
+variables [inner_product_space 𝕜 E] [inner_product_space 𝕜 F]
+variables [complete_space E] [complete_space F]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
 /-- A continuous linear endomorphism `T` of a Hilbert space is **positive** if it is self adjoint
@@ -111,7 +113,7 @@ end
 
 section complex
 
-variables {E' : Type*} [inner_product_space ℂ E'] [complete_space E']
+variables {E' : Type*} [normed_add_comm_group E'] [inner_product_space ℂ E'] [complete_space E']
 
 lemma is_positive_iff_complex (T : E' →L[ℂ] E') :
   is_positive T ↔ ∀ x, (re ⟪T x, x⟫_ℂ : ℂ) = ⟪T x, x⟫_ℂ ∧ 0 ≤ re ⟪T x, x⟫_ℂ :=

--- a/src/analysis/inner_product_space/projection.lean
+++ b/src/analysis/inner_product_space/projection.lean
@@ -43,6 +43,7 @@ open is_R_or_C real filter linear_map (ker range)
 open_locale big_operators topology
 
 variables {𝕜 E F : Type*} [is_R_or_C 𝕜]
+variables [normed_add_comm_group E] [normed_add_comm_group F]
 variables [inner_product_space 𝕜 E] [inner_product_space ℝ F]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 local notation `absR` := has_abs.abs
@@ -116,7 +117,7 @@ begin
         have eq₂ : u + u - (wq + wp) = a + b, show u + u - (wq + wp) = (u - wq) + (u - wp), abel,
         rw [eq₁, eq₂],
       end
-      ... = 2 * (‖a‖ * ‖a‖ + ‖b‖ * ‖b‖) : parallelogram_law_with_norm _ _,
+      ... = 2 * (‖a‖ * ‖a‖ + ‖b‖ * ‖b‖) : parallelogram_law_with_norm ℝ _ _,
     have eq : δ ≤ ‖u - half • (wq + wp)‖,
     { rw smul_add,
       apply δ_le', apply h₂,
@@ -204,7 +205,7 @@ begin
       end
       ... = ‖u - v‖^2 - 2 * θ * inner (u - v) (w - v) + θ*θ*‖w - v‖^2 :
       begin
-        rw [norm_sub_sq, inner_smul_right, norm_smul],
+        rw [@norm_sub_sq ℝ, inner_smul_right, norm_smul],
         simp only [sq],
         show ‖u-v‖*‖u-v‖-2*(θ*inner(u-v)(w-v))+absR (θ)*‖w-v‖*(absR (θ)*‖w-v‖)=
                 ‖u-v‖*‖u-v‖-2*θ*inner(u-v)(w-v)+θ*θ*(‖w-v‖*‖w-v‖),
@@ -246,7 +247,7 @@ begin
       ‖u - v‖ * ‖u - v‖ ≤ ‖u - v‖ * ‖u - v‖ - 2 * inner (u - v) ((w:F) - v) : by linarith
       ... ≤ ‖u - v‖^2 - 2 * inner (u - v) ((w:F) - v) + ‖(w:F) - v‖^2 :
         by { rw sq, refine le_add_of_nonneg_right _, exact sq_nonneg _ }
-      ... = ‖(u - v) - (w - v)‖^2 : (norm_sub_sq _ _).symm
+      ... = ‖(u - v) - (w - v)‖^2 : (@norm_sub_sq ℝ _ _ _ _ _ _).symm
       ... = ‖u - w‖ * ‖u - w‖ :
         by { have : (u - v) - (w - v) = u - w, abel, rw [this, sq] } },
   { show (⨅ (w : K), ‖u - w‖) ≤ (λw:K, ‖u - w‖) ⟨v, hv⟩,
@@ -382,7 +383,7 @@ lemma eq_orthogonal_projection_fn_of_mem_of_inner_eq_zero
   {u v : E} (hvm : v ∈ K) (hvo : ∀ w ∈ K, ⟪u - v, w⟫ = 0) :
   orthogonal_projection_fn K u = v :=
 begin
-  rw [←sub_eq_zero, ←inner_self_eq_zero],
+  rw [←sub_eq_zero, ←@inner_self_eq_zero 𝕜],
   have hvs : orthogonal_projection_fn K u - v ∈ K :=
     submodule.sub_mem K (orthogonal_projection_fn_mem u) hvm,
   have huo : ⟪u - orthogonal_projection_fn K u, orthogonal_projection_fn K u - v⟫ = 0 :=
@@ -499,8 +500,10 @@ begin
   { simp }
 end
 
-lemma linear_isometry.map_orthogonal_projection {E E' : Type*} [inner_product_space 𝕜 E]
-  [inner_product_space 𝕜 E'] (f : E →ₗᵢ[𝕜] E') (p : submodule 𝕜 E) [complete_space p]
+lemma linear_isometry.map_orthogonal_projection {E E' : Type*}
+  [normed_add_comm_group E] [normed_add_comm_group E']
+  [inner_product_space 𝕜 E] [inner_product_space 𝕜 E']
+  (f : E →ₗᵢ[𝕜] E') (p : submodule 𝕜 E) [complete_space p]
   (x : E) :
   f (orthogonal_projection p x) = orthogonal_projection (p.map f.to_linear_map) (f x) :=
 begin
@@ -511,8 +514,10 @@ begin
   rw [← f.map_sub, f.inner_map_map, orthogonal_projection_inner_eq_zero x x' hx']
 end
 
-lemma linear_isometry.map_orthogonal_projection' {E E' : Type*} [inner_product_space 𝕜 E]
-  [inner_product_space 𝕜 E'] (f : E →ₗᵢ[𝕜] E') (p : submodule 𝕜 E) [complete_space p]
+lemma linear_isometry.map_orthogonal_projection' {E E' : Type*}
+  [normed_add_comm_group E] [normed_add_comm_group E']
+  [inner_product_space 𝕜 E] [inner_product_space 𝕜 E']
+  (f : E →ₗᵢ[𝕜] E') (p : submodule 𝕜 E) [complete_space p]
   (x : E) :
   f (orthogonal_projection p x) = orthogonal_projection (p.map f) (f x) :=
 begin
@@ -524,8 +529,10 @@ begin
 end
 
 /-- Orthogonal projection onto the `submodule.map` of a subspace. -/
-lemma orthogonal_projection_map_apply {E E' : Type*} [inner_product_space 𝕜 E]
-  [inner_product_space 𝕜 E'] (f : E ≃ₗᵢ[𝕜] E') (p : submodule 𝕜 E) [complete_space p]
+lemma orthogonal_projection_map_apply {E E' : Type*}
+  [normed_add_comm_group E] [normed_add_comm_group E']
+  [inner_product_space 𝕜 E] [inner_product_space 𝕜 E']
+  (f : E ≃ₗᵢ[𝕜] E') (p : submodule 𝕜 E) [complete_space p]
   (x : E') :
   (orthogonal_projection (p.map (f.to_linear_equiv : E →ₗ[𝕜] E')) x : E')
   = f (orthogonal_projection p (f.symm x)) :=
@@ -554,7 +561,7 @@ begin
     use ⟪v, w⟫ },
   { intros x hx,
     obtain ⟨c, rfl⟩ := submodule.mem_span_singleton.mp hx,
-    have hv : ↑‖v‖ ^ 2 = ⟪v, v⟫ := by { norm_cast, simp [norm_sq_eq_inner] },
+    have hv : ↑‖v‖ ^ 2 = ⟪v, v⟫ := by { norm_cast, simp [@norm_sq_eq_inner 𝕜] },
     simp [inner_sub_left, inner_smul_left, inner_smul_right, map_div₀, mul_comm, hv,
       inner_product_space.conj_symm, hv] }
 end
@@ -658,13 +665,17 @@ lemma reflection_mem_subspace_eq_self {x : E} (hx : x ∈ K) : reflection K x = 
 (reflection_eq_self_iff x).mpr hx
 
 /-- Reflection in the `submodule.map` of a subspace. -/
-lemma reflection_map_apply {E E' : Type*} [inner_product_space 𝕜 E] [inner_product_space 𝕜 E']
+lemma reflection_map_apply {E E' : Type*}
+  [normed_add_comm_group E] [normed_add_comm_group E']
+  [inner_product_space 𝕜 E] [inner_product_space 𝕜 E']
   (f : E ≃ₗᵢ[𝕜] E') (K : submodule 𝕜 E) [complete_space K] (x : E') :
   reflection (K.map (f.to_linear_equiv : E →ₗ[𝕜] E')) x = f (reflection K (f.symm x)) :=
 by simp [bit0, reflection_apply, orthogonal_projection_map_apply f K x]
 
 /-- Reflection in the `submodule.map` of a subspace. -/
-lemma reflection_map {E E' : Type*} [inner_product_space 𝕜 E] [inner_product_space 𝕜 E']
+lemma reflection_map {E E' : Type*}
+  [normed_add_comm_group E] [normed_add_comm_group E']
+  [inner_product_space 𝕜 E] [inner_product_space 𝕜 E']
   (f : E ≃ₗᵢ[𝕜] E') (K : submodule 𝕜 E) [complete_space K] :
   reflection (K.map (f.to_linear_equiv : E →ₗ[𝕜] E')) = f.symm.trans ((reflection K).trans f) :=
 linear_isometry_equiv.ext $ reflection_map_apply f K

--- a/src/analysis/inner_product_space/rayleigh.lean
+++ b/src/analysis/inner_product_space/rayleigh.lean
@@ -35,7 +35,7 @@ A slightly more elaborate corollary is that if `E` is complete and `T` is a comp
 -/
 
 variables {𝕜 : Type*} [is_R_or_C 𝕜]
-variables {E : Type*} [inner_product_space 𝕜 E]
+variables {E : Type*} [normed_add_comm_group E] [inner_product_space 𝕜 E]
 
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 open_locale nnreal
@@ -89,7 +89,7 @@ end continuous_linear_map
 namespace is_self_adjoint
 
 section real
-variables {F : Type*} [inner_product_space ℝ F]
+variables {F : Type*} [normed_add_comm_group F] [inner_product_space ℝ F]
 
 lemma _root_.linear_map.is_symmetric.has_strict_fderiv_at_re_apply_inner_self
   {T : F →L[ℝ] F} (hT : (T : F →ₗ[ℝ] F).is_symmetric) (x₀ : F) :

--- a/src/analysis/inner_product_space/rayleigh.lean
+++ b/src/analysis/inner_product_space/rayleigh.lean
@@ -95,7 +95,7 @@ lemma _root_.linear_map.is_symmetric.has_strict_fderiv_at_re_apply_inner_self
   {T : F →L[ℝ] F} (hT : (T : F →ₗ[ℝ] F).is_symmetric) (x₀ : F) :
   has_strict_fderiv_at T.re_apply_inner_self (_root_.bit0 (innerSL ℝ (T x₀))) x₀ :=
 begin
-  convert T.has_strict_fderiv_at.inner (has_strict_fderiv_at_id x₀),
+  convert T.has_strict_fderiv_at.inner _ (has_strict_fderiv_at_id x₀),
   ext y,
   simp_rw [_root_.bit0, continuous_linear_map.comp_apply, continuous_linear_map.add_apply,
     innerSL_apply, fderiv_inner_clm_apply, id.def, continuous_linear_map.prod_apply,

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -44,7 +44,7 @@ self-adjoint operator, spectral theorem, diagonalization theorem
 -/
 
 variables {𝕜 : Type*} [is_R_or_C 𝕜] [dec_𝕜 : decidable_eq 𝕜]
-variables {E : Type*} [inner_product_space 𝕜 E]
+variables {E : Type*} [normed_add_comm_group E] [inner_product_space 𝕜 E]
 
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 E _ x y
 

--- a/src/analysis/inner_product_space/symmetric.lean
+++ b/src/analysis/inner_product_space/symmetric.lean
@@ -35,8 +35,10 @@ open is_R_or_C
 open_locale complex_conjugate
 
 variables {𝕜 E E' F G : Type*} [is_R_or_C 𝕜]
-variables [inner_product_space 𝕜 E] [inner_product_space 𝕜 F] [inner_product_space 𝕜 G]
-variables [inner_product_space ℝ E']
+variables [normed_add_comm_group E] [inner_product_space 𝕜 E]
+variables [normed_add_comm_group F] [inner_product_space 𝕜 F]
+variables [normed_add_comm_group G] [inner_product_space 𝕜 G]
+variables [normed_add_comm_group E'] [inner_product_space ℝ E']
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
 namespace linear_map
@@ -89,7 +91,7 @@ lemma is_symmetric.continuous [complete_space E] {T : E →ₗ[𝕜] E} (hT : is
 begin
   -- We prove it by using the closed graph theorem
   refine T.continuous_of_seq_closed_graph (λ u x y hu hTu, _),
-  rw [←sub_eq_zero, ←inner_self_eq_zero],
+  rw [←sub_eq_zero, ←@inner_self_eq_zero 𝕜],
   have hlhs : ∀ k : ℕ, ⟪T (u k) - T x, y - T x⟫ = ⟪u k - x, T (y - T x)⟫ :=
   by { intro k, rw [←T.map_sub, hT] },
   refine tendsto_nhds_unique ((hTu.sub_const _).inner tendsto_const_nhds) _,
@@ -119,7 +121,7 @@ lemma is_symmetric.restrict_invariant {T : E →ₗ[𝕜] E} (hT : is_symmetric 
 λ v w, hT v w
 
 lemma is_symmetric.restrict_scalars {T : E →ₗ[𝕜] E} (hT : T.is_symmetric) :
-  @linear_map.is_symmetric ℝ E _ (inner_product_space.is_R_or_C_to_real 𝕜 E)
+  @linear_map.is_symmetric ℝ E _ _ (inner_product_space.is_R_or_C_to_real 𝕜 E)
   (@linear_map.restrict_scalars ℝ 𝕜 _ _ _ _ _ _
     (inner_product_space.is_R_or_C_to_real 𝕜 E).to_module
     (inner_product_space.is_R_or_C_to_real 𝕜 E).to_module _ _ _ T) :=
@@ -128,7 +130,7 @@ lemma is_symmetric.restrict_scalars {T : E →ₗ[𝕜] E} (hT : T.is_symmetric)
 section complex
 
 variables {V : Type*}
-  [inner_product_space ℂ V]
+  [normed_add_comm_group V] [inner_product_space ℂ V]
 
 /-- A linear operator on a complex inner product space is symmetric precisely when
 `⟪T v, v⟫_ℂ` is real for all v.-/

--- a/src/analysis/inner_product_space/two_dim.lean
+++ b/src/analysis/inner_product_space/two_dim.lean
@@ -71,7 +71,7 @@ open finite_dimensional
 
 local attribute [instance] fact_finite_dimensional_of_finrank_eq_succ
 
-variables {E : Type*} [inner_product_space ℝ E] [fact (finrank ℝ E = 2)]
+variables {E : Type*} [normed_add_comm_group E] [inner_product_space ℝ E] [fact (finrank ℝ E = 2)]
   (o : orientation ℝ E (fin 2))
 
 namespace orientation
@@ -147,7 +147,8 @@ begin
   { simpa }
 end
 
-lemma area_form_map {F : Type*} [inner_product_space ℝ F] [fact (finrank ℝ F = 2)]
+lemma area_form_map {F : Type*}
+  [normed_add_comm_group F] [inner_product_space ℝ F] [fact (finrank ℝ F = 2)]
   (φ : E ≃ₗᵢ[ℝ] F) (x y : F) :
   (orientation.map (fin 2) φ.to_linear_equiv o).area_form x y = o.area_form (φ.symm x) (φ.symm y) :=
 begin
@@ -308,7 +309,8 @@ end
   (-o).right_angle_rotation = o.right_angle_rotation.trans (linear_isometry_equiv.neg ℝ) :=
 linear_isometry_equiv.ext $ o.right_angle_rotation_neg_orientation
 
-lemma right_angle_rotation_map {F : Type*} [inner_product_space ℝ F] [fact (finrank ℝ F = 2)]
+lemma right_angle_rotation_map {F : Type*}
+  [normed_add_comm_group F] [inner_product_space ℝ F] [fact (finrank ℝ F = 2)]
   (φ : E ≃ₗᵢ[ℝ] F) (x : F) :
   (orientation.map (fin 2) φ.to_linear_equiv o).right_angle_rotation x
   = φ (o.right_angle_rotation (φ.symm x)) :=
@@ -335,7 +337,8 @@ begin
     rw [fact.out (finrank ℝ E = 2), fintype.card_fin] },
 end
 
-lemma right_angle_rotation_map' {F : Type*} [inner_product_space ℝ F] [fact (finrank ℝ F = 2)]
+lemma right_angle_rotation_map' {F : Type*}
+  [normed_add_comm_group F] [inner_product_space ℝ F] [fact (finrank ℝ F = 2)]
   (φ : E ≃ₗᵢ[ℝ] F) :
   (orientation.map (fin 2) φ.to_linear_equiv o).right_angle_rotation
   = (φ.symm.trans o.right_angle_rotation).trans φ :=
@@ -556,7 +559,8 @@ begin
   simp,
 end
 
-lemma kahler_map {F : Type*} [inner_product_space ℝ F] [fact (finrank ℝ F = 2)]
+lemma kahler_map {F : Type*}
+  [normed_add_comm_group F] [inner_product_space ℝ F] [fact (finrank ℝ F = 2)]
   (φ : E ≃ₗᵢ[ℝ] F) (x y : F) :
   (orientation.map (fin 2) φ.to_linear_equiv o).kahler x y = o.kahler (φ.symm x) (φ.symm y) :=
 by simp [kahler_apply_apply, area_form_map]

--- a/src/analysis/matrix.lean
+++ b/src/analysis/matrix.lean
@@ -453,7 +453,7 @@ begin
   rw [← nnreal.rpow_le_rpow_iff one_half_pos, ← nnreal.rpow_mul,
     mul_div_cancel' (1 : ℝ) two_ne_zero, nnreal.rpow_one, nnreal.mul_rpow],
   dsimp only,
-  have := @nnnorm_inner_le_nnnorm α _ _ _
+  have := @nnnorm_inner_le_nnnorm α _ _ _ _
     ((pi_Lp.equiv 2 (λ i, α)).symm (λ j, star (A i j)))
     ((pi_Lp.equiv 2 (λ i, α)).symm (λ k, B k j)),
   simpa only [pi_Lp.equiv_symm_apply, pi_Lp.inner_apply,

--- a/src/analysis/quaternion.lean
+++ b/src/analysis/quaternion.lean
@@ -41,14 +41,17 @@ lemma inner_self (a : ℍ) : ⟪a, a⟫ = norm_sq a := rfl
 
 lemma inner_def (a b : ℍ) : ⟪a, b⟫ = (a * b.conj).re := rfl
 
-noncomputable instance : inner_product_space ℝ ℍ :=
-inner_product_space.of_core
+noncomputable instance : normed_add_comm_group ℍ :=
+@inner_product_space.of_core.to_normed_add_comm_group ℝ ℍ _ _ _
 { inner := has_inner.inner,
   conj_symm := λ x y, by simp [inner_def, mul_comm],
   nonneg_re := λ x, norm_sq_nonneg,
   definite := λ x, norm_sq_eq_zero.1,
   add_left := λ x y z, by simp only [inner_def, add_mul, add_re],
   smul_left := λ x y r, by simp [inner_def] }
+
+noncomputable instance : inner_product_space ℝ ℍ :=
+inner_product_space.of_core _
 
 lemma norm_sq_eq_norm_sq (a : ℍ) : norm_sq a = ‖a‖ * ‖a‖ :=
 by rw [← inner_self, real_inner_self_eq_norm_mul_norm]

--- a/src/analysis/von_neumann_algebra/basic.lean
+++ b/src/analysis/von_neumann_algebra/basic.lean
@@ -65,7 +65,8 @@ Thus we can't say that the bounded operators `H →L[ℂ] H` form a `von_neumann
 and instead will use `⊤ : von_neumann_algebra H`.
 -/
 @[nolint has_nonempty_instance]
-structure von_neumann_algebra (H : Type u) [inner_product_space ℂ H] [complete_space H] extends
+structure von_neumann_algebra (H : Type u)
+  [normed_add_comm_group H] [inner_product_space ℂ H] [complete_space H] extends
   star_subalgebra ℂ (H →L[ℂ] H) :=
 (centralizer_centralizer' :
   set.centralizer (set.centralizer carrier) = carrier)
@@ -78,7 +79,7 @@ or equivalently that it is closed in the weak and strong operator topologies.)
 add_decl_doc von_neumann_algebra.to_star_subalgebra
 
 namespace von_neumann_algebra
-variables {H : Type u} [inner_product_space ℂ H] [complete_space H]
+variables {H : Type u} [normed_add_comm_group H] [inner_product_space ℂ H] [complete_space H]
 
 instance : set_like (von_neumann_algebra H) (H →L[ℂ] H) :=
 ⟨von_neumann_algebra.carrier, λ S T h, by cases S; cases T; congr'⟩

--- a/src/geometry/euclidean/angle/oriented/affine.lean
+++ b/src/geometry/euclidean/angle/oriented/affine.lean
@@ -26,8 +26,9 @@ open_locale affine euclidean_geometry real real_inner_product_space complex_conj
 
 namespace euclidean_geometry
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-variables [normed_add_torsor V P] [hd2 : fact (finrank ℝ V = 2)] [module.oriented ℝ V (fin 2)]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
+  [hd2 : fact (finrank ℝ V = 2)] [module.oriented ℝ V (fin 2)]
 include hd2
 
 local notation `o` := module.oriented.positive_orientation
@@ -596,10 +597,10 @@ begin
     { rw [@dist_eq_norm_vsub' V, @dist_eq_norm_vsub' V,
           ←mul_self_inj (norm_nonneg _) (norm_nonneg _), ←real_inner_self_eq_norm_mul_norm,
           ←real_inner_self_eq_norm_mul_norm] at hd,
-      simp_rw [vsub_midpoint, ←vsub_sub_vsub_cancel_left p₂ p₁ p, inner_sub_left, 
+      simp_rw [vsub_midpoint, ←vsub_sub_vsub_cancel_left p₂ p₁ p, inner_sub_left,
                inner_add_right, inner_smul_right, hd, real_inner_comm (p -ᵥ p₁)],
       abel },
-    rw [@orientation.inner_eq_zero_iff_eq_zero_or_eq_smul_rotation_pi_div_two V _ _ o,
+    rw [@orientation.inner_eq_zero_iff_eq_zero_or_eq_smul_rotation_pi_div_two V _ _ _ o,
         or_iff_right (vsub_ne_zero.2 h.symm)] at hi,
     rcases hi with ⟨r, hr⟩,
     rw [eq_comm, ←eq_vadd_iff_vsub_eq] at hr,

--- a/src/geometry/euclidean/angle/oriented/basic.lean
+++ b/src/geometry/euclidean/angle/oriented/basic.lean
@@ -39,7 +39,9 @@ namespace orientation
 local attribute [instance] fact_finite_dimensional_of_finrank_eq_succ
 local attribute [instance] complex.finrank_real_complex_fact
 
-variables {V V' : Type*} [inner_product_space ℝ V] [inner_product_space ℝ V']
+variables {V V' : Type*}
+variables [normed_add_comm_group V] [normed_add_comm_group V']
+variables [inner_product_space ℝ V] [inner_product_space ℝ V']
 variables [fact (finrank ℝ V = 2)] [fact (finrank ℝ V' = 2)] (o : orientation ℝ V (fin 2))
 
 local notation `ω` := o.area_form

--- a/src/geometry/euclidean/angle/oriented/right_angle.lean
+++ b/src/geometry/euclidean/angle/oriented/right_angle.lean
@@ -24,7 +24,7 @@ namespace orientation
 
 open finite_dimensional
 
-variables {V : Type*} [inner_product_space ℝ V]
+variables {V : Type*} [normed_add_comm_group V] [inner_product_space ℝ V]
 variables [hd2 : fact (finrank ℝ V = 2)] (o : orientation ℝ V (fin 2))
 include hd2 o
 
@@ -625,8 +625,9 @@ namespace euclidean_geometry
 
 open finite_dimensional
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-variables [normed_add_torsor V P] [hd2 : fact (finrank ℝ V = 2)] [module.oriented ℝ V (fin 2)]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
+  [hd2 : fact (finrank ℝ V = 2)] [module.oriented ℝ V (fin 2)]
 include hd2
 
 /-- An angle in a right-angled triangle expressed using `arccos`. -/

--- a/src/geometry/euclidean/angle/oriented/rotation.lean
+++ b/src/geometry/euclidean/angle/oriented/rotation.lean
@@ -26,7 +26,9 @@ namespace orientation
 local attribute [instance] fact_finite_dimensional_of_finrank_eq_succ
 local attribute [instance] complex.finrank_real_complex_fact
 
-variables {V V' : Type*} [inner_product_space ℝ V] [inner_product_space ℝ V']
+variables {V V' : Type*}
+variables [normed_add_comm_group V] [normed_add_comm_group V']
+variables [inner_product_space ℝ V] [inner_product_space ℝ V']
 variables [fact (finrank ℝ V = 2)] [fact (finrank ℝ V' = 2)] (o : orientation ℝ V (fin 2))
 
 local notation `J` := o.right_angle_rotation

--- a/src/geometry/euclidean/angle/sphere.lean
+++ b/src/geometry/euclidean/angle/sphere.lean
@@ -20,7 +20,7 @@ open_locale euclidean_geometry real real_inner_product_space complex_conjugate
 
 namespace orientation
 
-variables {V : Type*} [inner_product_space ℝ V]
+variables {V : Type*} [normed_add_comm_group V] [inner_product_space ℝ V]
 variables [fact (finrank ℝ V = 2)] (o : orientation ℝ V (fin 2))
 
 /-- Angle at center of a circle equals twice angle at circumference, oriented vector angle
@@ -67,8 +67,9 @@ end orientation
 
 namespace euclidean_geometry
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-variables [normed_add_torsor V P] [hd2 : fact (finrank ℝ V = 2)] [module.oriented ℝ V (fin 2)]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
+  [hd2 : fact (finrank ℝ V = 2)] [module.oriented ℝ V (fin 2)]
 include hd2
 
 local notation `o` := module.oriented.positive_orientation
@@ -248,8 +249,9 @@ namespace triangle
 
 open euclidean_geometry
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-variables [normed_add_torsor V P] [hd2 : fact (finrank ℝ V = 2)] [module.oriented ℝ V (fin 2)]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
+  [hd2 : fact (finrank ℝ V = 2)] [module.oriented ℝ V (fin 2)]
 include hd2
 
 local notation `o` := module.oriented.positive_orientation
@@ -353,8 +355,9 @@ end affine
 
 namespace euclidean_geometry
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-variables [normed_add_torsor V P] [hd2 : fact (finrank ℝ V = 2)] [module.oriented ℝ V (fin 2)]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
+  [hd2 : fact (finrank ℝ V = 2)] [module.oriented ℝ V (fin 2)]
 include hd2
 
 local notation `o` := module.oriented.positive_orientation

--- a/src/geometry/euclidean/angle/unoriented/affine.lean
+++ b/src/geometry/euclidean/angle/unoriented/affine.lean
@@ -27,8 +27,8 @@ namespace euclidean_geometry
 
 open inner_product_geometry
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-    [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 include V
 
 /-- The undirected angle at `p2` between the line segments to `p1` and
@@ -50,7 +50,8 @@ begin
       (continuous_snd.snd.vsub continuous_snd.fst)).continuous_at
 end
 
-@[simp] lemma _root_.affine_isometry.angle_map {V₂ P₂ : Type*} [inner_product_space ℝ V₂]
+@[simp] lemma _root_.affine_isometry.angle_map {V₂ P₂ : Type*}
+  [normed_add_comm_group V₂] [inner_product_space ℝ V₂]
   [metric_space P₂] [normed_add_torsor V₂ P₂] (f : P →ᵃⁱ[ℝ] P₂) (p₁ p₂ p₃ : P) :
   ∠ (f p₁) (f p₂) (f p₃) = ∠ p₁ p₂ p₃ :=
 by simp_rw [angle, ←affine_isometry.map_vsub, linear_isometry.angle_map]

--- a/src/geometry/euclidean/angle/unoriented/basic.lean
+++ b/src/geometry/euclidean/angle/unoriented/basic.lean
@@ -28,7 +28,7 @@ open_locale real_inner_product_space
 
 namespace inner_product_geometry
 
-variables {V : Type*} [inner_product_space ℝ V] {x y : V}
+variables {V : Type*} [normed_add_comm_group V] [inner_product_space ℝ V] {x y : V}
 
 /-- The undirected angle between two vectors. If either vector is 0,
 this is π/2. See `orientation.oangle` for the corresponding oriented angle
@@ -48,6 +48,7 @@ by rw [angle, angle, real_inner_smul_left, inner_smul_right, norm_smul, norm_smu
   mul_mul_mul_comm _ (‖x‖), abs_mul_abs_self, ← mul_assoc c c, mul_div_mul_left _ _ this]
 
 @[simp] lemma _root_.linear_isometry.angle_map {E F : Type*}
+  [normed_add_comm_group E] [normed_add_comm_group F]
   [inner_product_space ℝ E] [inner_product_space ℝ F] (f : E →ₗᵢ[ℝ] F) (u v : E) :
   angle (f u) (f v) = angle u v :=
 by rw [angle, angle, f.inner_map_map, f.norm_map, f.norm_map]
@@ -112,7 +113,8 @@ end
 @[simp] lemma angle_self {x : V} (hx : x ≠ 0) : angle x x = 0 :=
 begin
   unfold angle,
-  rw [←real_inner_self_eq_norm_mul_norm, div_self (inner_self_ne_zero.2 hx), real.arccos_one]
+  rw [←real_inner_self_eq_norm_mul_norm, div_self (inner_self_ne_zero.2 hx : ⟪x, x⟫ ≠ 0),
+    real.arccos_one]
 end
 
 /-- The angle between a nonzero vector and its negation. -/

--- a/src/geometry/euclidean/angle/unoriented/conformal.lean
+++ b/src/geometry/euclidean/angle/unoriented/conformal.lean
@@ -15,11 +15,11 @@ This file proves that conformal maps preserve angles.
 
 namespace inner_product_geometry
 
-variables {V : Type*} [inner_product_space ℝ V]
+variables {E F : Type*}
+variables [normed_add_comm_group E] [normed_add_comm_group F]
+variables [inner_product_space ℝ E] [inner_product_space ℝ F]
 
-lemma is_conformal_map.preserves_angle {E F : Type*}
-  [inner_product_space ℝ E] [inner_product_space ℝ F]
-  {f' : E →L[ℝ] F} (h : is_conformal_map f') (u v : E) :
+lemma is_conformal_map.preserves_angle {f' : E →L[ℝ] F} (h : is_conformal_map f') (u v : E) :
   angle (f' u) (f' v) = angle u v :=
 begin
   obtain ⟨c, hc, li, rfl⟩ := h,
@@ -28,9 +28,7 @@ end
 
 /-- If a real differentiable map `f` is conformal at a point `x`,
     then it preserves the angles at that point. -/
-lemma conformal_at.preserves_angle {E F : Type*}
-  [inner_product_space ℝ E] [inner_product_space ℝ F]
-  {f : E → F} {x : E} {f' : E →L[ℝ] F}
+lemma conformal_at.preserves_angle {f : E → F} {x : E} {f' : E →L[ℝ] F}
   (h : has_fderiv_at f f' x) (H : conformal_at f x) (u v : E) :
   angle (f' u) (f' v) = angle u v :=
 let ⟨f₁, h₁, c⟩ := H in h₁.unique h ▸ is_conformal_map.preserves_angle c u v

--- a/src/geometry/euclidean/angle/unoriented/right_angle.lean
+++ b/src/geometry/euclidean/angle/unoriented/right_angle.lean
@@ -32,7 +32,7 @@ open_locale real_inner_product_space
 
 namespace inner_product_geometry
 
-variables {V : Type*} [inner_product_space ℝ V]
+variables {V : Type*} [normed_add_comm_group V] [inner_product_space ℝ V]
 
 /-- Pythagorean theorem, if-and-only-if vector angle form. -/
 lemma norm_add_sq_eq_norm_sq_add_norm_sq_iff_angle_eq_pi_div_two (x y : V) :
@@ -387,8 +387,8 @@ namespace euclidean_geometry
 
 open inner_product_geometry
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-    [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 include V
 
 /-- **Pythagorean theorem**, if-and-only-if angle-at-point form. -/

--- a/src/geometry/euclidean/basic.lean
+++ b/src/geometry/euclidean/basic.lean
@@ -27,8 +27,9 @@ proofs or more geometrical content generally go in separate files.
 ## Implementation notes
 
 To declare `P` as the type of points in a Euclidean affine space with
-`V` as the type of vectors, use `[inner_product_space ℝ V] [metric_space P]
-[normed_add_torsor V P]`.  This works better with `out_param` to make
+`V` as the type of vectors, use
+`[normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]`.
+This works better with `out_param` to make
 `V` implicit in most cases than having a separate type alias for
 Euclidean affine spaces.
 
@@ -55,8 +56,9 @@ This section develops some geometrical definitions and results on
 Euclidean affine spaces.
 -/
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-    [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+variables [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P]
+variables [normed_add_torsor V P]
 include V
 
 /-- The midpoint of the segment AB is the same distance from A as it is from B. -/
@@ -89,7 +91,7 @@ lemma dist_affine_combination {ι : Type*} {s : finset ι} {w₁ w₂ : ι → �
       (w₁ - w₂) i₁ * (w₁ - w₂) i₂ * (dist (p i₁) (p i₂) * dist (p i₁) (p i₂))) / 2 :=
 begin
   rw [dist_eq_norm_vsub V (s.affine_combination p w₁) (s.affine_combination p w₂),
-      ←inner_self_eq_norm_mul_norm, finset.affine_combination_vsub],
+      ←@inner_self_eq_norm_mul_norm ℝ, finset.affine_combination_vsub],
   have h : ∑ i in s, (w₁ - w₂) i = 0,
   { simp_rw [pi.sub_apply, finset.sum_sub_distrib, h₁, h₂, sub_self] },
   exact inner_weighted_vsub p h p h

--- a/src/geometry/euclidean/circumcenter.lean
+++ b/src/geometry/euclidean/circumcenter.lean
@@ -34,8 +34,8 @@ open_locale real_inner_product_space
 
 namespace euclidean_geometry
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-    [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 include V
 
 open affine_subspace
@@ -252,8 +252,8 @@ namespace simplex
 
 open finset affine_subspace euclidean_geometry
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-    [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 include V
 
 /-- The circumsphere of a simplex. -/
@@ -735,8 +735,8 @@ namespace euclidean_geometry
 
 open affine affine_subspace finite_dimensional
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-    [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 include V
 
 /-- Given a nonempty affine subspace, whose direction is complete,

--- a/src/geometry/euclidean/inversion.lean
+++ b/src/geometry/euclidean/inversion.lean
@@ -25,7 +25,8 @@ open metric real function
 
 namespace euclidean_geometry
 
-variables {V P : Type*} [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
+variables {V P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
   {a b c d x y z : P} {R : ℝ}
 
 include V

--- a/src/geometry/euclidean/monge_point.lean
+++ b/src/geometry/euclidean/monge_point.lean
@@ -57,8 +57,8 @@ namespace simplex
 
 open finset affine_subspace euclidean_geometry points_with_circumcenter_index
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-    [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 include V
 
 /-- The Monge point of a simplex (in 2 or more dimensions) is a
@@ -443,8 +443,8 @@ namespace triangle
 
 open euclidean_geometry finset simplex affine_subspace finite_dimensional
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-    [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 include V
 
 /-- The orthocenter of a triangle is the intersection of its
@@ -626,8 +626,8 @@ namespace euclidean_geometry
 
 open affine affine_subspace finite_dimensional
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-    [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 
 include V
 

--- a/src/geometry/euclidean/sphere/basic.lean
+++ b/src/geometry/euclidean/sphere/basic.lean
@@ -185,7 +185,8 @@ lemma concyclic_pair (p₁ p₂ : P) : concyclic ({p₁, p₂} : set P) :=
 end normed_space
 
 section euclidean_space
-variables [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
+variables
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 include V
 
 /-- Any three points in a cospherical set are affinely independent. -/

--- a/src/geometry/euclidean/sphere/power.lean
+++ b/src/geometry/euclidean/sphere/power.lean
@@ -21,7 +21,7 @@ secants) in spheres in real inner product spaces and Euclidean affine spaces.
 open real
 open_locale euclidean_geometry real_inner_product_space real
 
-variables {V : Type*} [inner_product_space ℝ V]
+variables {V : Type*} [normed_add_comm_group V] [inner_product_space ℝ V]
 
 namespace inner_product_geometry
 

--- a/src/geometry/euclidean/sphere/ptolemy.lean
+++ b/src/geometry/euclidean/sphere/ptolemy.lean
@@ -42,7 +42,7 @@ open_locale euclidean_geometry real_inner_product_space real
 
 namespace euclidean_geometry
 
-variables {V : Type*} [inner_product_space ℝ V]
+variables {V : Type*} [normed_add_comm_group V] [inner_product_space ℝ V]
 variables {P : Type*} [metric_space P] [normed_add_torsor V P]
 include V
 

--- a/src/geometry/euclidean/sphere/second_inter.lean
+++ b/src/geometry/euclidean/sphere/second_inter.lean
@@ -23,7 +23,8 @@ open_locale real_inner_product_space
 
 namespace euclidean_geometry
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 include V
 
 /-- The second intersection of a sphere with a line through a point on that sphere; that point

--- a/src/geometry/euclidean/triangle.lean
+++ b/src/geometry/euclidean/triangle.lean
@@ -50,7 +50,7 @@ most conveniently be developed in terms of vectors and then used to
 deduce corresponding results for Euclidean affine spaces.
 -/
 
-variables {V : Type*} [inner_product_space ℝ V]
+variables {V : Type*} [normed_add_comm_group V] [inner_product_space ℝ V]
 
 /-- Law of cosines (cosine rule), vector angle form. -/
 lemma norm_sub_sq_eq_norm_sq_add_norm_sq_sub_two_mul_norm_mul_norm_mul_cos_angle
@@ -262,8 +262,8 @@ open inner_product_geometry
 
 open_locale euclidean_geometry
 
-variables {V : Type*} {P : Type*} [inner_product_space ℝ V] [metric_space P]
-    [normed_add_torsor V P]
+variables {V : Type*} {P : Type*}
+  [normed_add_comm_group V] [inner_product_space ℝ V] [metric_space P] [normed_add_torsor V P]
 include V
 
 /-- **Law of cosines** (cosine rule), angle-at-point form. -/

--- a/src/geometry/manifold/instances/sphere.lean
+++ b/src/geometry/manifold/instances/sphere.lean
@@ -162,7 +162,7 @@ end
 
 lemma cont_diff_stereo_inv_fun_aux : cont_diff ℝ ⊤ (stereo_inv_fun_aux v) :=
 begin
-  have h₀ : cont_diff ℝ ⊤ (λ w : E, ‖w‖ ^ 2) := cont_diff_norm_sq,
+  have h₀ : cont_diff ℝ ⊤ (λ w : E, ‖w‖ ^ 2) := cont_diff_norm_sq _,
   have h₁ : cont_diff ℝ ⊤ (λ w : E, (‖w‖ ^ 2 + 4)⁻¹),
   { refine (h₀.add cont_diff_const).inv _,
     intros x,

--- a/src/geometry/manifold/instances/sphere.lean
+++ b/src/geometry/manifold/instances/sphere.lean
@@ -55,7 +55,7 @@ naive expression `euclidean_space ℝ (fin (finrank ℝ E - 1))` for the model s
 `euclidean_space ℝ (fin 1)`.
 -/
 
-variables {E : Type*} [inner_product_space ℝ E]
+variables {E : Type*} [normed_add_comm_group E] [inner_product_space ℝ E]
 
 noncomputable theory
 
@@ -95,7 +95,7 @@ end
 
 lemma continuous_on_stereo_to_fun [complete_space E] :
   continuous_on (stereo_to_fun v) {x : E | innerSL _ v x ≠ (1:ℝ)} :=
-(@cont_diff_on_stereo_to_fun E _ v _).continuous_on
+(@cont_diff_on_stereo_to_fun E _ _ v _).continuous_on
 
 variables (v)
 
@@ -162,7 +162,7 @@ end
 
 lemma cont_diff_stereo_inv_fun_aux : cont_diff ℝ ⊤ (stereo_inv_fun_aux v) :=
 begin
-  have h₀ : cont_diff ℝ ⊤ (λ w : E, ‖w‖ ^ 2) := cont_diff_norm_sq _,
+  have h₀ : cont_diff ℝ ⊤ (λ w : E, ‖w‖ ^ 2) := cont_diff_norm_sq ℝ,
   have h₁ : cont_diff ℝ ⊤ (λ w : E, (‖w‖ ^ 2 + 4)⁻¹),
   { refine (h₀.add cont_diff_const).inv _,
     intros x,
@@ -417,7 +417,7 @@ begin
   split,
   { exact continuous_subtype_coe },
   { intros v _,
-    let U := -- Again, removing type ascription...
+    let U : _ ≃ₗᵢ[ℝ] _ := -- Again, partially removing type ascription...
       (orthonormal_basis.from_orthogonal_span_singleton n
         (ne_zero_of_mem_unit_sphere (-v))).repr,
     exact ((cont_diff_stereo_inv_fun_aux.comp
@@ -438,7 +438,7 @@ begin
   rw cont_mdiff_iff_target,
   refine ⟨continuous_induced_rng.2 hf.continuous, _⟩,
   intros v,
-  let U := -- Again, removing type ascription... Weird that this helps!
+  let U : _ ≃ₗᵢ[ℝ] _ := -- Again, partially removing type ascription... Weird that this helps!
     (orthonormal_basis.from_orthogonal_span_singleton n (ne_zero_of_mem_unit_sphere (-v))).repr,
   have h : cont_diff_on ℝ ⊤ _ set.univ :=
     U.cont_diff.cont_diff_on,

--- a/src/linear_algebra/matrix/ldl.lean
+++ b/src/linear_algebra/matrix/ldl.lean
@@ -41,11 +41,13 @@ applying Gram-Schmidt-Orthogonalization w.r.t. the inner product induced by `S�
 basis vectors `pi.basis_fun`. -/
 noncomputable def LDL.lower_inv : matrix n n 𝕜 :=
 @gram_schmidt
-  𝕜 (n → 𝕜) _ (inner_product_space.of_matrix hS.transpose) n _ _ _ (pi.basis_fun 𝕜 n)
+  𝕜 (n → 𝕜) _
+  (_ : _)
+  (inner_product_space.of_matrix hS.transpose) n _ _ _ (pi.basis_fun 𝕜 n)
 
 lemma LDL.lower_inv_eq_gram_schmidt_basis :
   LDL.lower_inv hS = ((pi.basis_fun 𝕜 n).to_matrix
-    (@gram_schmidt_basis 𝕜 (n → 𝕜) _
+    (@gram_schmidt_basis 𝕜 (n → 𝕜) _ (_ : _)
     (inner_product_space.of_matrix hS.transpose) n _ _ _ (pi.basis_fun 𝕜 n)))ᵀ :=
 begin
   ext i j,
@@ -57,17 +59,14 @@ noncomputable instance LDL.invertible_lower_inv : invertible (LDL.lower_inv hS) 
 begin
   rw [LDL.lower_inv_eq_gram_schmidt_basis],
   haveI := basis.invertible_to_matrix (pi.basis_fun 𝕜 n)
-    (@gram_schmidt_basis 𝕜 (n → 𝕜) _ (inner_product_space.of_matrix hS.transpose)
+    (@gram_schmidt_basis 𝕜 (n → 𝕜) _ (_ : _) (inner_product_space.of_matrix hS.transpose)
       n _ _ _ (pi.basis_fun 𝕜 n)),
   apply_instance
 end
 
 lemma LDL.lower_inv_orthogonal {i j : n} (h₀ : i ≠ j) :
   ⟪(LDL.lower_inv hS i), Sᵀ.mul_vec (LDL.lower_inv hS j)⟫ₑ = 0 :=
-show @inner 𝕜 (n → 𝕜) (inner_product_space.of_matrix hS.transpose).to_has_inner
-    (LDL.lower_inv hS i)
-    (LDL.lower_inv hS j) = 0,
-by apply gram_schmidt_orthogonal _ _ h₀
+@gram_schmidt_orthogonal 𝕜 _ _ (_ : _) (inner_product_space.of_matrix hS.transpose) _ _ _ _ _ _ _ h₀
 
 /-- The entries of the diagonal matrix `D` of the LDL decomposition. -/
 noncomputable def LDL.diag_entries : n → 𝕜 :=
@@ -78,7 +77,8 @@ noncomputable def LDL.diag : matrix n n 𝕜 := matrix.diagonal (LDL.diag_entrie
 
 lemma LDL.lower_inv_triangular {i j : n} (hij : i < j) :
   LDL.lower_inv hS i j = 0 :=
-by rw [← @gram_schmidt_triangular 𝕜 (n → 𝕜) _ (inner_product_space.of_matrix hS.transpose) n _ _ _
+by rw [← @gram_schmidt_triangular
+    𝕜 (n → 𝕜) _ (_ : _) (inner_product_space.of_matrix hS.transpose) n _ _ _
     i j hij (pi.basis_fun 𝕜 n), pi.basis_fun_repr, LDL.lower_inv]
 
 /-- Inverse statement of **LDL decomposition**: we can conjugate a positive definite matrix

--- a/src/linear_algebra/matrix/pos_def.lean
+++ b/src/linear_algebra/matrix/pos_def.lean
@@ -139,10 +139,11 @@ namespace matrix
 
 variables {𝕜 : Type*} [is_R_or_C 𝕜] {n : Type*} [fintype n]
 
-/-- A positive definite matrix `M` induces an inner product `⟪x, y⟫ = xᴴMy`. -/
-noncomputable def inner_product_space.of_matrix
-  {M : matrix n n 𝕜} (hM : M.pos_def) : inner_product_space 𝕜 (n → 𝕜) :=
-inner_product_space.of_core
+/-- A positive definite matrix `M` induces a norm `‖x‖ = sqrt (re xᴴMx)`. -/
+@[reducible]
+noncomputable def normed_add_comm_group.of_matrix {M : matrix n n 𝕜} (hM : M.pos_def) :
+  normed_add_comm_group (n → 𝕜) :=
+@inner_product_space.of_core.to_normed_add_comm_group _ _ _ _ _
 { inner := λ x y, dot_product (star x) (M.mul_vec y),
   conj_symm := λ x y, by
     rw [star_dot_product, star_ring_end_apply, star_star, star_mul_vec,
@@ -160,5 +161,10 @@ inner_product_space.of_core
     end,
   add_left := by simp only [star_add, add_dot_product, eq_self_iff_true, forall_const],
   smul_left := λ x y r, by rw [← smul_eq_mul, ←smul_dot_product, star_ring_end_apply, ← star_smul] }
+
+/-- A positive definite matrix `M` induces an inner product `⟪x, y⟫ = xᴴMy`. -/
+def inner_product_space.of_matrix {M : matrix n n 𝕜} (hM : M.pos_def) :
+  @inner_product_space 𝕜 (n → 𝕜) _ (normed_add_comm_group.of_matrix hM) :=
+inner_product_space.of_core _
 
 end matrix

--- a/src/linear_algebra/matrix/spectrum.lean
+++ b/src/linear_algebra/matrix/spectrum.lean
@@ -99,8 +99,8 @@ begin
     simp_rw [mul_vec_single, mul_one, orthonormal_basis.coe_to_basis_repr_apply,
       orthonormal_basis.repr_reindex],
     refl },
-  { simp only [diagonal_mul, (∘), eigenvalues, eigenvector_basis],
-    rw [basis.to_matrix_apply,
+  { simp only [diagonal_mul, (∘), eigenvalues],
+    rw [eigenvector_basis, basis.to_matrix_apply,
       orthonormal_basis.coe_to_basis_repr_apply, orthonormal_basis.repr_reindex,
       eigenvalues₀, pi_Lp.basis_fun_apply, pi_Lp.equiv_symm_single] }
 end

--- a/src/measure_theory/function/ae_eq_of_integral.lean
+++ b/src/measure_theory/function/ae_eq_of_integral.lean
@@ -52,7 +52,8 @@ section ae_eq_of_forall
 
 variables {α E 𝕜 : Type*} {m : measurable_space α} {μ : measure α} [is_R_or_C 𝕜]
 
-lemma ae_eq_zero_of_forall_inner [inner_product_space 𝕜 E] [second_countable_topology E]
+lemma ae_eq_zero_of_forall_inner
+  [normed_add_comm_group E] [inner_product_space 𝕜 E] [second_countable_topology E]
   {f : α → E} (hf : ∀ c : E, (λ x, (inner c (f x) : 𝕜)) =ᵐ[μ] 0) :
   f =ᵐ[μ] 0 :=
 begin
@@ -60,7 +61,7 @@ begin
   have hs : dense_range s := dense_range_dense_seq E,
   have hf' : ∀ᵐ x ∂μ, ∀ n : ℕ, inner (s n) (f x) = (0 : 𝕜), from ae_all_iff.mpr (λ n, hf (s n)),
   refine hf'.mono (λ x hx, _),
-  rw [pi.zero_apply, ← inner_self_eq_zero],
+  rw [pi.zero_apply, ← @inner_self_eq_zero 𝕜],
   have h_closed : is_closed {c : E | inner c (f x) = (0 : 𝕜)},
     from is_closed_eq (continuous_id.inner continuous_const) continuous_const,
   exact @is_closed_property ℕ E _ s (λ c, inner c (f x) = (0 : 𝕜)) hs h_closed (λ n, hx n) _,

--- a/src/measure_theory/function/conditional_expectation/basic.lean
+++ b/src/measure_theory/function/conditional_expectation/basic.lean
@@ -137,7 +137,7 @@ begin
   exact eventually_eq.fun_comp hff' (λ x, c • x),
 end
 
-lemma const_inner {𝕜 β} [is_R_or_C 𝕜] [inner_product_space 𝕜 β]
+lemma const_inner {𝕜 β} [is_R_or_C 𝕜] [normed_add_comm_group β] [inner_product_space 𝕜 β]
   {f : α → β} (hfm : ae_strongly_measurable' m f μ) (c : β) :
   ae_strongly_measurable' m (λ x, (inner c (f x) : 𝕜)) μ :=
 begin
@@ -218,9 +218,9 @@ variables {α β γ E E' F F' G G' H 𝕜 : Type*} {p : ℝ≥0∞}
   [is_R_or_C 𝕜] -- 𝕜 for ℝ or ℂ
   [topological_space β] -- β for a generic topological space
   -- E for an inner product space
-  [inner_product_space 𝕜 E]
+  [normed_add_comm_group E] [inner_product_space 𝕜 E]
   -- E' for an inner product space on which we compute integrals
-  [inner_product_space 𝕜 E']
+  [normed_add_comm_group E'] [inner_product_space 𝕜 E']
   [complete_space E'] [normed_space ℝ E']
   -- F for a Lp submodule
   [normed_add_comm_group F] [normed_space 𝕜 F]
@@ -754,6 +754,7 @@ begin
 end
 
 include 𝕜
+variables (𝕜)
 
 lemma Lp.ae_eq_zero_of_forall_set_integral_eq_zero'
   (hm : m ≤ m0) (f : Lp E' p μ) (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞)
@@ -798,10 +799,11 @@ begin
     exact (hf_int_finite s hs hμs).sub (hg_int_finite s hs hμs), },
   have hfg_meas : ae_strongly_measurable' m ⇑(f - g) μ,
     from ae_strongly_measurable'.congr (hf_meas.sub hg_meas) (Lp.coe_fn_sub f g).symm,
-  exact Lp.ae_eq_zero_of_forall_set_integral_eq_zero' hm (f-g) hp_ne_zero hp_ne_top hfg_int hfg'
+  exact Lp.ae_eq_zero_of_forall_set_integral_eq_zero' 𝕜 hm (f-g) hp_ne_zero hp_ne_top hfg_int hfg'
     hfg_meas,
 end
 
+variables {𝕜}
 omit 𝕜
 
 lemma ae_eq_of_forall_set_integral_eq_of_sigma_finite' (hm : m ≤ m0) [sigma_finite (μ.trim hm)]
@@ -917,7 +919,7 @@ local notation `⟪`x`, `y`⟫₂` := @inner 𝕜 (α →₂[μ] E) _ x y
 variables (𝕜)
 /-- Conditional expectation of a function in L2 with respect to a sigma-algebra -/
 def condexp_L2 (hm : m ≤ m0) : (α →₂[μ] E) →L[𝕜] (Lp_meas E 𝕜 m 2 μ) :=
-@orthogonal_projection 𝕜 (α →₂[μ] E) _ _ (Lp_meas E 𝕜 m 2 μ)
+@orthogonal_projection 𝕜 (α →₂[μ] E) _ _ _ (Lp_meas E 𝕜 m 2 μ)
   (by { haveI : fact (m ≤ m0) := ⟨hm⟩, exact infer_instance, })
 variables {𝕜}
 
@@ -935,11 +937,11 @@ lemma integrable_condexp_L2_of_is_finite_measure (hm : m ≤ m0) [is_finite_meas
   integrable (condexp_L2 𝕜 hm f) μ :=
 integrable_on_univ.mp $ integrable_on_condexp_L2_of_measure_ne_top hm (measure_ne_top _ _) f
 
-lemma norm_condexp_L2_le_one (hm : m ≤ m0) : ‖@condexp_L2 α E 𝕜 _ _ _ _ _ μ hm‖ ≤ 1 :=
+lemma norm_condexp_L2_le_one (hm : m ≤ m0) : ‖@condexp_L2 α E 𝕜 _ _ _ _ _ _ μ hm‖ ≤ 1 :=
 by { haveI : fact (m ≤ m0) := ⟨hm⟩, exact orthogonal_projection_norm_le _, }
 
 lemma norm_condexp_L2_le (hm : m ≤ m0) (f : α →₂[μ] E) : ‖condexp_L2 𝕜 hm f‖ ≤ ‖f‖ :=
-((@condexp_L2 _ E 𝕜 _ _ _ _ _ μ hm).le_op_norm f).trans
+((@condexp_L2 _ E 𝕜 _ _ _ _ _ _ μ hm).le_op_norm f).trans
   (mul_le_of_le_one_left (norm_nonneg _) (norm_condexp_L2_le_one hm))
 
 lemma snorm_condexp_L2_le (hm : m ≤ m0) (f : α →₂[μ] E) :
@@ -1081,7 +1083,7 @@ begin
   { refine mem_ℒp.const_inner _ _, rw Lp_meas_coe, exact Lp.mem_ℒp _, },
   have h_eq : h_mem_Lp.to_Lp _ =ᵐ[μ] λ a, ⟪c, condexp_L2 𝕜 hm f a⟫, from h_mem_Lp.coe_fn_to_Lp,
   refine eventually_eq.trans _ h_eq,
-  refine Lp.ae_eq_of_forall_set_integral_eq' hm _ _ two_ne_zero ennreal.coe_ne_top
+  refine Lp.ae_eq_of_forall_set_integral_eq' 𝕜 hm _ _ two_ne_zero ennreal.coe_ne_top
     (λ s hs hμs, integrable_on_condexp_L2_of_measure_ne_top hm hμs.ne _) _ _ _ _,
   { intros s hs hμs,
     rw [integrable_on, integrable_congr (ae_restrict_of_ae h_eq)],
@@ -1107,7 +1109,7 @@ begin
   rw [← sub_eq_zero, Lp_meas_coe, ← integral_sub'
       (integrable_on_Lp_of_measure_ne_top _ fact_one_le_two_ennreal.elim hμs)
       (integrable_on_Lp_of_measure_ne_top _ fact_one_le_two_ennreal.elim hμs)],
-  refine integral_eq_zero_of_forall_integral_inner_eq_zero _ _ _,
+  refine integral_eq_zero_of_forall_integral_inner_eq_zero 𝕜 _ _ _,
   { rw integrable_congr (ae_restrict_of_ae (Lp.coe_fn_sub ↑(condexp_L2 𝕜 hm f) f).symm),
     exact integrable_on_Lp_of_measure_ne_top _ fact_one_le_two_ennreal.elim hμs, },
   intro c,
@@ -1122,14 +1124,14 @@ begin
   exact integral_condexp_L2_eq_of_fin_meas_real _ hs hμs,
 end
 
-variables {E'' 𝕜' : Type*} [is_R_or_C 𝕜']
+variables {E'' 𝕜' : Type*} [is_R_or_C 𝕜'] [normed_add_comm_group E'']
   [inner_product_space 𝕜' E''] [complete_space E''] [normed_space ℝ E'']
 
 variables (𝕜 𝕜')
 lemma condexp_L2_comp_continuous_linear_map (hm : m ≤ m0) (T : E' →L[ℝ] E'') (f : α →₂[μ] E') :
   (condexp_L2 𝕜' hm (T.comp_Lp f) : α →₂[μ] E'') =ᵐ[μ] T.comp_Lp (condexp_L2 𝕜 hm f : α →₂[μ] E') :=
 begin
-  refine Lp.ae_eq_of_forall_set_integral_eq' hm _ _ two_ne_zero ennreal.coe_ne_top
+  refine Lp.ae_eq_of_forall_set_integral_eq' 𝕜' hm _ _ two_ne_zero ennreal.coe_ne_top
     (λ s hs hμs, integrable_on_condexp_L2_of_measure_ne_top hm hμs.ne _)
     (λ s hs hμs, integrable_on_Lp_of_measure_ne_top _ fact_one_le_two_ennreal.elim hμs.ne)
     _ _ _,
@@ -1321,7 +1323,8 @@ lemma set_integral_condexp_L2_indicator (hs : measurable_set[m] s) (ht : measura
   ∫ x in s, (condexp_L2 ℝ hm (indicator_const_Lp 2 ht hμt (1 : ℝ))) x ∂μ = (μ (t ∩ s)).to_real :=
 calc ∫ x in s, (condexp_L2 ℝ hm (indicator_const_Lp 2 ht hμt (1 : ℝ))) x ∂μ
     = ∫ x in s, indicator_const_Lp 2 ht hμt (1 : ℝ) x ∂μ :
-      @integral_condexp_L2_eq α _ ℝ _ _ _ _ _ _ _ _ hm (indicator_const_Lp 2 ht hμt (1 : ℝ)) hs hμs
+      @integral_condexp_L2_eq
+        α _ ℝ _ _ _ _ _ _ _ _ _ hm (indicator_const_Lp 2 ht hμt (1 : ℝ)) hs hμs
 ... = (μ (t ∩ s)).to_real • 1 : set_integral_indicator_const_Lp (hm s hs) ht hμt (1 : ℝ)
 ... = (μ (t ∩ s)).to_real : by rw [smul_eq_mul, mul_one]
 

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -1014,7 +1014,8 @@ by { rw ← mem_ℒp_one_iff_integrable at hf ⊢, exact hf.im, }
 end is_R_or_C
 
 section inner_product
-variables {𝕜 E : Type*} [is_R_or_C 𝕜] [inner_product_space 𝕜 E] {f : α → E}
+variables {𝕜 E : Type*}
+variables [is_R_or_C 𝕜] [normed_add_comm_group E] [inner_product_space 𝕜 E] {f : α → E}
 
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 E _ x y
 

--- a/src/measure_theory/function/l2_space.lean
+++ b/src/measure_theory/function/l2_space.lean
@@ -58,7 +58,7 @@ end
 namespace L2
 
 variables {α E F 𝕜 : Type*} [is_R_or_C 𝕜] [measurable_space α] {μ : measure α}
-  [inner_product_space 𝕜 E] [normed_add_comm_group F]
+  [normed_add_comm_group E] [inner_product_space 𝕜 E] [normed_add_comm_group F]
 
 
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -1418,7 +1418,7 @@ end
 end is_R_or_C
 
 section inner_product
-variables {E' 𝕜 : Type*} [is_R_or_C 𝕜] [inner_product_space 𝕜 E']
+variables {E' 𝕜 : Type*} [is_R_or_C 𝕜] [normed_add_comm_group E'] [inner_product_space 𝕜 E']
 
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 E' _ x y
 

--- a/src/measure_theory/function/special_functions/inner.lean
+++ b/src/measure_theory/function/special_functions/inner.lean
@@ -11,7 +11,8 @@ import measure_theory.constructions.borel_space
 # Measurability of scalar products
 -/
 
-variables {α : Type*} {𝕜 : Type*} {E : Type*} [is_R_or_C 𝕜] [inner_product_space 𝕜 E]
+variables {α : Type*} {𝕜 : Type*} {E : Type*}
+variables [is_R_or_C 𝕜] [normed_add_comm_group E] [inner_product_space 𝕜 E]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
 @[measurability]

--- a/src/measure_theory/function/strongly_measurable/inner.lean
+++ b/src/measure_theory/function/strongly_measurable/inner.lean
@@ -18,7 +18,8 @@ namespace measure_theory
 
 namespace strongly_measurable
 
-protected lemma inner {𝕜 : Type*} {E : Type*} [is_R_or_C 𝕜] [inner_product_space 𝕜 E]
+protected lemma inner {𝕜 : Type*} {E : Type*}
+  [is_R_or_C 𝕜] [normed_add_comm_group E] [inner_product_space 𝕜 E]
   {m : measurable_space α} {f g : α → E} (hf : strongly_measurable f) (hg : strongly_measurable g) :
   strongly_measurable (λ t, @inner 𝕜 _ _(f t) (g t)) :=
 continuous.comp_strongly_measurable continuous_inner (hf.prod_mk hg)
@@ -28,7 +29,7 @@ end strongly_measurable
 namespace ae_strongly_measurable
 
 variables {m : measurable_space α} {μ : measure α} {𝕜 : Type*} {E : Type*} [is_R_or_C 𝕜]
-  [inner_product_space 𝕜 E]
+  [normed_add_comm_group E] [inner_product_space 𝕜 E]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
 protected lemma re {f : α → 𝕜} (hf : ae_strongly_measurable f μ) :

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -1126,13 +1126,19 @@ end
 
 section inner
 
-variables {E' : Type*} [inner_product_space 𝕜 E'] [complete_space E'] [normed_space ℝ E']
+variables {E' : Type*}
+variables [normed_add_comm_group E'] [inner_product_space 𝕜 E']
+variables [complete_space E'] [normed_space ℝ E']
 
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 E' _ x y
 
 lemma integral_inner {f : α → E'} (hf : integrable f μ) (c : E') :
   ∫ x, ⟪c, f x⟫ ∂μ = ⟪c, ∫ x, f x ∂μ⟫ :=
 ((innerSL 𝕜 c).restrict_scalars ℝ).integral_comp_comm hf
+
+variables (𝕜)
+-- variable binder update doesn't work for lemmas which refer to `𝕜` only via the notation
+local notation (name := inner_with_explicit) `⟪`x`, `y`⟫` := @inner 𝕜 E' _ x y
 
 lemma integral_eq_zero_of_forall_integral_inner_eq_zero (f : α → E') (hf : integrable f μ)
   (hf_int : ∀ (c : E'), ∫ x, ⟪c, f x⟫ ∂μ = 0) :

--- a/src/measure_theory/measure/haar_of_basis.lean
+++ b/src/measure_theory/measure/haar_of_basis.lean
@@ -151,7 +151,8 @@ volume `1` to the parallelepiped spanned by any orthonormal basis. We define the
 some arbitrary choice of orthonormal basis. The fact that it works with any orthonormal basis
 is proved in `orthonormal_basis.volume_parallelepiped`. -/
 @[priority 100] instance measure_space_of_inner_product_space
-  [inner_product_space ℝ E] [finite_dimensional ℝ E] [measurable_space E] [borel_space E] :
+  [normed_add_comm_group E] [inner_product_space ℝ E] [finite_dimensional ℝ E]
+  [measurable_space E] [borel_space E] :
   measure_space E :=
 { volume := (std_orthonormal_basis ℝ E).to_basis.add_haar }
 

--- a/src/measure_theory/measure/haar_of_inner.lean
+++ b/src/measure_theory/measure/haar_of_inner.lean
@@ -18,8 +18,9 @@ the canonical `volume` from the `measure_space` instance.
 
 open finite_dimensional measure_theory measure_theory.measure set
 
-variables {ι F : Type*} [fintype ι] [inner_product_space ℝ F] [finite_dimensional ℝ F]
-[measurable_space F] [borel_space F]
+variables {ι F : Type*}
+variables [fintype ι] [normed_add_comm_group F] [inner_product_space ℝ F] [finite_dimensional ℝ F]
+  [measurable_space F] [borel_space F]
 
 section
 


### PR DESCRIPTION
This replaces `[inner_product_space K V]` with `[normed_add_comm_group V] [inner_product_space K V]`.

Before this PR, we had `inner_product_space K V extends normed_add_comm_group V`.
At first glance this is a rather strange arrangement; we certainly don't have `module R V extends add_comm_group V`.
The argument usually goes that `Derived A B extends Base B` is unsafe, because the `Derived.toBase` instance has no way of knowing which `A` to look for.

For `inner_product_space K V` we argued that this problem doesn't apply, as `is_R_or_C K` means that in practice there are only two possible values of `K`. This is indeed enough to stop typeclass search grinding to a halt.

The motivation for the old design is described by @dupuisf [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Dangerous.20instance.20vs.20elaboration.20problems/near/210594971):

> However, when I do (the contents of this PR), I run into some very annoying elaboration issues where I have to constantly spoonfeed it `𝕜` and/or `α` in lemmas that rewrite norms in terms of inner products, even though the relevant instance is directly present in the context.

While it may ease elaboration issues, there are a number of new problems that `inner_product_space K V extends normed_add_comm_group V` causes:
1. It is confusing when compared to all other typeclasses. After being told to write
    ```lean
    variables [add_comm_group U] [module R U]
    variables [normed_add_comm_group V] [normed_space R V]
    ```
    it is natural to assume that the inner product space version would be
    ```lean
    variables [normed_add_comm_group W] [inner_product_space K W]
    ```
    But writing this leads to `W` having two unrelated addition operations!
2. It doesn't allow a space `W` to be an inner product space over both R and C. For a (normed) module, you can write
    ```lean
    variables [add_comm_group U] [module R U] [module C U]
    variables [normed_add_comm_group V] [normed_space R V] [normed_space C V]
    ```
    but writing `[inner_product_space R W] [inner_product_space C W]` again puts two unrelated `+` operators on `V`
3. It doesn't compose with other normed typeclasses. We can talk about a (normed) module with multiplication as
    ```lean
    variables [ring U] [module R U]
    variables [normed_ring V] [normed_space K V]
    ```
    but once again, typing `[normed_ring W] [inner_product_space K W]` gives us two unrelated `+` operators.
    This prevents us generalizing over `real`, `complex`, and `quaternion`.

    We could work around this by defining variants of `inner_product_space` for `normed_ring A`, `normed_comm_ring A`, `normed_division_ring A`, `normed_field A`, but this doesn't scale well. If we do things "the module way" then we only need one new typeclass instead of four,
    ```lean
    class inner_product_algebra (K A) [is_R_or_C K] [normed_ring A]
      extends normed_algebra K A, inner_product_space K A
    ```
5. The "`is_R_or_C` makes it OK" argument stops working if we generalize to [quaternionic inner product spaces](https://link.springer.com/chapter/10.1007/978-94-009-3713-0_13)

The majority of this PR is adding `[normed_add_comm_group _]` to every `variables` line about `inner_product_space`.
The rest is specifying the scalar manually where previously unification would find it for us.

[This Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/inner_product_space.20and.20normed_algebra/near/341848831) has some initial discussion about this change.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #18584
- [x] depends on: #18574
- [x] depends on: #18613
- [x] depends on: #18605

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Thread in #PR reviews](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2318583.20.C2.AC.28inner_product_space.20extends.20normed_add_comm_group.29/near/343112593)