### PR TITLE
[Merged by Bors] - chore(algebra/star/self_adjoint): generalize a lemma to `semifield`

### DIFF
--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -196,13 +196,13 @@ star_rat_cast _
 
 end division_ring
 
-section field
-variables [field R] [star_ring R]
+section semifield
+variables [semifield R] [star_ring R]
 
 lemma div {x y : R} (hx : is_self_adjoint x) (hy : is_self_adjoint y) : is_self_adjoint (x / y) :=
 by simp only [is_self_adjoint_iff, star_div', hx.star_eq, hy.star_eq]
 
-end field
+end semifield
 
 section has_smul
 variables [has_star R] [add_monoid A] [star_add_monoid A] [has_smul R A] [star_module R A]


### PR DESCRIPTION
This was missed in a previous commit, and backports a change made during forward-porting.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
