### PR TITLE
[Merged by Bors] - feat(analysis/calculus/cont_diff): bound for the iterated derivative of a product

### DIFF
--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -2576,6 +2576,9 @@ lemma norm_iterated_fderiv_smul_le
   .norm_iterated_fderiv_le_of_bilinear_of_le_one hf hg x hn
   continuous_linear_map.op_norm_lsmul_le
 
+end
+
+section
 variables {A : Type*} [normed_ring A] [normed_algebra 𝕜 A]
 
 lemma norm_iterated_fderiv_within_mul_le

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -2321,7 +2321,7 @@ lemma continuous_linear_map.norm_iterated_fderiv_within_le_of_bilinear_aux
       * ‖iterated_fderiv_within 𝕜 i f s x‖ * ‖iterated_fderiv_within 𝕜 (n-i) g s x‖ :=
 begin
   /- We argue by induction on `n`. The bound is trivial for `n = 0`. For `n + 1`, we write
-  the `(n+1)`-th derivative as the derivative of the `n`-th derivative `B f g' + B f' g`, and apply
+  the `(n+1)`-th derivative as the `n`-th derivative of derivative `B f g' + B f' g`, and apply
   the inductive assumption to each of those two terms. This requires applying the inductive
   assumption to other spaces (of linear maps), which should be in the same universe for the
   induction to make sense. -/

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -35,6 +35,63 @@ universes u v w uD uE uF uG
 local attribute [instance, priority 1001]
 normed_add_comm_group.to_add_comm_group normed_space.to_module' add_comm_group.to_add_comm_monoid
 
+namespace finset
+
+/- TODO porting note: move the next two lemmas to the file `data.nat.choose.sum` -/
+/-- The sum of `(n+1).choose i * f i (n+1-i)` can be split into two sums at rank `n`,
+respectively of `n.choose i * f i (n+1-i)` and `n.choose i * f (i+1) (n-i)`. -/
+lemma sum_choose_succ_mul {R : Type*} [semiring R] (f : ℕ → ℕ → R) (n : ℕ) :
+  ∑ i in range (n+2), ((n+1).choose i : R) * f i (n + 1 - i) =
+    ∑ i in range (n+1), (n.choose i : R) * f i (n + 1 - i)
+      + ∑ i in range (n+1), (n.choose i : R) * f (i + 1) (n - i) :=
+begin
+  have A : ∑ i in range (n + 1), (n.choose (i+1) : R) * f (i + 1) (n - i) + f 0 (n + 1)
+    = ∑ i in range (n+1), n.choose i * f i (n + 1 - i),
+  { rw [finset.sum_range_succ, finset.sum_range_succ'],
+    simp only [nat.choose_succ_self, algebra_map.coe_zero, zero_mul, add_zero,
+      nat.succ_sub_succ_eq_sub, nat.choose_zero_right, algebra_map.coe_one, one_mul, tsub_zero] },
+  calc
+  ∑ i in finset.range (n+2), ((n+1).choose i : R) * f i (n + 1 - i)
+      = ∑ i in finset.range (n+1), ((n+1).choose (i+1) : R) * f (i+1) (n + 1 - (i+1))
+        + f 0 (n + 1 - 0) :
+    begin
+      rw finset.sum_range_succ',
+      simp only [nat.choose_zero_right, algebra_map.coe_one, one_mul],
+    end
+  ... = ∑ i in finset.range (n+1), (n.choose i : R) * f i (n + 1 - i)
+        + ∑ i in finset.range (n+1), n.choose i * f (i + 1) (n - i) :
+    begin
+      simp only [nat.choose_succ_succ, nat.cast_add, nat.succ_sub_succ_eq_sub, tsub_zero, add_mul],
+      rw [finset.sum_add_distrib, ← A],
+      abel,
+    end
+end
+
+/-- The sum along the antidiagonal of `(n+1).choose i * f i j` can be split into two sums along the
+antidiagonal at rank `n`, respectively of `n.choose i * f i (j+1)` and `n.choose j * f (i+1) j`. -/
+lemma sum_antidiagonal_choose_succ_mul {R : Type*} [semiring R] (f : ℕ → ℕ → R) (n : ℕ) :
+  ∑ ij in nat.antidiagonal (n + 1), ((n + 1).choose ij.1 : R) * f ij.1 ij.2 =
+    ∑ ij in nat.antidiagonal n, (n.choose ij.1 : R) * f ij.1 (ij.2 + 1)
+      + ∑ ij in nat.antidiagonal n, (n.choose ij.2 : R) * f (ij.1 + 1) ij.2 :=
+begin
+  convert sum_choose_succ_mul f n using 1,
+  { exact nat.sum_antidiagonal_eq_sum_range_succ (λ i j, ((n+1).choose i : R) * f i j) (n+1) },
+  congr' 1,
+  { rw nat.sum_antidiagonal_eq_sum_range_succ (λ i j, (n.choose i : R) * f i (j + 1)) n,
+    apply finset.sum_congr rfl (λ i hi, _),
+    have : n + 1 - i = n - i + 1, from nat.sub_add_comm (nat.lt_succ_iff.1 (finset.mem_range.1 hi)),
+    simp only [this] },
+  { suffices H : ∑ ij in nat.antidiagonal n, (n.choose ij.2 : R) * f (ij.1 + 1) ij.2
+      = ∑ ij in nat.antidiagonal n, (n.choose ij.1 : R) * f (ij.1 + 1) ij.2,
+    by rw [H, nat.sum_antidiagonal_eq_sum_range_succ (λ i j, (n.choose i : R) * f (i + 1) j) n],
+    apply finset.sum_congr rfl (λ i hi, _),
+    congr' 2,
+    apply nat.choose_symm_of_eq_add,
+    rw [← nat.mem_antidiagonal.1 hi, add_comm] }
+end
+
+end finset
+
 open set fin filter function
 open_locale topology
 
@@ -2268,65 +2325,6 @@ end restrict_scalars
 
 /-!## Quantitative bounds -/
 
-section
-
-open finset
-
-/- TODO porting note: move the next two lemmas to the file `data.nat.choose.sum` -/
-/-- The sum of `(n+1).choose i * f i (n+1-i)` can be split into two sums at rank `n`,
-respectively of `n.choose i * f i (n+1-i)` and `n.choose i * f (i+1) (n-i)`. -/
-lemma sum_choose_succ_mul {R : Type*} [semiring R] (f : ℕ → ℕ → R) (n : ℕ) :
-  ∑ i in range (n+2), ((n+1).choose i : R) * f i (n + 1 - i) =
-    ∑ i in range (n+1), (n.choose i : R) * f i (n + 1 - i)
-      + ∑ i in range (n+1), (n.choose i : R) * f (i + 1) (n - i) :=
-begin
-  have A : ∑ i in range (n + 1), (n.choose (i+1) : R) * f (i + 1) (n - i) + f 0 (n + 1)
-  = ∑ i in range (n+1), n.choose i * f i (n + 1 - i),
-  { rw [finset.sum_range_succ, finset.sum_range_succ'],
-    simp only [nat.choose_succ_self, algebra_map.coe_zero, zero_mul, add_zero,
-      nat.succ_sub_succ_eq_sub, nat.choose_zero_right, algebra_map.coe_one, one_mul, tsub_zero] },
-  calc
-  ∑ i in finset.range (n+2), ((n+1).choose i : R) * f i (n + 1 - i)
-  = ∑ i in finset.range (n+1), ((n+1).choose (i+1) : R) * f (i+1) (n + 1 - (i+1))
-      + f 0 (n + 1 - 0) :
-    begin
-      rw finset.sum_range_succ',
-      simp only [nat.choose_zero_right, algebra_map.coe_one, one_mul],
-    end
-  ... = ∑ i in finset.range (n+1), (n.choose i : R) * f i (n + 1 - i)
-  + ∑ i in finset.range (n+1), n.choose i * f (i + 1) (n - i) :
-    begin
-      simp only [nat.choose_succ_succ, nat.cast_add, nat.succ_sub_succ_eq_sub, tsub_zero, add_mul],
-      rw [finset.sum_add_distrib, ← A],
-      abel,
-    end
-end
-
-/-- The sum along the antidiagonal of `(n+1).choose i * f i j` can be split into two sums along the
-antidiagonal at rank `n`, respectively of `n.choose i * f i (j+1)` and `n.choose j * f (i+1) j`. -/
-lemma sum_antidiagonal_choose_succ_mul {R : Type*} [semiring R] (f : ℕ → ℕ → R) (n : ℕ) :
-  ∑ ij in nat.antidiagonal (n + 1), ((n + 1).choose ij.1 : R) * f ij.1 ij.2 =
-    ∑ ij in nat.antidiagonal n, (n.choose ij.1 : R) * f ij.1 (ij.2 + 1)
-      + ∑ ij in nat.antidiagonal n, (n.choose ij.2 : R) * f (ij.1 + 1) ij.2 :=
-begin
-  convert sum_choose_succ_mul f n using 1,
-  { exact nat.sum_antidiagonal_eq_sum_range_succ (λ i j, ((n+1).choose i : R) * f i j) (n+1) },
-  congr' 1,
-  { rw nat.sum_antidiagonal_eq_sum_range_succ (λ i j, (n.choose i : R) * f i (j + 1)) n,
-    apply finset.sum_congr rfl (λ i hi, _),
-    have : n + 1 - i = n - i + 1, from nat.sub_add_comm (nat.lt_succ_iff.1 (finset.mem_range.1 hi)),
-    simp only [this] },
-  { suffices H : ∑ ij in nat.antidiagonal n, (n.choose ij.2 : R) * f (ij.1 + 1) ij.2
-      = ∑ ij in nat.antidiagonal n, (n.choose ij.1 : R) * f (ij.1 + 1) ij.2,
-    by rw [H, nat.sum_antidiagonal_eq_sum_range_succ (λ i j, (n.choose i : R) * f (i + 1) j) n],
-    apply finset.sum_congr rfl (λ i hi, _),
-    congr' 2,
-    apply nat.choose_symm_of_eq_add,
-    rw [← nat.mem_antidiagonal.1 hi, add_comm] }
-end
-
-end
-
 /-- Bounding the norm of the iterated derivative of `B (f x) (g x)` within a set in terms of the
 iterated derivatives of `f` and `g` when `B` is bilinear. This lemma is an auxiliary version
 assuming all spaces live in the same universe, to enable an induction. Use instead
@@ -2415,7 +2413,7 @@ begin
     apply (norm_add_le _ _).trans ((add_le_add I1 I2).trans (le_of_eq _)),
     simp_rw [← mul_add, mul_assoc],
     congr' 1,
-    exact (sum_choose_succ_mul (λ i j, ‖iterated_fderiv_within 𝕜 i f s x‖ *
+    exact (finset.sum_choose_succ_mul (λ i j, ‖iterated_fderiv_within 𝕜 i f s x‖ *
       ‖iterated_fderiv_within 𝕜 j g s x‖) n).symm }
 end
 

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -2321,10 +2321,11 @@ lemma continuous_linear_map.norm_iterated_fderiv_within_le_of_bilinear_aux
       * ‖iterated_fderiv_within 𝕜 i f s x‖ * ‖iterated_fderiv_within 𝕜 (n-i) g s x‖ :=
 begin
   /- We argue by induction on `n`. The bound is trivial for `n = 0`. For `n + 1`, we write
-  the `(n+1)`-th derivative as the `n`-th derivative of derivative `B f g' + B f' g`, and apply
-  the inductive assumption to each of those two terms. This requires applying the inductive
-  assumption to other spaces (of linear maps), which should be in the same universe for the
-  induction to make sense. -/
+  the `(n+1)`-th derivative as the `n`-th derivative of the derivative `B f g' + B f' g`, and apply
+  the inductive assumption to each of those two terms. For this induction to make sense,
+  the spaces of linear maps that appear in the induction should be in the same universe as the
+  original spaces, which explains why we assume in the lemma that all spaces live in the same
+  universe. -/
   unfreezingI { induction n with n IH generalizing Eu Fu Gu},
   { simp only [←mul_assoc, norm_iterated_fderiv_within_zero, finset.range_one, finset.sum_singleton,
       nat.choose_self, algebra_map.coe_one, one_mul],

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -2553,20 +2553,27 @@ lemma norm_iterated_fderiv_smul_le
   .norm_iterated_fderiv_le_of_bilinear_of_le_one hf hg x hn
   continuous_linear_map.op_norm_lsmul_le
 
+variables {A : Type*} [normed_ring A] [normed_algebra 𝕜 A]
+
 lemma norm_iterated_fderiv_within_mul_le
-  {f : E → 𝕜'} {g : E → 𝕜'} {N : with_top ℕ} (hf : cont_diff_on 𝕜 N f s) (hg : cont_diff_on 𝕜 N g s)
+  {f : E → A} {g : E → A} {N : with_top ℕ} (hf : cont_diff_on 𝕜 N f s) (hg : cont_diff_on 𝕜 N g s)
   (hs : unique_diff_on 𝕜 s) {x : E} (hx : x ∈ s) {n : ℕ} (hn : (n : with_top ℕ) ≤ N) :
   ‖iterated_fderiv_within 𝕜 n (λ y, f y * g y) s x‖
     ≤ ∑ i in finset.range (n+1), (n.choose i : ℝ)
       * ‖iterated_fderiv_within 𝕜 i f s x‖ * ‖iterated_fderiv_within 𝕜 (n-i) g s x‖ :=
-(norm_iterated_fderiv_within_smul_le hf hg hs hx hn : _)
+(continuous_linear_map.mul 𝕜 A : A →L[𝕜] A →L[𝕜] A)
+  .norm_iterated_fderiv_within_le_of_bilinear_of_le_one hf hg hs hx hn (op_norm_mul_le _ _)
 
 lemma norm_iterated_fderiv_mul_le
-  {f : E → 𝕜'} {g : E → 𝕜'} {N : with_top ℕ} (hf : cont_diff 𝕜 N f) (hg : cont_diff 𝕜 N g)
+  {f : E → A} {g : E → A} {N : with_top ℕ} (hf : cont_diff 𝕜 N f) (hg : cont_diff 𝕜 N g)
   (x : E) {n : ℕ} (hn : (n : with_top ℕ) ≤ N) :
   ‖iterated_fderiv 𝕜 n (λ y, f y * g y) x‖
     ≤ ∑ i in finset.range (n+1), (n.choose i : ℝ)
       * ‖iterated_fderiv 𝕜 i f x‖ * ‖iterated_fderiv 𝕜 (n-i) g x‖ :=
-(norm_iterated_fderiv_smul_le hf hg x hn : _)
+begin
+  simp_rw [← iterated_fderiv_within_univ],
+  exact norm_iterated_fderiv_within_mul_le hf.cont_diff_on
+    hg.cont_diff_on unique_diff_on_univ (mem_univ x) hn,
+end
 
 end

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -2483,8 +2483,8 @@ end
 iterated derivatives of `f` and `g` when `B` is bilinear:
 `‖D^n (x ↦ B (f x) (g x))‖ ≤ ‖B‖ ∑_{k ≤ n} n.choose k ‖D^k f‖ ‖D^{n-k} g‖` -/
 lemma continuous_linear_map.norm_iterated_fderiv_le_of_bilinear
-  (B : E →L[𝕜] F →L[𝕜] G) {f : D → E} {g : D → F} {N : with_top ℕ} (x : D)
-  (hf : cont_diff 𝕜 N f) (hg : cont_diff 𝕜 N g)
+  (B : E →L[𝕜] F →L[𝕜] G) {f : D → E} {g : D → F} {N : with_top ℕ}
+  (hf : cont_diff 𝕜 N f) (hg : cont_diff 𝕜 N g) (x : D)
   {n : ℕ} (hn : (n : with_top ℕ) ≤ N) :
   ‖iterated_fderiv 𝕜 n (λ y, B (f y) (g y)) x‖
     ≤ ‖B‖ * ∑ i in finset.range (n+1), (n.choose i : ℝ)
@@ -2493,4 +2493,79 @@ begin
   simp_rw [← iterated_fderiv_within_univ],
   exact B.norm_iterated_fderiv_within_le_of_bilinear hf.cont_diff_on hg.cont_diff_on
     unique_diff_on_univ (mem_univ x) hn,
+end
+
+/-- Bounding the norm of the iterated derivative of `B (f x) (g x)` within a set in terms of the
+iterated derivatives of `f` and `g` when `B` is bilinear of norm at most `1`:
+`‖D^n (x ↦ B (f x) (g x))‖ ≤ ∑_{k ≤ n} n.choose k ‖D^k f‖ ‖D^{n-k} g‖` -/
+lemma continuous_linear_map.norm_iterated_fderiv_within_le_of_bilinear_of_le_one
+  (B : E →L[𝕜] F →L[𝕜] G) {f : D → E} {g : D → F} {N : with_top ℕ} {s : set D} {x : D}
+  (hf : cont_diff_on 𝕜 N f s) (hg : cont_diff_on 𝕜 N g s) (hs : unique_diff_on 𝕜 s) (hx : x ∈ s)
+  {n : ℕ} (hn : (n : with_top ℕ) ≤ N) (hB : ‖B‖ ≤ 1) :
+  ‖iterated_fderiv_within 𝕜 n (λ y, B (f y) (g y)) s x‖
+    ≤ ∑ i in finset.range (n+1), (n.choose i : ℝ)
+      * ‖iterated_fderiv_within 𝕜 i f s x‖ * ‖iterated_fderiv_within 𝕜 (n-i) g s x‖ :=
+begin
+  apply (B.norm_iterated_fderiv_within_le_of_bilinear hf hg hs hx hn).trans,
+  apply mul_le_of_le_one_left (finset.sum_nonneg' (λ i, _)) hB,
+  positivity
+end
+
+/-- Bounding the norm of the iterated derivative of `B (f x) (g x)` in terms of the
+iterated derivatives of `f` and `g` when `B` is bilinear of norm at most `1`:
+`‖D^n (x ↦ B (f x) (g x))‖ ≤ ∑_{k ≤ n} n.choose k ‖D^k f‖ ‖D^{n-k} g‖` -/
+lemma continuous_linear_map.norm_iterated_fderiv_le_of_bilinear_of_le_one
+  (B : E →L[𝕜] F →L[𝕜] G) {f : D → E} {g : D → F} {N : with_top ℕ}
+  (hf : cont_diff 𝕜 N f) (hg : cont_diff 𝕜 N g) (x : D)
+  {n : ℕ} (hn : (n : with_top ℕ) ≤ N) (hB : ‖B‖ ≤ 1) :
+  ‖iterated_fderiv 𝕜 n (λ y, B (f y) (g y)) x‖
+    ≤ ∑ i in finset.range (n+1), (n.choose i : ℝ)
+      * ‖iterated_fderiv 𝕜 i f x‖ * ‖iterated_fderiv 𝕜 (n-i) g x‖ :=
+begin
+  simp_rw [← iterated_fderiv_within_univ],
+  exact B.norm_iterated_fderiv_within_le_of_bilinear_of_le_one hf.cont_diff_on hg.cont_diff_on
+    unique_diff_on_univ (mem_univ x) hn hB,
+end
+
+section
+
+variables {𝕜' : Type*} [normed_field 𝕜'] [normed_algebra 𝕜 𝕜'] [normed_space 𝕜' F]
+  [is_scalar_tower 𝕜 𝕜' F]
+
+lemma norm_iterated_fderiv_within_smul_le
+  {f : E → 𝕜'} {g : E → F} {N : with_top ℕ} (hf : cont_diff_on 𝕜 N f s) (hg : cont_diff_on 𝕜 N g s)
+  (hs : unique_diff_on 𝕜 s) {x : E} (hx : x ∈ s) {n : ℕ} (hn : (n : with_top ℕ) ≤ N) :
+  ‖iterated_fderiv_within 𝕜 n (λ y, f y • g y) s x‖
+    ≤ ∑ i in finset.range (n+1), (n.choose i : ℝ)
+      * ‖iterated_fderiv_within 𝕜 i f s x‖ * ‖iterated_fderiv_within 𝕜 (n-i) g s x‖ :=
+(continuous_linear_map.lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] F →L[𝕜] F)
+  .norm_iterated_fderiv_within_le_of_bilinear_of_le_one hf hg hs hx hn
+  continuous_linear_map.op_norm_lsmul_le
+
+lemma norm_iterated_fderiv_smul_le
+  {f : E → 𝕜'} {g : E → F} {N : with_top ℕ} (hf : cont_diff 𝕜 N f) (hg : cont_diff 𝕜 N g)
+  (x : E) {n : ℕ} (hn : (n : with_top ℕ) ≤ N) :
+  ‖iterated_fderiv 𝕜 n (λ y, f y • g y) x‖
+    ≤ ∑ i in finset.range (n+1), (n.choose i : ℝ)
+      * ‖iterated_fderiv 𝕜 i f x‖ * ‖iterated_fderiv 𝕜 (n-i) g x‖ :=
+(continuous_linear_map.lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] F →L[𝕜] F)
+  .norm_iterated_fderiv_le_of_bilinear_of_le_one hf hg x hn
+  continuous_linear_map.op_norm_lsmul_le
+
+lemma norm_iterated_fderiv_within_mul_le
+  {f : E → 𝕜'} {g : E → 𝕜'} {N : with_top ℕ} (hf : cont_diff_on 𝕜 N f s) (hg : cont_diff_on 𝕜 N g s)
+  (hs : unique_diff_on 𝕜 s) {x : E} (hx : x ∈ s) {n : ℕ} (hn : (n : with_top ℕ) ≤ N) :
+  ‖iterated_fderiv_within 𝕜 n (λ y, f y * g y) s x‖
+    ≤ ∑ i in finset.range (n+1), (n.choose i : ℝ)
+      * ‖iterated_fderiv_within 𝕜 i f s x‖ * ‖iterated_fderiv_within 𝕜 (n-i) g s x‖ :=
+(norm_iterated_fderiv_within_smul_le hf hg hs hx hn : _)
+
+lemma norm_iterated_fderiv_mul_le
+  {f : E → 𝕜'} {g : E → 𝕜'} {N : with_top ℕ} (hf : cont_diff 𝕜 N f) (hg : cont_diff 𝕜 N g)
+  (x : E) {n : ℕ} (hn : (n : with_top ℕ) ≤ N) :
+  ‖iterated_fderiv 𝕜 n (λ y, f y * g y) x‖
+    ≤ ∑ i in finset.range (n+1), (n.choose i : ℝ)
+      * ‖iterated_fderiv 𝕜 i f x‖ * ‖iterated_fderiv 𝕜 (n-i) g x‖ :=
+(norm_iterated_fderiv_smul_le hf hg x hn : _)
+
 end

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -2268,7 +2268,6 @@ end restrict_scalars
 
 /-!## Quantitative bounds -/
 
-
 section
 
 open finset
@@ -2410,7 +2409,7 @@ begin
   /- We reduce the bound to the case where all spaces live in the same universe (in which we
   already have proved the result), by using linear isometries between the spaces and their `ulift`
   to a common universe. These linear isometries preserve the norm of the iterated derivative. -/
-  let Du : Type (max uD uE uF uG) := ulift D,
+  let Du : Type (max uD uE uF uG) := ulift.{(max uE uF uG) uD} D,
   let Eu : Type (max uD uE uF uG) := ulift.{(max uD uF uG) uE} E,
   let Fu : Type (max uD uE uF uG) := ulift.{(max uD uE uG) uF} F,
   let Gu : Type (max uD uE uF uG) := ulift.{(max uD uE uF) uG} G,
@@ -2422,8 +2421,8 @@ begin
   let fu : Du → Eu := isoE.symm ∘ f ∘ isoD,
   let gu : Du → Fu := isoF.symm ∘ g ∘ isoD,
   -- lift the bilinear map `B` to a bilinear map `Bu` on the lifted spaces.
-  let Bu₀ : Eu →L[𝕜] Fu →L[𝕜] G :=
-    ((B.comp (isoE : Eu →L[𝕜] E)).flip.comp (isoF : Fu →L[𝕜] F)).flip,
+  let Bu₀ : Eu →L[𝕜] Fu →L[𝕜] G,
+    from ((B.comp (isoE : Eu →L[𝕜] E)).flip.comp (isoF : Fu →L[𝕜] F)).flip,
   let Bu : Eu →L[𝕜] Fu →L[𝕜] Gu, from continuous_linear_map.compL 𝕜 Eu (Fu →L[𝕜] G) (Fu →L[𝕜] Gu)
     (continuous_linear_map.compL 𝕜 Fu G Gu (isoG.symm : G →L[𝕜] Gu)) Bu₀,
   have Bu_eq : (λ y, Bu (fu y) (gu y)) = isoG.symm ∘ (λ y, B (f y) (g y)) ∘ isoD,

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -922,6 +922,9 @@ def mul : 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' := (linear_map.mul 𝕜 𝕜')
 @[simp] lemma op_norm_mul_apply_le (x : 𝕜') : ‖mul 𝕜 𝕜' x‖ ≤ ‖x‖ :=
 (op_norm_le_bound _ (norm_nonneg x) (norm_mul_le x))
 
+lemma op_norm_mul_le : ‖mul 𝕜 𝕜'‖ ≤ 1 :=
+linear_map.mk_continuous₂_norm_le _ zero_le_one _
+
 /-- Simultaneous left- and right-multiplication in a non-unital normed algebra, considered as a
 continuous trilinear map. This is akin to its non-continuous version `linear_map.mul_left_right`,
 but there is a minor difference: `linear_map.mul_left_right` is uncurried. -/


### PR DESCRIPTION
We show that `‖D^n (x ↦ B (f x) (g x))‖ ≤ ‖B‖ ∑_{k ≤ n} n.choose k ‖D^k f‖ ‖D^{n-k} g‖` for a general continuous bilinear map `B`, and specialize this inequality to the case of the product of two functions.

This is a first step to control the norm of the iterated derivative of a composition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
