### PR TITLE
[Merged by Bors] - chore(data/fintype/fin): add Iio lemmas

### DIFF
--- a/src/data/fintype/fin.lean
+++ b/src/data/fintype/fin.lean
@@ -23,6 +23,7 @@ namespace fin
 
 variables {α β : Type*} {n : ℕ}
 
+-- TODO: replace `subtype` with `coe` in the name of this lemma and `fin.map_subtype_embedding_Iio` 
 lemma map_subtype_embedding_univ :
   (finset.univ : finset (fin n)).map fin.coe_embedding = Iio n :=
 begin

--- a/src/data/fintype/fin.lean
+++ b/src/data/fintype/fin.lean
@@ -23,6 +23,15 @@ namespace fin
 
 variables {α β : Type*} {n : ℕ}
 
+lemma map_subtype_embedding_univ :
+  (finset.univ : finset (fin n)).map fin.coe_embedding = Iio n :=
+begin
+  ext,
+  simp_rw [finset.mem_map, order_iso_subtype.symm.surjective.exists, finset.mem_univ,
+    exists_true_left, coe_embedding_apply, order_iso.symm, order_iso_subtype_symm_apply,
+    subtype.exists, fin.coe_mk, subtype.coe_mk, mem_Iio, exists_prop, exists_eq_right],
+end
+
 @[simp] lemma Ioi_zero_eq_map :
   Ioi (0 : fin n.succ) = univ.map (fin.succ_embedding _).to_embedding :=
 begin
@@ -34,6 +43,14 @@ begin
     { intros j _, exact ⟨j, rfl⟩ } },
   { rintro ⟨i, _, rfl⟩,
     exact succ_pos _ },
+end
+
+@[simp] lemma Iio_last_eq_map :
+  Iio (fin.last n) = finset.univ.map fin.cast_succ.to_embedding :=
+begin
+  apply finset.map_injective fin.coe_embedding,
+  rw [finset.map_map, fin.map_subtype_embedding_Iio, fin.coe_last],
+  exact map_subtype_embedding_univ.symm
 end
 
 @[simp] lemma Ioi_succ (i : fin n) :
@@ -48,6 +65,14 @@ begin
     { intros i hi,
       refine ⟨i, succ_lt_succ_iff.mp hi, rfl⟩ } },
   { rintro ⟨i, hi, rfl⟩, simpa },
+end
+
+@[simp] lemma Iio_cast_succ (i : fin n) :
+  Iio (cast_succ i) = (Iio i).map fin.cast_succ.to_embedding :=
+begin
+  apply finset.map_injective fin.coe_embedding,
+  rw [finset.map_map, fin.map_subtype_embedding_Iio],
+  exact (fin.map_subtype_embedding_Iio i).symm,
 end
 
 lemma card_filter_univ_succ' (p : fin (n + 1) → Prop) [decidable_pred p] :

--- a/src/data/fintype/fin.lean
+++ b/src/data/fintype/fin.lean
@@ -27,9 +27,7 @@ lemma map_subtype_embedding_univ :
   (finset.univ : finset (fin n)).map fin.coe_embedding = Iio n :=
 begin
   ext,
-  simp_rw [finset.mem_map, order_iso_subtype.symm.surjective.exists, finset.mem_univ,
-    exists_true_left, coe_embedding_apply, order_iso.symm, order_iso_subtype_symm_apply,
-    subtype.exists, fin.coe_mk, subtype.coe_mk, mem_Iio, exists_prop, exists_eq_right],
+  simp [order_iso_subtype.symm.surjective.exists, order_iso.symm],
 end
 
 @[simp] lemma Ioi_zero_eq_map :


### PR DESCRIPTION
These are the analogue to the existing `Ioi` lemmas in this file.

`Iio_last_eq_map` is the dual of `Ioi_zero_eq_map`, and `Iio_cast_succ` is the dual of `Ioi_succ`.

I couldn't find a better home for `map_subtype_embedding_univ`.
Note that it is deliberately `subtype_embedding` and not `coe_embedding` to match the similarly-misnamed `fin.map_subtype_embedding_Iio`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
