### PR TITLE
[Merged by Bors] - chore(data/matrix/kronecker): make the `R` argument implicit

### DIFF
--- a/src/data/matrix/kronecker.lean
+++ b/src/data/matrix/kronecker.lean
@@ -246,8 +246,6 @@ end kronecker_map
 
 section kronecker
 
-variables (R)
-
 open_locale matrix
 
 /-- The Kronecker product. This is just a shorthand for `kronecker_map (*)`. Prefer the notation


### PR DESCRIPTION
This was copied erroneously from the `tensor_product` section, where an explicit `R` _is_ needed.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
