### PR TITLE
[Merged by Bors] - chore(linear_algebra/affine_space/combination): make k explicit in affine_combination

### DIFF
--- a/src/analysis/convex/between.lean
+++ b/src/analysis/convex/between.lean
@@ -463,12 +463,10 @@ lemma sbtw.affine_combination_of_mem_affine_span_pair [no_zero_divisors R]
   [no_zero_smul_divisors R V] {ι : Type*} {p : ι → P} (ha : affine_independent R p)
   {w w₁ w₂ : ι → R} {s : finset ι} (hw : ∑ i in s, w i = 1) (hw₁ : ∑ i in s, w₁ i = 1)
   (hw₂ : ∑ i in s, w₂ i = 1)
-  (h : s.affine_combination p w ∈
-    line[R, s.affine_combination p w₁, s.affine_combination p w₂]) {i : ι} (his : i ∈ s)
-  (hs : sbtw R (w₁ i) (w i) (w₂ i)) :
-  sbtw R (@finset.affine_combination R V _ _ _ _ _ _ s p w₁)
-    (@finset.affine_combination R V _ _ _ _ _ _ s p w)
-    (@finset.affine_combination R V _ _ _ _ _ _ s p w₂) :=
+  (h : s.affine_combination R p w ∈
+    line[R, s.affine_combination R p w₁, s.affine_combination R p w₂])
+  {i : ι} (his : i ∈ s) (hs : sbtw R (w₁ i) (w i) (w₂ i)) :
+  sbtw R (s.affine_combination R p w₁) (s.affine_combination R p w) (s.affine_combination R p w₂) :=
 begin
   rw affine_combination_mem_affine_span_pair ha hw hw₁ hw₂ at h,
   rcases h with ⟨r, hr⟩,

--- a/src/analysis/convex/between.lean
+++ b/src/analysis/convex/between.lean
@@ -455,10 +455,6 @@ lemma sbtw.trans_wbtw_right_ne [no_zero_smul_divisors R V] {w x y z : P} (h₁ :
   (h₂ : wbtw R x y z) : w ≠ y :=
 h₁.wbtw.trans_right_ne h₂ h₁.left_ne
 
-/- Calls to `affine_combination` are slow to elaborate (generally, not just for this lemma), and
-without the use of `@finset.affine_combination R V _ _ _ _ _ _` for at least three of the six
-calls in this lemma statement, elaboration of the statement times out (even if the proof is
-replaced by `sorry`). -/
 lemma sbtw.affine_combination_of_mem_affine_span_pair [no_zero_divisors R]
   [no_zero_smul_divisors R V] {ι : Type*} {p : ι → P} (ha : affine_independent R p)
   {w w₁ w₂ : ι → R} {s : finset ι} (hw : ∑ i in s, w i = 1) (hw₁ : ∑ i in s, w₁ i = 1)

--- a/src/analysis/convex/combination.lean
+++ b/src/analysis/convex/combination.lean
@@ -223,7 +223,7 @@ t.center_mass_mem_convex_hull hw₀ hws (λ i, mem_coe.2)
 
 lemma affine_combination_eq_center_mass {ι : Type*} {t : finset ι} {p : ι → E} {w : ι → R}
   (hw₂ : ∑ i in t, w i = 1) :
-  affine_combination t p w = center_mass t w p :=
+  t.affine_combination R p w = center_mass t w p :=
 begin
   rw [affine_combination_eq_weighted_vsub_of_point_vadd_of_sum_eq_one _ w _ hw₂ (0 : E),
     finset.weighted_vsub_of_point_apply, vadd_eq_add, add_zero, t.center_mass_eq_of_sum_1 _ hw₂],
@@ -232,7 +232,7 @@ end
 
 lemma affine_combination_mem_convex_hull
   {s : finset ι} {v : ι → E} {w : ι → R} (hw₀ : ∀ i ∈ s, 0 ≤ w i) (hw₁ : s.sum w = 1) :
-  s.affine_combination v w ∈ convex_hull R (range v) :=
+  s.affine_combination R v w ∈ convex_hull R (range v) :=
 begin
   rw affine_combination_eq_center_mass hw₁,
   apply s.center_mass_mem_convex_hull hw₀,
@@ -258,7 +258,7 @@ end
 
 lemma convex_hull_range_eq_exists_affine_combination (v : ι → E) :
   convex_hull R (range v) = { x | ∃ (s : finset ι) (w : ι → R)
-    (hw₀ : ∀ i ∈ s, 0 ≤ w i) (hw₁ : s.sum w = 1), s.affine_combination v w = x } :=
+    (hw₀ : ∀ i ∈ s, 0 ≤ w i) (hw₁ : s.sum w = 1), s.affine_combination R v w = x } :=
 begin
   refine subset.antisymm (convex_hull_min _ _) _,
   { intros x hx,

--- a/src/geometry/euclidean/basic.lean
+++ b/src/geometry/euclidean/basic.lean
@@ -86,11 +86,11 @@ in terms of the pairwise distances between the points in that
 combination. -/
 lemma dist_affine_combination {ι : Type*} {s : finset ι} {w₁ w₂ : ι → ℝ} (p : ι → P)
     (h₁ : ∑ i in s, w₁ i = 1) (h₂ : ∑ i in s, w₂ i = 1) :
-  by have a₁ := s.affine_combination p w₁; have a₂ := s.affine_combination p w₂; exact
+  by have a₁ := s.affine_combination ℝ p w₁; have a₂ := s.affine_combination ℝ p w₂; exact
   dist a₁ a₂ * dist a₁ a₂ = (-∑ i₁ in s, ∑ i₂ in s,
       (w₁ - w₂) i₁ * (w₁ - w₂) i₂ * (dist (p i₁) (p i₂) * dist (p i₁) (p i₂))) / 2 :=
 begin
-  rw [dist_eq_norm_vsub V (s.affine_combination p w₁) (s.affine_combination p w₂),
+  rw [dist_eq_norm_vsub V (s.affine_combination ℝ p w₁) (s.affine_combination ℝ p w₂),
       ←@inner_self_eq_norm_mul_norm ℝ, finset.affine_combination_vsub],
   have h : ∑ i in s, (w₁ - w₂) i = 0,
   { simp_rw [pi.sub_apply, finset.sum_sub_distrib, h₁, h₂, sub_self] },

--- a/src/geometry/euclidean/circumcenter.lean
+++ b/src/geometry/euclidean/circumcenter.lean
@@ -583,7 +583,7 @@ include V
 lemma point_eq_affine_combination_of_points_with_circumcenter {n : ℕ} (s : simplex ℝ P n)
   (i : fin (n + 1)) :
   s.points i =
-    (univ : finset (points_with_circumcenter_index n)).affine_combination
+    (univ : finset (points_with_circumcenter_index n)).affine_combination ℝ
       s.points_with_circumcenter (point_weights_with_circumcenter i) :=
 begin
   rw ←points_with_circumcenter_point,
@@ -627,7 +627,7 @@ include V
 lemma centroid_eq_affine_combination_of_points_with_circumcenter {n : ℕ} (s : simplex ℝ P n)
   (fs : finset (fin (n + 1))) :
   fs.centroid ℝ s.points =
-    (univ : finset (points_with_circumcenter_index n)).affine_combination
+    (univ : finset (points_with_circumcenter_index n)).affine_combination ℝ
       s.points_with_circumcenter (centroid_weights_with_circumcenter fs) :=
 begin
   simp_rw [centroid_def, affine_combination_apply,
@@ -666,7 +666,7 @@ include V
 `points_with_circumcenter`. -/
 lemma circumcenter_eq_affine_combination_of_points_with_circumcenter {n : ℕ}
   (s : simplex ℝ P n) :
-  s.circumcenter = (univ : finset (points_with_circumcenter_index n)).affine_combination
+  s.circumcenter = (univ : finset (points_with_circumcenter_index n)).affine_combination ℝ
     s.points_with_circumcenter (circumcenter_weights_with_circumcenter n) :=
 begin
   rw ←points_with_circumcenter_eq_circumcenter,
@@ -702,7 +702,7 @@ terms of `points_with_circumcenter`. -/
 lemma reflection_circumcenter_eq_affine_combination_of_points_with_circumcenter {n : ℕ}
   (s : simplex ℝ P n) {i₁ i₂ : fin (n + 1)} (h : i₁ ≠ i₂) :
   reflection (affine_span ℝ (s.points '' {i₁, i₂})) s.circumcenter =
-    (univ : finset (points_with_circumcenter_index n)).affine_combination
+    (univ : finset (points_with_circumcenter_index n)).affine_combination ℝ
       s.points_with_circumcenter (reflection_circumcenter_weights_with_circumcenter i₁ i₂) :=
 begin
   have hc : card ({i₁, i₂} : finset (fin (n + 1))) = 2,

--- a/src/geometry/euclidean/monge_point.lean
+++ b/src/geometry/euclidean/monge_point.lean
@@ -126,7 +126,7 @@ include V
 `points_with_circumcenter`. -/
 lemma monge_point_eq_affine_combination_of_points_with_circumcenter {n : ℕ}
   (s : simplex ℝ P (n + 2)) :
-  s.monge_point = (univ : finset (points_with_circumcenter_index (n + 2))).affine_combination
+  s.monge_point = (univ : finset (points_with_circumcenter_index (n + 2))).affine_combination ℝ
     s.points_with_circumcenter (monge_point_weights_with_circumcenter n) :=
 begin
   rw [monge_point_eq_smul_vsub_vadd_circumcenter,

--- a/src/linear_algebra/affine_space/basis.lean
+++ b/src/linear_algebra/affine_space/basis.lean
@@ -145,7 +145,7 @@ lemma coord_apply [decidable_eq ι] (i j : ι) : b.coord i (b j) = if i = j then
 by cases eq_or_ne i j; simp [h]
 
 @[simp] lemma coord_apply_combination_of_mem (hi : i ∈ s) {w : ι → k} (hw : s.sum w = 1) :
-  b.coord i (s.affine_combination b w) = w i :=
+  b.coord i (s.affine_combination k b w) = w i :=
 begin
   classical,
   simp only [coord_apply, hi, finset.affine_combination_eq_linear_combination, if_true, mul_boole,
@@ -153,7 +153,7 @@ begin
 end
 
 @[simp] lemma coord_apply_combination_of_not_mem (hi : i ∉ s) {w : ι → k} (hw : s.sum w = 1) :
-  b.coord i (s.affine_combination b w) = 0 :=
+  b.coord i (s.affine_combination k b w) = 0 :=
 begin
   classical,
   simp only [coord_apply, hi, finset.affine_combination_eq_linear_combination, if_false, mul_boole,
@@ -171,7 +171,7 @@ begin
 end
 
 @[simp] lemma affine_combination_coord_eq_self [fintype ι] (q : P) :
-  finset.univ.affine_combination b (λ i, b.coord i q) = q :=
+  finset.univ.affine_combination k b (λ i, b.coord i q) = q :=
 begin
   have hq : q ∈ affine_span k (range b), { rw b.tot, exact affine_subspace.mem_top k V q, },
   obtain ⟨w, hw, rfl⟩ := eq_affine_combination_of_mem_affine_span_of_fintype hq,
@@ -208,7 +208,7 @@ begin
   let s : finset ι := {i},
   have hi : i ∈ s, { simp, },
   have hw : s.sum (function.const ι (1 : k)) = 1, { simp, },
-  have hq : q = s.affine_combination b (function.const ι (1 : k)), { simp, },
+  have hq : q = s.affine_combination k b (function.const ι (1 : k)), { simp, },
   rw [pi.one_apply, hq, b.coord_apply_combination_of_mem hi hw],
 end
 
@@ -223,7 +223,7 @@ begin
   have hj : j ∈ s, { simp, },
   let w : ι → k := λ j', if j' = i then x else 1-x,
   have hw : s.sum w = 1, { simp [hij, finset.sum_ite, finset.filter_insert, finset.filter_eq'], },
-  use s.affine_combination b w,
+  use s.affine_combination k b w,
   simp [b.coord_apply_combination_of_mem hi hw],
 end
 

--- a/src/linear_algebra/affine_space/combination.lean
+++ b/src/linear_algebra/affine_space/combination.lean
@@ -331,6 +331,8 @@ lemma weighted_vsub_const_smul (w : ι → k) (p : ι → P) (c : k) :
   s.weighted_vsub p (c • w) = c • s.weighted_vsub p w :=
 s.weighted_vsub_of_point_const_smul _ _ _ _
 
+variables (k)
+
 /-- A weighted sum of the results of subtracting a default base point
 from the given points, added to that base point, as an affine map on
 the weights.  This is intended to be used when the sum of the weights
@@ -346,8 +348,10 @@ def affine_combination (p : ι → P) : (ι → k) →ᵃ[k] P :=
 /-- The linear map corresponding to `affine_combination` is
 `weighted_vsub`. -/
 @[simp] lemma affine_combination_linear (p : ι → P) :
-  (s.affine_combination p : (ι → k) →ᵃ[k] P).linear = s.weighted_vsub p :=
+  (s.affine_combination k p).linear = s.weighted_vsub p :=
 rfl
+
+variables {k}
 
 /-- Applying `affine_combination` with given weights.  This is for the
 case where a result involving a default base point is OK (for example,
@@ -357,41 +361,41 @@ point with
 `affine_combination_eq_weighted_vsub_of_point_vadd_of_sum_eq_one` and
 then using `weighted_vsub_of_point_apply`. -/
 lemma affine_combination_apply (w : ι → k) (p : ι → P) :
-  s.affine_combination p w =
+  s.affine_combination k p w =
     s.weighted_vsub_of_point p (classical.choice S.nonempty) w +ᵥ (classical.choice S.nonempty) :=
 rfl
 
 /-- The value of `affine_combination`, where the given points are equal. -/
 @[simp] lemma affine_combination_apply_const (w : ι → k) (p : P) (h : ∑ i in s, w i = 1) :
-  s.affine_combination (λ _, p) w = p :=
+  s.affine_combination k (λ _, p) w = p :=
 by rw [affine_combination_apply, s.weighted_vsub_of_point_apply_const, h, one_smul, vsub_vadd]
 
 /-- `affine_combination` gives equal results for two families of weights and two families of
 points that are equal on `s`. -/
 lemma affine_combination_congr {w₁ w₂ : ι → k} (hw : ∀ i ∈ s, w₁ i = w₂ i) {p₁ p₂ : ι → P}
-  (hp : ∀ i ∈ s, p₁ i = p₂ i) : s.affine_combination p₁ w₁ = s.affine_combination p₂ w₂ :=
+  (hp : ∀ i ∈ s, p₁ i = p₂ i) : s.affine_combination k p₁ w₁ = s.affine_combination k p₂ w₂ :=
 by simp_rw [affine_combination_apply, s.weighted_vsub_of_point_congr hw hp]
 
 /-- `affine_combination` gives the sum with any base point, when the
 sum of the weights is 1. -/
 lemma affine_combination_eq_weighted_vsub_of_point_vadd_of_sum_eq_one (w : ι → k) (p : ι → P)
     (h : ∑ i in s, w i = 1) (b : P) :
-  s.affine_combination p w = s.weighted_vsub_of_point p b w +ᵥ b :=
+  s.affine_combination k p w = s.weighted_vsub_of_point p b w +ᵥ b :=
 s.weighted_vsub_of_point_vadd_eq_of_sum_eq_one w p h _ _
 
 /-- Adding a `weighted_vsub` to an `affine_combination`. -/
 lemma weighted_vsub_vadd_affine_combination (w₁ w₂ : ι → k) (p : ι → P) :
-  s.weighted_vsub p w₁ +ᵥ s.affine_combination p w₂ = s.affine_combination p (w₁ + w₂) :=
+  s.weighted_vsub p w₁ +ᵥ s.affine_combination k p w₂ = s.affine_combination k p (w₁ + w₂) :=
 by rw [←vadd_eq_add, affine_map.map_vadd, affine_combination_linear]
 
 /-- Subtracting two `affine_combination`s. -/
 lemma affine_combination_vsub (w₁ w₂ : ι → k) (p : ι → P) :
-  s.affine_combination p w₁ -ᵥ s.affine_combination p w₂ = s.weighted_vsub p (w₁ - w₂) :=
+  s.affine_combination k p w₁ -ᵥ s.affine_combination k p w₂ = s.weighted_vsub p (w₁ - w₂) :=
 by rw [←affine_map.linear_map_vsub, affine_combination_linear, vsub_eq_sub]
 
 lemma attach_affine_combination_of_injective [decidable_eq P]
   (s : finset P) (w : P → k) (f : s → P) (hf : function.injective f) :
-  s.attach.affine_combination f (w ∘ f) = (image f univ).affine_combination id w :=
+  s.attach.affine_combination k f (w ∘ f) = (image f univ).affine_combination k id w :=
 begin
   simp only [affine_combination, weighted_vsub_of_point_apply, id.def, vadd_right_cancel_iff,
     function.comp_app, affine_map.coe_mk],
@@ -404,7 +408,7 @@ begin
 end
 
 lemma attach_affine_combination_coe (s : finset P) (w : P → k) :
-  s.attach.affine_combination (coe : s → P) (w ∘ coe) = s.affine_combination id w :=
+  s.attach.affine_combination k (coe : s → P) (w ∘ coe) = s.affine_combination k id w :=
 by classical; rw [attach_affine_combination_of_injective s w (coe : s → P) subtype.coe_injective,
   univ_eq_attach, attach_image_coe]
 
@@ -421,7 +425,7 @@ by simp [s.weighted_vsub_apply, vsub_eq_sub, smul_sub, ← finset.sum_smul, hw]
 combinations. -/
 @[simp] lemma affine_combination_eq_linear_combination (s : finset ι) (p : ι → V) (w : ι → k)
   (hw : ∑ i in s, w i = 1) :
-  s.affine_combination p w = ∑ i in s, w i • p i :=
+  s.affine_combination k p w = ∑ i in s, w i • p i :=
 by simp [s.affine_combination_eq_weighted_vsub_of_point_vadd_of_sum_eq_one w p hw 0]
 
 include S
@@ -430,7 +434,7 @@ include S
 and has weight 1 and the other points in the set have weight 0. -/
 @[simp] lemma affine_combination_of_eq_one_of_eq_zero (w : ι → k) (p : ι → P) {i : ι}
     (his : i ∈ s) (hwi : w i = 1) (hw0 : ∀ i2 ∈ s, i2 ≠ i → w i2 = 0) :
-  s.affine_combination p w = p i :=
+  s.affine_combination k p w = p i :=
 begin
   have h1 : ∑ i in s, w i = 1 := hwi ▸ sum_eq_single i hw0 (λ h, false.elim (h his)),
   rw [s.affine_combination_eq_weighted_vsub_of_point_vadd_of_sum_eq_one w p h1 (p i),
@@ -447,7 +451,7 @@ end
 corresponding indicator function and adding points to the set. -/
 lemma affine_combination_indicator_subset (w : ι → k) (p : ι → P) {s₁ s₂ : finset ι}
     (h : s₁ ⊆ s₂) :
-  s₁.affine_combination p w = s₂.affine_combination p (set.indicator ↑s₁ w) :=
+  s₁.affine_combination k p w = s₂.affine_combination k p (set.indicator ↑s₁ w) :=
 by rw [affine_combination_apply, affine_combination_apply,
        weighted_vsub_of_point_indicator_subset _ _ _ h]
 
@@ -455,13 +459,13 @@ by rw [affine_combination_apply, affine_combination_apply,
 affine combination with the same points and weights over the original
 `finset`. -/
 lemma affine_combination_map (e : ι₂ ↪ ι) (w : ι → k) (p : ι → P) :
-  (s₂.map e).affine_combination p w = s₂.affine_combination (p ∘ e) (w ∘ e) :=
+  (s₂.map e).affine_combination k p w = s₂.affine_combination k (p ∘ e) (w ∘ e) :=
 by simp_rw [affine_combination_apply, weighted_vsub_of_point_map]
 
 /-- A weighted sum of pairwise subtractions, expressed as a subtraction of two `affine_combination`
 expressions. -/
 lemma sum_smul_vsub_eq_affine_combination_vsub (w : ι → k) (p₁ p₂ : ι → P) :
-  ∑ i in s, w i • (p₁ i -ᵥ p₂ i) = s.affine_combination p₁ w -ᵥ s.affine_combination p₂ w :=
+  ∑ i in s, w i • (p₁ i -ᵥ p₂ i) = s.affine_combination k p₁ w -ᵥ s.affine_combination k p₂ w :=
 begin
   simp_rw [affine_combination_apply, vadd_vsub_vadd_cancel_right],
   exact s.sum_smul_vsub_eq_weighted_vsub_of_point_sub _ _ _ _
@@ -471,20 +475,20 @@ end
 sum of the weights is 1. -/
 lemma sum_smul_vsub_const_eq_affine_combination_vsub (w : ι → k) (p₁ : ι → P) (p₂ : P)
   (h : ∑ i in s, w i = 1) :
-  ∑ i in s, w i • (p₁ i -ᵥ p₂) = s.affine_combination p₁ w -ᵥ p₂ :=
+  ∑ i in s, w i • (p₁ i -ᵥ p₂) = s.affine_combination k p₁ w -ᵥ p₂ :=
 by rw [sum_smul_vsub_eq_affine_combination_vsub, affine_combination_apply_const _ _ _ h]
 
 /-- A weighted sum of pairwise subtractions, where the point on the left is constant and the
 sum of the weights is 1. -/
 lemma sum_smul_const_vsub_eq_vsub_affine_combination (w : ι → k) (p₂ : ι → P) (p₁ : P)
   (h : ∑ i in s, w i = 1) :
-  ∑ i in s, w i • (p₁ -ᵥ p₂ i) = p₁ -ᵥ s.affine_combination p₂ w :=
+  ∑ i in s, w i • (p₁ -ᵥ p₂ i) = p₁ -ᵥ s.affine_combination k p₂ w :=
 by rw [sum_smul_vsub_eq_affine_combination_vsub, affine_combination_apply_const _ _ _ h]
 
 /-- A weighted sum may be split into a subtraction of affine combinations over two subsets. -/
 lemma affine_combination_sdiff_sub [decidable_eq ι] {s₂ : finset ι} (h : s₂ ⊆ s) (w : ι → k)
   (p : ι → P) :
-  (s \ s₂).affine_combination p w -ᵥ s₂.affine_combination p (-w) = s.weighted_vsub p w :=
+  (s \ s₂).affine_combination k p w -ᵥ s₂.affine_combination k p (-w) = s.weighted_vsub p w :=
 begin
   simp_rw [affine_combination_apply, vadd_vsub_vadd_cancel_right],
   exact s.weighted_vsub_sdiff_sub h _ _
@@ -494,7 +498,7 @@ end
 the affine combination of the other points with the given weights. -/
 lemma affine_combination_eq_of_weighted_vsub_eq_zero_of_eq_neg_one {w : ι → k} {p : ι → P}
   (hw : s.weighted_vsub p w = (0 : V)) {i : ι} [decidable_pred (≠ i)] (his : i ∈ s)
-  (hwi : w i = -1) : (s.filter (≠ i)).affine_combination p w = p i :=
+  (hwi : w i = -1) : (s.filter (≠ i)).affine_combination k p w = p i :=
 begin
   classical,
   rw [←@vsub_eq_zero_iff_eq V, ←hw,
@@ -509,15 +513,15 @@ end
 /-- An affine combination over `s.subtype pred` equals one over `s.filter pred`. -/
 lemma affine_combination_subtype_eq_filter (w : ι → k) (p : ι → P) (pred : ι → Prop)
   [decidable_pred pred] :
-  (s.subtype pred).affine_combination (λ i, p i) (λ i, w i) =
-  (s.filter pred).affine_combination p w :=
+  (s.subtype pred).affine_combination k (λ i, p i) (λ i, w i) =
+  (s.filter pred).affine_combination k p w :=
 by rw [affine_combination_apply, affine_combination_apply, weighted_vsub_of_point_subtype_eq_filter]
 
 /-- An affine combination over `s.filter pred` equals one over `s` if all the weights at indices
 in `s` not satisfying `pred` are zero. -/
 lemma affine_combination_filter_of_ne (w : ι → k) (p : ι → P) {pred : ι → Prop}
   [decidable_pred pred] (h : ∀ i ∈ s, w i ≠ 0 → pred i) :
-  (s.filter pred).affine_combination p w = s.affine_combination p w :=
+  (s.filter pred).affine_combination k p w = s.affine_combination k p w :=
 by rw [affine_combination_apply, affine_combination_apply,
        s.weighted_vsub_of_point_filter_of_ne _ _ _ h]
 
@@ -575,9 +579,9 @@ subset. -/
 lemma eq_affine_combination_subset_iff_eq_affine_combination_subtype {p0 : P} {s : set ι}
     {p : ι → P} :
   (∃ (fs : finset ι) (hfs : ↑fs ⊆ s) (w : ι → k) (hw : ∑ i in fs, w i = 1),
-    p0 = fs.affine_combination p w) ↔
+    p0 = fs.affine_combination k p w) ↔
   ∃ (fs : finset s) (w : s → k) (hw : ∑ i in fs, w i = 1),
-    p0 = fs.affine_combination (λ (i : s), p i) w :=
+    p0 = fs.affine_combination k (λ (i : s), p i) w :=
 begin
   simp_rw [affine_combination_apply, eq_vadd_iff_vsub_eq],
   exact eq_weighted_vsub_of_point_subset_iff_eq_weighted_vsub_of_point_subtype
@@ -588,7 +592,7 @@ variables {k V}
 /-- Affine maps commute with affine combinations. -/
 lemma map_affine_combination {V₂ P₂ : Type*} [add_comm_group V₂] [module k V₂] [affine_space V₂ P₂]
   (p : ι → P) (w : ι → k) (hw : s.sum w = 1) (f : P →ᵃ[k] P₂) :
-  f (s.affine_combination p w) = s.affine_combination (f ∘ p) w :=
+  f (s.affine_combination k p w) = s.affine_combination k (f ∘ p) w :=
 begin
   have b := classical.choice (infer_instance : affine_space V P).nonempty,
   have b₂ := classical.choice (infer_instance : affine_space V₂ P₂).nonempty,
@@ -684,7 +688,7 @@ variables (k)
 
 /-- An affine combination with `affine_combination_single_weights` gives the specified point. -/
 @[simp] lemma affine_combination_affine_combination_single_weights [decidable_eq ι] (p : ι → P)
-  {i : ι} (hi : i ∈ s) : s.affine_combination p (affine_combination_single_weights k i) = p i :=
+  {i : ι} (hi : i ∈ s) : s.affine_combination k p (affine_combination_single_weights k i) = p i :=
 begin
   refine s.affine_combination_of_eq_one_of_eq_zero _ _ hi (by simp) _,
   rintro j - hj,
@@ -707,7 +711,7 @@ variables {k}
 `line_map`. -/
 @[simp] lemma affine_combination_affine_combination_line_map_weights [decidable_eq ι] (p : ι → P)
   {i j : ι} (hi : i ∈ s) (hj : j ∈ s) (c : k) :
-  s.affine_combination p (affine_combination_line_map_weights i j c) =
+  s.affine_combination k p (affine_combination_line_map_weights i j c) =
     affine_map.line_map (p i) (p j) c :=
 by rw [affine_combination_line_map_weights, ←weighted_vsub_vadd_affine_combination,
        weighted_vsub_const_smul, s.affine_combination_affine_combination_single_weights k p hi,
@@ -766,11 +770,11 @@ include V
 is intended to be used in the case where the number of points,
 converted to `k`, is not zero. -/
 def centroid (p : ι → P) : P :=
-s.affine_combination p (s.centroid_weights k)
+s.affine_combination k p (s.centroid_weights k)
 
 /-- The definition of the centroid. -/
 lemma centroid_def (p : ι → P) :
-  s.centroid k p = s.affine_combination p (s.centroid_weights k) :=
+  s.centroid k p = s.affine_combination k p (s.centroid_weights k) :=
 rfl
 
 lemma centroid_univ (s : finset P) :
@@ -865,7 +869,7 @@ include V
 
 /-- The centroid as an affine combination over a `fintype`. -/
 lemma centroid_eq_affine_combination_fintype [fintype ι] (p : ι → P) :
-  s.centroid k p = univ.affine_combination p (s.centroid_weights_indicator k) :=
+  s.centroid k p = univ.affine_combination k p (s.centroid_weights_indicator k) :=
 affine_combination_indicator_subset _ _ (subset_univ _)
 
 /-- An indexed family of points that is injective on the given
@@ -948,7 +952,7 @@ end
 nontrivial. -/
 lemma affine_combination_mem_affine_span [nontrivial k] {s : finset ι} {w : ι → k}
     (h : ∑ i in s, w i = 1) (p : ι → P) :
-  s.affine_combination p w ∈ affine_span k (set.range p) :=
+  s.affine_combination k p w ∈ affine_span k (set.range p) :=
 begin
   classical,
   have hnz : ∑ i in s, w i ≠ 0 := h.symm ▸ one_ne_zero,
@@ -957,14 +961,14 @@ begin
   let w1 : ι → k := function.update (function.const ι 0) i1 1,
   have hw1 : ∑ i in s, w1 i = 1,
   { rw [finset.sum_update_of_mem hi1, finset.sum_const_zero, add_zero] },
-  have hw1s : s.affine_combination p w1 = p i1 :=
+  have hw1s : s.affine_combination k p w1 = p i1 :=
     s.affine_combination_of_eq_one_of_eq_zero w1 p hi1 (function.update_same _ _ _)
                                               (λ _ _ hne, function.update_noteq hne _ _),
-  have hv : s.affine_combination p w -ᵥ p i1 ∈ (affine_span k (set.range p)).direction,
+  have hv : s.affine_combination k p w -ᵥ p i1 ∈ (affine_span k (set.range p)).direction,
   { rw [direction_affine_span, ←hw1s, finset.affine_combination_vsub],
     apply weighted_vsub_mem_vector_span,
     simp [pi.sub_apply, h, hw1] },
-  rw ←vsub_vadd (s.affine_combination p w) (p i1),
+  rw ←vsub_vadd (s.affine_combination k p w) (p i1),
   exact affine_subspace.vadd_mem_of_mem_direction hv (mem_affine_span k (set.mem_range_self _))
 end
 
@@ -1019,7 +1023,7 @@ variables {k}
 `eq_affine_combination_of_mem_affine_span_of_fintype`. -/
 lemma eq_affine_combination_of_mem_affine_span {p1 : P} {p : ι → P}
     (h : p1 ∈ affine_span k (set.range p)) :
-  ∃ (s : finset ι) (w : ι → k) (hw : ∑ i in s, w i = 1), p1 = s.affine_combination p w :=
+  ∃ (s : finset ι) (w : ι → k) (hw : ∑ i in s, w i = 1), p1 = s.affine_combination k p w :=
 begin
   classical,
   have hn : ((affine_span k (set.range p)) : set P).nonempty := ⟨p1, h⟩,
@@ -1040,7 +1044,7 @@ begin
   let w0 : ι → k := function.update (function.const ι 0) i0 1,
   have hw0 : ∑ i in s', w0 i = 1,
   { rw [finset.sum_update_of_mem (finset.mem_insert_self _ _), finset.sum_const_zero, add_zero] },
-  have hw0s : s'.affine_combination p w0 = p i0 :=
+  have hw0s : s'.affine_combination k p w0 = p i0 :=
     s'.affine_combination_of_eq_one_of_eq_zero w0 p
                                                (finset.mem_insert_self _ _)
                                                (function.update_same _ _ _)
@@ -1053,7 +1057,7 @@ end
 
 lemma eq_affine_combination_of_mem_affine_span_of_fintype [fintype ι] {p1 : P} {p : ι → P}
   (h : p1 ∈ affine_span k (set.range p)) :
-  ∃ (w : ι → k) (hw : ∑ i, w i = 1), p1 = finset.univ.affine_combination p w :=
+  ∃ (w : ι → k) (hw : ∑ i, w i = 1), p1 = finset.univ.affine_combination k p w :=
 begin
   classical,
   obtain ⟨s, w, hw, rfl⟩ := eq_affine_combination_of_mem_affine_span h,
@@ -1069,7 +1073,7 @@ if it is an `affine_combination` with sum of weights 1, provided the
 underlying ring is nontrivial. -/
 lemma mem_affine_span_iff_eq_affine_combination [nontrivial k] {p1 : P} {p : ι → P} :
   p1 ∈ affine_span k (set.range p) ↔
-    ∃ (s : finset ι) (w : ι → k) (hw : ∑ i in s, w i = 1), p1 = s.affine_combination p w :=
+    ∃ (s : finset ι) (w : ι → k) (hw : ∑ i in s, w i = 1), p1 = s.affine_combination k p w :=
 begin
   split,
   { exact eq_affine_combination_of_mem_affine_span },

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -176,7 +176,7 @@ combinations (with sum of weights 1) that evaluate to the same point
 have equal `set.indicator`. -/
 lemma affine_independent_iff_indicator_eq_of_affine_combination_eq (p : ι → P) :
   affine_independent k p ↔ ∀ (s1 s2 : finset ι) (w1 w2 : ι → k), ∑ i in s1, w1 i = 1 →
-    ∑ i in s2, w2 i = 1 → s1.affine_combination p w1 = s2.affine_combination p w2 →
+    ∑ i in s2, w2 i = 1 → s1.affine_combination k p w1 = s2.affine_combination k p w2 →
       set.indicator ↑s1 w1 = set.indicator ↑s2 w2 :=
 begin
   classical,
@@ -199,13 +199,13 @@ begin
     let w1 : ι → k := function.update (function.const ι 0) i0 1,
     have hw1 : ∑ i in s, w1 i = 1,
     { rw [finset.sum_update_of_mem hi0, finset.sum_const_zero, add_zero] },
-    have hw1s : s.affine_combination p w1 = p i0 :=
+    have hw1s : s.affine_combination k p w1 = p i0 :=
       s.affine_combination_of_eq_one_of_eq_zero w1 p hi0 (function.update_same _ _ _)
                                                 (λ _ _ hne, function.update_noteq hne _ _),
     let w2 := w + w1,
     have hw2 : ∑ i in s, w2 i = 1,
     { simp [w2, finset.sum_add_distrib, hw, hw1] },
-    have hw2s : s.affine_combination p w2 = p i0,
+    have hw2s : s.affine_combination k p w2 = p i0,
     { simp [w2, ←finset.weighted_vsub_vadd_affine_combination, hs, hw1s] },
     replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s),
     have hws : w2 i0 - w1 i0 = 0,
@@ -218,7 +218,7 @@ end
 combinations (with sum of weights 1) that evaluate to the same point are equal. -/
 lemma affine_independent_iff_eq_of_fintype_affine_combination_eq [fintype ι] (p : ι → P) :
   affine_independent k p ↔ ∀ (w1 w2 : ι → k), ∑ i, w1 i = 1 → ∑ i, w2 i = 1 →
-    finset.univ.affine_combination p w1 = finset.univ.affine_combination p w2 → w1 = w2 :=
+    finset.univ.affine_combination k p w1 = finset.univ.affine_combination k p w2 → w1 = w2 :=
 begin
   rw affine_independent_iff_indicator_eq_of_affine_combination_eq,
   split,
@@ -252,7 +252,7 @@ end
 
 lemma affine_independent.indicator_eq_of_affine_combination_eq {p : ι → P}
   (ha : affine_independent k p) (s₁ s₂ : finset ι) (w₁ w₂ : ι → k) (hw₁ : ∑ i in s₁, w₁ i = 1)
-  (hw₂ : ∑ i in s₂, w₂ i = 1) (h : s₁.affine_combination p w₁ = s₂.affine_combination p w₂) :
+  (hw₂ : ∑ i in s₂, w₂ i = 1) (h : s₁.affine_combination k p w₁ = s₂.affine_combination k p w₂) :
   set.indicator ↑s₁ w₁ = set.indicator ↑s₂ w₂ :=
 (affine_independent_iff_indicator_eq_of_affine_combination_eq k p).1 ha s₁ s₂ w₁ w₂ hw₁ hw₂ h
 
@@ -479,7 +479,7 @@ lemma weighted_vsub_mem_vector_span_pair {p : ι → P} (h : affine_independent 
   {w w₁ w₂ : ι → k} {s : finset ι} (hw : ∑ i in s, w i = 0) (hw₁ : ∑ i in s, w₁ i = 1)
   (hw₂ : ∑ i in s, w₂ i = 1) :
   s.weighted_vsub p w ∈
-    vector_span k ({s.affine_combination p w₁, s.affine_combination p w₂} : set P) ↔
+    vector_span k ({s.affine_combination k p w₁, s.affine_combination k p w₂} : set P) ↔
     ∃ r : k, ∀ i ∈ s, w i = r * (w₁ i - w₂ i) :=
 begin
   rw mem_vector_span_pair,
@@ -509,11 +509,11 @@ two points. -/
 lemma affine_combination_mem_affine_span_pair {p : ι → P} (h : affine_independent k p)
   {w w₁ w₂ : ι → k} {s : finset ι} (hw : ∑ i in s, w i = 1) (hw₁ : ∑ i in s, w₁ i = 1)
   (hw₂ : ∑ i in s, w₂ i = 1) :
-  s.affine_combination p w ∈
-    line[k, s.affine_combination p w₁, s.affine_combination p w₂] ↔
+  s.affine_combination k p w ∈
+    line[k, s.affine_combination k p w₁, s.affine_combination k p w₂] ↔
     ∃ r : k, ∀ i ∈ s, w i = r * (w₂ i - w₁ i) + w₁ i :=
 begin
-  rw [←vsub_vadd (s.affine_combination p w) (s.affine_combination p w₁),
+  rw [←vsub_vadd (s.affine_combination k p w) (s.affine_combination k p w₁),
       affine_subspace.vadd_mem_iff_mem_direction _ (left_mem_affine_span_pair _ _ _),
       direction_affine_span, s.affine_combination_vsub, set.pair_comm,
       weighted_vsub_mem_vector_span_pair h _ hw₂ hw₁],
@@ -719,7 +719,8 @@ sign. -/
 lemma sign_eq_of_affine_combination_mem_affine_span_pair {p : ι → P} (h : affine_independent k p)
   {w w₁ w₂ : ι → k} {s : finset ι} (hw : ∑ i in s, w i = 1) (hw₁ : ∑ i in s, w₁ i = 1)
   (hw₂ : ∑ i in s, w₂ i = 1)
-  (hs : s.affine_combination p w ∈ line[k, s.affine_combination p w₁, s.affine_combination p w₂])
+  (hs : s.affine_combination k p w ∈
+    line[k, s.affine_combination k p w₁, s.affine_combination k p w₂])
   {i j : ι} (hi : i ∈ s) (hj : j ∈ s) (hi0 : w₁ i = 0) (hj0 : w₁ j = 0)
   (hij : sign (w₂ i) = sign (w₂ j)) : sign (w i) = sign (w j) :=
 begin
@@ -737,7 +738,7 @@ lemma sign_eq_of_affine_combination_mem_affine_span_single_line_map {p : ι → 
   (h : affine_independent k p) {w : ι → k} {s : finset ι} (hw : ∑ i in s, w i = 1)
   {i₁ i₂ i₃ : ι} (h₁ : i₁ ∈ s) (h₂ : i₂ ∈ s) (h₃ : i₃ ∈ s) (h₁₂ : i₁ ≠ i₂) (h₁₃ : i₁ ≠ i₃)
   (h₂₃ : i₂ ≠ i₃) {c : k} (hc0 : 0 < c) (hc1 : c < 1)
-  (hs : s.affine_combination p w ∈ line[k, p i₁, affine_map.line_map (p i₂) (p i₃) c]) :
+  (hs : s.affine_combination k p w ∈ line[k, p i₁, affine_map.line_map (p i₂) (p i₃) c]) :
   sign (w i₂) = sign (w i₃) :=
 begin
   classical,

--- a/src/linear_algebra/affine_space/matrix.lean
+++ b/src/linear_algebra/affine_space/matrix.lean
@@ -85,7 +85,7 @@ begin
                 ... = ∑ l, ∑ j, (A i j) * b.to_matrix p j l : by rw finset.sum_comm
                 ... = ∑ l, (A ⬝ b.to_matrix p) i l : rfl
                 ... = 1 : by simp [hA, matrix.one_apply, finset.filter_eq], },
-  have hbi : b i = finset.univ.affine_combination p (A i),
+  have hbi : b i = finset.univ.affine_combination k p (A i),
   { apply b.ext_elem,
     intros j,
     rw [b.coord_apply, finset.univ.map_affine_combination _ _ hAi,


### PR DESCRIPTION
The implicitness caused problems in elaboration. In Lean 3 it only amounts to long elaboration times, but in Lean 4 elaboration fails.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
