### PR TITLE
[Merged by Bors] - chore(analysis/locally_convex/strong_topology): generalize to semilinear maps

### DIFF
--- a/src/analysis/locally_convex/strong_topology.lean
+++ b/src/analysis/locally_convex/strong_topology.lean
@@ -27,22 +27,25 @@ locally convex, bounded convergence
 
 open_locale topology uniform_convergence
 
-variables {E F : Type*}
+variables {𝕜 𝕜₂ E F : Type*}
 
 namespace continuous_linear_map
 
+variables [add_comm_group E] [topological_space E]
+  [add_comm_group F] [topological_space F] [topological_add_group F]
+
 section general
 
-variables [add_comm_group E] [module ℝ E] [topological_space E]
-  [add_comm_group F] [module ℝ F] [topological_space F] [topological_add_group F]
-  [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
+variables [normed_field 𝕜] [normed_field 𝕜₂] [module 𝕜 E] [module 𝕜₂ F] {σ₁₂ : 𝕜 →+* 𝕜₂}
+variables [module ℝ E] [module ℝ F] [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
+  [smul_comm_class 𝕜₂ ℝ F]
 
 lemma strong_topology.locally_convex_space (𝔖 : set (set E)) (h𝔖₁ : 𝔖.nonempty)
   (h𝔖₂ : directed_on (⊆) 𝔖) :
-  @locally_convex_space ℝ (E →L[ℝ] F) _ _ _ (strong_topology (ring_hom.id ℝ) F 𝔖) :=
+  @locally_convex_space ℝ (E →SL[σ₁₂] F) _ _ _ (strong_topology σ₁₂ F 𝔖) :=
 begin
-  letI : topological_space (E →L[ℝ] F) := strong_topology (ring_hom.id ℝ) F 𝔖,
-  haveI : topological_add_group (E →L[ℝ] F) := strong_topology.topological_add_group _ _ _,
+  letI : topological_space (E →SL[σ₁₂] F) := strong_topology σ₁₂ F 𝔖,
+  haveI : topological_add_group (E →SL[σ₁₂] F) := strong_topology.topological_add_group _ _ _,
   refine locally_convex_space.of_basis_zero _ _ _ _
     (strong_topology.has_basis_nhds_zero_of_basis _ _ _ h𝔖₁ h𝔖₂
       (locally_convex_space.convex_basis_zero ℝ F)) _,
@@ -54,12 +57,12 @@ end general
 
 section bounded_sets
 
-variables [add_comm_group E] [module ℝ E] [topological_space E]
-  [add_comm_group F] [module ℝ F] [topological_space F] [topological_add_group F]
-  [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
+variables [normed_field 𝕜] [normed_field 𝕜₂] [module 𝕜 E] [module 𝕜₂ F] {σ₁₂ : 𝕜 →+* 𝕜₂}
+variables [module ℝ E] [module ℝ F] [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
+  [smul_comm_class 𝕜₂ ℝ F]
 
-instance : locally_convex_space ℝ (E →L[ℝ] F) :=
-strong_topology.locally_convex_space _ ⟨∅, bornology.is_vonN_bounded_empty ℝ E⟩
+instance : locally_convex_space ℝ (E →SL[σ₁₂] F) :=
+strong_topology.locally_convex_space _ ⟨∅, bornology.is_vonN_bounded_empty 𝕜 E⟩
   (directed_on_of_sup_mem $ λ _ _, bornology.is_vonN_bounded.union)
 
 end bounded_sets

--- a/src/analysis/locally_convex/strong_topology.lean
+++ b/src/analysis/locally_convex/strong_topology.lean
@@ -27,7 +27,7 @@ locally convex, bounded convergence
 
 open_locale topology uniform_convergence
 
-variables {𝕜₁ 𝕜₂ E F : Type*}
+variables {R 𝕜₁ 𝕜₂ E F : Type*}
 
 namespace continuous_linear_map
 
@@ -36,19 +36,21 @@ variables [add_comm_group E] [topological_space E]
 
 section general
 
+variables (R)
+variables [ordered_semiring R]
 variables [normed_field 𝕜₁] [normed_field 𝕜₂] [module 𝕜₁ E] [module 𝕜₂ F] {σ : 𝕜₁ →+* 𝕜₂}
-variables [module ℝ F] [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
-  [smul_comm_class 𝕜₂ ℝ F]
+variables [module R F] [has_continuous_const_smul R F] [locally_convex_space R F]
+  [smul_comm_class 𝕜₂ R F]
 
 lemma strong_topology.locally_convex_space (𝔖 : set (set E)) (h𝔖₁ : 𝔖.nonempty)
   (h𝔖₂ : directed_on (⊆) 𝔖) :
-  @locally_convex_space ℝ (E →SL[σ] F) _ _ _ (strong_topology σ F 𝔖) :=
+  @locally_convex_space R (E →SL[σ] F) _ _ _ (strong_topology σ F 𝔖) :=
 begin
   letI : topological_space (E →SL[σ] F) := strong_topology σ F 𝔖,
   haveI : topological_add_group (E →SL[σ] F) := strong_topology.topological_add_group _ _ _,
   refine locally_convex_space.of_basis_zero _ _ _ _
     (strong_topology.has_basis_nhds_zero_of_basis _ _ _ h𝔖₁ h𝔖₂
-      (locally_convex_space.convex_basis_zero ℝ F)) _,
+      (locally_convex_space.convex_basis_zero R F)) _,
   rintros ⟨S, V⟩ ⟨hS, hVmem, hVconvex⟩ f hf g hg a b ha hb hab x hx,
   exact hVconvex (hf x hx) (hg x hx) ha hb hab,
 end
@@ -57,12 +59,13 @@ end general
 
 section bounded_sets
 
+variables [ordered_semiring R]
 variables [normed_field 𝕜₁] [normed_field 𝕜₂] [module 𝕜₁ E] [module 𝕜₂ F] {σ : 𝕜₁ →+* 𝕜₂}
-variables [module ℝ F] [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
-  [smul_comm_class 𝕜₂ ℝ F]
+variables [module R F] [has_continuous_const_smul R F] [locally_convex_space R F]
+  [smul_comm_class 𝕜₂ R F]
 
-instance : locally_convex_space ℝ (E →SL[σ] F) :=
-strong_topology.locally_convex_space _ ⟨∅, bornology.is_vonN_bounded_empty 𝕜₁ E⟩
+instance : locally_convex_space R (E →SL[σ] F) :=
+strong_topology.locally_convex_space R _ ⟨∅, bornology.is_vonN_bounded_empty 𝕜₁ E⟩
   (directed_on_of_sup_mem $ λ _ _, bornology.is_vonN_bounded.union)
 
 end bounded_sets

--- a/src/analysis/locally_convex/strong_topology.lean
+++ b/src/analysis/locally_convex/strong_topology.lean
@@ -37,7 +37,7 @@ variables [add_comm_group E] [topological_space E]
 section general
 
 variables [normed_field 𝕜₁] [normed_field 𝕜₂] [module 𝕜₁ E] [module 𝕜₂ F] {σ : 𝕜₁ →+* 𝕜₂}
-variables [module ℝ E] [module ℝ F] [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
+variables [module ℝ F] [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
   [smul_comm_class 𝕜₂ ℝ F]
 
 lemma strong_topology.locally_convex_space (𝔖 : set (set E)) (h𝔖₁ : 𝔖.nonempty)
@@ -58,7 +58,7 @@ end general
 section bounded_sets
 
 variables [normed_field 𝕜₁] [normed_field 𝕜₂] [module 𝕜₁ E] [module 𝕜₂ F] {σ : 𝕜₁ →+* 𝕜₂}
-variables [module ℝ E] [module ℝ F] [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
+variables [module ℝ F] [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
   [smul_comm_class 𝕜₂ ℝ F]
 
 instance : locally_convex_space ℝ (E →SL[σ] F) :=

--- a/src/analysis/locally_convex/strong_topology.lean
+++ b/src/analysis/locally_convex/strong_topology.lean
@@ -27,7 +27,7 @@ locally convex, bounded convergence
 
 open_locale topology uniform_convergence
 
-variables {𝕜 𝕜₂ E F : Type*}
+variables {𝕜₁ 𝕜₂ E F : Type*}
 
 namespace continuous_linear_map
 
@@ -36,16 +36,16 @@ variables [add_comm_group E] [topological_space E]
 
 section general
 
-variables [normed_field 𝕜] [normed_field 𝕜₂] [module 𝕜 E] [module 𝕜₂ F] {σ₁₂ : 𝕜 →+* 𝕜₂}
+variables [normed_field 𝕜₁] [normed_field 𝕜₂] [module 𝕜₁ E] [module 𝕜₂ F] {σ : 𝕜₁ →+* 𝕜₂}
 variables [module ℝ E] [module ℝ F] [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
   [smul_comm_class 𝕜₂ ℝ F]
 
 lemma strong_topology.locally_convex_space (𝔖 : set (set E)) (h𝔖₁ : 𝔖.nonempty)
   (h𝔖₂ : directed_on (⊆) 𝔖) :
-  @locally_convex_space ℝ (E →SL[σ₁₂] F) _ _ _ (strong_topology σ₁₂ F 𝔖) :=
+  @locally_convex_space ℝ (E →SL[σ] F) _ _ _ (strong_topology σ F 𝔖) :=
 begin
-  letI : topological_space (E →SL[σ₁₂] F) := strong_topology σ₁₂ F 𝔖,
-  haveI : topological_add_group (E →SL[σ₁₂] F) := strong_topology.topological_add_group _ _ _,
+  letI : topological_space (E →SL[σ] F) := strong_topology σ F 𝔖,
+  haveI : topological_add_group (E →SL[σ] F) := strong_topology.topological_add_group _ _ _,
   refine locally_convex_space.of_basis_zero _ _ _ _
     (strong_topology.has_basis_nhds_zero_of_basis _ _ _ h𝔖₁ h𝔖₂
       (locally_convex_space.convex_basis_zero ℝ F)) _,
@@ -57,12 +57,12 @@ end general
 
 section bounded_sets
 
-variables [normed_field 𝕜] [normed_field 𝕜₂] [module 𝕜 E] [module 𝕜₂ F] {σ₁₂ : 𝕜 →+* 𝕜₂}
+variables [normed_field 𝕜₁] [normed_field 𝕜₂] [module 𝕜₁ E] [module 𝕜₂ F] {σ : 𝕜₁ →+* 𝕜₂}
 variables [module ℝ E] [module ℝ F] [has_continuous_const_smul ℝ F] [locally_convex_space ℝ F]
   [smul_comm_class 𝕜₂ ℝ F]
 
-instance : locally_convex_space ℝ (E →SL[σ₁₂] F) :=
-strong_topology.locally_convex_space _ ⟨∅, bornology.is_vonN_bounded_empty 𝕜 E⟩
+instance : locally_convex_space ℝ (E →SL[σ] F) :=
+strong_topology.locally_convex_space _ ⟨∅, bornology.is_vonN_bounded_empty 𝕜₁ E⟩
   (directed_on_of_sup_mem $ λ _ _, bornology.is_vonN_bounded.union)
 
 end bounded_sets


### PR DESCRIPTION
This is needed to show that the space of C-linear maps is locally convex.

Also generalizes the ring from `real` to a general ordered semiring, since the proofs didn't need the `real`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
