### PR TITLE
[Merged by Bors] - chore(measure_theory/function/ess_sup): Generalise

### DIFF
--- a/src/measure_theory/function/ess_sup.lean
+++ b/src/measure_theory/function/ess_sup.lean
@@ -72,34 +72,27 @@ by { dsimp [ess_inf, liminf, Liminf], simp only [ae_iff, not_le] }
 
 lemma ae_lt_of_ess_sup_lt (hx : ess_sup f μ < x)
   (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, f y < x :=
-filter.eventually_lt_of_limsup_lt hx hf
+eventually_lt_of_limsup_lt hx hf
 
 lemma ae_lt_of_lt_ess_inf (hx : x < ess_inf f μ)
   (hf : is_bounded_under (≥) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, x < f y :=
-filter.eventually_lt_of_lt_liminf hx hf
+eventually_lt_of_lt_liminf hx hf
 
-variables [topological_space β] [first_countable_topology β] [densely_ordered β] [order_topology β]
+variables [topological_space β] [densely_ordered β] [order_topology β]
 
 lemma ae_le_of_ess_sup_le (hx : ess_sup f μ ≤ x)
   (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, f y ≤ x :=
-begin
-  obtain hx | ⟨y, hxy⟩ := is_top_or_exists_gt x,
-  { exact eventually_of_forall (λ _, hx _) },
-  obtain ⟨u, -, hu, hux⟩ := exists_seq_strict_anti_tendsto' hxy,
-  have := λ n, ae_lt_of_ess_sup_lt (hx.trans_lt (hu n).1) hf,
-  exact (eventually_countable_forall.2 this).mono
-    (λ y hy, ge_of_tendsto hux $ eventually_of_forall $ λ n, (hy _).le),
-end
+eventually_le_of_limsup_le hx hf
 
 lemma ae_le_of_le_ess_inf (hx : x ≤ ess_inf f μ)
   (hf : is_bounded_under (≥) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, x ≤ f y :=
-@ae_le_of_ess_sup_le α βᵒᵈ _ _ _ _ _ _ _ _ _ hx hf
+eventually_le_of_le_liminf hx hf
 
-lemma meas_lt_of_ess_sup_le [no_max_order β] (hx : ess_sup f μ ≤ x)
+lemma meas_lt_of_ess_sup_le (hx : ess_sup f μ ≤ x)
   (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) : μ {y | x < f y} = 0 :=
 by { simp_rw ←not_le, exact ae_le_of_ess_sup_le hx hf }
 
-lemma meas_lt_of_le_ess_inf [no_min_order β] (hx : x ≤ ess_inf f μ)
+lemma meas_lt_of_le_ess_inf (hx : x ≤ ess_inf f μ)
   (hf : is_bounded_under (≥) μ.ae f . is_bounded_default) : μ {y | f y < x} = 0 :=
 by { simp_rw ←not_le, exact ae_le_of_le_ess_inf hx hf }
 

--- a/src/measure_theory/function/ess_sup.lean
+++ b/src/measure_theory/function/ess_sup.lean
@@ -48,11 +48,14 @@ limsup_congr hfg
 lemma ess_inf_congr_ae {f g : α → β} (hfg : f =ᵐ[μ] g) :  ess_inf f μ = ess_inf g μ :=
 @ess_sup_congr_ae α βᵒᵈ _ _ _ _ _ hfg
 
+@[simp] lemma ess_sup_const' [μ.ae.ne_bot] (c : β) : ess_sup (λ x : α, c) μ = c := limsup_const _
+@[simp] lemma ess_inf_const' [μ.ae.ne_bot] (c : β) : ess_inf (λ x : α, c) μ = c := liminf_const _
+
 lemma ess_sup_const (c : β) (hμ : μ ≠ 0) : ess_sup (λ x : α, c) μ = c :=
-by { rw ←ae_ne_bot at hμ, exactI limsup_const c }
+by { rw ←ae_ne_bot at hμ, exactI ess_sup_const' _ }
 
 lemma ess_inf_const (c : β) (hμ : μ ≠ 0) : ess_inf (λ x : α, c) μ = c :=
-by { rw ←ae_ne_bot at hμ, exactI liminf_const c }
+by { rw ←ae_ne_bot at hμ, exactI ess_inf_const' _ }
 
 end conditionally_complete_lattice
 
@@ -77,18 +80,20 @@ filter.eventually_lt_of_lt_liminf hx hf
 
 variables [topological_space β] [first_countable_topology β] [densely_ordered β] [order_topology β]
 
-lemma ae_le_of_ess_sup_le [no_max_order β] (hx : ess_sup f μ ≤ x)
+lemma ae_le_of_ess_sup_le (hx : ess_sup f μ ≤ x)
   (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, f y ≤ x :=
 begin
-  obtain ⟨u, -, hu, hux⟩ := exists_seq_strict_anti_tendsto x,
-  have := λ n, ae_lt_of_ess_sup_lt (hx.trans_lt $ hu n) hf,
+  obtain hx | ⟨y, hxy⟩ := is_top_or_exists_gt x,
+  { exact eventually_of_forall (λ _, hx _) },
+  obtain ⟨u, -, hu, hux⟩ := exists_seq_strict_anti_tendsto' hxy,
+  have := λ n, ae_lt_of_ess_sup_lt (hx.trans_lt (hu n).1) hf,
   exact (eventually_countable_forall.2 this).mono
     (λ y hy, ge_of_tendsto hux $ eventually_of_forall $ λ n, (hy _).le),
 end
 
-lemma ae_le_of_le_ess_inf [no_min_order β] (hx : x ≤ ess_inf f μ)
+lemma ae_le_of_le_ess_inf (hx : x ≤ ess_inf f μ)
   (hf : is_bounded_under (≥) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, x ≤ f y :=
-@ae_le_of_ess_sup_le α βᵒᵈ _ _ _ _ _ _ _ _ _ _ hx hf
+@ae_le_of_ess_sup_le α βᵒᵈ _ _ _ _ _ _ _ _ _ hx hf
 
 lemma meas_lt_of_ess_sup_le [no_max_order β] (hx : ess_sup f μ ≤ x)
   (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) : μ {y | x < f y} = 0 :=

--- a/src/measure_theory/function/ess_sup.lean
+++ b/src/measure_theory/function/ess_sup.lean
@@ -78,7 +78,7 @@ lemma ae_lt_of_lt_ess_inf (hx : x < ess_inf f μ)
   (hf : is_bounded_under (≥) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, x < f y :=
 eventually_lt_of_lt_liminf hx hf
 
-variables [topological_space β] [first_countable_topology β] [densely_ordered β] [order_topology β]
+variables [topological_space β] [first_countable_topology β] [order_topology β]
 
 lemma ae_le_of_ess_sup_le (hx : ess_sup f μ ≤ x)
   (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, f y ≤ x :=

--- a/src/measure_theory/function/ess_sup.lean
+++ b/src/measure_theory/function/ess_sup.lean
@@ -80,21 +80,21 @@ eventually_lt_of_lt_liminf hx hf
 
 variables [topological_space β] [first_countable_topology β] [order_topology β]
 
-lemma ae_le_of_ess_sup_le (hx : ess_sup f μ ≤ x)
-  (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, f y ≤ x :=
-eventually_le_of_limsup_le hx hf
+lemma ae_le_ess_sup (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) :
+  ∀ᵐ y ∂μ, f y ≤ ess_sup f μ :=
+eventually_le_limsup hf
 
-lemma ae_le_of_le_ess_inf (hx : x ≤ ess_inf f μ)
-  (hf : is_bounded_under (≥) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, x ≤ f y :=
-eventually_le_of_le_liminf hx hf
+lemma ae_ess_inf_le (hf : is_bounded_under (≥) μ.ae f . is_bounded_default) :
+  ∀ᵐ y ∂μ, ess_inf f μ ≤ f y :=
+eventually_liminf_le hf
 
-lemma meas_lt_of_ess_sup_le (hx : ess_sup f μ ≤ x)
-  (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) : μ {y | x < f y} = 0 :=
-by { simp_rw ←not_le, exact ae_le_of_ess_sup_le hx hf }
+lemma meas_ess_sup_lt (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) :
+  μ {y | ess_sup f μ < f y} = 0 :=
+by { simp_rw ←not_le, exact ae_le_ess_sup hf }
 
-lemma meas_lt_of_le_ess_inf (hx : x ≤ ess_inf f μ)
-  (hf : is_bounded_under (≥) μ.ae f . is_bounded_default) : μ {y | f y < x} = 0 :=
-by { simp_rw ←not_le, exact ae_le_of_le_ess_inf hx hf }
+lemma meas_lt_ess_inf (hf : is_bounded_under (≥) μ.ae f . is_bounded_default) :
+  μ {y | f y < ess_inf f μ} = 0 :=
+by { simp_rw ←not_le, exact ae_ess_inf_le hf }
 
 end conditionally_complete_linear_order
 

--- a/src/measure_theory/function/ess_sup.lean
+++ b/src/measure_theory/function/ess_sup.lean
@@ -78,7 +78,7 @@ lemma ae_lt_of_lt_ess_inf (hx : x < ess_inf f μ)
   (hf : is_bounded_under (≥) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, x < f y :=
 eventually_lt_of_lt_liminf hx hf
 
-variables [topological_space β] [densely_ordered β] [order_topology β]
+variables [topological_space β] [first_countable_topology β] [densely_ordered β] [order_topology β]
 
 lemma ae_le_of_ess_sup_le (hx : ess_sup f μ ≤ x)
   (hf : is_bounded_under (≤) μ.ae f . is_bounded_default) : ∀ᵐ y ∂μ, f y ≤ x :=

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -789,6 +789,19 @@ begin
   rw [mem_ℒp, snorm_eq_snorm' h0 hp_top] at hf hg,
   exact snorm'_add_lt_top_of_le_one hf.1 hf.2 hg.2 hp_pos hp1_real,
 end
+lemma ae_le_of_snorm_ess_sup_le {f : α → F} {x : ℝ≥0∞} (hx : snorm_ess_sup f μ ≤ x)
+  (hf : is_bounded_under (≤) μ.ae (λ y, ‖f y‖₊) . is_bounded_default) : ∀ᵐ y ∂μ, ↑‖f y‖₊ ≤ x :=
+begin
+  cases x,
+  { simp },
+  simp only [ennreal.some_eq_coe, ennreal.coe_le_coe],
+  refine ae_le_of_ess_sup_le _ hf,
+  rwa [←ennreal.coe_le_coe, ennreal.coe_ess_sup hf],
+end
+
+lemma meas_lt_of_snorm_ess_sup_le {f : α → F} {x : ℝ≥0∞} (hx : snorm_ess_sup f μ ≤ x)
+  (hf : is_bounded_under (≤) μ.ae (λ y, ‖f y‖₊) . is_bounded_default) : μ {y | x < ‖f y‖₊} = 0 :=
+by { simp_rw ←not_le, exact ae_le_of_snorm_ess_sup_le hx hf }
 
 section map_measure
 

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -790,8 +790,7 @@ begin
   exact snorm'_add_lt_top_of_le_one hf.1 hf.2 hg.2 hp_pos hp1_real,
 end
 
-lemma ae_le_snorm_ess_sup {f : α → F} : ∀ᵐ y ∂μ, ↑‖f y‖₊ ≤ snorm_ess_sup f μ ≤ x :=
-ae_le_of_ess_sup_le
+lemma ae_le_snorm_ess_sup {f : α → F} : ∀ᵐ y ∂μ, ↑‖f y‖₊ ≤ snorm_ess_sup f μ := ae_le_of_ess_sup_le
 
 lemma meas_snorm_ess_sup_lt {f : α → F} : μ {y | snorm_ess_sup f μ < ‖f y‖₊} = 0 :=
 meas_ess_sup_lt

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -789,6 +789,7 @@ begin
   rw [mem_ℒp, snorm_eq_snorm' h0 hp_top] at hf hg,
   exact snorm'_add_lt_top_of_le_one hf.1 hf.2 hg.2 hp_pos hp1_real,
 end
+
 lemma ae_le_of_snorm_ess_sup_le {f : α → F} {x : ℝ≥0∞} (hx : snorm_ess_sup f μ ≤ x)
   (hf : is_bounded_under (≤) μ.ae (λ y, ‖f y‖₊) . is_bounded_default) : ∀ᵐ y ∂μ, ↑‖f y‖₊ ≤ x :=
 begin

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -790,13 +790,11 @@ begin
   exact snorm'_add_lt_top_of_le_one hf.1 hf.2 hg.2 hp_pos hp1_real,
 end
 
-lemma ae_le_of_snorm_ess_sup_le {f : α → F} {x : ℝ≥0∞} :
-  snorm_ess_sup f μ ≤ x → ∀ᵐ y ∂μ, ↑‖f y‖₊ ≤ x :=
+lemma ae_le_snorm_ess_sup {f : α → F} : ∀ᵐ y ∂μ, ↑‖f y‖₊ ≤ snorm_ess_sup f μ ≤ x :=
 ae_le_of_ess_sup_le
 
-lemma meas_lt_of_snorm_ess_sup_le {f : α → F} {x : ℝ≥0∞} :
-  snorm_ess_sup f μ ≤ x → μ {y | x < ‖f y‖₊} = 0 :=
-meas_lt_of_ess_sup_le
+lemma meas_snorm_ess_sup_lt {f : α → F} : μ {y | snorm_ess_sup f μ < ‖f y‖₊} = 0 :=
+meas_ess_sup_lt
 
 section map_measure
 

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -790,19 +790,13 @@ begin
   exact snorm'_add_lt_top_of_le_one hf.1 hf.2 hg.2 hp_pos hp1_real,
 end
 
-lemma ae_le_of_snorm_ess_sup_le {f : α → F} {x : ℝ≥0∞} (hx : snorm_ess_sup f μ ≤ x)
-  (hf : is_bounded_under (≤) μ.ae (λ y, ‖f y‖₊) . is_bounded_default) : ∀ᵐ y ∂μ, ↑‖f y‖₊ ≤ x :=
-begin
-  cases x,
-  { simp },
-  simp only [ennreal.some_eq_coe, ennreal.coe_le_coe],
-  refine ae_le_of_ess_sup_le _ hf,
-  rwa [←ennreal.coe_le_coe, ennreal.coe_ess_sup hf],
-end
+lemma ae_le_of_snorm_ess_sup_le {f : α → F} {x : ℝ≥0∞} :
+  snorm_ess_sup f μ ≤ x → ∀ᵐ y ∂μ, ↑‖f y‖₊ ≤ x :=
+ae_le_of_ess_sup_le
 
-lemma meas_lt_of_snorm_ess_sup_le {f : α → F} {x : ℝ≥0∞} (hx : snorm_ess_sup f μ ≤ x)
-  (hf : is_bounded_under (≤) μ.ae (λ y, ‖f y‖₊) . is_bounded_default) : μ {y | x < ‖f y‖₊} = 0 :=
-by { simp_rw ←not_le, exact ae_le_of_snorm_ess_sup_le hx hf }
+lemma meas_lt_of_snorm_ess_sup_le {f : α → F} {x : ℝ≥0∞} :
+  snorm_ess_sup f μ ≤ x → μ {y | x < ‖f y‖₊} = 0 :=
+meas_lt_of_ess_sup_le
 
 section map_measure
 

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -790,7 +790,7 @@ begin
   exact snorm'_add_lt_top_of_le_one hf.1 hf.2 hg.2 hp_pos hp1_real,
 end
 
-lemma ae_le_snorm_ess_sup {f : α → F} : ∀ᵐ y ∂μ, ↑‖f y‖₊ ≤ snorm_ess_sup f μ := ae_le_of_ess_sup_le
+lemma ae_le_snorm_ess_sup {f : α → F} : ∀ᵐ y ∂μ, ↑‖f y‖₊ ≤ snorm_ess_sup f μ := ae_le_ess_sup
 
 lemma meas_snorm_ess_sup_lt {f : α → F} : μ {y | snorm_ess_sup f μ < ‖f y‖₊} = 0 :=
 meas_ess_sup_lt

--- a/src/order/filter/ennreal.lean
+++ b/src/order/filter/ennreal.lean
@@ -3,10 +3,7 @@ Copyright (c) 2021 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
-
-import data.real.ennreal
-import order.filter.countable_Inter
-import order.liminf_limsup
+import topology.instances.ennreal
 
 /-!
 # Order properties of extended non-negative reals
@@ -25,34 +22,11 @@ variables {α : Type*} {f : filter α}
 
 lemma eventually_le_limsup [countable_Inter_filter f] (u : α → ℝ≥0∞) :
   ∀ᶠ y in f, u y ≤ f.limsup u :=
-begin
-  by_cases hx_top : f.limsup u = ⊤,
-  { simp_rw hx_top,
-    exact eventually_of_forall (λ a, le_top), },
-  have h_forall_le : ∀ᶠ y in f, ∀ n : ℕ, u y < f.limsup u + (1:ℝ≥0∞)/n,
-  { rw eventually_countable_forall,
-    refine λ n, eventually_lt_of_limsup_lt _,
-    nth_rewrite 0 ←add_zero (f.limsup u),
-    exact (ennreal.add_lt_add_iff_left hx_top).mpr (by simp), },
-  refine h_forall_le.mono (λ y hy, le_of_forall_pos_le_add (λ r hr_pos hx_top, _)),
-  have hr_ne_zero : (r : ℝ≥0∞) ≠ 0,
-  { rw [ne.def, coe_eq_zero],
-    exact (ne_of_lt hr_pos).symm, },
-  cases (exists_inv_nat_lt hr_ne_zero) with i hi,
-  rw inv_eq_one_div at hi,
-  exact (hy i).le.trans (add_le_add_left hi.le (f.limsup u)),
-end
+eventually_le_limsup
 
 lemma limsup_eq_zero_iff [countable_Inter_filter f] {u : α → ℝ≥0∞} :
   f.limsup u = 0 ↔ u =ᶠ[f] 0 :=
-begin
-  split; intro h,
-  { have hu_zero := eventually_le.trans (eventually_le_limsup u)
-      (eventually_of_forall (λ _, le_of_eq h)),
-    exact hu_zero.mono (λ x hx, le_antisymm hx (zero_le _)), },
-  { rw limsup_congr h,
-    simp_rw [pi.zero_apply, ←ennreal.bot_eq_zero, limsup_const_bot] },
-end
+limsup_eq_bot
 
 lemma limsup_const_mul_of_ne_top {u : α → ℝ≥0∞} {a : ℝ≥0∞} (ha_top : a ≠ ⊤) :
   f.limsup (λ (x : α), a * (u x)) = a * f.limsup u :=

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -216,7 +216,7 @@ begin
   exact H a as b bs ab ⟨A, B⟩,
 end
 
-variables [densely_ordered α] [first_countable_topology α] {f : filter β} [countable_Inter_filter f]
+variables [first_countable_topology α] {f : filter β} [countable_Inter_filter f]
   {u : β → α} {a : α}
 
 lemma eventually_le_of_limsup_le (hfua : f.limsup u ≤ a)
@@ -224,15 +224,23 @@ lemma eventually_le_of_limsup_le (hfua : f.limsup u ≤ a)
 begin
   obtain ha | ha := is_top_or_exists_gt a,
   { exact eventually_of_forall (λ _, ha _) },
-  obtain ⟨u, -, -, hua, hu⟩ := is_glb_Ioi.exists_seq_antitone_tendsto ha,
-  have := λ n, eventually_lt_of_limsup_lt (hfua.trans_lt $ hu n) hf,
-  exact (eventually_countable_forall.2 this).mono
-    (λ b hb, ge_of_tendsto hua $ eventually_of_forall $ λ n, (hb _).le),
+  by_cases H : is_glb (set.Ioi a) a,
+  { obtain ⟨u, -, -, hua, hu⟩ := H.exists_seq_antitone_tendsto ha,
+    have := λ n, eventually_lt_of_limsup_lt (hfua.trans_lt $ hu n) hf,
+    exact (eventually_countable_forall.2 this).mono
+      (λ b hb, ge_of_tendsto hua $ eventually_of_forall $ λ n, (hb _).le) },
+  { obtain ⟨x, hx, xa⟩ : ∃ (x : α), (∀ ⦃b : α⦄, a < b → x ≤ b) ∧ a < x,
+    { simp only [is_glb, is_greatest, lower_bounds, upper_bounds, set.mem_Ioi, set.mem_set_of_eq,
+        not_and, not_forall, not_le, exists_prop] at H,
+      exact H (λ x hx, le_of_lt hx) },
+    filter_upwards [eventually_lt_of_limsup_lt (hfua.trans_lt xa) hf] with y hy,
+    contrapose! hy,
+    exact hx hy }
 end
 
 lemma eventually_le_of_le_liminf (hfua : a ≤ f.liminf u)
   (hf : is_bounded_under (≥) f u . is_bounded_default) : ∀ᶠ b in f, a ≤ u b :=
-@eventually_le_of_limsup_le αᵒᵈ _ _ _ _ _ _ _ _ _ _ hfua hf
+@eventually_le_of_limsup_le αᵒᵈ _ _ _ _ _ _ _ _ _ hfua hf
 
 end conditionally_complete_linear_order
 

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -8,6 +8,7 @@ import algebra.big_operators.order
 import algebra.indicator_function
 import order.liminf_limsup
 import order.filter.archimedean
+import order.filter.countable_Inter
 import topology.order.basic
 
 /-!
@@ -17,7 +18,7 @@ import topology.order.basic
 > Any changes to this file require a corresponding PR to mathlib4.
 -/
 
-open filter
+open filter topological_space
 open_locale topology classical
 
 universes u v
@@ -214,6 +215,24 @@ begin
     frequently_lt_of_lt_limsup (is_bounded.is_cobounded_le h') bu,
   exact H a as b bs ab ⟨A, B⟩,
 end
+
+variables [densely_ordered α] [first_countable_topology α] {f : filter β} [countable_Inter_filter f]
+  {u : β → α} {a : α}
+
+lemma eventually_le_of_limsup_le (hfua : f.limsup u ≤ a)
+  (hf : is_bounded_under (≤) f u . is_bounded_default) : ∀ᶠ b in f, u b ≤ a :=
+begin
+  obtain ha | ha := is_top_or_exists_gt a,
+  { exact eventually_of_forall (λ _, ha _) },
+  obtain ⟨u, -, -, hua, hu⟩ := is_glb_Ioi.exists_seq_antitone_tendsto ha,
+  have := λ n, eventually_lt_of_limsup_lt (hfua.trans_lt $ hu n) hf,
+  exact (eventually_countable_forall.2 this).mono
+    (λ b hb, ge_of_tendsto hua $ eventually_of_forall $ λ n, (hb _).le),
+end
+
+lemma eventually_le_of_le_liminf (hfua : a ≤ f.liminf u)
+  (hf : is_bounded_under (≥) f u . is_bounded_default) : ∀ᶠ b in f, a ≤ u b :=
+@eventually_le_of_limsup_le αᵒᵈ _ _ _ _ _ _ _ _ _ _ hfua hf
 
 end conditionally_complete_linear_order
 

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -216,33 +216,44 @@ begin
   exact H a as b bs ab ⟨A, B⟩,
 end
 
-variables [first_countable_topology α] {f : filter β} [countable_Inter_filter f]
-  {u : β → α} {a : α}
+variables [first_countable_topology α] {f : filter β} [countable_Inter_filter f] {u : β → α}
 
-lemma eventually_le_of_limsup_le (hfua : f.limsup u ≤ a)
-  (hf : is_bounded_under (≤) f u . is_bounded_default) : ∀ᶠ b in f, u b ≤ a :=
+lemma eventually_le_limsup (hf : is_bounded_under (≤) f u . is_bounded_default) :
+  ∀ᶠ b in f, u b ≤ f.limsup u :=
 begin
-  obtain ha | ha := is_top_or_exists_gt a,
+  obtain ha | ha := is_top_or_exists_gt (f.limsup u),
   { exact eventually_of_forall (λ _, ha _) },
-  by_cases H : is_glb (set.Ioi a) a,
+  by_cases H : is_glb (set.Ioi (f.limsup u)) (f.limsup u),
   { obtain ⟨u, -, -, hua, hu⟩ := H.exists_seq_antitone_tendsto ha,
-    have := λ n, eventually_lt_of_limsup_lt (hfua.trans_lt $ hu n) hf,
+    have := λ n, eventually_lt_of_limsup_lt (hu n) hf,
     exact (eventually_countable_forall.2 this).mono
       (λ b hb, ge_of_tendsto hua $ eventually_of_forall $ λ n, (hb _).le) },
-  { obtain ⟨x, hx, xa⟩ : ∃ (x : α), (∀ ⦃b : α⦄, a < b → x ≤ b) ∧ a < x,
+  { obtain ⟨x, hx, xa⟩ : ∃ x, (∀ ⦃b⦄, f.limsup u < b → x ≤ b) ∧ f.limsup u < x,
     { simp only [is_glb, is_greatest, lower_bounds, upper_bounds, set.mem_Ioi, set.mem_set_of_eq,
         not_and, not_forall, not_le, exists_prop] at H,
       exact H (λ x hx, le_of_lt hx) },
-    filter_upwards [eventually_lt_of_limsup_lt (hfua.trans_lt xa) hf] with y hy,
+    filter_upwards [eventually_lt_of_limsup_lt xa hf] with y hy,
     contrapose! hy,
     exact hx hy }
 end
 
-lemma eventually_le_of_le_liminf (hfua : a ≤ f.liminf u)
-  (hf : is_bounded_under (≥) f u . is_bounded_default) : ∀ᶠ b in f, a ≤ u b :=
-@eventually_le_of_limsup_le αᵒᵈ _ _ _ _ _ _ _ _ _ hfua hf
+lemma eventually_liminf_le (hf : is_bounded_under (≥) f u . is_bounded_default) :
+  ∀ᶠ b in f, f.liminf u ≤ u b :=
+@eventually_le_limsup αᵒᵈ _ _ _ _ _ _ _ _ hf
 
 end conditionally_complete_linear_order
+
+section complete_linear_order
+variables [complete_linear_order α] [topological_space α] [first_countable_topology α]
+  [order_topology α] {f : filter β} [countable_Inter_filter f] {u : β → α}
+
+@[simp] lemma limsup_eq_bot : f.limsup u = ⊥ ↔ u =ᶠ[f] ⊥ :=
+⟨λ h, (eventually_le.trans eventually_le_limsup $ eventually_of_forall $ λ _, h.le).mono $ λ x hx,
+  le_antisymm hx bot_le, λ h, by { rw limsup_congr h, exact limsup_const_bot }⟩
+
+@[simp] lemma liminf_eq_top : f.liminf u = ⊤ ↔ u =ᶠ[f] ⊤ := @limsup_eq_bot αᵒᵈ _ _ _ _ _ _ _ _
+
+end complete_linear_order
 
 end liminf_limsup
 


### PR DESCRIPTION
A handful of lemmas hold for bounded filters in conditionally complete lattices, rather than just filter in complete lattices (which are automatically bounded).

Also prove that `μ {y | x < f y} = 0` when `x` is greater than the essential supremum of `f`, and dually.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
