### PR TITLE
[Merged by Bors] - doc(representation_theory/basic): add docstring to dual_tensor_hom_comm

### DIFF
--- a/src/representation_theory/basic.lean
+++ b/src/representation_theory/basic.lean
@@ -378,7 +378,6 @@ lemma dual_apply (g : G) : (dual ρV) g = module.dual.transpose (ρV g⁻¹) := 
 Given `k`-modules `V, W`, there is an isomorphism `φ : V^* ⊗ W → Hom_k(V, W)`.
 Given representations of `G` on `V` and `W`,there are representations of `G` on `V^* ⊗ W` and on
 `Hom_k(V, W)`.
-
 This lemma says that `φ` is `G`-linear.
 -/
 lemma dual_tensor_hom_comm (g : G) :

--- a/src/representation_theory/basic.lean
+++ b/src/representation_theory/basic.lean
@@ -375,7 +375,8 @@ def dual : representation k G (module.dual k V) :=
 lemma dual_apply (g : G) : (dual ρV) g = module.dual.transpose (ρV g⁻¹) := rfl
 
 /--
-Given `k`-modules `V, W`, there is an isomorphism `φ : V^* ⊗ W → Hom_k(V, W)`.
+Given `k`-modules `V, W`, there is an isomorphism `φ : V^* ⊗ W → Hom_k(V, W)`
+(implemented by `dual_tensor_hom`).
 Given representations of `G` on `V` and `W`,there are representations of `G` on `V^* ⊗ W` and on
 `Hom_k(V, W)`.
 This lemma says that `φ` is `G`-linear.

--- a/src/representation_theory/basic.lean
+++ b/src/representation_theory/basic.lean
@@ -375,8 +375,8 @@ def dual : representation k G (module.dual k V) :=
 lemma dual_apply (g : G) : (dual ρV) g = module.dual.transpose (ρV g⁻¹) := rfl
 
 /--
-Given `k`-modules `V, W`, there is an isomorphism `φ : V^* ⊗ W → Hom_k(V, W)`
-(implemented by `dual_tensor_hom`).
+Given `k`-modules `V, W`, there is a homomorphism `φ : V^* ⊗ W → Hom_k(V, W)`
+(implemented by `linear_algebra.contraction.dual_tensor_hom`).
 Given representations of `G` on `V` and `W`,there are representations of `G` on `V^* ⊗ W` and on
 `Hom_k(V, W)`.
 This lemma says that `φ` is `G`-linear.

--- a/src/representation_theory/basic.lean
+++ b/src/representation_theory/basic.lean
@@ -375,11 +375,11 @@ def dual : representation k G (module.dual k V) :=
 lemma dual_apply (g : G) : (dual ρV) g = module.dual.transpose (ρV g⁻¹) := rfl
 
 /--
-Given `k`-modules `V, W`, there is a homomorphism `φ : V^* ⊗ W → Hom_k(V, W)`
+Given $k$-modules $V, W$, there is a homomorphism $φ : V^* ⊗ W → Hom_k(V, W)$
 (implemented by `linear_algebra.contraction.dual_tensor_hom`).
-Given representations of `G` on `V` and `W`,there are representations of `G` on `V^* ⊗ W` and on
-`Hom_k(V, W)`.
-This lemma says that `φ` is `G`-linear.
+Given representations of $G$ on $V$ and $W$,there are representations of $G$ on  $V^* ⊗ W$ and on
+$Hom_k(V, W)$.
+This lemma says that $φ$ is $G$-linear.
 -/
 lemma dual_tensor_hom_comm (g : G) :
   (dual_tensor_hom k V W) ∘ₗ (tensor_product.map (ρV.dual g) (ρW g)) =

--- a/src/representation_theory/basic.lean
+++ b/src/representation_theory/basic.lean
@@ -374,6 +374,13 @@ def dual : representation k G (module.dual k V) :=
 @[simp]
 lemma dual_apply (g : G) : (dual ρV) g = module.dual.transpose (ρV g⁻¹) := rfl
 
+/--
+Given `k`-modules `V, W`, there is an isomorphism `φ : V^* ⊗ W → Hom_k(V, W)`.
+Given representations of `G` on `V` and `W`,there are representations of `G` on `V^* ⊗ W` and on
+`Hom_k(V, W)`.
+
+This lemma says that `φ` is `G`-linear.
+-/
 lemma dual_tensor_hom_comm (g : G) :
   (dual_tensor_hom k V W) ∘ₗ (tensor_product.map (ρV.dual g) (ρW g)) =
   (lin_hom ρV ρW) g ∘ₗ (dual_tensor_hom k V W) :=


### PR DESCRIPTION
add a docstring to dual_tensor_hom_comm to describe its mathematical content explicitly

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
