### PR TITLE
[Merged by Bors] - chore(algebra/order/nonneg/*): Separate `floor_ring` from `field`

### DIFF
--- a/src/algebra/order/nonneg/field.lean
+++ b/src/algebra/order/nonneg/field.lean
@@ -3,10 +3,10 @@ Copyright (c) 2021 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import algebra.order.archimedean
-import algebra.order.nonneg.ring
-import algebra.order.field.inj_surj
+import algebra.order.field.basic
 import algebra.order.field.canonical.defs
+import algebra.order.field.inj_surj
+import algebra.order.nonneg.ring
 
 /-!
 # Semifield structure on the type of nonnegative elements
@@ -70,31 +70,5 @@ instance canonically_linear_ordered_semifield [linear_ordered_field α] :
 instance linear_ordered_comm_group_with_zero [linear_ordered_field α] :
   linear_ordered_comm_group_with_zero {x : α // 0 ≤ x} :=
 infer_instance
-
-/-! ### Floor -/
-
-instance archimedean [ordered_add_comm_monoid α] [archimedean α] : archimedean {x : α // 0 ≤ x} :=
-⟨λ x y hy,
-  let ⟨n, hr⟩ := archimedean.arch (x : α) (hy : (0 : α) < y) in
-  ⟨n, show (x : α) ≤ (n • y : {x : α // 0 ≤ x}), by simp [*, -nsmul_eq_mul, nsmul_coe]⟩⟩
-
-instance floor_semiring [ordered_semiring α] [floor_semiring α] : floor_semiring {r : α // 0 ≤ r} :=
-{ floor := λ a, ⌊(a : α)⌋₊,
-  ceil := λ a, ⌈(a : α)⌉₊,
-  floor_of_neg := λ a ha, floor_semiring.floor_of_neg ha,
-  gc_floor := λ a n ha, begin
-    refine (floor_semiring.gc_floor (show 0 ≤ (a : α), from ha)).trans _,
-    rw [←subtype.coe_le_coe, nonneg.coe_nat_cast]
-  end,
-  gc_ceil := λ a n, begin
-    refine (floor_semiring.gc_ceil (a : α) n).trans _,
-    rw [←subtype.coe_le_coe, nonneg.coe_nat_cast]
-  end}
-
-@[norm_cast] lemma nat_floor_coe [ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
-  ⌊(a : α)⌋₊ = ⌊a⌋₊ := rfl
-
-@[norm_cast] lemma nat_ceil_coe [ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
-  ⌈(a : α)⌉₊ = ⌈a⌉₊  := rfl
 
 end nonneg

--- a/src/algebra/order/nonneg/floor.lean
+++ b/src/algebra/order/nonneg/floor.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2021 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+-/
+import algebra.order.nonneg.ring
+import algebra.order.archimedean
+
+/-!
+# Nonnegative elements are archimedean
+
+> THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
+> Any changes to this file require a corresponding PR to mathlib4.
+
+This file defines instances and prove some properties about the nonnegative elements
+`{x : α // 0 ≤ x}` of an arbitrary type `α`.
+
+This is used to derive algebraic structures on `ℝ≥0` and `ℚ≥0` automatically.
+
+## Main declarations
+
+* `{x : α // 0 ≤ x}` is a `floor_semiring` if `α` is.
+-/
+
+namespace nonneg
+variables {α : Type*}
+
+instance archimedean [ordered_add_comm_monoid α] [archimedean α] : archimedean {x : α // 0 ≤ x} :=
+⟨λ x y hy,
+  let ⟨n, hr⟩ := archimedean.arch (x : α) (hy : (0 : α) < y) in
+  ⟨n, show (x : α) ≤ (n • y : {x : α // 0 ≤ x}), by simp [*, -nsmul_eq_mul, nsmul_coe]⟩⟩
+
+instance floor_semiring [ordered_semiring α] [floor_semiring α] : floor_semiring {r : α // 0 ≤ r} :=
+{ floor := λ a, ⌊(a : α)⌋₊,
+  ceil := λ a, ⌈(a : α)⌉₊,
+  floor_of_neg := λ a ha, floor_semiring.floor_of_neg ha,
+  gc_floor := λ a n ha, begin
+    refine (floor_semiring.gc_floor (show 0 ≤ (a : α), from ha)).trans _,
+    rw [←subtype.coe_le_coe, nonneg.coe_nat_cast]
+  end,
+  gc_ceil := λ a n, begin
+    refine (floor_semiring.gc_ceil (a : α) n).trans _,
+    rw [←subtype.coe_le_coe, nonneg.coe_nat_cast]
+  end}
+
+@[norm_cast] lemma nat_floor_coe [ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
+  ⌊(a : α)⌋₊ = ⌊a⌋₊ := rfl
+
+@[norm_cast] lemma nat_ceil_coe [ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
+  ⌈(a : α)⌉₊ = ⌈a⌉₊  := rfl
+
+end nonneg

--- a/src/data/rat/nnrat.lean
+++ b/src/data/rat/nnrat.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies, Bhavik Mehta
 -/
 import algebra.algebra.basic
 import algebra.order.nonneg.field
+import algebra.order.nonneg.floor
 
 /-!
 # Nonnegative rationals

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -3,11 +3,12 @@ Copyright (c) 2018 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import order.conditionally_complete_lattice.group
 import algebra.algebra.basic
-import algebra.order.nonneg.field
 import algebra.order.field.canonical.basic
+import algebra.order.nonneg.field
+import algebra.order.nonneg.floor
 import data.real.pointwise
+import order.conditionally_complete_lattice.group
 import tactic.positivity
 
 /-!


### PR DESCRIPTION
Move the `archimedean` and `floor_ring` instances out of `algebra.order.nonneg.field` into a new file `algebra.order.nonneg.floor`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
This is crucial for unmangling imports and defining `nnrat.cast` in #16554.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
