### PR TITLE
[Merged by Bors] - feat(number_theory/pell): add API for solutions

### DIFF
--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -144,6 +144,16 @@ lemma x_neg (a : solution₁ d) : (-a).x = -a.x := rfl
 @[simp]
 lemma y_neg (a : solution₁ d) : (-a).y = -a.y := rfl
 
+/-- When `d` is negative, then `x` or `y` must be zero in a solution. -/
+lemma eq_zero_of_d_neg (h₀ : d < 0) (a : solution₁ d) : a.x = 0 ∨ a.y = 0 :=
+begin
+  have h := a.prop,
+  contrapose! h,
+  have h1 := sq_pos_of_ne_zero a.x h.1,
+  have h2 := sq_pos_of_ne_zero a.y h.2,
+  nlinarith,
+end
+
 /-- A solution has `x ≠ 0`. -/
 lemma x_ne_zero (h₀ : 0 < d) (a : solution₁ d) : a.x ≠ 0 :=
 begin

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -310,6 +310,15 @@ begin
   simpa [mul_self_pos.mp h₀, sub_eq_add_neg, eq_neg_self_iff] using int.eq_of_mul_eq_one hxy,
 end
 
+/-- If `d` is a positive integer that is not a square, then there exists a nontrivial solution
+to the Pell equation `x^2 - d*y^2 = 1`. -/
+theorem solution₁.exists_nontrivial_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
+  ∃ a : solution₁ d, a ≠ 1 ∧ a ≠ -1 :=
+begin
+  obtain ⟨x, y, prop, hy⟩ := exists_of_not_is_square h₀ hd,
+  refine ⟨solution₁.mk x y prop, λ H, _, λ H, _⟩; apply_fun solution₁.y at H; simpa [hy] using H,
+end
+
 /-- If `d` is a positive integer that is not a square, then there exists a solution
 to the Pell equation `x^2 - d*y^2 = 1` with `x > 1` and `y > 0`. -/
 lemma exists_pos_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -260,7 +260,7 @@ begin
 end
 
 /-- The set of solutions with `x > 0` is closed under multiplication. -/
-lemma pos_x_mul_pos_x (h₀ : 0 < d) {a b : solution₁ d} (ha : 0 < a.x) (hb : 0 < b.x) :
+lemma x_mul_pos_of_x_pos (h₀ : 0 < d) {a b : solution₁ d} (ha : 0 < a.x) (hb : 0 < b.x) :
   0 < (a * b).x :=
 begin
   simp only [x_mul],
@@ -272,7 +272,7 @@ begin
 end
 
 /-- The set of solutions with `x` and `y` positive is closed under multiplication. -/
-lemma pos_x_pos_y_mul_pos_x_pos_y (h₀ : 0 < d) {a b : solution₁ d} (hax : 0 < a.x)
+lemma x_mul_pos_and_y_mul_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a b : solution₁ d} (hax : 0 < a.x)
   (hay : 0 < a.y) (hbx : 0 < b.x) (hby : 0 < b.y) :
   0 < (a * b).x ∧ 0 < (a * b).y :=
 begin
@@ -282,7 +282,7 @@ end
 
 /-- If `(x, y)` is a solution with `x` and `y` positive, then all powers of it have positive `x`,
 and the sign of `y` agrees with that of the exponent. -/
-lemma pos_x_pos_y_pow (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y) (n : ℤ) :
+lemma x_pow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y) (n : ℤ) :
   0 < (a ^ n).x ∧
   (if 0 < n then 0 < (a ^ n).y else if n < 0 then (a ^ n).y < 0 else (a ^ n).y = 0) :=
 begin
@@ -290,7 +290,7 @@ begin
   { change ∀ m : ℤ, 1 ≤ m → _,
     refine λ m, int.le_induction (by simp only [hax, hay, zpow_one, and_self]) (λ m hm ih, _) m,
     rw zpow_add_one,
-    exact pos_x_pos_y_mul_pos_x_pos_y h₀ ih.1 ih.2 hax hay, },
+    exact x_mul_pos_and_y_mul_pos_of_x_pos_of_y_pos h₀ ih.1 ih.2 hax hay, },
   split_ifs with hn₁ hn₂,
   -- three cases: `0 < n`, `n < 0`, `n = 0`
   { exact H n hn₁, },

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -192,17 +192,17 @@ begin
 end
 
 /-- The set of solutions with `x` and `y` positive is closed under multiplication. -/
-lemma x_mul_pos_and_y_mul_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a b : solution₁ d} (hax : 0 < a.x)
+lemma y_mul_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a b : solution₁ d} (hax : 0 < a.x)
   (hay : 0 < a.y) (hbx : 0 < b.x) (hby : 0 < b.y) :
-  0 < (a * b).x ∧ 0 < (a * b).y :=
+  0 < (a * b).y :=
 begin
-  simp only [x_mul, y_mul],
-  split; positivity,
+  simp only [y_mul],
+  positivity,
 end
 
 /-- If `(x, y)` is a solution with `x` and `y` positive, then all powers of it have positive `x`,
 and the sign of `y` agrees with that of the exponent. -/
-lemma x_pow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
+lemma x_zpow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
   (n : ℤ) :
   0 < (a ^ n).x ∧ (a ^ n).y.sign = n.sign :=
 begin
@@ -210,7 +210,7 @@ begin
   { change ∀ m : ℤ, 1 ≤ m → _,
     refine λ m, int.le_induction (by simp only [hax, hay, zpow_one, and_self]) (λ m hm ih, _) m,
     rw zpow_add_one,
-    exact x_mul_pos_and_y_mul_pos_of_x_pos_of_y_pos h₀ ih.1 ih.2 hax hay, },
+    exact ⟨x_mul_pos_of_x_pos h₀ ih.1 hax, y_mul_pos_of_x_pos_of_y_pos h₀ ih.1 ih.2 hax hay⟩, },
   rcases lt_trichotomy 0 n with hpos | rfl | hneg,
   { rw [(int.sign_eq_one_iff_pos n).mpr hpos, int.sign_eq_one_iff_pos],
     exact H n hpos, },
@@ -221,10 +221,22 @@ begin
     exact H (-n) (lt_neg.mp hneg), }
 end
 
+/-- If `(x, y)` is a solution with `x` and `y` positive, then all powers of it with positive
+natural exponents have positive `x` and `y`. -/
+lemma x_npow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
+  (n : ℕ) :
+  0 < (a ^ n.succ).x ∧ 0 < (a ^ n.succ).y :=
+begin
+  induction n with n ih,
+  { simp only [hax, hay, pow_one, and_self], },
+  { rw [pow_succ],
+    exact ⟨x_mul_pos_of_x_pos h₀ hax ih.1, y_mul_pos_of_x_pos_of_y_pos h₀ hax hay ih.1 ih.2⟩, }
+end
+
 /-- If `a` is any solution, then one of `a`, `a⁻¹`, `-a`, `-a⁻¹` has
 positive `x` and nonnegative `y`. -/
 lemma exists_pos_variant (h₀ : 0 < d) (a : solution₁ d) :
-  ∃ b : solution₁ d, 0 < b.x ∧ 0 ≤ b.y ∧ (a = b ∨ a = b⁻¹ ∨ a = -b ∨ a = -b⁻¹) :=
+  ∃ b : solution₁ d, 0 < b.x ∧ 0 ≤ b.y ∧ a ∈ ({b, b⁻¹, -b, -b⁻¹} : set (solution₁ d)) :=
 begin
   refine ⟨mk (|a.x|) (|a.y|) (by simp [a.prop]), abs_pos.mpr (a.x_ne_zero h₀), abs_nonneg a.y, _⟩,
   cases le_or_lt 0 a.x with hax hax; cases le_or_lt 0 a.y with hay hay,

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -155,10 +155,10 @@ begin
 end
 
 /-- A solution has `x ≠ 0`. -/
-lemma x_ne_zero (h₀ : 0 < d) (a : solution₁ d) : a.x ≠ 0 :=
+lemma x_ne_zero (h₀ : 0 ≤ d) (a : solution₁ d) : a.x ≠ 0 :=
 begin
   intro hx,
-  have h : 0 ≤ d * a.y ^ 2 := mul_nonneg h₀.le (sq_nonneg _),
+  have h : 0 ≤ d * a.y ^ 2 := mul_nonneg h₀ (sq_nonneg _),
   rw [a.prop_y, hx, sq, zero_mul, zero_sub] at h,
   exact not_le.mpr (neg_one_lt_zero : (-1 : ℤ) < 0) h,
 end
@@ -173,10 +173,10 @@ begin
 end
 
 /-- A solution with `x = 1` is trivial. -/
-lemma eq_one_of_x_eq_one (h₀ : 0 < d) {a : solution₁ d} (ha : a.x = 1) : a = 1 :=
+lemma eq_one_of_x_eq_one (h₀ : d ≠ 0) {a : solution₁ d} (ha : a.x = 1) : a = 1 :=
 begin
   have prop := a.prop_y,
-  rw [ha, one_pow, sub_self, mul_eq_zero, or_iff_right h₀.ne', sq_eq_zero_iff] at prop,
+  rw [ha, one_pow, sub_self, mul_eq_zero, or_iff_right h₀, sq_eq_zero_iff] at prop,
   exact ext ha prop,
 end
 
@@ -215,46 +215,46 @@ end
 
 /-- If `(x, y)` is a solution with `x` positive, then all its powers with natural exponents
 have positive `x`. -/
-lemma x_pow_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (n : ℕ) : 0 < (a ^ n).x :=
+lemma x_pow_pos {a : solution₁ d} (hax : 0 < a.x) (n : ℕ) : 0 < (a ^ n).x :=
 begin
   induction n with n ih,
   { simp only [pow_zero, x_one, zero_lt_one], },
   { rw [pow_succ],
-    exact x_mul_pos h₀ hax ih, }
+    exact x_mul_pos hax ih, }
 end
 
 /-- If `(x, y)` is a solution with `x` and `y` positive, then all its powers with positive
-natural exponents have positive `x` and `y`. -/
-lemma y_pow_succ_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y) (n : ℕ) :
+natural exponents have positive `y`. -/
+lemma y_pow_succ_pos {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y) (n : ℕ) :
   0 < (a ^ n.succ).y :=
 begin
   induction n with n ih,
   { simp only [hay, pow_one], },
   { rw [pow_succ],
-    exact y_mul_pos hax hay (x_pow_pos h₀ hax _) ih, }
+    exact y_mul_pos hax hay (x_pow_pos hax _) ih, }
 end
 
 /-- If `(x, y)` is a solution with `x` positive, then all its powers have positive `x`. -/
-lemma x_zpow_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (n : ℤ) : 0 < (a ^ n).x :=
+lemma x_zpow_pos {a : solution₁ d} (hax : 0 < a.x) (n : ℤ) : 0 < (a ^ n).x :=
 begin
   cases le_or_lt 0 n with h h,
   { rw [← int.to_nat_of_nonneg h, zpow_coe_nat],
-    exact x_pow_pos h₀ hax _, },
+    exact x_pow_pos hax _, },
   { rw [← neg_neg n, zpow_neg, x_inv, ← int.to_nat_of_nonneg (neg_nonneg.mpr h.le), zpow_coe_nat],
-    exact x_pow_pos h₀ hax _, },
+    exact x_pow_pos hax _, },
 end
 
-/-- If `(x, y)` is a solution with `x` and `y` positive, then the `y` component of its powers
-have the same sign as the exponent. -/
-lemma sign_y_zpow_eq_sign_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x)
-  (hay : 0 < a.y) (n : ℤ) :
+/-- If `(x, y)` is a solution with `x` and `y` positive, then the `y` component of any power
+has the same sign as the exponent. -/
+lemma sign_y_zpow_eq_sign_of_x_pos_of_y_pos {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
+   (n : ℤ) :
   (a ^ n).y.sign = n.sign :=
 begin
   have H : ∀ m : ℤ, 0 < m → 0 < (a ^ m).y,
   { change ∀ m : ℤ, 1 ≤ m → _,
     refine λ m, int.le_induction (by simp only [hay, zpow_one]) (λ m hm ih, _) m,
     rw zpow_add_one,
-    exact y_mul_pos (x_zpow_pos h₀ hax m) ih hax hay, },
+    exact y_mul_pos (x_zpow_pos hax m) ih hax hay, },
   rcases lt_trichotomy 0 n with hpos | rfl | hneg,
   { rw [(int.sign_eq_one_iff_pos n).mpr hpos, int.sign_eq_one_iff_pos],
     exact H n hpos, },
@@ -269,7 +269,8 @@ positive `x` and nonnegative `y`. -/
 lemma exists_pos_variant (h₀ : 0 < d) (a : solution₁ d) :
   ∃ b : solution₁ d, 0 < b.x ∧ 0 ≤ b.y ∧ a ∈ ({b, b⁻¹, -b, -b⁻¹} : set (solution₁ d)) :=
 begin
-  refine ⟨mk (|a.x|) (|a.y|) (by simp [a.prop]), abs_pos.mpr (a.x_ne_zero h₀), abs_nonneg a.y, _⟩,
+  refine ⟨mk (|a.x|) (|a.y|) (by simp [a.prop]),
+          abs_pos.mpr (a.x_ne_zero h₀.le), abs_nonneg a.y, _⟩,
   cases le_or_lt 0 a.x with hax hax; cases le_or_lt 0 a.y with hay hay,
   { exact or.inl (ext (abs_of_nonneg hax).symm (abs_of_nonneg hay).symm), },
   { exact or.inr (or.inl $ ext (by simp [abs_of_nonneg hax]) (by simp [abs_of_neg hay])), },
@@ -387,8 +388,8 @@ begin
   obtain ⟨a, ha₁, ha₂⟩ := exists_nontrivial_of_not_is_square h₀ hd,
   obtain ⟨b, hb₁, hb₂, hb₃⟩ := exists_pos_variant h₀ a,
   refine ⟨b, lt_iff_le_and_ne.mpr ⟨hb₁, λ hf, _⟩, lt_iff_le_and_ne.mpr ⟨hb₂, λ hf, _⟩⟩,
-  { have := eq_one_of_x_eq_one h₀ hf.symm,
-    rw [eq_one_of_x_eq_one h₀ hf.symm, inv_one] at hb₃,
+  { have := eq_one_of_x_eq_one h₀.ne' hf.symm,
+    rw [eq_one_of_x_eq_one h₀.ne' hf.symm, inv_one] at hb₃,
     simpa only [ha₁, ha₂, or_self, mem_insert_iff, mem_singleton_iff] using hb₃, },
   { cases eq_one_or_neg_one_iff_y_eq_zero.mpr hf.symm with h h; rw h at hb₃,
     { simpa only [ha₁, ha₂, inv_one, or_self, mem_insert_iff, mem_singleton_iff] using hb₃, },

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -220,10 +220,9 @@ begin
   { rw [pow_succ],
     exact y_mul_pos hax hay (x_pow_pos h₀ hax _) ih, }
 end
-example (n : ℤ) (h : n ≤ 0) : 0 ≤ -n := neg_nonneg.mpr h
+
 /-- If `(x, y)` is a solution with `x` positive, then all its powers have positive `x`. -/
-lemma x_zpow_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (n : ℤ) :
-  0 < (a ^ n).x :=
+lemma x_zpow_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (n : ℤ) : 0 < (a ^ n).x :=
 begin
   cases le_or_lt 0 n with h h,
   { rw [← int.to_nat_of_nonneg h, zpow_coe_nat],

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -231,13 +231,11 @@ lemma exists_pos_variant (h₀ : 0 < d) (a : solution₁ d) :
 begin
   refine ⟨mk (|a.x|) (|a.y|) (by simp [a.prop]), abs_pos.mpr (a.x_ne_zero h₀), abs_nonneg a.y, _⟩,
   cases le_or_lt 0 a.x with hax hax; cases le_or_lt 0 a.y with hay hay,
-  { exact or.inl (solution₁.ext (abs_of_nonneg hax).symm (abs_of_nonneg hay).symm), },
-  { exact or.inr (or.inl $ solution₁.ext (by simp [abs_of_nonneg hax])
-                                         (by simp [abs_of_neg hay])), },
-  { exact or.inr (or.inr $ or.inr $ solution₁.ext (by simp [abs_of_neg hax])
-                                                  (by simp [abs_of_nonneg hay])), },
-  { exact or.inr (or.inr $ or.inl $ solution₁.ext (by simp [abs_of_neg hax])
-                                                  (by simp [abs_of_neg hay])),}
+  { exact or.inl (ext (abs_of_nonneg hax).symm (abs_of_nonneg hay).symm), },
+  { exact or.inr (or.inl $ ext (by simp [abs_of_nonneg hax]) (by simp [abs_of_neg hay])), },
+  { exact or.inr (or.inr $ or.inr $ ext (by simp [abs_of_neg hax])
+                                        (by simp [abs_of_nonneg hay])), },
+  { exact or.inr (or.inr $ or.inl $ ext (by simp [abs_of_neg hax]) (by simp [abs_of_neg hay])),}
 end
 
 end solution₁
@@ -330,30 +328,34 @@ begin
   simpa [mul_self_pos.mp h₀, sub_eq_add_neg, eq_neg_self_iff] using int.eq_of_mul_eq_one hxy,
 end
 
+namespace solution₁
+
 /-- If `d` is a positive integer that is not a square, then there exists a nontrivial solution
 to the Pell equation `x^2 - d*y^2 = 1`. -/
-theorem solution₁.exists_nontrivial_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
+theorem exists_nontrivial_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
   ∃ a : solution₁ d, a ≠ 1 ∧ a ≠ -1 :=
 begin
   obtain ⟨x, y, prop, hy⟩ := exists_of_not_is_square h₀ hd,
-  refine ⟨solution₁.mk x y prop, λ H, _, λ H, _⟩; apply_fun solution₁.y at H; simpa [hy] using H,
+  refine ⟨mk x y prop, λ H, _, λ H, _⟩; apply_fun solution₁.y at H; simpa [hy] using H,
 end
 
 /-- If `d` is a positive integer that is not a square, then there exists a solution
 to the Pell equation `x^2 - d*y^2 = 1` with `x > 1` and `y > 0`. -/
-lemma solution₁.exists_pos_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
+lemma exists_pos_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
   ∃ a : solution₁ d, 1 < a.x ∧ 0 < a.y :=
 begin
-  obtain ⟨a, ha₁, ha₂⟩ := solution₁.exists_nontrivial_of_not_is_square h₀ hd,
-  obtain ⟨b, hb₁, hb₂, hb₃⟩ := solution₁.exists_pos_variant h₀ a,
+  obtain ⟨a, ha₁, ha₂⟩ := exists_nontrivial_of_not_is_square h₀ hd,
+  obtain ⟨b, hb₁, hb₂, hb₃⟩ := exists_pos_variant h₀ a,
   refine ⟨b, lt_iff_le_and_ne.mpr ⟨hb₁, λ hf, _⟩, lt_iff_le_and_ne.mpr ⟨hb₂, λ hf, _⟩⟩,
-  { have := solution₁.eq_one_of_x_eq_one h₀ hf.symm,
-    rw [solution₁.eq_one_of_x_eq_one h₀ hf.symm, inv_one] at hb₃,
+  { have := eq_one_of_x_eq_one h₀ hf.symm,
+    rw [eq_one_of_x_eq_one h₀ hf.symm, inv_one] at hb₃,
     simpa only [ha₁, ha₂, or_self] using hb₃, },
-  { cases solution₁.eq_one_or_neg_one_iff_y_eq_zero.mpr hf.symm with h h; rw h at hb₃,
+  { cases eq_one_or_neg_one_iff_y_eq_zero.mpr hf.symm with h h; rw h at hb₃,
     { simpa only [ha₁, ha₂, inv_one, or_self] using hb₃, },
     { simpa only [ha₁, ha₂, inv_neg', inv_one, neg_neg, or_self] using hb₃, } }
 end
+
+end solution₁
 
 end existence
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -383,4 +383,6 @@ end
 
 end solution₁
 
+end existence
+
 end pell

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -190,15 +190,18 @@ begin
 end
 
 /-- The set of solutions with `x > 0` is closed under multiplication. -/
-lemma x_mul_pos (h₀ : 0 < d) {a b : solution₁ d} (ha : 0 < a.x) (hb : 0 < b.x) :
-  0 < (a * b).x :=
+lemma x_mul_pos {a b : solution₁ d} (ha : 0 < a.x) (hb : 0 < b.x) : 0 < (a * b).x :=
 begin
   simp only [x_mul],
   refine neg_lt_iff_pos_add'.mp (abs_lt.mp _).1,
   rw [← abs_of_pos ha, ← abs_of_pos hb, ← abs_mul, ← sq_lt_sq, mul_pow a.x, a.prop_x, b.prop_x,
       ← sub_pos],
   ring_nf,
-  positivity,
+  cases le_or_lt 0 d with h h,
+  { positivity, },
+  { rw [(eq_zero_of_d_neg h a).resolve_left ha.ne', (eq_zero_of_d_neg h b).resolve_left hb.ne',
+        zero_pow two_pos, zero_add, zero_mul, zero_add],
+    exact one_pos, },
 end
 
 /-- The set of solutions with `x` and `y` positive is closed under multiplication. -/

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -180,7 +180,7 @@ begin
 end
 
 /-- The set of solutions with `x > 0` is closed under multiplication. -/
-lemma x_mul_pos_of_x_pos (h₀ : 0 < d) {a b : solution₁ d} (ha : 0 < a.x) (hb : 0 < b.x) :
+lemma x_mul_pos (h₀ : 0 < d) {a b : solution₁ d} (ha : 0 < a.x) (hb : 0 < b.x) :
   0 < (a * b).x :=
 begin
   simp only [x_mul],
@@ -209,7 +209,7 @@ begin
   induction n with n ih,
   { simp only [hax, hay, pow_one, and_self], },
   { rw [pow_succ],
-    exact ⟨x_mul_pos_of_x_pos h₀ hax ih.1, y_mul_pos_of_x_pos_of_y_pos hax hay ih.1 ih.2⟩, }
+    exact ⟨x_mul_pos h₀ hax ih.1, y_mul_pos_of_x_pos_of_y_pos hax hay ih.1 ih.2⟩, }
 end
 
 /-- If `(x, y)` is a solution with `x` positive, then all its powers have positive `x`. -/
@@ -221,7 +221,7 @@ begin
   { change ∀ m : ℤ, 1 ≤ m → _,
     refine λ m, int.le_induction (by simp only [hax, zpow_one]) (λ m hm ih, _) m,
     rw zpow_add_one,
-    exact x_mul_pos_of_x_pos h₀ ih hax, },
+    exact x_mul_pos h₀ ih hax, },
   rcases lt_trichotomy 0 n with hpos | rfl | hneg,
   { exact H n hpos, },
   { simp only [zpow_zero, x_one, zero_lt_one], },

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -358,10 +358,11 @@ begin
   refine ⟨b, lt_iff_le_and_ne.mpr ⟨hb₁, λ hf, _⟩, lt_iff_le_and_ne.mpr ⟨hb₂, λ hf, _⟩⟩,
   { have := eq_one_of_x_eq_one h₀ hf.symm,
     rw [eq_one_of_x_eq_one h₀ hf.symm, inv_one] at hb₃,
-    simpa only [ha₁, ha₂, or_self] using hb₃, },
+    simpa only [ha₁, ha₂, or_self, mem_insert_iff, mem_singleton_iff] using hb₃, },
   { cases eq_one_or_neg_one_iff_y_eq_zero.mpr hf.symm with h h; rw h at hb₃,
-    { simpa only [ha₁, ha₂, inv_one, or_self] using hb₃, },
-    { simpa only [ha₁, ha₂, inv_neg', inv_one, neg_neg, or_self] using hb₃, } }
+    { simpa only [ha₁, ha₂, inv_one, or_self, mem_insert_iff, mem_singleton_iff] using hb₃, },
+    { simpa only [ha₁, ha₂, inv_neg', inv_one, neg_neg, or_self, mem_insert_iff, mem_singleton_iff]
+        using hb₃, } }
 end
 
 end solution₁

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -250,7 +250,6 @@ begin
   exact not_le.mpr (neg_one_lt_zero : (-1 : ℤ) < 0) h,
 end
 
-example (a b : ℤ) : ¬ a ≤ b ↔ b < a := not_le
 /-- A solution with `x > 1` must have `y ≠ 0`. -/
 lemma y_ne_zero_of_one_lt_x {a : solution₁ d} (ha : 1 < a.x) : a.y ≠ 0 :=
 begin

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -222,8 +222,7 @@ begin
 end
 
 /-- If `(x, y)` is a solution with `x` positive, then all its powers have positive `x`. -/
-lemma x_zpow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x)
-  (n : ℤ) :
+lemma x_zpow_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (n : ℤ) :
   0 < (a ^ n).x :=
 begin
   have H : ∀ m : ℤ, 0 < m → 0 < (a ^ m).x,
@@ -248,7 +247,7 @@ begin
   { change ∀ m : ℤ, 1 ≤ m → _,
     refine λ m, int.le_induction (by simp only [hay, zpow_one]) (λ m hm ih, _) m,
     rw zpow_add_one,
-    exact y_mul_pos (x_zpow_pos_of_x_pos_of_y_pos h₀ hax m) ih hax hay, },
+    exact y_mul_pos (x_zpow_pos h₀ hax m) ih hax hay, },
   rcases lt_trichotomy 0 n with hpos | rfl | hneg,
   { rw [(int.sign_eq_one_iff_pos n).mpr hpos, int.sign_eq_one_iff_pos],
     exact H n hpos, },

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -41,103 +41,6 @@ Pell's equation
 
 namespace pell
 
-section existence
-
-variables {d : ℤ}
-
-open set real
-
-/-- If `d` is a positive integer that is not a square, then there is a nontrivial solution
-to the Pell equation `x^2 - d*y^2 = 1`. -/
-theorem exists_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
-  ∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ y ≠ 0 :=
-begin
-  let ξ : ℝ := sqrt d,
-  have hξ : irrational ξ,
-  { refine irrational_nrt_of_notint_nrt 2 d (sq_sqrt $ int.cast_nonneg.mpr h₀.le) _ two_pos,
-    rintro ⟨x, hx⟩,
-    refine hd ⟨x, @int.cast_injective ℝ _ _ d (x * x) _⟩,
-    rw [← sq_sqrt $ int.cast_nonneg.mpr h₀.le, int.cast_mul, ← hx, sq], },
-  obtain ⟨M, hM₁⟩ := exists_int_gt (2 * |ξ| + 1),
-  have hM : {q : ℚ | |q.1 ^ 2 - d * q.2 ^ 2| < M}.infinite,
-  { refine infinite.mono (λ q h, _) (infinite_rat_abs_sub_lt_one_div_denom_sq_of_irrational hξ),
-    have h0 : 0 < (q.2 : ℝ) ^ 2 := pow_pos (nat.cast_pos.mpr q.pos) 2,
-    have h1 : (q.num : ℝ) / (q.denom : ℝ) = q := by exact_mod_cast q.num_div_denom,
-    rw [mem_set_of, abs_sub_comm, ← @int.cast_lt ℝ, ← div_lt_div_right (abs_pos_of_pos h0)],
-    push_cast,
-    rw [← abs_div, abs_sq, sub_div, mul_div_cancel _ h0.ne',
-        ← div_pow, h1, ← sq_sqrt (int.cast_pos.mpr h₀).le, sq_sub_sq, abs_mul, ← mul_one_div],
-    refine mul_lt_mul'' (((abs_add ξ q).trans _).trans_lt hM₁) h (abs_nonneg _) (abs_nonneg _),
-    rw [two_mul, add_assoc, add_le_add_iff_left, ← sub_le_iff_le_add'],
-    rw [mem_set_of, abs_sub_comm] at h,
-    refine (abs_sub_abs_le_abs_sub (q : ℝ) ξ).trans (h.le.trans _),
-    rw [div_le_one h0, one_le_sq_iff_one_le_abs, nat.abs_cast, nat.one_le_cast],
-    exact q.pos, },
-  obtain ⟨m, hm⟩ : ∃ m : ℤ, {q : ℚ | q.1 ^ 2 - d * q.2 ^ 2 = m}.infinite,
-  { contrapose! hM,
-    simp only [not_infinite] at hM ⊢,
-    refine (congr_arg _ (ext (λ x, _))).mp (finite.bUnion (finite_Ioo (-M) M) (λ m _, hM m)),
-    simp only [abs_lt, mem_set_of_eq, mem_Ioo, mem_Union, exists_prop, exists_eq_right'], },
-  have hm₀ : m ≠ 0,
-  { rintro rfl,
-    obtain ⟨q, hq⟩ := hm.nonempty,
-    rw [mem_set_of, sub_eq_zero, mul_comm] at hq,
-    obtain ⟨a, ha⟩ := (int.pow_dvd_pow_iff two_pos).mp ⟨d, hq⟩,
-    rw [ha, mul_pow, mul_right_inj' (pow_pos (int.coe_nat_pos.mpr q.pos) 2).ne'] at hq,
-    exact hd ⟨a, sq a ▸ hq.symm⟩, },
-  haveI := ne_zero_iff.mpr (int.nat_abs_ne_zero.mpr hm₀),
-  let f : ℚ → (zmod m.nat_abs) × (zmod m.nat_abs) := λ q, (q.1, q.2),
-  obtain ⟨q₁, h₁ : q₁.1 ^ 2 - d * q₁.2 ^ 2 = m, q₂, h₂ : q₂.1 ^ 2 - d * q₂.2 ^ 2 = m, hne, hqf⟩ :=
-    hm.exists_ne_map_eq_of_maps_to (maps_to_univ f _) finite_univ,
-  obtain ⟨hq1 : (q₁.1 : zmod m.nat_abs) = q₂.1, hq2 : (q₁.2 : zmod m.nat_abs) = q₂.2⟩ :=
-    prod.ext_iff.mp hqf,
-  have hd₁ : m ∣ q₁.1 * q₂.1 - d * (q₁.2 * q₂.2),
-  { rw [← int.nat_abs_dvd, ← zmod.int_coe_zmod_eq_zero_iff_dvd],
-    push_cast,
-    rw [hq1, hq2, ← sq, ← sq],
-    norm_cast,
-    rw [zmod.int_coe_zmod_eq_zero_iff_dvd, int.nat_abs_dvd, nat.cast_pow, ← h₂], },
-  have hd₂ : m ∣ q₁.1 * q₂.2 - q₂.1 * q₁.2,
-  { rw [← int.nat_abs_dvd, ← zmod.int_coe_eq_int_coe_iff_dvd_sub],
-    push_cast,
-    rw [hq1, hq2], },
-  replace hm₀ : (m : ℚ) ≠ 0 := int.cast_ne_zero.mpr hm₀,
-  refine ⟨(q₁.1 * q₂.1 - d * (q₁.2 * q₂.2)) / m, (q₁.1 * q₂.2 - q₂.1 * q₁.2) / m, _, _⟩,
-  { qify [hd₁, hd₂],
-    field_simp [hm₀],
-    norm_cast,
-    conv_rhs {congr, rw sq, congr, rw ← h₁, skip, rw ← h₂},
-    push_cast,
-    ring, },
-  { qify [hd₂],
-    refine div_ne_zero_iff.mpr ⟨_, hm₀⟩,
-    exact_mod_cast mt sub_eq_zero.mp (mt rat.eq_iff_mul_eq_mul.mpr hne), },
-end
-
-/-- If `d` is a positive integer, then there is a nontrivial solution
-to the Pell equation `x^2 - d*y^2 = 1` if and only if `d` is not a square. -/
-theorem exists_iff_not_is_square (h₀ : 0 < d) :
-  (∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ y ≠ 0) ↔ ¬ is_square d :=
-begin
-  refine ⟨_, exists_of_not_is_square h₀⟩,
-  rintros ⟨x, y, hxy, hy⟩ ⟨a, rfl⟩,
-  rw [← sq, ← mul_pow, sq_sub_sq] at hxy,
-  simpa [mul_self_pos.mp h₀, sub_eq_add_neg, eq_neg_self_iff] using int.eq_of_mul_eq_one hxy,
-end
-
-/-- If `d` is a positive integer that is not a square, then there exists a solution
-to the Pell equation `x^2 - d*y^2 = 1` with `x > 1` and `y > 0`. -/
-lemma exists_pos_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
-  ∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ 1 < x ∧ 0 < y :=
-begin
-  obtain ⟨x, y, h, hy⟩ := exists_of_not_is_square h₀ hd,
-  refine ⟨|x|, |y|, by rwa [sq_abs, sq_abs], _, abs_pos.mpr hy⟩,
-  rw [← one_lt_sq_iff_one_lt_abs, eq_add_of_sub_eq h, lt_add_iff_pos_right],
-  exact mul_pos h₀ (sq_pos_of_ne_zero y hy),
-end
-
-end existence
-
 /-!
 ### Group structure of the solution set
 
@@ -318,5 +221,107 @@ begin
 end
 
 end solution₁
+
+section existence
+
+/-!
+### Existence of nontrivial solutions
+-/
+
+variables {d : ℤ}
+
+open set real
+
+/-- If `d` is a positive integer that is not a square, then there is a nontrivial solution
+to the Pell equation `x^2 - d*y^2 = 1`. -/
+theorem exists_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
+  ∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ y ≠ 0 :=
+begin
+  let ξ : ℝ := sqrt d,
+  have hξ : irrational ξ,
+  { refine irrational_nrt_of_notint_nrt 2 d (sq_sqrt $ int.cast_nonneg.mpr h₀.le) _ two_pos,
+    rintro ⟨x, hx⟩,
+    refine hd ⟨x, @int.cast_injective ℝ _ _ d (x * x) _⟩,
+    rw [← sq_sqrt $ int.cast_nonneg.mpr h₀.le, int.cast_mul, ← hx, sq], },
+  obtain ⟨M, hM₁⟩ := exists_int_gt (2 * |ξ| + 1),
+  have hM : {q : ℚ | |q.1 ^ 2 - d * q.2 ^ 2| < M}.infinite,
+  { refine infinite.mono (λ q h, _) (infinite_rat_abs_sub_lt_one_div_denom_sq_of_irrational hξ),
+    have h0 : 0 < (q.2 : ℝ) ^ 2 := pow_pos (nat.cast_pos.mpr q.pos) 2,
+    have h1 : (q.num : ℝ) / (q.denom : ℝ) = q := by exact_mod_cast q.num_div_denom,
+    rw [mem_set_of, abs_sub_comm, ← @int.cast_lt ℝ, ← div_lt_div_right (abs_pos_of_pos h0)],
+    push_cast,
+    rw [← abs_div, abs_sq, sub_div, mul_div_cancel _ h0.ne',
+        ← div_pow, h1, ← sq_sqrt (int.cast_pos.mpr h₀).le, sq_sub_sq, abs_mul, ← mul_one_div],
+    refine mul_lt_mul'' (((abs_add ξ q).trans _).trans_lt hM₁) h (abs_nonneg _) (abs_nonneg _),
+    rw [two_mul, add_assoc, add_le_add_iff_left, ← sub_le_iff_le_add'],
+    rw [mem_set_of, abs_sub_comm] at h,
+    refine (abs_sub_abs_le_abs_sub (q : ℝ) ξ).trans (h.le.trans _),
+    rw [div_le_one h0, one_le_sq_iff_one_le_abs, nat.abs_cast, nat.one_le_cast],
+    exact q.pos, },
+  obtain ⟨m, hm⟩ : ∃ m : ℤ, {q : ℚ | q.1 ^ 2 - d * q.2 ^ 2 = m}.infinite,
+  { contrapose! hM,
+    simp only [not_infinite] at hM ⊢,
+    refine (congr_arg _ (ext (λ x, _))).mp (finite.bUnion (finite_Ioo (-M) M) (λ m _, hM m)),
+    simp only [abs_lt, mem_set_of_eq, mem_Ioo, mem_Union, exists_prop, exists_eq_right'], },
+  have hm₀ : m ≠ 0,
+  { rintro rfl,
+    obtain ⟨q, hq⟩ := hm.nonempty,
+    rw [mem_set_of, sub_eq_zero, mul_comm] at hq,
+    obtain ⟨a, ha⟩ := (int.pow_dvd_pow_iff two_pos).mp ⟨d, hq⟩,
+    rw [ha, mul_pow, mul_right_inj' (pow_pos (int.coe_nat_pos.mpr q.pos) 2).ne'] at hq,
+    exact hd ⟨a, sq a ▸ hq.symm⟩, },
+  haveI := ne_zero_iff.mpr (int.nat_abs_ne_zero.mpr hm₀),
+  let f : ℚ → (zmod m.nat_abs) × (zmod m.nat_abs) := λ q, (q.1, q.2),
+  obtain ⟨q₁, h₁ : q₁.1 ^ 2 - d * q₁.2 ^ 2 = m, q₂, h₂ : q₂.1 ^ 2 - d * q₂.2 ^ 2 = m, hne, hqf⟩ :=
+    hm.exists_ne_map_eq_of_maps_to (maps_to_univ f _) finite_univ,
+  obtain ⟨hq1 : (q₁.1 : zmod m.nat_abs) = q₂.1, hq2 : (q₁.2 : zmod m.nat_abs) = q₂.2⟩ :=
+    prod.ext_iff.mp hqf,
+  have hd₁ : m ∣ q₁.1 * q₂.1 - d * (q₁.2 * q₂.2),
+  { rw [← int.nat_abs_dvd, ← zmod.int_coe_zmod_eq_zero_iff_dvd],
+    push_cast,
+    rw [hq1, hq2, ← sq, ← sq],
+    norm_cast,
+    rw [zmod.int_coe_zmod_eq_zero_iff_dvd, int.nat_abs_dvd, nat.cast_pow, ← h₂], },
+  have hd₂ : m ∣ q₁.1 * q₂.2 - q₂.1 * q₁.2,
+  { rw [← int.nat_abs_dvd, ← zmod.int_coe_eq_int_coe_iff_dvd_sub],
+    push_cast,
+    rw [hq1, hq2], },
+  replace hm₀ : (m : ℚ) ≠ 0 := int.cast_ne_zero.mpr hm₀,
+  refine ⟨(q₁.1 * q₂.1 - d * (q₁.2 * q₂.2)) / m, (q₁.1 * q₂.2 - q₂.1 * q₁.2) / m, _, _⟩,
+  { qify [hd₁, hd₂],
+    field_simp [hm₀],
+    norm_cast,
+    conv_rhs {congr, rw sq, congr, rw ← h₁, skip, rw ← h₂},
+    push_cast,
+    ring, },
+  { qify [hd₂],
+    refine div_ne_zero_iff.mpr ⟨_, hm₀⟩,
+    exact_mod_cast mt sub_eq_zero.mp (mt rat.eq_iff_mul_eq_mul.mpr hne), },
+end
+
+/-- If `d` is a positive integer, then there is a nontrivial solution
+to the Pell equation `x^2 - d*y^2 = 1` if and only if `d` is not a square. -/
+theorem exists_iff_not_is_square (h₀ : 0 < d) :
+  (∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ y ≠ 0) ↔ ¬ is_square d :=
+begin
+  refine ⟨_, exists_of_not_is_square h₀⟩,
+  rintros ⟨x, y, hxy, hy⟩ ⟨a, rfl⟩,
+  rw [← sq, ← mul_pow, sq_sub_sq] at hxy,
+  simpa [mul_self_pos.mp h₀, sub_eq_add_neg, eq_neg_self_iff] using int.eq_of_mul_eq_one hxy,
+end
+
+/-- If `d` is a positive integer that is not a square, then there exists a solution
+to the Pell equation `x^2 - d*y^2 = 1` with `x > 1` and `y > 0`. -/
+lemma exists_pos_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
+  ∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ 1 < x ∧ 0 < y :=
+begin
+  obtain ⟨x, y, h, hy⟩ := exists_of_not_is_square h₀ hd,
+  refine ⟨|x|, |y|, by rwa [sq_abs, sq_abs], _, abs_pos.mpr hy⟩,
+  rw [← one_lt_sq_iff_one_lt_abs, eq_add_of_sub_eq h, lt_add_iff_pos_right],
+  exact mul_pos h₀ (sq_pos_of_ne_zero y hy),
+end
+
+end existence
+
 
 end pell

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -192,8 +192,8 @@ begin
 end
 
 /-- The set of solutions with `x` and `y` positive is closed under multiplication. -/
-lemma y_mul_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a b : solution₁ d} (hax : 0 < a.x)
-  (hay : 0 < a.y) (hbx : 0 < b.x) (hby : 0 < b.y) :
+lemma y_mul_pos_of_x_pos_of_y_pos {a b : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
+  (hbx : 0 < b.x) (hby : 0 < b.y) :
   0 < (a * b).y :=
 begin
   simp only [y_mul],
@@ -209,7 +209,7 @@ begin
   induction n with n ih,
   { simp only [hax, hay, pow_one, and_self], },
   { rw [pow_succ],
-    exact ⟨x_mul_pos_of_x_pos h₀ hax ih.1, y_mul_pos_of_x_pos_of_y_pos h₀ hax hay ih.1 ih.2⟩, }
+    exact ⟨x_mul_pos_of_x_pos h₀ hax ih.1, y_mul_pos_of_x_pos_of_y_pos hax hay ih.1 ih.2⟩, }
 end
 
 /-- If `(x, y)` is a solution with `x` positive, then all its powers have positive `x`. -/
@@ -239,7 +239,7 @@ begin
   { change ∀ m : ℤ, 1 ≤ m → _,
     refine λ m, int.le_induction (by simp only [hay, zpow_one]) (λ m hm ih, _) m,
     rw zpow_add_one,
-    exact y_mul_pos_of_x_pos_of_y_pos h₀ (x_zpow_pos_of_x_pos_of_y_pos h₀ hax m) ih hax hay, },
+    exact y_mul_pos_of_x_pos_of_y_pos (x_zpow_pos_of_x_pos_of_y_pos h₀ hax m) ih hax hay, },
   rcases lt_trichotomy 0 n with hpos | rfl | hneg,
   { rw [(int.sign_eq_one_iff_pos n).mpr hpos, int.sign_eq_one_iff_pos],
     exact H n hpos, },
@@ -384,6 +384,5 @@ end
 end solution₁
 
 end existence
-
 
 end pell

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -192,24 +192,33 @@ begin
 end
 
 /-- The set of solutions with `x` and `y` positive is closed under multiplication. -/
-lemma y_mul_pos_of_x_pos_of_y_pos {a b : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
-  (hbx : 0 < b.x) (hby : 0 < b.y) :
+lemma y_mul_pos {a b : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y) (hbx : 0 < b.x)
+  (hby : 0 < b.y) :
   0 < (a * b).y :=
 begin
   simp only [y_mul],
   positivity,
 end
 
-/-- If `(x, y)` is a solution with `x` and `y` positive, then all its powers with positive
-natural exponents have positive `x` and `y`. -/
-lemma x_npow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
-  (n : ℕ) :
-  0 < (a ^ n.succ).x ∧ 0 < (a ^ n.succ).y :=
+/-- If `(x, y)` is a solution with `x` positive, then all its powers with natural exponents
+have positive `x`. -/
+lemma x_pow_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (n : ℕ) : 0 < (a ^ n).x :=
 begin
   induction n with n ih,
-  { simp only [hax, hay, pow_one, and_self], },
+  { simp only [pow_zero, x_one, zero_lt_one], },
   { rw [pow_succ],
-    exact ⟨x_mul_pos h₀ hax ih.1, y_mul_pos_of_x_pos_of_y_pos hax hay ih.1 ih.2⟩, }
+    exact x_mul_pos h₀ hax ih, }
+end
+
+/-- If `(x, y)` is a solution with `x` and `y` positive, then all its powers with positive
+natural exponents have positive `x` and `y`. -/
+lemma y_pow_succ_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y) (n : ℕ) :
+  0 < (a ^ n.succ).y :=
+begin
+  induction n with n ih,
+  { simp only [hay, pow_one], },
+  { rw [pow_succ],
+    exact y_mul_pos hax hay (x_pow_pos h₀ hax _) ih, }
 end
 
 /-- If `(x, y)` is a solution with `x` positive, then all its powers have positive `x`. -/
@@ -239,7 +248,7 @@ begin
   { change ∀ m : ℤ, 1 ≤ m → _,
     refine λ m, int.le_induction (by simp only [hay, zpow_one]) (λ m hm ih, _) m,
     rw zpow_add_one,
-    exact y_mul_pos_of_x_pos_of_y_pos (x_zpow_pos_of_x_pos_of_y_pos h₀ hax m) ih hax hay, },
+    exact y_mul_pos (x_zpow_pos_of_x_pos_of_y_pos h₀ hax m) ih hax hay, },
   rcases lt_trichotomy 0 n with hpos | rfl | hneg,
   { rw [(int.sign_eq_one_iff_pos n).mpr hpos, int.sign_eq_one_iff_pos],
     exact H n hpos, },

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -220,21 +220,16 @@ begin
   { rw [pow_succ],
     exact y_mul_pos hax hay (x_pow_pos h₀ hax _) ih, }
 end
-
+example (n : ℤ) (h : n ≤ 0) : 0 ≤ -n := neg_nonneg.mpr h
 /-- If `(x, y)` is a solution with `x` positive, then all its powers have positive `x`. -/
 lemma x_zpow_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (n : ℤ) :
   0 < (a ^ n).x :=
 begin
-  have H : ∀ m : ℤ, 0 < m → 0 < (a ^ m).x,
-  { change ∀ m : ℤ, 1 ≤ m → _,
-    refine λ m, int.le_induction (by simp only [hax, zpow_one]) (λ m hm ih, _) m,
-    rw zpow_add_one,
-    exact x_mul_pos h₀ ih hax, },
-  rcases lt_trichotomy 0 n with hpos | rfl | hneg,
-  { exact H n hpos, },
-  { simp only [zpow_zero, x_one, zero_lt_one], },
-  { rw [← neg_neg n, zpow_neg, x_inv],
-    exact H (-n) (lt_neg.mp hneg), }
+  cases le_or_lt 0 n with h h,
+  { rw [← int.to_nat_of_nonneg h, zpow_coe_nat],
+    exact x_pow_pos h₀ hax _, },
+  { rw [← neg_neg n, zpow_neg, x_inv, ← int.to_nat_of_nonneg (neg_nonneg.mpr h.le), zpow_coe_nat],
+    exact x_pow_pos h₀ hax _, },
 end
 
 /-- If `(x, y)` is a solution with `x` and `y` positive, then the `y` component of its powers

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -200,28 +200,7 @@ begin
   positivity,
 end
 
-/-- If `(x, y)` is a solution with `x` and `y` positive, then all powers of it have positive `x`,
-and the sign of `y` agrees with that of the exponent. -/
-lemma x_zpow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
-  (n : ℤ) :
-  0 < (a ^ n).x ∧ (a ^ n).y.sign = n.sign :=
-begin
-  have H : ∀ m : ℤ, 0 < m → 0 < (a ^ m).x ∧ 0 < (a ^ m).y,
-  { change ∀ m : ℤ, 1 ≤ m → _,
-    refine λ m, int.le_induction (by simp only [hax, hay, zpow_one, and_self]) (λ m hm ih, _) m,
-    rw zpow_add_one,
-    exact ⟨x_mul_pos_of_x_pos h₀ ih.1 hax, y_mul_pos_of_x_pos_of_y_pos h₀ ih.1 ih.2 hax hay⟩, },
-  rcases lt_trichotomy 0 n with hpos | rfl | hneg,
-  { rw [(int.sign_eq_one_iff_pos n).mpr hpos, int.sign_eq_one_iff_pos],
-    exact H n hpos, },
-  { rw [int.sign_zero, int.sign_eq_zero_iff_zero, zpow_zero],
-    simp only [x_one, zero_lt_one, y_one, eq_self_iff_true, and_self], },
-  { rw [(int.sign_eq_neg_one_iff_neg n).mpr hneg, int.sign_eq_neg_one_iff_neg, ← neg_neg n,
-        zpow_neg, x_inv, y_inv, neg_lt, neg_zero],
-    exact H (-n) (lt_neg.mp hneg), }
-end
-
-/-- If `(x, y)` is a solution with `x` and `y` positive, then all powers of it with positive
+/-- If `(x, y)` is a solution with `x` and `y` positive, then all its powers with positive
 natural exponents have positive `x` and `y`. -/
 lemma x_npow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
   (n : ℕ) :
@@ -231,6 +210,43 @@ begin
   { simp only [hax, hay, pow_one, and_self], },
   { rw [pow_succ],
     exact ⟨x_mul_pos_of_x_pos h₀ hax ih.1, y_mul_pos_of_x_pos_of_y_pos h₀ hax hay ih.1 ih.2⟩, }
+end
+
+/-- If `(x, y)` is a solution with `x` positive, then all its powers have positive `x`. -/
+lemma x_zpow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x)
+  (n : ℤ) :
+  0 < (a ^ n).x :=
+begin
+  have H : ∀ m : ℤ, 0 < m → 0 < (a ^ m).x,
+  { change ∀ m : ℤ, 1 ≤ m → _,
+    refine λ m, int.le_induction (by simp only [hax, zpow_one]) (λ m hm ih, _) m,
+    rw zpow_add_one,
+    exact x_mul_pos_of_x_pos h₀ ih hax, },
+  rcases lt_trichotomy 0 n with hpos | rfl | hneg,
+  { exact H n hpos, },
+  { simp only [zpow_zero, x_one, zero_lt_one], },
+  { rw [← neg_neg n, zpow_neg, x_inv],
+    exact H (-n) (lt_neg.mp hneg), }
+end
+
+/-- If `(x, y)` is a solution with `x` and `y` positive, then the `y` component of its powers
+have the same sign as the exponent. -/
+lemma sign_y_zpow_eq_sign_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x)
+  (hay : 0 < a.y) (n : ℤ) :
+  (a ^ n).y.sign = n.sign :=
+begin
+  have H : ∀ m : ℤ, 0 < m → 0 < (a ^ m).y,
+  { change ∀ m : ℤ, 1 ≤ m → _,
+    refine λ m, int.le_induction (by simp only [hay, zpow_one]) (λ m hm ih, _) m,
+    rw zpow_add_one,
+    exact y_mul_pos_of_x_pos_of_y_pos h₀ (x_zpow_pos_of_x_pos_of_y_pos h₀ hax m) ih hax hay, },
+  rcases lt_trichotomy 0 n with hpos | rfl | hneg,
+  { rw [(int.sign_eq_one_iff_pos n).mpr hpos, int.sign_eq_one_iff_pos],
+    exact H n hpos, },
+  { rw [int.sign_zero, int.sign_eq_zero_iff_zero, zpow_zero, y_one], },
+  { rw [(int.sign_eq_neg_one_iff_neg n).mpr hneg, int.sign_eq_neg_one_iff_neg, ← neg_neg n,
+        zpow_neg, y_inv, neg_lt, neg_zero],
+    exact H (-n) (lt_neg.mp hneg), }
 end
 
 /-- If `a` is any solution, then one of `a`, `a⁻¹`, `-a`, `-a⁻¹` has

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -162,6 +162,26 @@ begin
   exact lt_irrefl _ (((one_lt_sq_iff $ zero_le_one.trans ha.le).mpr ha).trans_eq prop),
 end
 
+/-- A solution with `x = 1` is trivial. -/
+lemma eq_one_of_x_eq_one (h₀ : 0 < d) {a : solution₁ d} (ha : a.x = 1) : a = 1 :=
+begin
+  have hy : a.y = 0,
+  { have prop := a.prop.symm,
+    rw [ha, ← sub_eq_zero] at prop,
+    ring_nf at prop,
+    nlinarith, },
+  ext; simp [ha, hy],
+end
+
+/-- A solution is `1` or `-1` if and only if `y = 0`. -/
+lemma eq_one_or_neg_one_iff_y_eq_zero {a : solution₁ d} : a = 1 ∨ a = -1 ↔ a.y = 0 :=
+begin
+  refine ⟨λ H, H.elim (λ h, by simp [h]) (λ h, by simp [h]), λ H, _⟩,
+  have prop := a.prop,
+  rw [H, sq (0 : ℤ), mul_zero, mul_zero, sub_zero, sq_eq_one_iff] at prop,
+  refine prop.elim (λ h, or.inl $ by ext; simp [h, H]) (λ h, or.inr $ by ext; simp [h, H]),
+end
+
 /-- The set of solutions with `x > 0` is closed under multiplication. -/
 lemma x_mul_pos_of_x_pos (h₀ : 0 < d) {a b : solution₁ d} (ha : 0 < a.x) (hb : 0 < b.x) :
   0 < (a * b).x :=
@@ -321,13 +341,18 @@ end
 
 /-- If `d` is a positive integer that is not a square, then there exists a solution
 to the Pell equation `x^2 - d*y^2 = 1` with `x > 1` and `y > 0`. -/
-lemma exists_pos_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
-  ∃ x y : ℤ, x ^ 2 - d * y ^ 2 = 1 ∧ 1 < x ∧ 0 < y :=
+lemma solution₁.exists_pos_of_not_is_square (h₀ : 0 < d) (hd : ¬ is_square d) :
+  ∃ a : solution₁ d, 1 < a.x ∧ 0 < a.y :=
 begin
-  obtain ⟨x, y, h, hy⟩ := exists_of_not_is_square h₀ hd,
-  refine ⟨|x|, |y|, by rwa [sq_abs, sq_abs], _, abs_pos.mpr hy⟩,
-  rw [← one_lt_sq_iff_one_lt_abs, eq_add_of_sub_eq h, lt_add_iff_pos_right],
-  exact mul_pos h₀ (sq_pos_of_ne_zero y hy),
+  obtain ⟨a, ha₁, ha₂⟩ := solution₁.exists_nontrivial_of_not_is_square h₀ hd,
+  obtain ⟨b, hb₁, hb₂, hb₃⟩ := solution₁.exists_pos_variant h₀ a,
+  refine ⟨b, lt_iff_le_and_ne.mpr ⟨hb₁, λ hf, _⟩, lt_iff_le_and_ne.mpr ⟨hb₂, λ hf, _⟩⟩,
+  { have := solution₁.eq_one_of_x_eq_one h₀ hf.symm,
+    rw [solution₁.eq_one_of_x_eq_one h₀ hf.symm, inv_one] at hb₃,
+    simpa only [ha₁, ha₂, or_self] using hb₃, },
+  { cases solution₁.eq_one_or_neg_one_iff_y_eq_zero.mpr hf.symm with h h; rw h at hb₃,
+    { simpa only [ha₁, ha₂, inv_one, or_self] using hb₃, },
+    { simpa only [ha₁, ha₂, inv_neg', inv_one, neg_neg, or_self] using hb₃, } }
 end
 
 end existence

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -12,16 +12,27 @@ import number_theory.zsqrtd.basic
 /-!
 # Pell's Equation
 
-We prove the following
+*Pell's Equation* is the equation $x^2 - d y^2 = 1$, where $d$ is a positive integer
+that is not a square, and one is interested in solutions in integers $x$ and $y$.
+
+In this file, we aim at providing all of the essential theory of Pell's Equation for general $d$
+(as opposed to the contents of `number_theory.pell_matiyasevic`, which is specific to the case
+$d = a^2 - 1$ for some $a > 1$).
+
+We begin by defining a type `pell.solution₁ d` for solutions of the equation,
+show that it has a natural structure as an abelian group, and prove some basic
+properties.
+
+We then prove the following
 
 **Theorem.** Let $d$ be a positive integer that is not a square. Then the equation
 $x^2 - d y^2 = 1$ has a nontrivial (i.e., with $y \ne 0$) solution in integers.
 
-See `pell.exists_of_not_is_square`.
+See `pell.exists_of_not_is_square` and `pell.exists_nontrivial_of_not_is_square`.
 
-This is the beginning of a development that aims at providing all of the essential theory
-of Pell's Equation for general $d$ (as opposed to the contents of `number_theory.pell_matiyasevic`,
-which is specific to the case $d = a^2 - 1$ for some $a > 1$).
+The next step (TODO) will be to define the *fundamental solution* as the solution
+with smallest $x$ among all solutions satisfying $x > 1$ and $y > 0$ and to show
+that every solution is a power of the fundamental solution up to a (common) sign.
 
 ## References
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -282,7 +282,8 @@ end
 
 /-- If `(x, y)` is a solution with `x` and `y` positive, then all powers of it have positive `x`,
 and the sign of `y` agrees with that of the exponent. -/
-lemma x_pow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y) (n : ℤ) :
+lemma x_pow_pos_of_x_pos_of_y_pos (h₀ : 0 < d) {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
+  (n : ℤ) :
   0 < (a ^ n).x ∧
   (if 0 < n then 0 < (a ^ n).y else if n < 0 then (a ^ n).y < 0 else (a ^ n).y = 0) :=
 begin


### PR DESCRIPTION
This continues the devlopment of the theory of Pell's equation.

We add some API lemmas for solutions, which will be needed for defining of the fundamental solution and proving its properties.

See [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Proving.20Pell's.20equation.20is.20solvable/near/343270338).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
