### PR TITLE
[Merged by Bors] - feat(measure_theory/function): Functions locally integrable on a set

### DIFF
--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -9,15 +9,17 @@ import measure_theory.integral.integrable_on
 # Locally integrable functions
 
 A function is called *locally integrable* (`measure_theory.locally_integrable`) if it is integrable
-on a neighborhood of every point.
+on a neighborhood of every point. More generally, it is *locally integrable on `s`* if it is
+locally integrable on a neighbourhood within `s` of any point of `s`.
 
-This file contains properties of locally integrable functions and integrability results
+This file contains properties of locally integrable functions, and integrability results
 on compact sets.
 
 ## Main statements
 
 * `continuous.locally_integrable`: A continuous function is locally integrable.
-
+* `continuous_on.locally_integrable_on`: A function which is continuous on `s` is locally
+  integrable on `s`.
 -/
 
 open measure_theory measure_theory.measure set function topological_space
@@ -25,18 +27,105 @@ open_locale topology interval
 
 variables {X Y E R : Type*} [measurable_space X] [topological_space X]
 variables [measurable_space Y] [topological_space Y]
-variables [normed_add_comm_group E] {f : X → E} {μ : measure X}
+variables [normed_add_comm_group E] {f : X → E} {μ : measure X} {s : set X}
 
 namespace measure_theory
 
-/-- A function `f : X → E` is locally integrable if it is integrable on a neighborhood of every
+section locally_integrable_on
+
+/-- A function `f : X → E` is *locally integrable on s*, for `s ⊆ X`, if for every `x ∈ s` there is
+a neighbourhood of `x` within `s` on which `f` is integrable. (Note this is, in general, strictly
+weaker than local integrability with respect to `μ.restrict s`.) -/
+def locally_integrable_on (f : X → E) (s : set X) (μ : measure X . volume_tac) : Prop :=
+∀ (x : X), x ∈ s → integrable_at_filter f (𝓝[s] x) μ
+
+lemma locally_integrable_on.mono
+  (hf : measure_theory.locally_integrable_on f s μ) {t : set X} (hst : t ⊆ s) :
+  locally_integrable_on f t μ :=
+λ x hx, (hf x $ hst hx).filter_mono (nhds_within_mono x hst)
+
+lemma locally_integrable_on.norm (hf : locally_integrable_on f s μ) :
+  locally_integrable_on (λ x, ‖f x‖) s μ :=
+λ t ht, let ⟨U, hU_nhd, hU_int⟩ := hf t ht in ⟨U, hU_nhd, hU_int.norm⟩
+
+lemma integrable_on.locally_integrable_on (hf : integrable_on f s μ) :
+  locally_integrable_on f s μ :=
+λ x hx, ⟨s, self_mem_nhds_within, hf⟩
+
+/-- If a function is locally integrable on a compact set, then it is integrable on that set. -/
+lemma locally_integrable_on.integrable_on_is_compact
+  (hf : locally_integrable_on f s μ) (hs : is_compact s) :
+  integrable_on f s μ :=
+is_compact.induction_on hs integrable_on_empty (λ u v huv hv, hv.mono_set huv)
+  (λ u v hu hv, integrable_on_union.mpr ⟨hu, hv⟩) hf
+
+lemma locally_integrable_on.integrable_on_compact_subset
+  (hf : locally_integrable_on f s μ) {t : set X} (hst : t ⊆ s) (ht : is_compact t) :
+  integrable_on f t μ :=
+(hf.mono hst).integrable_on_is_compact ht
+
+lemma locally_integrable_on.ae_strongly_measurable [second_countable_topology X]
+  (hf : locally_integrable_on f s μ) :
+  ae_strongly_measurable f (μ.restrict s) :=
+begin
+  have : ∀ (x : s), ∃ u, is_open u ∧ x.1 ∈ u ∧ integrable_on f (u ∩ s) μ,
+  { rintro ⟨x, hx⟩,
+    rcases hf x hx with ⟨t, ht, h't⟩,
+    rcases mem_nhds_within.1 ht with ⟨u, u_open, x_mem, u_sub⟩,
+    refine ⟨u, u_open, x_mem, h't.mono_set u_sub⟩ },
+  choose u u_open xu hu using this,
+  obtain ⟨T, T_count, hT⟩ : ∃ (T : set s), T.countable ∧ s = (⋃ (i : T), u i ∩ s),
+  { have : s ⊆ (⋃ (x : s), u x), from λ y hy, mem_Union_of_mem ⟨y, hy⟩ (xu ⟨y, hy⟩),
+    obtain ⟨T, hT_count, hT_un⟩ := is_open_Union_countable u u_open,
+    refine ⟨T, hT_count, _⟩,
+    rw [←hT_un, bUnion_eq_Union] at this,
+    rw [←Union_inter, eq_comm, inter_eq_right_iff_subset],
+    exact this },
+  haveI : countable T, from countable_coe_iff.mpr T_count,
+  rw [hT, ae_strongly_measurable_Union_iff],
+  exact λ (i : T), (hu i).ae_strongly_measurable,
+end
+
+/-- If `s` is either open, or closed, then `f` is locally integrable on `s` iff it is integrable on
+every compact subset contained in `s`. -/
+lemma locally_integrable_on_iff [locally_compact_space X] [t2_space X]
+  (hs : is_closed s ∨ is_open s) :
+  locally_integrable_on f s μ ↔ ∀ (k : set X) (hk : k ⊆ s), is_compact k → integrable_on f k μ :=
+begin
+  -- The correct condition is that `s` be *locally closed*, i.e. for every `x ∈ s` there is some
+  -- `U ∈ 𝓝 x` such that `U ∩ s` is closed. But mathlib doesn't have locally closed sets yet.
+  refine ⟨λ hf k hk, hf.integrable_on_compact_subset hk, λ hf x hx, _⟩,
+  cases hs,
+  { exact let ⟨K, hK, h2K⟩ := exists_compact_mem_nhds x in ⟨_, inter_mem_nhds_within s h2K,
+    hf _ (inter_subset_left _ _) (is_compact_of_is_closed_subset hK (hs.inter hK.is_closed)
+    (inter_subset_right _ _))⟩ },
+  { obtain ⟨K, hK, h2K, h3K⟩ := exists_compact_subset hs hx,
+    refine ⟨K, _, hf K h3K hK⟩,
+    simpa only [is_open.nhds_within_eq hs hx, interior_eq_nhds'] using h2K },
+end
+
+end locally_integrable_on
+
+/-- A function `f : X → E` is *locally integrable* if it is integrable on a neighborhood of every
 point. In particular, it is integrable on all compact sets,
 see `locally_integrable.integrable_on_is_compact`. -/
 def locally_integrable (f : X → E) (μ : measure X . volume_tac) : Prop :=
 ∀ (x : X), integrable_at_filter f (𝓝 x) μ
 
+lemma locally_integrable_on_univ : locally_integrable_on f univ μ ↔ locally_integrable f μ :=
+by simpa only [locally_integrable_on, nhds_within_univ, mem_univ, true_implies_iff]
+
+lemma locally_integrable.locally_integrable_on (hf : locally_integrable f μ) (s : set X) :
+  locally_integrable_on f s μ :=
+λ x hx, (hf x).filter_mono nhds_within_le_nhds
+
 lemma integrable.locally_integrable (hf : integrable f μ) : locally_integrable f μ :=
 λ x, hf.integrable_at_filter _
+
+/-- If a function is locally integrable, then it is integrable on any compact set. -/
+lemma locally_integrable.integrable_on_is_compact {k : set X} (hf : locally_integrable f μ)
+  (hk : is_compact k) : integrable_on f k μ :=
+(hf.locally_integrable_on k).integrable_on_is_compact hk
 
 /-- If a function is locally integrable, then it is integrable on an open neighborhood of any
 compact set. -/
@@ -55,40 +144,14 @@ begin
     exact ⟨v, nhds_within_le_nhds (v_open.mem_nhds xv), v, v_open, subset.rfl, hu.mono_set vu⟩ }
 end
 
-/-- If a function is locally integrable, then it is integrable on any compact set. -/
-lemma locally_integrable.integrable_on_is_compact {k : set X} (hf : locally_integrable f μ)
-  (hk : is_compact k) : integrable_on f k μ :=
-begin
-  rcases hf.integrable_on_nhds_is_compact hk with ⟨u, u_open, ku, hu⟩,
-  exact hu.mono_set ku
-end
-
 lemma locally_integrable_iff [locally_compact_space X] :
   locally_integrable f μ ↔ ∀ (k : set X), is_compact k → integrable_on f k μ :=
-begin
-  refine ⟨λ hf k hk, hf.integrable_on_is_compact hk, λ hf x, _⟩,
-  obtain ⟨K, hK, h2K⟩ := exists_compact_mem_nhds x,
-  exact ⟨K, h2K, hf K hK⟩,
-end
+⟨λ hf k hk, hf.integrable_on_is_compact hk,
+  λ hf x, let ⟨K, hK, h2K⟩ := exists_compact_mem_nhds x in ⟨K, h2K, hf K hK⟩⟩
 
 lemma locally_integrable.ae_strongly_measurable [second_countable_topology X]
   (hf : locally_integrable f μ) : ae_strongly_measurable f μ :=
-begin
-  have : ∀ x, ∃ u, is_open u ∧ x ∈ u ∧ integrable_on f u μ,
-  { assume x,
-    rcases hf x with ⟨s, hs, h's⟩,
-    rcases mem_nhds_iff.1 hs with ⟨u, us, u_open, xu⟩,
-    exact ⟨u, u_open, xu, h's.mono_set us⟩ },
-  choose u u_open xu hu using this,
-  obtain ⟨T, T_count, hT⟩ : ∃ (T : set X), T.countable ∧ (⋃ (i : T), u i) = univ,
-  { have : (⋃ x, u x) = univ, from eq_univ_of_forall (λ x, mem_Union_of_mem x (xu x)),
-    rw ← this,
-    simp only [Union_coe_set, subtype.coe_mk],
-    exact is_open_Union_countable u u_open },
-  haveI : countable T, from countable_coe_iff.mpr T_count,
-  rw [← @restrict_univ _ _ μ, ← hT, ae_strongly_measurable_Union_iff],
-  exact λ i, (hu i).ae_strongly_measurable,
-end
+by simpa only [restrict_univ] using (locally_integrable_on_univ.mpr hf).ae_strongly_measurable
 
 lemma locally_integrable_const [is_locally_finite_measure μ] (c : E) :
   locally_integrable (λ x, c) μ :=
@@ -98,6 +161,10 @@ begin
   refine ⟨U, hU, _⟩,
   simp only [h'U, integrable_on_const, or_true],
 end
+
+lemma locally_integrable_on_const [is_locally_finite_measure μ] (c : E) :
+  locally_integrable_on (λ x, c) s μ :=
+(locally_integrable_const c).locally_integrable_on s
 
 lemma locally_integrable.indicator (hf : locally_integrable f μ)
   {s : set X} (hs : measurable_set s) : locally_integrable (s.indicator f) μ :=
@@ -124,63 +191,9 @@ begin
     simp only [mem_preimage, homeomorph.symm_apply_apply] }
 end
 
-section mul
-
-variables [opens_measurable_space X] [normed_ring R] [second_countable_topology_either X R]
-  {A K : set X} {g g' : X → R}
-
-lemma integrable_on.mul_continuous_on_of_subset
-  (hg : integrable_on g A μ) (hg' : continuous_on g' K)
-  (hA : measurable_set A) (hK : is_compact K) (hAK : A ⊆ K) :
-  integrable_on (λ x, g x * g' x) A μ :=
-begin
-  rcases is_compact.exists_bound_of_continuous_on hK hg' with ⟨C, hC⟩,
-  rw [integrable_on, ← mem_ℒp_one_iff_integrable] at hg ⊢,
-  have : ∀ᵐ x ∂(μ.restrict A), ‖g x * g' x‖ ≤ C * ‖g x‖,
-  { filter_upwards [ae_restrict_mem hA] with x hx,
-    refine (norm_mul_le _ _).trans _,
-    rw mul_comm,
-    apply mul_le_mul_of_nonneg_right (hC x (hAK hx)) (norm_nonneg _), },
-  exact mem_ℒp.of_le_mul hg (hg.ae_strongly_measurable.mul $
-    (hg'.mono hAK).ae_strongly_measurable hA) this,
-end
-
-lemma integrable_on.mul_continuous_on [t2_space X]
-  (hg : integrable_on g K μ) (hg' : continuous_on g' K) (hK : is_compact K) :
-  integrable_on (λ x, g x * g' x) K μ :=
-hg.mul_continuous_on_of_subset hg' hK.measurable_set hK (subset.refl _)
-
-lemma integrable_on.continuous_on_mul_of_subset
-  (hg : continuous_on g K) (hg' : integrable_on g' A μ)
-  (hK : is_compact K) (hA : measurable_set A) (hAK : A ⊆ K) :
-  integrable_on (λ x, g x * g' x) A μ :=
-begin
-  rcases is_compact.exists_bound_of_continuous_on hK hg with ⟨C, hC⟩,
-  rw [integrable_on, ← mem_ℒp_one_iff_integrable] at hg' ⊢,
-  have : ∀ᵐ x ∂(μ.restrict A), ‖g x * g' x‖ ≤ C * ‖g' x‖,
-  { filter_upwards [ae_restrict_mem hA] with x hx,
-    refine (norm_mul_le _ _).trans _,
-    apply mul_le_mul_of_nonneg_right (hC x (hAK hx)) (norm_nonneg _), },
-  exact mem_ℒp.of_le_mul hg' (((hg.mono hAK).ae_strongly_measurable hA).mul
-    hg'.ae_strongly_measurable) this,
-end
-
-lemma integrable_on.continuous_on_mul [t2_space X]
-  (hg : continuous_on g K) (hg' : integrable_on g' K μ) (hK : is_compact K) :
-  integrable_on (λ x, g x * g' x) K μ :=
-hg'.continuous_on_mul_of_subset hg hK hK.measurable_set subset.rfl
-
-end mul
-
 end measure_theory
-open measure_theory
 
-/-- If a function is integrable at `𝓝[s] x` for each point `x` of a compact set `s`, then it is
-integrable on `s`. -/
-lemma is_compact.integrable_on_of_nhds_within {K : set X} (hK : is_compact K)
-  (hf : ∀ x ∈ K, integrable_at_filter f (𝓝[K] x) μ) : integrable_on f K μ :=
-is_compact.induction_on hK integrable_on_empty (λ s t hst ht, ht.mono_set hst)
-  (λ s t hs ht, hs.union ht) hf
+open measure_theory
 
 section borel
 
@@ -192,6 +205,13 @@ lemma continuous.locally_integrable [second_countable_topology_either X E]
   (hf : continuous f) : locally_integrable f μ :=
 hf.integrable_at_nhds
 
+/-- A function `f` continuous on a set `K` is locally integrable on this set with respect
+to any locally finite measure. -/
+lemma continuous_on.locally_integrable_on [second_countable_topology_either X E]
+  (hf : continuous_on f K) (hK : measurable_set K) :
+  locally_integrable_on f K μ :=
+λ x hx, hf.integrable_at_nhds_within hK hx
+
 variables [metrizable_space X]
 
 /-- A function `f` continuous on a compact set `K` is integrable on this set with respect to any
@@ -200,7 +220,7 @@ lemma continuous_on.integrable_on_compact (hK : is_compact K) (hf : continuous_o
   integrable_on f K μ :=
 begin
   letI := metrizable_space_metric X,
-  apply hK.integrable_on_of_nhds_within (λ x hx, _),
+  refine locally_integrable_on.integrable_on_is_compact (λ x hx, _) hK,
   exact hf.integrable_at_nhds_within_of_is_separable hK.measurable_set hK.is_separable hx,
 end
 
@@ -243,7 +263,6 @@ section monotone
 variables [borel_space X]
   [conditionally_complete_linear_order X] [conditionally_complete_linear_order E]
   [order_topology X] [order_topology E] [second_countable_topology E]
-  {s : set X}
 
 lemma monotone_on.integrable_on_of_measure_ne_top
   (hmono : monotone_on f s) {a b : X} (ha : is_least s a) (hb : is_greatest s b) (hs : μ s ≠ ∞)
@@ -303,3 +322,127 @@ lemma antitone.locally_integrable [is_locally_finite_measure μ] (hanti : antito
 hanti.dual_right.locally_integrable
 
 end monotone
+
+namespace measure_theory
+
+variables [opens_measurable_space X] {A K : set X}
+
+section mul
+
+variables [normed_ring R] [second_countable_topology_either X R] {g g' : X → R}
+
+lemma integrable_on.mul_continuous_on_of_subset
+  (hg : integrable_on g A μ) (hg' : continuous_on g' K)
+  (hA : measurable_set A) (hK : is_compact K) (hAK : A ⊆ K) :
+  integrable_on (λ x, g x * g' x) A μ :=
+begin
+  rcases is_compact.exists_bound_of_continuous_on hK hg' with ⟨C, hC⟩,
+  rw [integrable_on, ← mem_ℒp_one_iff_integrable] at hg ⊢,
+  have : ∀ᵐ x ∂(μ.restrict A), ‖g x * g' x‖ ≤ C * ‖g x‖,
+  { filter_upwards [ae_restrict_mem hA] with x hx,
+    refine (norm_mul_le _ _).trans _,
+    rw mul_comm,
+    apply mul_le_mul_of_nonneg_right (hC x (hAK hx)) (norm_nonneg _), },
+  exact mem_ℒp.of_le_mul hg (hg.ae_strongly_measurable.mul $
+    (hg'.mono hAK).ae_strongly_measurable hA) this,
+end
+
+lemma integrable_on.mul_continuous_on [t2_space X]
+  (hg : integrable_on g K μ) (hg' : continuous_on g' K) (hK : is_compact K) :
+  integrable_on (λ x, g x * g' x) K μ :=
+hg.mul_continuous_on_of_subset hg' hK.measurable_set hK (subset.refl _)
+
+lemma integrable_on.continuous_on_mul_of_subset
+  (hg : continuous_on g K) (hg' : integrable_on g' A μ)
+  (hK : is_compact K) (hA : measurable_set A) (hAK : A ⊆ K) :
+  integrable_on (λ x, g x * g' x) A μ :=
+begin
+  rcases is_compact.exists_bound_of_continuous_on hK hg with ⟨C, hC⟩,
+  rw [integrable_on, ← mem_ℒp_one_iff_integrable] at hg' ⊢,
+  have : ∀ᵐ x ∂(μ.restrict A), ‖g x * g' x‖ ≤ C * ‖g' x‖,
+  { filter_upwards [ae_restrict_mem hA] with x hx,
+    refine (norm_mul_le _ _).trans _,
+    apply mul_le_mul_of_nonneg_right (hC x (hAK hx)) (norm_nonneg _), },
+  exact mem_ℒp.of_le_mul hg' (((hg.mono hAK).ae_strongly_measurable hA).mul
+    hg'.ae_strongly_measurable) this,
+end
+
+lemma integrable_on.continuous_on_mul [t2_space X]
+  (hg : continuous_on g K) (hg' : integrable_on g' K μ) (hK : is_compact K) :
+  integrable_on (λ x, g x * g' x) K μ :=
+hg'.continuous_on_mul_of_subset hg hK hK.measurable_set subset.rfl
+
+end mul
+
+section smul
+
+variables {𝕜 : Type*} [normed_field 𝕜] [normed_space 𝕜 E]
+
+lemma integrable_on.continuous_on_smul [t2_space X] [second_countable_topology_either X 𝕜]
+  {g : X → E} (hg : integrable_on g K μ) {f : X → 𝕜} (hf : continuous_on f K) (hK : is_compact K) :
+  integrable_on (λ x, f x • g x) K μ :=
+begin
+  rw [integrable_on, ←integrable_norm_iff],
+  { simp_rw norm_smul,
+    refine integrable_on.continuous_on_mul _ hg.norm hK,
+    exact continuous_norm.comp_continuous_on hf },
+  { exact (hf.ae_strongly_measurable hK.measurable_set).smul hg.1 }
+end
+
+lemma integrable_on.smul_continuous_on [t2_space X] [second_countable_topology_either X E]
+  {f : X → 𝕜} (hf : integrable_on f K μ) {g : X → E} (hg : continuous_on g K) (hK : is_compact K) :
+  integrable_on (λ x, f x • g x) K μ :=
+begin
+  rw [integrable_on, ←integrable_norm_iff],
+  { simp_rw norm_smul,
+    refine integrable_on.mul_continuous_on hf.norm _ hK,
+    exact continuous_norm.comp_continuous_on hg },
+  { exact hf.1.smul (hg.ae_strongly_measurable hK.measurable_set) }
+end
+
+end smul
+
+namespace locally_integrable_on
+
+lemma continuous_on_mul [locally_compact_space X] [t2_space X] [normed_ring R]
+  [second_countable_topology_either X R]
+  {f g : X → R} {s : set X}
+  (hf : locally_integrable_on f s μ) (hg : continuous_on g s) (hs : is_open s) :
+  locally_integrable_on (λ x, g x * f x) s μ :=
+begin
+  rw measure_theory.locally_integrable_on_iff (or.inr hs) at hf ⊢,
+  exact λ k hk_sub hk_c, (hf k hk_sub hk_c).continuous_on_mul (hg.mono hk_sub) hk_c
+end
+
+lemma mul_continuous_on [locally_compact_space X] [t2_space X] [normed_ring R]
+  [second_countable_topology_either X R] {f g : X → R} {s : set X}
+  (hf : locally_integrable_on f s μ) (hg : continuous_on g s) (hs : is_open s) :
+  locally_integrable_on (λ x, f x * g x) s μ :=
+begin
+  rw measure_theory.locally_integrable_on_iff (or.inr hs) at hf ⊢,
+  exact λ k hk_sub hk_c, (hf k hk_sub hk_c).mul_continuous_on (hg.mono hk_sub) hk_c
+end
+
+lemma continuous_on_smul [locally_compact_space X] [t2_space X]
+  {𝕜 : Type*} [normed_field 𝕜] [second_countable_topology_either X 𝕜] [normed_space 𝕜 E]
+  {f : X → E} {g : X → 𝕜} {s : set X} (hs : is_open s)
+  (hf : locally_integrable_on f s μ) (hg : continuous_on g s) :
+  locally_integrable_on (λ x, g x • f x) s μ :=
+begin
+  rw measure_theory.locally_integrable_on_iff (or.inr hs) at hf ⊢,
+  exact λ k hk_sub hk_c, (hf k hk_sub hk_c).continuous_on_smul (hg.mono hk_sub) hk_c
+end
+
+lemma smul_continuous_on [locally_compact_space X] [t2_space X]
+  {𝕜 : Type*} [normed_field 𝕜] [second_countable_topology_either X E] [normed_space 𝕜 E]
+  {f : X → 𝕜} {g : X → E} {s : set X} (hs : is_open s)
+  (hf : locally_integrable_on f s μ) (hg : continuous_on g s)  :
+  locally_integrable_on (λ x, f x • g x) s μ :=
+begin
+  rw measure_theory.locally_integrable_on_iff (or.inr hs) at hf ⊢,
+  exact λ k hk_sub hk_c, (hf k hk_sub hk_c).smul_continuous_on (hg.mono hk_sub) hk_c
+end
+
+end locally_integrable_on
+
+end measure_theory

--- a/src/measure_theory/function/locally_integrable.lean
+++ b/src/measure_theory/function/locally_integrable.lean
@@ -101,7 +101,7 @@ begin
     (inter_subset_right _ _))⟩ },
   { obtain ⟨K, hK, h2K, h3K⟩ := exists_compact_subset hs hx,
     refine ⟨K, _, hf K h3K hK⟩,
-    simpa only [is_open.nhds_within_eq hs hx, interior_eq_nhds'] using h2K },
+    simpa only [is_open.nhds_within_eq hs hx, interior_eq_nhds'] using h2K }
 end
 
 end locally_integrable_on
@@ -121,6 +121,41 @@ lemma locally_integrable.locally_integrable_on (hf : locally_integrable f μ) (s
 
 lemma integrable.locally_integrable (hf : integrable f μ) : locally_integrable f μ :=
 λ x, hf.integrable_at_filter _
+
+/-- If `f` is locally integrable with respect to `μ.restrict s`, it is locally integrable on `s`.
+(See `locally_integrable_on_iff_locally_integrable_restrict` for an iff statement when `s` is
+closed.) -/
+lemma locally_integrable_on_of_locally_integrable_restrict [opens_measurable_space X]
+  (hf : locally_integrable f (μ.restrict s)) :
+  locally_integrable_on f s μ :=
+begin
+  intros x hx,
+  obtain ⟨t, ht_mem, ht_int⟩ := hf x,
+  obtain ⟨u, hu_sub, hu_o, hu_mem⟩ := mem_nhds_iff.mp ht_mem,
+  refine ⟨_, inter_mem_nhds_within s (hu_o.mem_nhds hu_mem), _⟩,
+  simpa only [integrable_on, measure.restrict_restrict hu_o.measurable_set, inter_comm]
+    using ht_int.mono_set hu_sub,
+end
+
+/-- If `s` is closed, being locally integrable on `s` wrt `μ` is equivalent to being locally
+integrable with respect to `μ.restrict s`. For the one-way implication without assuming `s` closed,
+see `locally_integrable_on_of_locally_integrable_restrict`. -/
+lemma locally_integrable_on_iff_locally_integrable_restrict [opens_measurable_space X]
+  (hs : is_closed s) :
+  locally_integrable_on f s μ ↔ locally_integrable f (μ.restrict s) :=
+begin
+  refine ⟨λ hf x, _, locally_integrable_on_of_locally_integrable_restrict⟩,
+  by_cases h : x ∈ s,
+  { obtain ⟨t, ht_nhds, ht_int⟩ := hf x h,
+    obtain ⟨u, hu_o, hu_x, hu_sub⟩ := mem_nhds_within.mp ht_nhds,
+    refine ⟨u, hu_o.mem_nhds hu_x, _⟩,
+    rw [integrable_on, restrict_restrict hu_o.measurable_set],
+    exact ht_int.mono_set hu_sub },
+  { rw ←is_open_compl_iff at hs,
+    refine ⟨sᶜ, hs.mem_nhds h, _⟩,
+    rw [integrable_on, restrict_restrict, inter_comm, inter_compl_self, ←integrable_on],
+    exacts [integrable_on_empty, hs.measurable_set] },
+end
 
 /-- If a function is locally integrable, then it is integrable on any compact set. -/
 lemma locally_integrable.integrable_on_is_compact {k : set X} (hf : locally_integrable f μ)

--- a/src/measure_theory/integral/integrable_on.lean
+++ b/src/measure_theory/integral/integrable_on.lean
@@ -114,20 +114,25 @@ lemma integrable_on.congr_set_ae (h : integrable_on f t μ) (hst : s =ᵐ[μ] t)
   integrable_on f s μ :=
 h.mono_set_ae hst.le
 
-lemma integrable_on.congr_fun' (h : integrable_on f s μ) (hst : f =ᵐ[μ.restrict s] g) :
+lemma integrable_on.congr_fun_ae (h : integrable_on f s μ) (hst : f =ᵐ[μ.restrict s] g) :
   integrable_on g s μ :=
 integrable.congr h hst
+
+lemma integrable_on_congr_fun_ae (hst : f =ᵐ[μ.restrict s] g) :
+  integrable_on f s μ ↔ integrable_on g s μ :=
+⟨λ h, h.congr_fun_ae hst, λ h, h.congr_fun_ae hst.symm⟩
 
 lemma integrable_on.congr_fun (h : integrable_on f s μ) (hst : eq_on f g s)
   (hs : measurable_set s) :
   integrable_on g s μ :=
-h.congr_fun' ((ae_restrict_iff' hs).2 (eventually_of_forall hst))
+h.congr_fun_ae ((ae_restrict_iff' hs).2 (eventually_of_forall hst))
+
+lemma integrable_on_congr_fun (hst : eq_on f g s) (hs : measurable_set s) :
+  integrable_on f s μ ↔ integrable_on g s μ :=
+⟨λ h, h.congr_fun hst hs, λ h, h.congr_fun hst.symm hs⟩
 
 lemma integrable.integrable_on (h : integrable f μ) : integrable_on f s μ :=
 h.mono_measure $ measure.restrict_le_self
-
-lemma integrable.integrable_on' (h : integrable f (μ.restrict s)) : integrable_on f s μ :=
-h
 
 lemma integrable_on.restrict (h : integrable_on f s μ) (hs : measurable_set s) :
   integrable_on f s (μ.restrict t) :=

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -616,8 +616,9 @@ lemma integral_undef (h : ¬ interval_integrable f μ a b) :
   ∫ x in a..b, f x ∂μ = 0 :=
 by cases le_total a b with hab hab;
   simp only [integral_of_le, integral_of_ge, hab, neg_eq_zero];
-    refine integral_undef (not_imp_not.mpr integrable.integrable_on' _);
-      simpa [hab] using not_and_distrib.mp h
+    refine integral_undef (not_imp_not.mpr _ h);
+      simpa only [hab, Ioc_eq_empty_of_le, integrable_on_empty, not_true, false_or, or_false]
+        using not_and_distrib.mp h
 
 lemma interval_integrable_of_integral_ne_zero {a b : ℝ}
   {f : ℝ → E} {μ : measure ℝ} (h : ∫ x in a..b, f x ∂μ ≠ 0) :

--- a/src/measure_theory/integral/layercake.lean
+++ b/src/measure_theory/integral/layercake.lean
@@ -170,7 +170,7 @@ begin
   have g_eq_G_on : ∀ t, g =ᵐ[volume.restrict (Ioc 0 t)] G,
     from λ t, ae_mono (measure.restrict_mono Ioc_subset_Ioi_self le_rfl) g_eq_G,
   have G_intble : ∀ t > 0, interval_integrable G volume 0 t,
-  { refine λ t t_pos, ⟨integrable_on.congr_fun' (g_intble t t_pos).1 (g_eq_G_on t), _⟩,
+  { refine λ t t_pos, ⟨(g_intble t t_pos).1.congr_fun_ae (g_eq_G_on t), _⟩,
     rw Ioc_eq_empty_of_le t_pos.lt.le,
     exact integrable_on_empty, },
   have eq₁ : ∫⁻ t in Ioi 0, μ {a : α | t ≤ f a} * ennreal.of_real (g t)

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -292,7 +292,7 @@ lemma integral_union_eq_left_of_ae (ht_eq : ∀ᵐ x ∂(μ.restrict t), f x = 0
   ∫ x in (s ∪ t), f x ∂μ = ∫ x in s, f x ∂μ :=
 begin
   have ht : integrable_on f t μ,
-  { apply integrable_on.congr_fun' integrable_on_zero, symmetry, exact ht_eq },
+  { apply integrable_on_zero.congr_fun_ae, symmetry, exact ht_eq },
   by_cases H : integrable_on f (s ∪ t) μ, swap,
   { rw [integral_undef H, integral_undef], simpa [integrable_on_union, ht] using H },
   let f' := H.1.mk f,
@@ -301,7 +301,7 @@ begin
   ... = ∫ x in s, f' x ∂μ :
     begin
       apply integral_union_eq_left_of_ae_aux _ H.1.strongly_measurable_mk
-        (H.congr_fun' H.1.ae_eq_mk),
+        (H.congr_fun_ae H.1.ae_eq_mk),
       filter_upwards [ht_eq, ae_mono (measure.restrict_mono (subset_union_right s t) le_rfl)
         H.1.ae_eq_mk] with x hx h'x,
       rw [← h'x, hx]


### PR DESCRIPTION
This PR adds a definition for local integrability of a function on a set (a relative version of the existing "locally integrable"), and proves some elementary properties of this definition (in particular, functions continuous on `s` are locally integrable on `s`). 
 
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
