### PR TITLE
[Merged by Bors] - chore(data/mv_polynomial): reverse an import

### DIFF
--- a/src/data/mv_polynomial/monad.lean
+++ b/src/data/mv_polynomial/monad.lean
@@ -203,40 +203,6 @@ lemma rename_bind₁ {υ : Type*} (f : σ → mv_polynomial τ R) (g : τ → υ
   rename g (bind₁ f φ) = bind₁ (λ i, rename g $ f i) φ :=
 alg_hom.congr_fun (rename_comp_bind₁ f g) φ
 
-lemma vars_bind₁ (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) :
-  (bind₁ f φ).vars ⊆ φ.vars.bUnion (λ i, (f i).vars) :=
-begin
-  calc (bind₁ f φ).vars
-      = (φ.support.sum (λ (x : σ →₀ ℕ), (bind₁ f) (monomial x (coeff x φ)))).vars :
-        by { rw [← alg_hom.map_sum, ← φ.as_sum], }
-  ... ≤ φ.support.bUnion (λ (i : σ →₀ ℕ), ((bind₁ f) (monomial i (coeff i φ))).vars) :
-        vars_sum_subset _ _
-  ... = φ.support.bUnion (λ (d : σ →₀ ℕ), (C (coeff d φ) * ∏ i in d.support, f i ^ d i).vars) :
-        by simp only [bind₁_monomial]
-  ... ≤ φ.support.bUnion (λ (d : σ →₀ ℕ), d.support.bUnion (λ i, (f i).vars)) : _ -- proof below
-  ... ≤ φ.vars.bUnion (λ (i : σ), (f i).vars) : _, -- proof below
-  { apply finset.bUnion_mono,
-    intros d hd,
-    calc (C (coeff d φ) * ∏ (i : σ) in d.support, f i ^ d i).vars
-        ≤ (C (coeff d φ)).vars ∪ (∏ (i : σ) in d.support, f i ^ d i).vars : vars_mul _ _
-    ... ≤ (∏ (i : σ) in d.support, f i ^ d i).vars :
-      by simp only [finset.empty_union, vars_C, finset.le_iff_subset, finset.subset.refl]
-    ... ≤ d.support.bUnion (λ (i : σ), (f i ^ d i).vars) : vars_prod _
-    ... ≤ d.support.bUnion (λ (i : σ), (f i).vars) : _,
-    apply finset.bUnion_mono,
-    intros i hi,
-    apply vars_pow, },
-  { intro j,
-    simp_rw finset.mem_bUnion,
-    rintro ⟨d, hd, ⟨i, hi, hj⟩⟩,
-    exact ⟨i, (mem_vars _).mpr ⟨d, hd, hi⟩, hj⟩ }
-end
-
-lemma mem_vars_bind₁ (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) {j : τ}
-  (h : j ∈ (bind₁ f φ).vars) :
-  ∃ (i : σ), i ∈ φ.vars ∧ j ∈ (f i).vars :=
-by simpa only [exists_prop, finset.mem_bUnion, mem_support_iff, ne.def] using vars_bind₁ f φ h
-
 lemma map_bind₂ (f : R →+* mv_polynomial σ S) (g : S →+* T) (φ : mv_polynomial σ R) :
   map g (bind₂ f φ) = bind₂ ((map g).comp f) φ :=
 begin
@@ -317,6 +283,44 @@ by simp only [monomial_eq, ring_hom.map_mul, bind₂_C_right, finsupp.prod,
 lemma bind₂_monomial_one (f : R →+* mv_polynomial σ S) (d : σ →₀ ℕ) :
   bind₂ f (monomial d 1) = monomial d 1 :=
 by rw [bind₂_monomial, f.map_one, one_mul]
+
+section
+open_locale classical
+
+lemma vars_bind₁ (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) :
+  (bind₁ f φ).vars ⊆ φ.vars.bUnion (λ i, (f i).vars) :=
+begin
+  calc (bind₁ f φ).vars
+      = (φ.support.sum (λ (x : σ →₀ ℕ), (bind₁ f) (monomial x (coeff x φ)))).vars :
+        by { rw [← alg_hom.map_sum, ← φ.as_sum], }
+  ... ≤ φ.support.bUnion (λ (i : σ →₀ ℕ), ((bind₁ f) (monomial i (coeff i φ))).vars) :
+        vars_sum_subset _ _
+  ... = φ.support.bUnion (λ (d : σ →₀ ℕ), (C (coeff d φ) * ∏ i in d.support, f i ^ d i).vars) :
+        by simp only [bind₁_monomial]
+  ... ≤ φ.support.bUnion (λ (d : σ →₀ ℕ), d.support.bUnion (λ i, (f i).vars)) : _ -- proof below
+  ... ≤ φ.vars.bUnion (λ (i : σ), (f i).vars) : _, -- proof below
+  { apply finset.bUnion_mono,
+    intros d hd,
+    calc (C (coeff d φ) * ∏ (i : σ) in d.support, f i ^ d i).vars
+        ≤ (C (coeff d φ)).vars ∪ (∏ (i : σ) in d.support, f i ^ d i).vars : vars_mul _ _
+    ... ≤ (∏ (i : σ) in d.support, f i ^ d i).vars :
+      by simp only [finset.empty_union, vars_C, finset.le_iff_subset, finset.subset.refl]
+    ... ≤ d.support.bUnion (λ (i : σ), (f i ^ d i).vars) : vars_prod _
+    ... ≤ d.support.bUnion (λ (i : σ), (f i).vars) : _,
+    apply finset.bUnion_mono,
+    intros i hi,
+    apply vars_pow, },
+  { intro j,
+    simp_rw finset.mem_bUnion,
+    rintro ⟨d, hd, ⟨i, hi, hj⟩⟩,
+    exact ⟨i, (mem_vars _).mpr ⟨d, hd, hi⟩, hj⟩ }
+end
+end
+
+lemma mem_vars_bind₁ (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) {j : τ}
+  (h : j ∈ (bind₁ f φ).vars) :
+  ∃ (i : σ), i ∈ φ.vars ∧ j ∈ (f i).vars :=
+by simpa only [exists_prop, finset.mem_bUnion, mem_support_iff, ne.def] using vars_bind₁ f φ h
 
 instance monad : monad (λ σ, mv_polynomial σ R) :=
 { map := λ α β f p, rename f p,

--- a/src/data/mv_polynomial/monad.lean
+++ b/src/data/mv_polynomial/monad.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Johan Commelin, Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Robert Y. Lewis
 -/
+import data.mv_polynomial.rename
 import data.mv_polynomial.variables
 
 /-!

--- a/src/data/mv_polynomial/monad.lean
+++ b/src/data/mv_polynomial/monad.lean
@@ -203,6 +203,40 @@ lemma rename_bind₁ {υ : Type*} (f : σ → mv_polynomial τ R) (g : τ → υ
   rename g (bind₁ f φ) = bind₁ (λ i, rename g $ f i) φ :=
 alg_hom.congr_fun (rename_comp_bind₁ f g) φ
 
+lemma vars_bind₁ (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) :
+  (bind₁ f φ).vars ⊆ φ.vars.bUnion (λ i, (f i).vars) :=
+begin
+  calc (bind₁ f φ).vars
+      = (φ.support.sum (λ (x : σ →₀ ℕ), (bind₁ f) (monomial x (coeff x φ)))).vars :
+        by { rw [← alg_hom.map_sum, ← φ.as_sum], }
+  ... ≤ φ.support.bUnion (λ (i : σ →₀ ℕ), ((bind₁ f) (monomial i (coeff i φ))).vars) :
+        vars_sum_subset _ _
+  ... = φ.support.bUnion (λ (d : σ →₀ ℕ), (C (coeff d φ) * ∏ i in d.support, f i ^ d i).vars) :
+        by simp only [bind₁_monomial]
+  ... ≤ φ.support.bUnion (λ (d : σ →₀ ℕ), d.support.bUnion (λ i, (f i).vars)) : _ -- proof below
+  ... ≤ φ.vars.bUnion (λ (i : σ), (f i).vars) : _, -- proof below
+  { apply finset.bUnion_mono,
+    intros d hd,
+    calc (C (coeff d φ) * ∏ (i : σ) in d.support, f i ^ d i).vars
+        ≤ (C (coeff d φ)).vars ∪ (∏ (i : σ) in d.support, f i ^ d i).vars : vars_mul _ _
+    ... ≤ (∏ (i : σ) in d.support, f i ^ d i).vars :
+      by simp only [finset.empty_union, vars_C, finset.le_iff_subset, finset.subset.refl]
+    ... ≤ d.support.bUnion (λ (i : σ), (f i ^ d i).vars) : vars_prod _
+    ... ≤ d.support.bUnion (λ (i : σ), (f i).vars) : _,
+    apply finset.bUnion_mono,
+    intros i hi,
+    apply vars_pow, },
+  { intro j,
+    simp_rw finset.mem_bUnion,
+    rintro ⟨d, hd, ⟨i, hi, hj⟩⟩,
+    exact ⟨i, (mem_vars _).mpr ⟨d, hd, hi⟩, hj⟩ }
+end
+
+lemma mem_vars_bind₁ (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) {j : τ}
+  (h : j ∈ (bind₁ f φ).vars) :
+  ∃ (i : σ), i ∈ φ.vars ∧ j ∈ (f i).vars :=
+by simpa only [exists_prop, finset.mem_bUnion, mem_support_iff, ne.def] using vars_bind₁ f φ h
+
 lemma map_bind₂ (f : R →+* mv_polynomial σ S) (g : S →+* T) (φ : mv_polynomial σ R) :
   map g (bind₂ f φ) = bind₂ ((map g).comp f) φ :=
 begin
@@ -312,39 +346,5 @@ def ajoin [algebra R S] : mv_polynomial (mv_polynomial σ R) S →ₐ[S] mv_poly
 join (algebra_map R S)
 
 -/
-
-lemma vars_bind₁ (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) :
-  (bind₁ f φ).vars ⊆ φ.vars.bUnion (λ i, (f i).vars) :=
-begin
-  calc (bind₁ f φ).vars
-      = (φ.support.sum (λ (x : σ →₀ ℕ), (bind₁ f) (monomial x (coeff x φ)))).vars :
-        by { rw [← alg_hom.map_sum, ← φ.as_sum], }
-  ... ≤ φ.support.bUnion (λ (i : σ →₀ ℕ), ((bind₁ f) (monomial i (coeff i φ))).vars) :
-        vars_sum_subset _ _
-  ... = φ.support.bUnion (λ (d : σ →₀ ℕ), (C (coeff d φ) * ∏ i in d.support, f i ^ d i).vars) :
-        by simp only [bind₁_monomial]
-  ... ≤ φ.support.bUnion (λ (d : σ →₀ ℕ), d.support.bUnion (λ i, (f i).vars)) : _ -- proof below
-  ... ≤ φ.vars.bUnion (λ (i : σ), (f i).vars) : _, -- proof below
-  { apply finset.bUnion_mono,
-    intros d hd,
-    calc (C (coeff d φ) * ∏ (i : σ) in d.support, f i ^ d i).vars
-        ≤ (C (coeff d φ)).vars ∪ (∏ (i : σ) in d.support, f i ^ d i).vars : vars_mul _ _
-    ... ≤ (∏ (i : σ) in d.support, f i ^ d i).vars :
-      by simp only [finset.empty_union, vars_C, finset.le_iff_subset, finset.subset.refl]
-    ... ≤ d.support.bUnion (λ (i : σ), (f i ^ d i).vars) : vars_prod _
-    ... ≤ d.support.bUnion (λ (i : σ), (f i).vars) : _,
-    apply finset.bUnion_mono,
-    intros i hi,
-    apply vars_pow, },
-  { intro j,
-    simp_rw finset.mem_bUnion,
-    rintro ⟨d, hd, ⟨i, hi, hj⟩⟩,
-    exact ⟨i, (mem_vars _).mpr ⟨d, hd, hi⟩, hj⟩ }
-end
-
-lemma mem_vars_bind₁ (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) {j : τ}
-  (h : j ∈ (bind₁ f φ).vars) :
-  ∃ (i : σ), i ∈ φ.vars ∧ j ∈ (f i).vars :=
-by simpa only [exists_prop, finset.mem_bUnion, mem_support_iff, ne.def] using vars_bind₁ f φ h
 
 end mv_polynomial

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Johan Commelin, Mario Carneiro
 -/
 import algebra.big_operators.order
-import data.mv_polynomial.monad
+import data.mv_polynomial.rename
 
 /-!
 # Degrees and variables of polynomials
@@ -773,7 +773,7 @@ lemma exists_rename_eq_of_vars_subset_range
   (p : mv_polynomial σ R) (f : τ → σ)
   (hfi : injective f) (hf : ↑p.vars ⊆ set.range f) :
   ∃ q : mv_polynomial τ R, rename f q = p :=
-⟨bind₁ (λ i : σ, option.elim 0 X $ partial_inv f i) p,
+⟨aeval (λ i : σ, option.elim 0 X $ partial_inv f i) p,
   begin
     show (rename f).to_ring_hom.comp _ p = ring_hom.id _ p,
     refine hom_congr_vars _ _ _,
@@ -784,40 +784,6 @@ lemma exists_rename_eq_of_vars_subset_range
       simp [partial_inv_left hfi] },
     { refl }
   end⟩
-
-lemma vars_bind₁ (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) :
-  (bind₁ f φ).vars ⊆ φ.vars.bUnion (λ i, (f i).vars) :=
-begin
-  calc (bind₁ f φ).vars
-      = (φ.support.sum (λ (x : σ →₀ ℕ), (bind₁ f) (monomial x (coeff x φ)))).vars :
-        by { rw [← alg_hom.map_sum, ← φ.as_sum], }
-  ... ≤ φ.support.bUnion (λ (i : σ →₀ ℕ), ((bind₁ f) (monomial i (coeff i φ))).vars) :
-        vars_sum_subset _ _
-  ... = φ.support.bUnion (λ (d : σ →₀ ℕ), (C (coeff d φ) * ∏ i in d.support, f i ^ d i).vars) :
-        by simp only [bind₁_monomial]
-  ... ≤ φ.support.bUnion (λ (d : σ →₀ ℕ), d.support.bUnion (λ i, (f i).vars)) : _ -- proof below
-  ... ≤ φ.vars.bUnion (λ (i : σ), (f i).vars) : _, -- proof below
-  { apply finset.bUnion_mono,
-    intros d hd,
-    calc (C (coeff d φ) * ∏ (i : σ) in d.support, f i ^ d i).vars
-        ≤ (C (coeff d φ)).vars ∪ (∏ (i : σ) in d.support, f i ^ d i).vars : vars_mul _ _
-    ... ≤ (∏ (i : σ) in d.support, f i ^ d i).vars :
-      by simp only [finset.empty_union, vars_C, finset.le_iff_subset, finset.subset.refl]
-    ... ≤ d.support.bUnion (λ (i : σ), (f i ^ d i).vars) : vars_prod _
-    ... ≤ d.support.bUnion (λ (i : σ), (f i).vars) : _,
-    apply finset.bUnion_mono,
-    intros i hi,
-    apply vars_pow, },
-  { intro j,
-    simp_rw finset.mem_bUnion,
-    rintro ⟨d, hd, ⟨i, hi, hj⟩⟩,
-    exact ⟨i, (mem_vars _).mpr ⟨d, hd, hi⟩, hj⟩ }
-end
-
-lemma mem_vars_bind₁ (f : σ → mv_polynomial τ R) (φ : mv_polynomial σ R) {j : τ}
-  (h : j ∈ (bind₁ f φ).vars) :
-  ∃ (i : σ), i ∈ φ.vars ∧ j ∈ (f i).vars :=
-by simpa only [exists_prop, finset.mem_bUnion, mem_support_iff, ne.def] using vars_bind₁ f φ h
 
 lemma vars_rename (f : σ → τ) (φ : mv_polynomial σ R) :
   (rename f φ).vars ⊆ (φ.vars.image f) :=

--- a/src/ring_theory/polynomial/quotient.lean
+++ b/src/ring_theory/polynomial/quotient.lean
@@ -201,14 +201,14 @@ def quotient_equiv_quotient_mv_polynomial (I : ideal R) :
     apply induction_on f,
     { rintro ⟨r⟩,
       rw [coe_eval₂_hom, eval₂_C],
-      simp only [eval₂_hom_eq_bind₂, submodule.quotient.quot_mk_eq_mk, ideal.quotient.lift_mk,
-        ideal.quotient.mk_eq_mk, bind₂_C_right, ring_hom.coe_comp] },
+      simp only [submodule.quotient.quot_mk_eq_mk, ideal.quotient.lift_mk,
+        mv_polynomial.eval₂_hom_C, function.comp_app, ideal.quotient.mk_eq_mk, mv_polynomial.C_inj,
+        ring_hom.coe_comp], },
     { simp_intros p q hp hq only [ring_hom.map_add, mv_polynomial.coe_eval₂_hom, coe_eval₂_hom,
-        mv_polynomial.eval₂_add, mv_polynomial.eval₂_hom_eq_bind₂, eval₂_hom_eq_bind₂],
+        mv_polynomial.eval₂_add],
       rw [hp, hq] },
-    { simp_intros p i hp only [eval₂_hom_eq_bind₂, coe_eval₂_hom],
-      simp only [hp, eval₂_hom_eq_bind₂, coe_eval₂_hom, ideal.quotient.lift_mk, bind₂_X_right,
-        eval₂_mul, ring_hom.map_mul, eval₂_X] }
+    { simp_intros p i hp only [coe_eval₂_hom],
+      simp only [hp, coe_eval₂_hom, ideal.quotient.lift_mk, eval₂_mul, ring_hom.map_mul, eval₂_X] }
   end,
   right_inv := begin
     rintro ⟨f⟩,
@@ -216,12 +216,11 @@ def quotient_equiv_quotient_mv_polynomial (I : ideal R) :
     { intros r,
       simp only [submodule.quotient.quot_mk_eq_mk, ideal.quotient.lift_mk, ideal.quotient.mk_eq_mk,
         ring_hom.coe_comp, eval₂_hom_C] },
-    { simp_intros p q hp hq only [eval₂_hom_eq_bind₂, submodule.quotient.quot_mk_eq_mk, eval₂_add,
+    { simp_intros p q hp hq only [submodule.quotient.quot_mk_eq_mk, eval₂_add,
         ring_hom.map_add, coe_eval₂_hom, ideal.quotient.lift_mk, ideal.quotient.mk_eq_mk],
       rw [hp, hq] },
-    { simp_intros p i hp only [eval₂_hom_eq_bind₂, submodule.quotient.quot_mk_eq_mk, coe_eval₂_hom,
-        ideal.quotient.lift_mk, ideal.quotient.mk_eq_mk, bind₂_X_right, eval₂_mul, ring_hom.map_mul,
-        eval₂_X],
+    { simp_intros p i hp only [submodule.quotient.quot_mk_eq_mk, coe_eval₂_hom,
+        ideal.quotient.lift_mk, ideal.quotient.mk_eq_mk, eval₂_mul, ring_hom.map_mul, eval₂_X],
       simp only [hp] }
   end,
   commutes' := λ r, eval₂_hom_C _ _ (ideal.quotient.mk I r) }


### PR DESCRIPTION
As proposed on [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.232887.20Data.2EMvPolynomial.2EMonad/near/342140597)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
