### PR TITLE
[Merged by Bors] - refactor(topology/algebra/module/strong_topology): split of local convexity

### DIFF
--- a/src/analysis/locally_convex/strong_topology.lean
+++ b/src/analysis/locally_convex/strong_topology.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2022 Anatole Dedecker. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anatole Dedecker
+-/
+import topology.algebra.module.strong_topology
+import topology.algebra.module.locally_convex
+
+/-!
+# Local convexity of the strong topology
+
+In this file we prove that the strong topology on `E →L[ℝ] F` is locally convex provided that `F` is
+locally convex.
+
+## References
+
+* [N. Bourbaki, *Topological Vector Spaces*][bourbaki1987]
+
+## Todo
+
+* Characterization in terms of seminorms
+
+## Tags
+
+locally convex, bounded convergence
+-/
+
+open_locale topology uniform_convergence
+
+variables {E F : Type*}
+
+namespace continuous_linear_map
+
+section general
+
+variables [add_comm_group E] [module ℝ E] [topological_space E]
+  [add_comm_group F] [module ℝ F] [topological_space F] [topological_add_group F]
+  [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
+
+lemma strong_topology.locally_convex_space (𝔖 : set (set E)) (h𝔖₁ : 𝔖.nonempty)
+  (h𝔖₂ : directed_on (⊆) 𝔖) :
+  @locally_convex_space ℝ (E →L[ℝ] F) _ _ _ (strong_topology (ring_hom.id ℝ) F 𝔖) :=
+begin
+  letI : topological_space (E →L[ℝ] F) := strong_topology (ring_hom.id ℝ) F 𝔖,
+  haveI : topological_add_group (E →L[ℝ] F) := strong_topology.topological_add_group _ _ _,
+  refine locally_convex_space.of_basis_zero _ _ _ _
+    (strong_topology.has_basis_nhds_zero_of_basis _ _ _ h𝔖₁ h𝔖₂
+      (locally_convex_space.convex_basis_zero ℝ F)) _,
+  rintros ⟨S, V⟩ ⟨hS, hVmem, hVconvex⟩ f hf g hg a b ha hb hab x hx,
+  exact hVconvex (hf x hx) (hg x hx) ha hb hab,
+end
+
+end general
+
+section bounded_sets
+
+variables [add_comm_group E] [module ℝ E] [topological_space E]
+  [add_comm_group F] [module ℝ F] [topological_space F] [topological_add_group F]
+  [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
+
+instance : locally_convex_space ℝ (E →L[ℝ] F) :=
+strong_topology.locally_convex_space _ ⟨∅, bornology.is_vonN_bounded_empty ℝ E⟩
+  (directed_on_of_sup_mem $ λ _ _, bornology.is_vonN_bounded.union)
+
+end bounded_sets
+
+end continuous_linear_map

--- a/src/topology/algebra/module/strong_topology.lean
+++ b/src/topology/algebra/module/strong_topology.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker
 -/
 import topology.algebra.uniform_convergence
-import topology.algebra.module.locally_convex
 
 /-!
 # Strong topologies on the space of continuous linear maps
@@ -47,7 +46,6 @@ sets).
 
 ## TODO
 
-* show that these topologies are T₂ and locally convex if the topology on `F` is
 * add a type alias for continuous linear maps with the topology of `𝔖`-convergence?
 
 ## Tags
@@ -170,20 +168,6 @@ lemma strong_topology.has_basis_nhds_zero [topological_space F] [topological_add
     (λ SV, {f : E →SL[σ] F | ∀ x ∈ SV.1, f x ∈ SV.2}) :=
 strong_topology.has_basis_nhds_zero_of_basis σ F 𝔖 h𝔖₁ h𝔖₂ (𝓝 0).basis_sets
 
-lemma strong_topology.locally_convex_space [topological_space F']
-  [topological_add_group F'] [has_continuous_const_smul ℝ F'] [locally_convex_space ℝ F']
-  (𝔖 : set (set E')) (h𝔖₁ : 𝔖.nonempty) (h𝔖₂ : directed_on (⊆) 𝔖) :
-  @locally_convex_space ℝ (E' →L[ℝ] F') _ _ _ (strong_topology (ring_hom.id ℝ) F' 𝔖) :=
-begin
-  letI : topological_space (E' →L[ℝ] F') := strong_topology (ring_hom.id ℝ) F' 𝔖,
-  haveI : topological_add_group (E' →L[ℝ] F') := strong_topology.topological_add_group _ _ _,
-  refine locally_convex_space.of_basis_zero _ _ _ _
-    (strong_topology.has_basis_nhds_zero_of_basis _ _ _ h𝔖₁ h𝔖₂
-      (locally_convex_space.convex_basis_zero ℝ F')) _,
-  rintros ⟨S, V⟩ ⟨hS, hVmem, hVconvex⟩ f hf g hg a b ha hb hab x hx,
-  exact hVconvex (hf x hx) (hg x hx) ha hb hab,
-end
-
 end general
 
 section bounded_sets
@@ -236,12 +220,6 @@ protected lemma has_basis_nhds_zero [topological_space F]
     (λ SV : set E × set F, bornology.is_vonN_bounded 𝕜₁ SV.1 ∧ SV.2 ∈ (𝓝 0 : filter F))
     (λ SV, {f : E →SL[σ] F | ∀ x ∈ SV.1, f x ∈ SV.2}) :=
 continuous_linear_map.has_basis_nhds_zero_of_basis (𝓝 0).basis_sets
-
-instance [topological_space E'] [topological_space F'] [topological_add_group F']
-  [has_continuous_const_smul ℝ F'] [locally_convex_space ℝ F'] :
-  locally_convex_space ℝ (E' →L[ℝ] F') :=
-strong_topology.locally_convex_space _ ⟨∅, bornology.is_vonN_bounded_empty ℝ E'⟩
-  (directed_on_of_sup_mem $ λ _ _, bornology.is_vonN_bounded.union)
 
 end bounded_sets
 


### PR DESCRIPTION
The reason for this split is not only to reduce the import tree, but also to find a good home for proving `with_seminorm` versions of the local convexity results.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
