### PR TITLE
[Merged by Bors] - chore(category_theory/adjunction/opposites): backport removal of simp lemmas

### DIFF
--- a/src/category_theory/adjunction/opposites.lean
+++ b/src/category_theory/adjunction/opposites.lean
@@ -29,7 +29,8 @@ variables {C : Type u₁} [category.{v₁} C] {D : Type u₂} [category.{v₂} D
 namespace category_theory.adjunction
 
 /-- If `G.op` is adjoint to `F.op` then `F` is adjoint to `G`. -/
-@[simps] def adjoint_of_op_adjoint_op (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G :=
+@[simps unit_app counit_app] def adjoint_of_op_adjoint_op
+  (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ X Y,
   ((h.hom_equiv (opposite.op Y) (opposite.op X)).trans (op_equiv _ _)).symm.trans (op_equiv _ _) }
@@ -47,7 +48,8 @@ def unop_adjoint_unop_of_adjoint (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : Dᵒᵖ ⥤ Cᵒ
 adjoint_unop_of_adjoint_op F.unop G (h.of_nat_iso_right F.op_unop_iso.symm)
 
 /-- If `G` is adjoint to `F` then `F.op` is adjoint to `G.op`. -/
-@[simps] def op_adjoint_op_of_adjoint (F : C ⥤ D) (G : D ⥤ C) (h : G ⊣ F) : F.op ⊣ G.op :=
+@[simps unit_app counit_app] def op_adjoint_op_of_adjoint
+  (F : C ⥤ D) (G : D ⥤ C) (h : G ⊣ F) : F.op ⊣ G.op :=
 adjunction.mk_of_hom_equiv
 { hom_equiv := λ X Y,
   (op_equiv _ Y).trans ((h.hom_equiv _ _).symm.trans (op_equiv X (opposite.op _)).symm) }


### PR DESCRIPTION
Some of the lemmas generated by `simps` in https://github.com/leanprover-community/mathlib4/pull/2424 are bad according to the simpNF linter, and have proved hard to fix by hand. Fortunately, they are simply not needed. This PR verifies this by backporting their removal to mathlib3. Compiles locally, lets hope CI agrees.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
