### PR TITLE
[Merged by Bors] - chore(topology/algebra/module/basic): move a lemma to a new file

### DIFF
--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -12,7 +12,6 @@ import topology.uniform_space.uniform_embedding
 import algebra.algebra.basic
 import linear_algebra.projection
 import linear_algebra.pi
-import ring_theory.simple_module
 
 /-!
 # Theory of topological modules and continuous linear maps.
@@ -168,13 +167,10 @@ S.to_add_subgroup.topological_add_group
 end submodule
 
 section closure
-variables {R R' : Type u} {M M' : Type v}
+variables {R : Type u} {M : Type v}
 [semiring R] [topological_space R]
-[ring R'] [topological_space R']
 [topological_space M] [add_comm_monoid M]
-[topological_space M'] [add_comm_group M']
 [module R M] [has_continuous_smul R M]
-[module R' M'] [has_continuous_smul R' M']
 
 lemma submodule.closure_smul_self_subset (s : submodule R M) :
   (λ p : R × M, p.1 • p.2) '' (set.univ ×ˢ closure s) ⊆ closure s :=
@@ -248,17 +244,6 @@ lemma submodule.is_closed_or_dense_of_is_coatom (s : submodule R M) (hs : is_coa
   is_closed (s : set M) ∨ dense (s : set M) :=
 (hs.le_iff.mp s.le_topological_closure).swap.imp (is_closed_of_closure_subset ∘ eq.le)
   submodule.dense_iff_topological_closure_eq_top.mpr
-
-lemma linear_map.is_closed_or_dense_ker [has_continuous_add M'] [is_simple_module R' R']
-  (l : M' →ₗ[R'] R') :
-  is_closed (l.ker : set M') ∨ dense (l.ker : set M') :=
-begin
-  rcases l.surjective_or_eq_zero with (hl|rfl),
-  { refine l.ker.is_closed_or_dense_of_is_coatom (linear_map.is_coatom_ker_of_surjective hl) },
-  { rw linear_map.ker_zero,
-    left,
-    exact is_closed_univ },
-end
 
 end closure
 

--- a/src/topology/algebra/module/finite_dimension.lean
+++ b/src/topology/algebra/module/finite_dimension.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Anatole Dedecker
 -/
 import analysis.locally_convex.balanced_core_hull
+import topology.algebra.module.simple
 import topology.algebra.module.determinant
 
 /-!

--- a/src/topology/algebra/module/simple.lean
+++ b/src/topology/algebra/module/simple.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2022 Anatole Dedecker. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anatole Dedecker
+-/
+import ring_theory.simple_module
+import topology.algebra.module.basic
+
+/-!
+# The kernel of a linear function is closed or dense
+
+In this file we prove (`linear_map.is_closed_or_dense_ker`) that the kernel of a linear function `f
+: M →ₗ[R] N` is either closed or dense in `M` provided that `N` is a simple module over `R`. This
+applies, e.g., to the case when `R = N` is a division ring.
+-/
+
+universes u v w
+
+variables {R : Type u} {M : Type v} {N : Type w}
+  [ring R] [topological_space R]
+  [topological_space M] [add_comm_group M] [add_comm_group N]
+  [module R M] [has_continuous_smul R M] [module R N]
+  [has_continuous_add M] [is_simple_module R N]
+
+/-- The kernel of a linear map taking values in a simple module over the base ring is closed or
+dense. Applies, e.g., to the case when `R = N` is a division ring. -/
+lemma linear_map.is_closed_or_dense_ker (l : M →ₗ[R] N) :
+  is_closed (l.ker : set M) ∨ dense (l.ker : set M) :=
+begin
+  rcases l.surjective_or_eq_zero with (hl|rfl),
+  { exact l.ker.is_closed_or_dense_of_is_coatom (linear_map.is_coatom_ker_of_surjective hl) },
+  { rw linear_map.ker_zero,
+    left,
+    exact is_closed_univ },
+end


### PR DESCRIPTION
Also slightly generalize from `[is_simple_module R R]` to `[is_simple_module R N]`.

---
This way `topology.algebra.module.basic` no longer depends on `linear_algebra.isomorphisms`, thus we can port it without waiting for leanprover-community/mathlib4#2364

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
