### PR TITLE
[Merged by Bors] - chore(data/{nat,int}/cast/field): generalize to division_ring

### DIFF
--- a/src/algebra/char_zero/lemmas.lean
+++ b/src/algebra/char_zero/lemmas.lean
@@ -35,7 +35,7 @@ def cast_embedding : ℕ ↪ R := ⟨coe, cast_injective⟩
 by { rw [←cast_pow, cast_eq_one], exact pow_eq_one_iff hn }
 
 @[simp, norm_cast]
-theorem cast_div_char_zero {k : Type*} [field k] [char_zero k] {m n : ℕ}
+theorem cast_div_char_zero {k : Type*} [division_semiring k] [char_zero k] {m n : ℕ}
   (n_dvd : n ∣ m) : ((m / n : ℕ) : k) = m / n :=
 begin
   rcases eq_or_ne n 0 with rfl | hn,

--- a/src/data/int/cast/field.lean
+++ b/src/data/int/cast/field.lean
@@ -28,18 +28,18 @@ variables {α : Type*}
 /--
 Auxiliary lemma for norm_cast to move the cast `-↑n` upwards to `↑-↑n`.
 
-(The restriction to `field` is necessary, otherwise this would also apply in the case where
+(The restriction to `division_ring` is necessary, otherwise this would also apply in the case where
 `R = ℤ` and cause nontermination.)
 -/
 @[norm_cast]
-lemma cast_neg_nat_cast {R} [field R] (n : ℕ) : ((-n : ℤ) : R) = -n := by simp
+lemma cast_neg_nat_cast {R} [division_ring R] (n : ℕ) : ((-n : ℤ) : R) = -n := by simp
 
-@[simp] theorem cast_div [field α] {m n : ℤ} (n_dvd : n ∣ m) (n_nonzero : (n : α) ≠ 0) :
+@[simp] theorem cast_div [division_ring α] {m n : ℤ} (n_dvd : n ∣ m) (n_nonzero : (n : α) ≠ 0) :
   ((m / n : ℤ) : α) = m / n :=
 begin
   rcases n_dvd with ⟨k, rfl⟩,
   have : n ≠ 0, { rintro rfl, simpa using n_nonzero },
-  rw [int.mul_div_cancel_left _ this, int.cast_mul, mul_div_cancel_left _ n_nonzero],
+  rw [int.mul_div_cancel_left _ this, mul_comm n k, int.cast_mul, mul_div_cancel _ n_nonzero],
 end
 
 end int

--- a/src/data/int/char_zero.lean
+++ b/src/data/int/char_zero.lean
@@ -38,7 +38,7 @@ theorem cast_ne_zero [add_group_with_one α] [char_zero α] {n : ℤ} : (n : α)
 not_congr cast_eq_zero
 
 @[simp, norm_cast]
-theorem cast_div_char_zero {k : Type*} [field k] [char_zero k] {m n : ℤ}
+theorem cast_div_char_zero {k : Type*} [division_ring k] [char_zero k] {m n : ℤ}
   (n_dvd : n ∣ m) : ((m / n : ℤ) : k) = m / n :=
 begin
   rcases eq_or_ne n 0 with rfl | hn,

--- a/src/data/nat/cast/field.lean
+++ b/src/data/nat/cast/field.lean
@@ -25,15 +25,16 @@ namespace nat
 
 variables {α : Type*}
 
-@[simp] theorem cast_div [field α] {m n : ℕ} (n_dvd : n ∣ m) (n_nonzero : (n : α) ≠ 0) :
+@[simp] theorem cast_div [division_semiring α] {m n : ℕ} (n_dvd : n ∣ m) (n_nonzero : (n : α) ≠ 0) :
   ((m / n : ℕ) : α) = m / n :=
 begin
   rcases n_dvd with ⟨k, rfl⟩,
   have : n ≠ 0, {rintro rfl, simpa using n_nonzero},
-  rw [nat.mul_div_cancel_left _ this.bot_lt, cast_mul, mul_div_cancel_left _ n_nonzero],
+  rw [nat.mul_div_cancel_left _ this.bot_lt, mul_comm n k, cast_mul, mul_div_cancel _ n_nonzero],
 end
 
-lemma cast_div_div_div_cancel_right [field α] [char_zero α] {m n d : ℕ} (hn : d ∣ n) (hm : d ∣ m) :
+lemma cast_div_div_div_cancel_right [division_semiring α] [char_zero α] {m n d : ℕ}
+  (hn : d ∣ n) (hm : d ∣ m) :
   (↑(m / d) : α) / (↑(n / d) : α) = (m : α) / n :=
 begin
   rcases eq_or_ne d 0 with rfl | hd, { simp [zero_dvd_iff.mp hm], },


### PR DESCRIPTION
Notably, this now works on quaternions.

Forward-ported at https://github.com/leanprover-community/mathlib4/pull/2928

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
