### PR TITLE
[Merged by Bors] - chore(ring_theory/ideal/local_ring): move ring_equiv.local_ring into local_ring.lean

### DIFF
--- a/src/algebra/module/injective.lean
+++ b/src/algebra/module/injective.lean
@@ -6,6 +6,7 @@ Authors: Jujian Zhang
 
 import category_theory.preadditive.injective
 import ring_theory.ideal.basic
+import linear_algebra.linear_pmap
 
 /-!
 # Injective modules

--- a/src/algebraic_topology/dold_kan/degeneracies.lean
+++ b/src/algebraic_topology/dold_kan/degeneracies.lean
@@ -5,6 +5,7 @@ Authors: Joël Riou
 -/
 
 import algebraic_topology.dold_kan.decomposition
+import tactic.fin_cases
 
 /-!
 

--- a/src/logic/equiv/transfer_instance.lean
+++ b/src/logic/equiv/transfer_instance.lean
@@ -3,10 +3,9 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import algebra.algebra.basic
+import algebra.algebra.equiv
 import algebra.field.basic
 import logic.equiv.defs
-import ring_theory.ideal.local_ring
 
 /-!
 # Transfer algebraic structures across `equiv`s
@@ -409,14 +408,3 @@ end R
 
 end instances
 end equiv
-
-namespace ring_equiv
-
-@[reducible] protected lemma local_ring {A B : Type*} [comm_semiring A] [local_ring A]
-  [comm_semiring B] (e : A ≃+* B) : local_ring B :=
-begin
-  haveI := e.symm.to_equiv.nontrivial,
-  exact local_ring.of_surjective (e : A →+* B) e.surjective
-end
-
-end ring_equiv

--- a/src/ring_theory/ideal/local_ring.lean
+++ b/src/ring_theory/ideal/local_ring.lean
@@ -7,6 +7,7 @@ Authors: Kenny Lau, Chris Hughes, Mario Carneiro
 import algebra.algebra.basic
 import ring_theory.ideal.operations
 import ring_theory.jacobson_ideal
+import logic.equiv.transfer_instance
 
 /-!
 
@@ -460,3 +461,14 @@ end field
 lemma local_ring.maximal_ideal_eq_bot {R : Type*} [field R] :
   local_ring.maximal_ideal R = ⊥ :=
 local_ring.is_field_iff_maximal_ideal_eq.mp (field.to_is_field R)
+
+namespace ring_equiv
+
+@[reducible] protected lemma local_ring {A B : Type*} [comm_semiring A] [local_ring A]
+  [comm_semiring B] (e : A ≃+* B) : local_ring B :=
+begin
+  haveI := e.symm.to_equiv.nontrivial,
+  exact local_ring.of_surjective (e : A →+* B) e.surjective
+end
+
+end ring_equiv


### PR DESCRIPTION
By having `ring_theory.ideal.local_ring` depend on `logic.equiv.transfer_instance`, rather than the other way around, we avoid importing all the dependencies for `local_ring` into files that just need to transfer "elementary" algebraic structures across equivalences.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
