### PR TITLE
chore(data/complex/module, analysis/complex/isometry): put matrix lemmas into new files

### DIFF
--- a/src/analysis/complex/isometry.lean
+++ b/src/analysis/complex/isometry.lean
@@ -5,7 +5,6 @@ Authors: François Sunatori
 -/
 import analysis.complex.circle
 import linear_algebra.determinant
-import linear_algebra.matrix.general_linear_group
 
 /-!
 # Isometries of the Complex Plane
@@ -139,25 +138,3 @@ begin
   { simpa using eq_mul_of_inv_mul_eq h₁ },
   { exact eq_mul_of_inv_mul_eq h₂ }
 end
-
-/-- The matrix representation of `rotation a` is equal to the conformal matrix
-`!![re a, -im a; im a, re a]`. -/
-lemma to_matrix_rotation (a : circle) :
-  linear_map.to_matrix basis_one_I basis_one_I (rotation a).to_linear_equiv =
-    matrix.plane_conformal_matrix (re a) (im a) (by simp [pow_two, ←norm_sq_apply]) :=
-begin
-  ext i j,
-  simp [linear_map.to_matrix_apply],
-  fin_cases i; fin_cases j; simp
-end
-
-/-- The determinant of `rotation` (as a linear map) is equal to `1`. -/
-@[simp] lemma det_rotation (a : circle) : ((rotation a).to_linear_equiv : ℂ →ₗ[ℝ] ℂ).det = 1 :=
-begin
-  rw [←linear_map.det_to_matrix basis_one_I, to_matrix_rotation, matrix.det_fin_two],
-  simp [←norm_sq_apply]
-end
-
-/-- The determinant of `rotation` (as a linear equiv) is equal to `1`. -/
-@[simp] lemma linear_equiv_det_rotation (a : circle) : (rotation a).to_linear_equiv.det = 1 :=
-by rw [←units.eq_iff, linear_equiv.coe_det, det_rotation, units.coe_one]

--- a/src/analysis/complex/isometry_matrix.lean
+++ b/src/analysis/complex/isometry_matrix.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2021 François Sunatori. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: François Sunatori
+-/
+import analysis.complex.isometry
+import linear_algebra.matrix.general_linear_group
+
+/-!
+# Isometries of the Complex Plane as Matrix Rotations
+
+Matrix representation of rotations.
+
+-/
+
+open complex
+
+/-- The matrix representation of `rotation a` is equal to the conformal matrix
+`!![re a, -im a; im a, re a]`. -/
+lemma to_matrix_rotation (a : circle) :
+  linear_map.to_matrix basis_one_I basis_one_I (rotation a).to_linear_equiv =
+    matrix.plane_conformal_matrix (re a) (im a) (by simp [pow_two, ←norm_sq_apply]) :=
+begin
+  ext i j,
+  simp [linear_map.to_matrix_apply],
+  fin_cases i; fin_cases j; simp
+end
+
+/-- The determinant of `rotation` (as a linear map) is equal to `1`. -/
+@[simp] lemma det_rotation (a : circle) : ((rotation a).to_linear_equiv : ℂ →ₗ[ℝ] ℂ).det = 1 :=
+begin
+  rw [←linear_map.det_to_matrix basis_one_I, to_matrix_rotation, matrix.det_fin_two],
+  simp [←norm_sq_apply]
+end
+
+/-- The determinant of `rotation` (as a linear equiv) is equal to `1`. -/
+@[simp] lemma linear_equiv_det_rotation (a : circle) : (rotation a).to_linear_equiv.det = 1 :=
+by rw [←units.eq_iff, linear_equiv.coe_det, det_rotation, units.coe_one]

--- a/src/analysis/inner_product_space/two_dim.lean
+++ b/src/analysis/inner_product_space/two_dim.lean
@@ -5,6 +5,7 @@ Authors: Heather Macbeth
 -/
 import analysis.inner_product_space.dual
 import analysis.inner_product_space.orientation
+import data.complex.orientation
 import tactic.linear_combination
 
 /-!

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Alexander Bentkamp, Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp, Sébastien Gouëzel, Eric Wieser
 -/
-import linear_algebra.orientation
 import algebra.order.smul
 import data.complex.basic
 import data.fin.vec_notation
@@ -166,9 +165,6 @@ by simp [← finrank_eq_dim, finrank_real_complex, bit0]
 /-- `fact` version of the dimension of `ℂ` over `ℝ`, locally useful in the definition of the
 circle. -/
 lemma finrank_real_complex_fact : fact (finrank ℝ ℂ = 2) := ⟨finrank_real_complex⟩
-
-/-- The standard orientation on `ℂ`. -/
-protected noncomputable def orientation : orientation ℝ ℂ (fin 2) := complex.basis_one_I.orientation
 
 end complex
 

--- a/src/data/complex/orientation.lean
+++ b/src/data/complex/orientation.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2020 Heather Macbeth. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Heather Macbeth
+-/
+import linear_algebra.orientation
+import data.complex.module
+
+/-!
+# Orientation on `ℂ`
+-/
+
+namespace complex
+
+/-- The standard orientation on `ℂ`. -/
+protected noncomputable def orientation : orientation ℝ ℂ (fin 2) := complex.basis_one_I.orientation
+
+end complex


### PR DESCRIPTION
Stick to linear maps and don't talk about matrices in two files that are not explicitly about matrices.
This PR removes 19 currently unported files from the import tree of data.complex.module, and then removes those same files from the import tree of analysis.complex.isometry.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->


TODO: the only file that imports analysis.complex.isometry (analysis.complex.conformal) imports all those files anyway because it imports something about finite dimension to prove that a linear isometry in C is an equivalence. The finite dimension file then needs determinants, which are constructed through matrices.
So there is almost no gain in doing the isometry split currently.
BUT: data.complex.module is more widely imported and its split can be good to have.

I'll investigate a bit more and delete this PR if it is not worthwhile. I started looking at this because all those matrix and finite dimension files looked very thinly connected to the remainder of the import graph in https://leanprover-community.github.io/mathlib-port-status/file/measure_theory/integral/bochner .
For example finite dimension is also used in the borel_space file, but only for the last pair of lemmas.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
