### PR TITLE
refactor(analysis/normed/field/basic): add a missing axiom to normed_ring

### DIFF
--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -57,6 +57,7 @@ add_group_norm.to_normed_add_comm_group
 instance : normed_field ℂ :=
 { norm := abs,
   dist_eq := λ _ _, rfl,
+  norm_one' := map_one abs,
   norm_mul' := map_mul abs,
   .. complex.field, .. complex.normed_add_comm_group }
 

--- a/src/analysis/normed/field/basic.lean
+++ b/src/analysis/normed/field/basic.lean
@@ -33,6 +33,7 @@ class non_unital_semi_normed_ring (α : Type*)
 `‖x y‖ ≤ ‖x‖ ‖y‖`. -/
 class semi_normed_ring (α : Type*) extends has_norm α, ring α, pseudo_metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
+(norm_one : norm (1 : α) ≤ 1)
 (norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b)
 
 /-- A seminormed ring is a non-unital seminormed ring. -/
@@ -56,18 +57,21 @@ instance non_unital_normed_ring.to_non_unital_semi_normed_ring [β : non_unital_
 /-- A normed ring is a ring endowed with a norm which satisfies the inequality `‖x y‖ ≤ ‖x‖ ‖y‖`. -/
 class normed_ring (α : Type*) extends has_norm α, ring α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
+(norm_one : norm (1 : α) ≤ 1)
 (norm_mul : ∀ a b, norm (a * b) ≤ norm a * norm b)
 
 /-- A normed division ring is a division ring endowed with a seminorm which satisfies the equality
 `‖x y‖ = ‖x‖ ‖y‖`. -/
 class normed_division_ring (α : Type*) extends has_norm α, division_ring α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
+(norm_one' : norm (1 : α) = 1)
 (norm_mul' : ∀ a b, norm (a * b) = norm a * norm b)
 
 /-- A normed division ring is a normed ring. -/
 @[priority 100] -- see Note [lower instance priority]
 instance normed_division_ring.to_normed_ring [β : normed_division_ring α] : normed_ring α :=
-{ norm_mul := λ a b, (normed_division_ring.norm_mul' a b).le,
+{ norm_one := normed_division_ring.norm_one'.le,
+  norm_mul := λ a b, (normed_division_ring.norm_mul' a b).le,
   ..β }
 
 /-- A normed ring is a seminormed ring. -/
@@ -96,12 +100,12 @@ instance normed_comm_ring.to_semi_normed_comm_ring [β : normed_comm_ring α] :
   semi_normed_comm_ring α := { ..β }
 
 instance : normed_comm_ring punit :=
-{ norm_mul := λ _ _, by simp,
+{ norm_one := by simp,
+  norm_mul := λ _ _, by simp,
   ..punit.normed_add_comm_group,
   ..punit.comm_ring, }
 
-/-- A mixin class with the axiom `‖1‖ = 1`. Many `normed_ring`s and all `normed_field`s satisfy this
-axiom. -/
+/-- A mixin class with the axiom `‖1‖ = 1`. Nontrivial `normed_ring`s satisfy this axiom. -/
 class norm_one_class (α : Type*) [has_norm α] [has_one α] : Prop :=
 (norm_one : ‖(1:α)‖ = 1)
 
@@ -156,13 +160,6 @@ non_unital_semi_normed_ring.norm_mul _ _
 lemma nnnorm_mul_le (a b : α) : ‖a * b‖₊ ≤ ‖a‖₊ * ‖b‖₊ :=
 by simpa only [←norm_to_nnreal, ←real.to_nnreal_mul (norm_nonneg _)]
   using real.to_nnreal_mono (norm_mul_le _ _)
-
-lemma one_le_norm_one (β) [normed_ring β] [nontrivial β] : 1 ≤ ‖(1 : β)‖ :=
-(le_mul_iff_one_le_left $ norm_pos_iff.mpr (one_ne_zero : (1 : β) ≠ 0)).mp
-  (by simpa only [mul_one] using norm_mul_le (1 : β) 1)
-
-lemma one_le_nnnorm_one (β) [normed_ring β] [nontrivial β] : 1 ≤ ‖(1 : β)‖₊ :=
-one_le_norm_one β
 
 lemma filter.tendsto.zero_mul_is_bounded_under_le {f g : ι → α} {l : filter ι}
   (hf : tendsto f l (𝓝 0)) (hg : is_bounded_under (≤) l (norm ∘ g)) :
@@ -229,12 +226,19 @@ section semi_normed_ring
 
 variables [semi_normed_ring α]
 
+lemma norm_one_le : ‖(1 : α)‖ ≤ 1 :=
+semi_normed_ring.norm_one
+
+lemma nnnorm_one_le : ‖(1 : α)‖₊ ≤ 1 :=
+norm_one_le
+
 /-- A subalgebra of a seminormed ring is also a seminormed ring, with the restriction of the norm.
 
 See note [implicit instance arguments]. -/
 instance subalgebra.semi_normed_ring {𝕜 : Type*} {_ : comm_ring 𝕜}
   {E : Type*} [semi_normed_ring E] {_ : algebra 𝕜 E} (s : subalgebra 𝕜 E) : semi_normed_ring s :=
-{ norm_mul := λ a b, norm_mul_le a.1 b.1,
+{ norm_one := norm_one_le,
+  norm_mul := λ a b, norm_mul_le a.1 b.1,
   ..s.to_submodule.seminormed_add_comm_group }
 
 /-- A subalgebra of a normed ring is also a normed ring, with the restriction of the norm.
@@ -320,14 +324,16 @@ lemma eventually_norm_pow_le (a : α) : ∀ᶠ (n:ℕ) in at_top, ‖a ^ n‖ �
 eventually_at_top.mpr ⟨1, λ b h, norm_pow_le' a (nat.succ_le_iff.mp h)⟩
 
 instance : semi_normed_ring (ulift α) :=
-{ .. ulift.non_unital_semi_normed_ring,
+{ norm_one := norm_one_le,
+  .. ulift.non_unital_semi_normed_ring,
   .. ulift.seminormed_add_comm_group }
 
 /-- Seminormed ring structure on the product of two seminormed rings,
   using the sup norm. -/
 instance prod.semi_normed_ring [semi_normed_ring β] :
   semi_normed_ring (α × β) :=
-{ ..prod.non_unital_semi_normed_ring,
+{ norm_one := sup_le norm_one_le norm_one_le,
+  ..prod.non_unital_semi_normed_ring,
   ..prod.seminormed_add_comm_group, }
 
 /-- Seminormed ring structure on the product of finitely many seminormed rings,
@@ -335,11 +341,16 @@ instance prod.semi_normed_ring [semi_normed_ring β] :
 instance pi.semi_normed_ring {π : ι → Type*} [fintype ι]
   [Π i, semi_normed_ring (π i)] :
   semi_normed_ring (Π i, π i) :=
-{ ..pi.non_unital_semi_normed_ring,
+{ norm_one := begin
+    simp_rw [pi.norm_def, ←nnreal.coe_one, nnreal.coe_le_coe],
+    exact finset.sup_le (λ i hi, nnnorm_one_le),
+  end,
+  ..pi.non_unital_semi_normed_ring,
   ..pi.seminormed_add_comm_group, }
 
 instance mul_opposite.semi_normed_ring : semi_normed_ring αᵐᵒᵖ :=
-{ ..mul_opposite.non_unital_semi_normed_ring,
+{ norm_one := norm_one_le,
+  ..mul_opposite.non_unital_semi_normed_ring,
   ..mul_opposite.seminormed_add_comm_group }
 
 end semi_normed_ring
@@ -375,6 +386,11 @@ section normed_ring
 
 variables [normed_ring α]
 
+instance normed_ring.to_norm_one_class [nontrivial α] : norm_one_class α :=
+⟨le_antisymm norm_one_le $
+  (le_mul_iff_one_le_left $ norm_pos_iff.mpr (one_ne_zero : (1 : α) ≠ 0)).mp
+    (by simpa only [mul_one] using norm_mul_le (1 : α) 1)⟩
+
 lemma units.norm_pos [nontrivial α] (x : αˣ) : 0 < ‖(x:α)‖ :=
 norm_pos_iff.mpr (units.ne_zero x)
 
@@ -387,17 +403,20 @@ instance : normed_ring (ulift α) :=
 
 /-- Normed ring structure on the product of two normed rings, using the sup norm. -/
 instance prod.normed_ring [normed_ring β] : normed_ring (α × β) :=
-{ norm_mul := norm_mul_le,
+{ norm_one := norm_one_le,
+  norm_mul := norm_mul_le,
   ..prod.normed_add_comm_group }
 
 /-- Normed ring structure on the product of finitely many normed rings, using the sup norm. -/
 instance pi.normed_ring {π : ι → Type*} [fintype ι] [Π i, normed_ring (π i)] :
   normed_ring (Π i, π i) :=
-{ norm_mul := norm_mul_le,
+{ norm_one := norm_one_le,
+  norm_mul := norm_mul_le,
   ..pi.normed_add_comm_group }
 
 instance mul_opposite.normed_ring : normed_ring αᵐᵒᵖ :=
-{ norm_mul := norm_mul_le,
+{ norm_one := norm_one_le,
+  norm_mul := norm_mul_le,
   ..mul_opposite.normed_add_comm_group }
 
 end normed_ring
@@ -433,8 +452,7 @@ normed_division_ring.norm_mul' a b
 
 @[priority 900]
 instance normed_division_ring.to_norm_one_class : norm_one_class α :=
-⟨mul_left_cancel₀ (mt norm_eq_zero.1 (one_ne_zero' α)) $
-  by rw [← norm_mul, mul_one, mul_one]⟩
+by apply_instance
 
 instance is_absolute_value_norm : is_absolute_value (norm : α → ℝ) :=
 { abv_nonneg := norm_nonneg,
@@ -542,6 +560,7 @@ end normed_division_ring
 /-- A normed field is a field with a norm satisfying ‖x y‖ = ‖x‖ ‖y‖. -/
 class normed_field (α : Type*) extends has_norm α, field α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = norm (x - y))
+(norm_one' : norm (1 : α) = 1)
 (norm_mul' : ∀ a b, norm (a * b) = norm a * norm b)
 
 /-- A nontrivially normed field is a normed field in which there is an element of norm different
@@ -574,7 +593,7 @@ instance normed_field.to_normed_division_ring : normed_division_ring α :=
 
 @[priority 100] -- see Note [lower instance priority]
 instance normed_field.to_normed_comm_ring : normed_comm_ring α :=
-{ norm_mul := λ a b, (norm_mul a b).le, ..‹normed_field α› }
+{ norm_one := norm_one.le, norm_mul := λ a b, (norm_mul a b).le, ..‹normed_field α› }
 
 @[simp] lemma norm_prod (s : finset β) (f : β → α) :
   ‖∏ b in s, f b‖ = ∏ b in s, ‖f b‖ :=
@@ -656,12 +675,14 @@ end densely
 end normed_field
 
 instance : normed_comm_ring ℝ :=
-{ norm_mul := λ x y, (abs_mul x y).le,
+{ norm_one := abs_one.le,
+  norm_mul := λ x y, (abs_mul x y).le,
   .. real.normed_add_comm_group,
   .. real.comm_ring }
 
 noncomputable instance : normed_field ℝ :=
-{ norm_mul' := abs_mul,
+{ norm_one' := abs_one,
+  norm_mul' := abs_mul,
   .. real.normed_add_comm_group }
 
 noncomputable instance : densely_normed_field ℝ :=
@@ -713,15 +734,16 @@ lemma normed_add_comm_group.tendsto_at_top' [nonempty α] [semilattice_sup α] [
 (at_top_basis_Ioi.tendsto_iff metric.nhds_basis_ball).trans (by simp [dist_eq_norm])
 
 instance : normed_comm_ring ℤ :=
-{ norm_mul := λ m n, le_of_eq $ by simp only [norm, int.cast_mul, abs_mul],
+{ norm_one := by simp [← int.norm_cast_real],
+  norm_mul := λ m n, le_of_eq $ by simp only [norm, int.cast_mul, abs_mul],
   mul_comm := mul_comm,
   .. int.normed_add_comm_group }
 
-instance : norm_one_class ℤ :=
-⟨by simp [← int.norm_cast_real]⟩
+instance : norm_one_class ℤ := by apply_instance
 
 instance : normed_field ℚ :=
-{ norm_mul' := λ r₁ r₂, by simp only [norm, rat.cast_mul, abs_mul],
+{ norm_one' := by simp only [norm, rat.cast_one, abs_one],
+  norm_mul' := λ r₁ r₂, by simp only [norm, rat.cast_mul, abs_mul],
   .. rat.normed_add_comm_group }
 
 instance : densely_normed_field ℚ :=
@@ -779,9 +801,10 @@ def non_unital_normed_ring.induced [non_unital_ring R] [non_unital_normed_ring S
 
 See note [reducible non-instances] -/
 @[reducible]
-def semi_normed_ring.induced [ring R] [semi_normed_ring S] [non_unital_ring_hom_class F R S]
+def semi_normed_ring.induced [ring R] [semi_normed_ring S] [ring_hom_class F R S]
   (f : F) : semi_normed_ring R :=
-{ .. non_unital_semi_normed_ring.induced R S f,
+{ norm_one := by { unfold norm, exact (map_one f).symm ▸ norm_one_le },
+  .. non_unital_semi_normed_ring.induced R S f,
   .. seminormed_add_comm_group.induced R S f }
 
 /-- An injective non-unital ring homomorphism from an `ring` to a `normed_ring` induces a
@@ -789,9 +812,9 @@ def semi_normed_ring.induced [ring R] [semi_normed_ring S] [non_unital_ring_hom_
 
 See note [reducible non-instances] -/
 @[reducible]
-def normed_ring.induced [ring R] [normed_ring S] [non_unital_ring_hom_class F R S] (f : F)
+def normed_ring.induced [ring R] [normed_ring S] [ring_hom_class F R S] (f : F)
   (hf : function.injective f) : normed_ring R :=
-{ .. non_unital_semi_normed_ring.induced R S f,
+{ .. semi_normed_ring.induced R S f,
   .. normed_add_comm_group.induced R S f hf }
 
 /-- A non-unital ring homomorphism from a `comm_ring` to a `semi_normed_ring` induces a
@@ -800,9 +823,9 @@ def normed_ring.induced [ring R] [normed_ring S] [non_unital_ring_hom_class F R 
 See note [reducible non-instances] -/
 @[reducible]
 def semi_normed_comm_ring.induced [comm_ring R] [semi_normed_ring S]
-  [non_unital_ring_hom_class F R S] (f : F) : semi_normed_comm_ring R :=
+  [ring_hom_class F R S] (f : F) : semi_normed_comm_ring R :=
 { mul_comm := mul_comm,
-  .. non_unital_semi_normed_ring.induced R S f,
+  .. semi_normed_ring.induced R S f,
   .. seminormed_add_comm_group.induced R S f }
 
 /-- An injective non-unital ring homomorphism from an `comm_ring` to a `normed_ring` induces a
@@ -810,7 +833,7 @@ def semi_normed_comm_ring.induced [comm_ring R] [semi_normed_ring S]
 
 See note [reducible non-instances] -/
 @[reducible]
-def normed_comm_ring.induced [comm_ring R] [normed_ring S] [non_unital_ring_hom_class F R S] (f : F)
+def normed_comm_ring.induced [comm_ring R] [normed_ring S] [ring_hom_class F R S] (f : F)
   (hf : function.injective f) : normed_comm_ring R :=
 { .. semi_normed_comm_ring.induced R S f,
   .. normed_add_comm_group.induced R S f hf }
@@ -821,8 +844,9 @@ def normed_comm_ring.induced [comm_ring R] [normed_ring S] [non_unital_ring_hom_
 See note [reducible non-instances] -/
 @[reducible]
 def normed_division_ring.induced [division_ring R] [normed_division_ring S]
-  [non_unital_ring_hom_class F R S] (f : F) (hf : function.injective f) : normed_division_ring R :=
-{ norm_mul' := λ x y, by { unfold norm, exact (map_mul f x y).symm ▸ norm_mul (f x) (f y) },
+  [ring_hom_class F R S] (f : F) (hf : function.injective f) : normed_division_ring R :=
+{ norm_one' := by { unfold norm, exact (map_one f).symm ▸ norm_one },
+  norm_mul' := λ x y, by { unfold norm, exact (map_mul f x y).symm ▸ norm_mul (f x) (f y) },
   .. normed_add_comm_group.induced R S f hf }
 
 /-- An injective non-unital ring homomorphism from an `field` to a `normed_ring` induces a
@@ -831,7 +855,7 @@ def normed_division_ring.induced [division_ring R] [normed_division_ring S]
 See note [reducible non-instances] -/
 @[reducible]
 def normed_field.induced [field R] [normed_field S]
-  [non_unital_ring_hom_class F R S] (f : F) (hf : function.injective f) : normed_field R :=
+  [ring_hom_class F R S] (f : F) (hf : function.injective f) : normed_field R :=
 { .. normed_division_ring.induced R S f hf }
 
 /-- A ring homomorphism from a `ring R` to a `semi_normed_ring S` which induces the norm structure

--- a/src/analysis/normed/group/quotient.lean
+++ b/src/analysis/normed/group/quotient.lean
@@ -612,6 +612,7 @@ quotient_norm_mk_le I.to_add_subgroup r
 
 instance ideal.quotient.semi_normed_comm_ring : semi_normed_comm_ring (R ⧸ I) :=
 { mul_comm := mul_comm,
+  norm_one := (ideal.quotient.norm_mk_le _ (1 : R)).trans norm_one_le,
   norm_mul := λ x y, le_of_forall_pos_le_add $ λ ε hε,
   begin
     have := ((nhds_basis_ball.prod_nhds nhds_basis_ball).tendsto_iff nhds_basis_ball).mp

--- a/src/analysis/normed/order/basic.lean
+++ b/src/analysis/normed/order/basic.lean
@@ -52,6 +52,7 @@ class normed_linear_ordered_group (α : Type*)
 class normed_linear_ordered_field (α : Type*)
 extends linear_ordered_field α, has_norm α, metric_space α :=
 (dist_eq : ∀ x y, dist x y = ‖x - y‖ . obviously)
+(norm_one' : ‖(1 : α)‖ = 1)
 (norm_mul' : ∀ x y : α, ‖x * y‖ = ‖x‖ * ‖y‖)
 
 @[to_additive, priority 100]
@@ -66,14 +67,15 @@ instance normed_linear_ordered_group.to_normed_ordered_group [normed_linear_orde
 @[priority 100] instance normed_linear_ordered_field.to_normed_field (α : Type*)
   [normed_linear_ordered_field α] : normed_field α :=
 { dist_eq := normed_linear_ordered_field.dist_eq,
+  norm_one' := normed_linear_ordered_field.norm_one',
   norm_mul' := normed_linear_ordered_field.norm_mul' }
 
 instance : normed_linear_ordered_field ℚ :=
-⟨dist_eq_norm, norm_mul⟩
+⟨dist_eq_norm, norm_one, norm_mul⟩
 
 noncomputable
 instance : normed_linear_ordered_field ℝ :=
-⟨dist_eq_norm, norm_mul⟩
+⟨dist_eq_norm, norm_one, norm_mul⟩
 
 @[to_additive] instance [normed_ordered_group α] : normed_ordered_group αᵒᵈ :=
 { ..normed_ordered_group.to_normed_comm_group, ..order_dual.ordered_comm_group }

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -485,11 +485,18 @@ See `normed_space.to_module'` for a similar situation. -/
 instance normed_algebra.to_normed_space' {𝕜'} [normed_ring 𝕜'] [normed_algebra 𝕜 𝕜'] :
   normed_space 𝕜 𝕜' := by apply_instance
 
-lemma norm_algebra_map (x : 𝕜) : ‖algebra_map 𝕜 𝕜' x‖ = ‖x‖ * ‖(1 : 𝕜')‖ :=
+lemma norm_algebra_map_le (x : 𝕜) : ‖algebra_map 𝕜 𝕜' x‖ ≤ ‖x‖ :=
 begin
   rw algebra.algebra_map_eq_smul_one,
-  exact norm_smul _ _,
+  refine (norm_smul_le _ _).trans _,
+  exact mul_le_of_le_one_right (norm_nonneg _) norm_one_le,
 end
+
+lemma nnnorm_algebra_map_le (x : 𝕜) : ‖algebra_map 𝕜 𝕜' x‖₊ ≤ ‖x‖₊ :=
+norm_algebra_map_le _ _
+
+lemma norm_algebra_map (x : 𝕜) : ‖algebra_map 𝕜 𝕜' x‖ = ‖x‖ * ‖(1 : 𝕜')‖ :=
+by rw [algebra.algebra_map_eq_smul_one, norm_smul]
 
 lemma nnnorm_algebra_map (x : 𝕜) : ‖algebra_map 𝕜 𝕜' x‖₊ = ‖x‖₊ * ‖(1 : 𝕜')‖₊ :=
 subtype.ext $ norm_algebra_map 𝕜' x
@@ -588,8 +595,8 @@ instance {𝕜 : Type*} {𝕜' : Type*} {E : Type*} [I : normed_add_comm_group E
 /-- If `E` is a normed space over `𝕜'` and `𝕜` is a normed algebra over `𝕜'`, then
 `restrict_scalars.module` is additionally a `normed_space`. -/
 instance : normed_space 𝕜 (restrict_scalars 𝕜 𝕜' E) :=
-{ norm_smul_le := λ c x, (norm_smul_le (algebra_map 𝕜 𝕜' c) (_ : E)).trans_eq $
-    by rw norm_algebra_map',
+{ norm_smul_le := λ c x, (norm_smul_le (algebra_map 𝕜 𝕜' c) (_ : E)).trans $
+    mul_le_mul_of_nonneg_right (norm_algebra_map_le 𝕜' c) (norm_nonneg _),
   ..restrict_scalars.module 𝕜 𝕜' E }
 
 /--

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -566,7 +566,7 @@ end normed_algebra
 See note [reducible non-instances] -/
 @[reducible]
 def normed_algebra.induced {F : Type*} (α β γ : Type*) [normed_field α] [ring β]
-  [algebra α β] [semi_normed_ring γ] [normed_algebra α γ] [non_unital_alg_hom_class F α β γ]
+  [algebra α β] [semi_normed_ring γ] [normed_algebra α γ] [alg_hom_class F α β γ]
   (f : F) : @normed_algebra α β _ (semi_normed_ring.induced β γ f) :=
 { norm_smul_le := λ a b, by {unfold norm, exact (map_smul f a b).symm ▸ norm_smul_le a (f b) } }
 

--- a/src/analysis/normed_space/completion.lean
+++ b/src/analysis/normed_space/completion.lean
@@ -72,6 +72,7 @@ instance [semi_normed_ring A] : normed_ring (completion A) :=
     { intros x y,
       rw [← completion.coe_sub, norm_coe, completion.dist_eq, dist_eq_norm] }
   end,
+  norm_one := by simpa only [←coe_one, norm_coe] using norm_one_le,
   norm_mul := λ x y,
   begin
     apply completion.induction_on₂ x y; clear x y,

--- a/src/analysis/normed_space/lp_space.lean
+++ b/src/analysis/normed_space/lp_space.lean
@@ -793,7 +793,8 @@ instance [nonempty I] : norm_one_class (lp B ∞) :=
 { norm_one := by simp_rw [lp.norm_eq_csupr, infty_coe_fn_one, pi.one_apply, norm_one, csupr_const]}
 
 instance infty_normed_ring : normed_ring (lp B ∞) :=
-{ .. lp.infty_ring, .. lp.non_unital_normed_ring }
+{ norm_one := norm_le_of_forall_le zero_le_one (λ _, norm_one_le),
+  .. lp.infty_ring, .. lp.non_unital_normed_ring }
 
 end normed_ring
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -418,7 +418,8 @@ omit σ₁₃
 
 /-- Continuous linear maps form a seminormed ring with respect to the operator norm. -/
 instance to_semi_normed_ring : semi_normed_ring (E →L[𝕜] E) :=
-{ norm_mul := λ f g, op_norm_comp_le f g,
+{ norm_one := norm_id_le,
+  norm_mul := λ f g, op_norm_comp_le f g,
   .. continuous_linear_map.to_seminormed_add_comm_group, .. continuous_linear_map.ring }
 
 /-- For a normed space `E`, continuous linear endomorphisms form a normed algebra with

--- a/src/analysis/normed_space/units.lean
+++ b/src/analysis/normed_space/units.lean
@@ -168,6 +168,8 @@ end
 
 lemma inverse_one_sub_norm : (λ t : R, inverse (1 - t)) =O[𝓝 0] (λ t, 1 : R → ℝ) :=
 begin
+  casesI subsingleton_or_nontrivial R,
+  { simp_rw [subsingleton.elim (inverse _) (0 : R), is_O_zero] },
   simp only [is_O, is_O_with, eventually_iff, metric.mem_nhds_iff],
   refine ⟨‖(1:R)‖ + 1, (2:ℝ)⁻¹, by norm_num, _⟩,
   intros t ht,
@@ -175,9 +177,10 @@ begin
   have ht' : ‖t‖ < 1,
   { have : (2:ℝ)⁻¹ < 1 := by cancel_denoms,
     linarith },
-  simp only [inverse_one_sub t ht', norm_one, mul_one, set.mem_set_of_eq],
+  simp only [inverse_one_sub t ht', norm_one_class.norm_one, mul_one, set.mem_set_of_eq],
   change ‖∑' n : ℕ, t ^ n‖ ≤ _,
   have := normed_ring.tsum_geometric_of_norm_lt_1 t ht',
+  rw norm_one_class.norm_one at this,
   have : (1 - ‖t‖)⁻¹ ≤ 2,
   { rw ← inv_inv (2:ℝ),
     refine inv_le_inv_of_le (by norm_num) _,
@@ -189,7 +192,9 @@ end
 /-- The function `λ t, inverse (x + t)` is O(1) as `t → 0`. -/
 lemma inverse_add_norm (x : Rˣ) : (λ t : R, inverse (↑x + t)) =O[𝓝 0] (λ t, (1:ℝ)) :=
 begin
-  simp only [is_O_iff, norm_one, mul_one],
+  casesI subsingleton_or_nontrivial R,
+  { simp_rw [subsingleton.elim (inverse _) (0 : R), is_O_zero] },
+  simp only [is_O_iff, norm_one_class.norm_one, mul_one],
   cases is_O_iff.mp (@inverse_one_sub_norm R _ _) with C hC,
   use C * ‖((x⁻¹:Rˣ):R)‖,
   have hzero : tendsto (λ t, - (↑x⁻¹ : R) * t) (𝓝 0) (𝓝 0),

--- a/src/number_theory/padics/padic_integers.lean
+++ b/src/number_theory/padics/padic_integers.lean
@@ -187,6 +187,7 @@ variables (p)
 
 instance : normed_comm_ring ℤ_[p] :=
 { dist_eq := λ ⟨_, _⟩ ⟨_, _⟩, rfl,
+  norm_one := by simp [norm_def],
   norm_mul := by simp [norm_def],
   norm := norm, .. padic_int.comm_ring, .. padic_int.metric_space p }
 

--- a/src/number_theory/padics/padic_numbers.lean
+++ b/src/number_theory/padics/padic_numbers.lean
@@ -661,6 +661,7 @@ instance : has_norm ℚ_[p] := ⟨λ x, padic_norm_e x⟩
 
 instance : normed_field ℚ_[p] :=
 { dist_eq := λ _ _, rfl,
+  norm_one' := by simp [has_norm.norm, map_one],
   norm_mul' := by simp [has_norm.norm, map_mul],
   norm := norm, .. padic.field, .. padic.metric_space p }
 

--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -1089,12 +1089,14 @@ fun_like.coe_injective.ring _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub
   coe_int_cast
 
 instance : semi_normed_ring (α →ᵇ R) :=
-{ ..bounded_continuous_function.non_unital_semi_normed_ring }
+{ norm_one := norm_of_normed_add_comm_group_le _ zero_le_one $ λ _, norm_one_le,
+  ..bounded_continuous_function.non_unital_semi_normed_ring }
 
 end semi_normed
 
 instance [normed_ring R] : normed_ring (α →ᵇ R) :=
-{ ..bounded_continuous_function.non_unital_normed_ring }
+{ ..bounded_continuous_function.semi_normed_ring,
+  ..bounded_continuous_function.non_unital_normed_ring }
 
 end normed_ring
 


### PR DESCRIPTION
[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/.E2.9C.94.20Is.20the.20zero.20algebra.20normed.3F/near/344865471). This adds the axiom `norm_one :  norm (1 : α) ≤ 1` to `semi_normed_ring`, and `norm 1 = 1` to `normed_field`.

The latter is essentially redundant, but making it automatic is more of a burden than the fixing the handful of places that prove it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
