### PR TITLE
[Merged by Bors] - feat(data/{set,finset}/pointwise): `a • t ⊆ s • t`

### DIFF
--- a/src/data/finset/n_ary.lean
+++ b/src/data/finset/n_ary.lean
@@ -75,7 +75,7 @@ image₂_subset hs subset.rfl
 lemma image_subset_image₂_left (hb : b ∈ t) : s.image (λ a, f a b) ⊆ image₂ f s t :=
 image_subset_iff.2 $ λ a ha, mem_image₂_of_mem ha hb
 
-lemma image_subset_image₂_right (ha : a ∈ s) : t.image (f a) ⊆ image₂ f s t :=
+lemma image_subset_image₂_right (ha : a ∈ s) : t.image (λ b, f a b) ⊆ image₂ f s t :=
 image_subset_iff.2 $ λ b, mem_image₂_of_mem ha
 
 lemma forall_image₂_iff {p : γ → Prop} : (∀ z ∈ image₂ f s t, p z) ↔ ∀ (x ∈ s) (y ∈ t), p (f x y) :=
@@ -120,7 +120,7 @@ lemma image₂_union_right [decidable_eq β] : image₂ f s (t ∪ t') = image�
 coe_injective $ by { push_cast, exact image2_union_right }
 
 @[simp] lemma image₂_insert_left [decidable_eq α] :
-  image₂ f (insert a s) t = t.image (f a) ∪ image₂ f s t :=
+  image₂ f (insert a s) t = t.image (λ b, f a b) ∪ image₂ f s t :=
 coe_injective $ by { push_cast, exact image2_insert_left }
 
 @[simp] lemma image₂_insert_right [decidable_eq β] :

--- a/src/data/finset/n_ary.lean
+++ b/src/data/finset/n_ary.lean
@@ -84,6 +84,12 @@ by simp_rw [←mem_coe, coe_image₂, forall_image2_iff]
 @[simp] lemma image₂_subset_iff : image₂ f s t ⊆ u ↔ ∀ (x ∈ s) (y ∈ t), f x y ∈ u :=
 forall_image₂_iff
 
+lemma image₂_subset_iff_left : image₂ f s t ⊆ u ↔ ∀ a ∈ s, t.image (f a) ⊆ u :=
+by simp_rw [image₂_subset_iff, image_subset_iff]
+
+lemma image₂_subset_iff_right : image₂ f s t ⊆ u ↔ ∀ b ∈ t, s.image (λ a, f a b) ⊆ u :=
+by simp_rw [image₂_subset_iff, image_subset_iff, @forall₂_swap α]
+
 @[simp] lemma image₂_nonempty_iff : (image₂ f s t).nonempty ↔ s.nonempty ∧ t.nonempty :=
 by { rw [←coe_nonempty, coe_image₂], exact image2_nonempty_iff }
 
@@ -112,6 +118,14 @@ coe_injective $ by { push_cast, exact image2_union_left }
 
 lemma image₂_union_right [decidable_eq β] : image₂ f s (t ∪ t') = image₂ f s t ∪ image₂ f s t' :=
 coe_injective $ by { push_cast, exact image2_union_right }
+
+@[simp] lemma image₂_insert_left [decidable_eq α] :
+  image₂ f (insert a s) t = t.image (f a) ∪ image₂ f s t :=
+coe_injective $ by { push_cast, exact image2_insert_left }
+
+@[simp] lemma image₂_insert_right [decidable_eq β] :
+  image₂ f s (insert b t) = s.image (λ a, f a b) ∪ image₂ f s t :=
+coe_injective $ by { push_cast, exact image2_insert_right }
 
 lemma image₂_inter_left [decidable_eq α] (hf : injective2 f) :
   image₂ f (s ∩ s') t = image₂ f s t ∩ image₂ f s' t :=
@@ -214,10 +228,6 @@ lemma image₂_image_right (f : α → γ → δ) (g : β → γ) :
   image₂ f s (t.image g) = image₂ (λ a b, f a (g b)) s t :=
 coe_injective $ by { push_cast, exact image2_image_right _ _ }
 
-lemma image₂_swap (f : α → β → γ) (s : finset α) (t : finset β) :
-  image₂ f s t = image₂ (λ a b, f b a) t s :=
-coe_injective $ by { push_cast, exact image2_swap _ _ _ }
-
 @[simp] lemma image₂_mk_eq_product [decidable_eq α] [decidable_eq β] (s : finset α) (t : finset β) :
   image₂ prod.mk s t = s ×ˢ t :=
 by ext; simp [prod.ext_iff]
@@ -228,6 +238,10 @@ by { classical, rw [←image₂_mk_eq_product, image_image₂, curry] }
 
 @[simp] lemma image_uncurry_product (f : α → β → γ) (s : finset α) (t : finset β) :
   (s ×ˢ t).image (uncurry f) = image₂ f s t := by rw [←image₂_curry, curry_uncurry]
+
+lemma image₂_swap (f : α → β → γ) (s : finset α) (t : finset β) :
+  image₂ f s t = image₂ (λ a b, f b a) t s :=
+coe_injective $ by { push_cast, exact image2_swap _ _ _ }
 
 @[simp] lemma image₂_left [decidable_eq α] (h : t.nonempty) : image₂ (λ x y, x) s t = s :=
 coe_injective $ by { push_cast, exact image2_left h }
@@ -345,6 +359,14 @@ lemma image₂_right_identity {f : γ → β → γ} {b : β} (h : ∀ a, f a b 
 by rw [image₂_singleton_right, funext h, image_id']
 
 variables [decidable_eq α] [decidable_eq β]
+
+lemma image₂_inter_union_subset_union :
+  image₂ f (s ∩ s') (t ∪ t') ⊆ image₂ f s t ∪ image₂ f s' t' :=
+coe_subset.1 $ by { push_cast, exact set.image2_inter_union_subset_union }
+
+lemma image₂_union_inter_subset_union :
+  image₂ f (s ∪ s') (t ∩ t') ⊆ image₂ f s t ∪ image₂ f s' t' :=
+coe_subset.1 $ by { push_cast, exact set.image2_union_inter_subset_union }
 
 lemma image₂_inter_union_subset {f : α → α → β} {s t : finset α} (hf : ∀ a b, f a b = f b a) :
   image₂ f (s ∩ t) (s ∪ t) ⊆ image₂ f s t :=

--- a/src/data/finset/n_ary.lean
+++ b/src/data/finset/n_ary.lean
@@ -84,7 +84,7 @@ by simp_rw [←mem_coe, coe_image₂, forall_image2_iff]
 @[simp] lemma image₂_subset_iff : image₂ f s t ⊆ u ↔ ∀ (x ∈ s) (y ∈ t), f x y ∈ u :=
 forall_image₂_iff
 
-lemma image₂_subset_iff_left : image₂ f s t ⊆ u ↔ ∀ a ∈ s, t.image (f a) ⊆ u :=
+lemma image₂_subset_iff_left : image₂ f s t ⊆ u ↔ ∀ a ∈ s, t.image (λ b, f a b) ⊆ u :=
 by simp_rw [image₂_subset_iff, image_subset_iff]
 
 lemma image₂_subset_iff_right : image₂ f s t ⊆ u ↔ ∀ b ∈ t, s.image (λ a, f a b) ⊆ u :=

--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -971,6 +971,15 @@ image₂_subset_iff_right
 
 end has_mul
 
+section semigroup
+variables [semigroup α] [decidable_eq α]
+
+@[to_additive] lemma op_smul_finset_mul_eq_mul_smul_finset (s : finset α) (a : α) (t : finset α) :
+  (op a • s) * t = s * a • t :=
+by simpa [mul_singleton, singleton_mul] using mul_assoc s {a} t
+
+end semigroup
+
 section left_cancel_semigroup
 variables [left_cancel_semigroup α] [decidable_eq α] (s t : finset α) (a : α)
 
@@ -1020,13 +1029,10 @@ image_comm $ map_mul _ _
 section monoid
 variables [decidable_eq α] [decidable_eq β] [monoid α] [mul_action α β]
 
+-- TODO: Generalise so that `s` and `a` are in two different types
 @[to_additive] lemma op_smul_finset_smul_eq_smul_smul_finset (s : finset α) (a : α) (t : finset β) :
   (op a • s) • t = s • a • t :=
 by simpa [mul_singleton] using mul_smul s {a} t
-
-@[to_additive] lemma op_smul_finset_mul_eq_mul_smul_finset (s : finset α) (a : α) (t : finset α) :
-  (op a • s) * t = s * a • t :=
-op_smul_finset_smul_eq_smul_smul_finset _ _ _
 
 end monoid
 

--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -955,10 +955,20 @@ coe_injective.no_zero_smul_divisors _ coe_zero coe_smul_finset
 
 end instances
 
+section has_smul
+variables [decidable_eq β] [decidable_eq γ] [has_smul αᵐᵒᵖ β] [has_smul β γ] [has_smul α γ]
+
+@[to_additive] lemma op_smul_finset_smul_eq_smul_smul_finset (a : α) (s : finset β) (t : finset γ)
+  (h : ∀ (a : α) (b : β) (c : γ), (op a • b) • c = b • a • c) :
+  (op a • s) • t = s • a • t :=
+by { ext, simp [mem_smul, mem_smul_finset, h] }
+
+end has_smul
+
 section has_mul
 variables [has_mul α] [decidable_eq α] {s t u : finset α} {a : α}
 
-@[to_additive] lemma op_smul_finset_subset_smul : a ∈ t → op a • s ⊆ s • t :=
+@[to_additive] lemma op_smul_finset_subset_mul : a ∈ t → op a • s ⊆ s * t :=
 image_subset_image₂_left
 
 @[simp, to_additive] lemma bUnion_op_smul_finset (s t : finset α) :
@@ -974,9 +984,9 @@ end has_mul
 section semigroup
 variables [semigroup α] [decidable_eq α]
 
-@[to_additive] lemma op_smul_finset_mul_eq_mul_smul_finset (s : finset α) (a : α) (t : finset α) :
+@[to_additive] lemma op_smul_finset_mul_eq_mul_smul_finset (a : α) (s : finset α) (t : finset α) :
   (op a • s) * t = s * a • t :=
-by simpa [mul_singleton, singleton_mul] using mul_assoc s {a} t
+op_smul_finset_smul_eq_smul_smul_finset _ _ _ $ λ _ _ _, mul_assoc _ _ _
 
 end semigroup
 
@@ -1025,16 +1035,6 @@ image_comm
   [monoid_hom_class F α β] (f : F) (a : α) (s : finset α) :
   (a • s).image f = f a • s.image f :=
 image_comm $ map_mul _ _
-
-section monoid
-variables [decidable_eq α] [decidable_eq β] [monoid α] [mul_action α β]
-
--- TODO: Generalise so that `s` and `a` are in two different types
-@[to_additive] lemma op_smul_finset_smul_eq_smul_smul_finset (s : finset α) (a : α) (t : finset β) :
-  (op a • s) • t = s • a • t :=
-by simpa [mul_singleton] using mul_smul s {a} t
-
-end monoid
 
 section group
 variables [decidable_eq β] [group α] [mul_action α β] {s t : finset β} {a : α} {b : β}

--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -958,6 +958,7 @@ end instances
 section has_smul
 variables [decidable_eq β] [decidable_eq γ] [has_smul αᵐᵒᵖ β] [has_smul β γ] [has_smul α γ]
 
+-- TODO: replace hypothesis and conclusion with a typeclass
 @[to_additive] lemma op_smul_finset_smul_eq_smul_smul_finset (a : α) (s : finset β) (t : finset γ)
   (h : ∀ (a : α) (b : β) (c : γ), (op a • b) • c = b • a • c) :
   (op a • s) • t = s • a • t :=

--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -54,7 +54,7 @@ finset multiplication, finset addition, pointwise addition, pointwise multiplica
 pointwise subtraction
 -/
 
-open function
+open function mul_opposite
 open_locale big_operators pointwise
 
 variables {F α β γ : Type*}
@@ -124,7 +124,9 @@ localized "attribute [instance] finset.has_inv finset.has_neg" in pointwise
 @[simp, to_additive] lemma inv_empty : (∅ : finset α)⁻¹ = ∅ := image_empty _
 @[simp, to_additive] lemma inv_nonempty_iff : s⁻¹.nonempty ↔ s.nonempty := nonempty.image_iff _
 
-alias inv_nonempty_iff ↔ nonempty.inv nonempty.of_inv
+alias inv_nonempty_iff ↔ nonempty.of_inv nonempty.inv
+
+attribute [to_additive] nonempty.inv nonempty.of_inv
 
 @[to_additive, mono] lemma inv_subset_inv  (h : s ⊆ t) : s⁻¹ ⊆ t⁻¹ := image_subset_image h
 
@@ -212,6 +214,10 @@ attribute [mono] add_subset_add
 image₂_inter_subset_left
 @[to_additive] lemma mul_inter_subset : s * (t₁ ∩ t₂) ⊆ s * t₁ ∩ (s * t₂) :=
 image₂_inter_subset_right
+@[to_additive] lemma inter_mul_union_subset_union : s₁ ∩ s₂ * (t₁ ∪ t₂) ⊆ (s₁ * t₁) ∪ (s₂ * t₂) :=
+image₂_inter_union_subset_union
+@[to_additive] lemma union_mul_inter_subset_union : (s₁ ∪ s₂) * (t₁ ∩ t₂) ⊆ (s₁ * t₁) ∪ (s₂ * t₂) :=
+image₂_union_inter_subset_union
 
 /-- If a finset `u` is contained in the product of two sets `s * t`, we can find two finsets `s'`,
 `t'` such that `s' ⊆ s`, `t' ⊆ t` and `u ⊆ s' * t'`. -/
@@ -294,6 +300,10 @@ attribute [mono] sub_subset_sub
 image₂_inter_subset_left
 @[to_additive] lemma div_inter_subset : s / (t₁ ∩ t₂) ⊆ s / t₁ ∩ (s / t₂) :=
 image₂_inter_subset_right
+@[to_additive] lemma inter_div_union_subset_union : (s₁ ∩ s₂) / (t₁ ∪ t₂) ⊆ (s₁ / t₁) ∪ (s₂ / t₂) :=
+image₂_inter_union_subset_union
+@[to_additive] lemma union_div_inter_subset_union : (s₁ ∪ s₂) / (t₁ ∩ t₂) ⊆ (s₁ / t₁) ∪ (s₂ / t₂) :=
+image₂_union_inter_subset_union
 
 /-- If a finset `u` is contained in the product of two sets `s / t`, we can find two finsets `s'`,
 `t'` such that `s' ⊆ s`, `t' ⊆ t` and `u ⊆ s' / t'`. -/
@@ -711,6 +721,12 @@ image₂_union_left
 image₂_inter_subset_left
 @[to_additive] lemma smul_inter_subset : s • (t₁ ∩ t₂) ⊆ s • t₁ ∩ s • t₂ :=
 image₂_inter_subset_right
+@[to_additive] lemma inter_smul_union_subset_union [decidable_eq α] :
+  (s₁ ∩ s₂) • (t₁ ∪ t₂) ⊆ (s₁ • t₁) ∪ (s₂ • t₂) :=
+image₂_inter_union_subset_union
+@[to_additive] lemma union_smul_inter_subset_union [decidable_eq α] :
+  (s₁ ∪ s₂) • (t₁ ∩ t₂) ⊆ (s₁ • t₁) ∪ (s₂ • t₂) :=
+image₂_union_inter_subset_union
 
 /-- If a finset `u` is contained in the scalar product of two sets `s • t`, we can find two finsets
 `s'`, `t'` such that `s' ⊆ s`, `t' ⊆ t` and `u ⊆ s' • t'`. -/
@@ -806,7 +822,7 @@ by simp only [finset.smul_finset_def, and.assoc, mem_image, exists_prop, prod.ex
 @[simp, norm_cast, to_additive]
 lemma coe_smul_finset (a : α) (s : finset β) : (↑(a • s) : set β) = a • s := coe_image
 
-@[to_additive] lemma smul_finset_mem_smul_finset : b ∈ s → a • b ∈ a • s := mem_image_of_mem _
+@[to_additive] lemma smul_mem_smul_finset : b ∈ s → a • b ∈ a • s := mem_image_of_mem _
 @[to_additive] lemma smul_finset_card_le : (a • s).card ≤ s.card := card_image_le
 
 @[simp, to_additive] lemma smul_finset_empty (a : α) : a • (∅ : finset β) = ∅ := image_empty _
@@ -829,7 +845,11 @@ lemma smul_finset_singleton (b : β) : a • ({b} : finset β) = {a • b} := im
 @[to_additive] lemma smul_finset_inter_subset : a • (s₁ ∩ s₂) ⊆ a • s₁ ∩ (a • s₂) :=
 image_inter_subset _ _ _
 
-@[simp] lemma bUnion_smul_finset (s : finset α) (t : finset β) : s.bUnion (• t) = s • t :=
+@[to_additive] lemma smul_finset_subset_smul {s : finset α} : a ∈ s → a • t ⊆ s • t :=
+image_subset_image₂_right
+
+@[simp, to_additive] lemma bUnion_smul_finset (s : finset α) (t : finset β) :
+  s.bUnion (• t) = s • t :=
 bUnion_image_left
 
 end has_smul
@@ -935,6 +955,22 @@ coe_injective.no_zero_smul_divisors _ coe_zero coe_smul_finset
 
 end instances
 
+section has_mul
+variables [has_mul α] [decidable_eq α] {s t u : finset α} {a : α}
+
+@[to_additive] lemma op_smul_finset_subset_smul : a ∈ t → op a • s ⊆ s • t :=
+image_subset_image₂_left
+
+@[simp, to_additive] lemma bUnion_op_smul_finset (s t : finset α) :
+  t.bUnion (λ a, op a • s) = s * t :=
+bUnion_image_right
+
+@[to_additive] lemma mul_subset_iff_left : s * t ⊆ u ↔ ∀ a ∈ s, a • t ⊆ u := image₂_subset_iff_left
+@[to_additive] lemma mul_subset_iff_right : s * t ⊆ u ↔ ∀ b ∈ t, op b • s ⊆ u :=
+image₂_subset_iff_right
+
+end has_mul
+
 section left_cancel_semigroup
 variables [left_cancel_semigroup α] [decidable_eq α] (s t : finset α) (a : α)
 
@@ -980,6 +1016,19 @@ image_comm
   [monoid_hom_class F α β] (f : F) (a : α) (s : finset α) :
   (a • s).image f = f a • s.image f :=
 image_comm $ map_mul _ _
+
+section monoid
+variables [decidable_eq α] [decidable_eq β] [monoid α] [mul_action α β]
+
+@[to_additive] lemma op_smul_finset_smul_eq_smul_smul_finset (s : finset α) (a : α) (t : finset β) :
+  (op a • s) • t = s • a • t :=
+by simpa [mul_singleton] using mul_smul s {a} t
+
+@[to_additive] lemma op_smul_finset_mul_eq_mul_smul_finset (s : finset α) (a : α) (t : finset α) :
+  (op a • s) * t = s * a • t :=
+op_smul_finset_smul_eq_smul_smul_finset _ _ _
+
+end monoid
 
 section group
 variables [decidable_eq β] [group α] [mul_action α β] {s t : finset β} {a : α} {b : β}

--- a/src/data/set/n_ary.lean
+++ b/src/data/set/n_ary.lean
@@ -141,7 +141,7 @@ by { rintro _ ⟨a, b, ha, ⟨h1b, h2b⟩, rfl⟩, split; exact ⟨_, _, ‹_›
 
 lemma image2_singleton : image2 f {a} {b} = {f a b} := by simp
 
-@[simp] lemma image2_insert_left : image2 f (insert a s) t = f a '' t ∪ image2 f s t :=
+@[simp] lemma image2_insert_left : image2 f (insert a s) t =(λ b, f a b) '' t ∪ image2 f s t :=
 by rw [insert_eq, image2_union_left, image2_singleton_left]
 
 @[simp] lemma image2_insert_right : image2 f s (insert b t) = (λ a, f a b) '' s  ∪ image2 f s t :=

--- a/src/data/set/n_ary.lean
+++ b/src/data/set/n_ary.lean
@@ -67,7 +67,7 @@ lemma forall_image2_iff {p : γ → Prop} :
   image2 f s t ⊆ u ↔ ∀ (x ∈ s) (y ∈ t), f x y ∈ u :=
 forall_image2_iff
 
-lemma image2_subset_iff_left : image2 f s t ⊆ u ↔ ∀ a ∈ s, f a '' t ⊆ u :=
+lemma image2_subset_iff_left : image2 f s t ⊆ u ↔ ∀ a ∈ s, (λ b, f a b) '' t ⊆ u :=
 by simp_rw [image2_subset_iff, image_subset_iff, subset_def, mem_preimage]
 
 lemma image2_subset_iff_right : image2 f s t ⊆ u ↔ ∀ b ∈ t, (λ a, f a b) '' s ⊆ u :=
@@ -141,7 +141,7 @@ by { rintro _ ⟨a, b, ha, ⟨h1b, h2b⟩, rfl⟩, split; exact ⟨_, _, ‹_›
 
 lemma image2_singleton : image2 f {a} {b} = {f a b} := by simp
 
-@[simp] lemma image2_insert_left : image2 f (insert a s) t =(λ b, f a b) '' t ∪ image2 f s t :=
+@[simp] lemma image2_insert_left : image2 f (insert a s) t = (λ b, f a b) '' t ∪ image2 f s t :=
 by rw [insert_eq, image2_union_left, image2_singleton_left]
 
 @[simp] lemma image2_insert_right : image2 f s (insert b t) = (λ a, f a b) '' s  ∪ image2 f s t :=

--- a/src/data/set/pointwise/basic.lean
+++ b/src/data/set/pointwise/basic.lean
@@ -223,6 +223,10 @@ attribute [mono] add_subset_add
 image2_inter_subset_left
 @[to_additive] lemma mul_inter_subset : s * (t₁ ∩ t₂) ⊆ s * t₁ ∩ (s * t₂) :=
 image2_inter_subset_right
+@[to_additive] lemma inter_mul_union_subset_union : s₁ ∩ s₂ * (t₁ ∪ t₂) ⊆ (s₁ * t₁) ∪ (s₂ * t₂) :=
+image2_inter_union_subset_union
+@[to_additive] lemma union_mul_inter_subset_union : (s₁ ∪ s₂) * (t₁ ∩ t₂) ⊆ (s₁ * t₁) ∪ (s₂ * t₂) :=
+image2_union_inter_subset_union
 
 @[to_additive] lemma Union_mul_left_image : (⋃ a ∈ s, ((*) a) '' t) = s * t := Union_image_left _
 @[to_additive] lemma Union_mul_right_image : (⋃ a ∈ t, (* a) '' s) = s * t := Union_image_right _
@@ -324,6 +328,10 @@ attribute [mono] sub_subset_sub
 image2_inter_subset_left
 @[to_additive] lemma div_inter_subset : s / (t₁ ∩ t₂) ⊆ s / t₁ ∩ (s / t₂) :=
 image2_inter_subset_right
+@[to_additive] lemma inter_div_union_subset_union : s₁ ∩ s₂ / (t₁ ∪ t₂) ⊆ (s₁ / t₁) ∪ (s₂ / t₂) :=
+image2_inter_union_subset_union
+@[to_additive] lemma union_div_inter_subset_union : (s₁ ∪ s₂) / (t₁ ∩ t₂) ⊆ (s₁ / t₁) ∪ (s₂ / t₂) :=
+image2_union_inter_subset_union
 
 @[to_additive] lemma Union_div_left_image : (⋃ a ∈ s, ((/) a) '' t) = s / t := Union_image_left _
 @[to_additive] lemma Union_div_right_image : (⋃ a ∈ t, (/ a) '' s) = s / t := Union_image_right _
@@ -412,8 +420,8 @@ variables [mul_one_class α]
 /-- `set α` is a `mul_one_class` under pointwise operations if `α` is. -/
 @[to_additive "`set α` is an `add_zero_class` under pointwise operations if `α` is."]
 protected def mul_one_class : mul_one_class (set α) :=
-{ mul_one := λ s, by { simp only [← singleton_one, mul_singleton, mul_one, image_id'] },
-  one_mul := λ s, by { simp only [← singleton_one, singleton_mul, one_mul, image_id'] },
+{ mul_one := image2_right_identity mul_one,
+  one_mul := image2_left_identity one_mul,
   ..set.has_one, ..set.has_mul }
 
 localized "attribute [instance] set.mul_one_class set.add_zero_class set.semigroup set.add_semigroup

--- a/src/data/set/pointwise/smul.lean
+++ b/src/data/set/pointwise/smul.lean
@@ -204,7 +204,7 @@ end has_smul_set
 section has_mul
 variables [has_mul α] {s t u : set α} {a : α}
 
-@[to_additive] lemma op_smul_set_subset_smul : a ∈ t → op a • s ⊆ s • t := image_subset_image2_left
+@[to_additive] lemma op_smul_set_subset_mul : a ∈ t → op a • s ⊆ s * t := image_subset_image2_left
 
 @[simp, to_additive] lemma bUnion_op_smul_set (s t : set α) : (⋃ a ∈ t, op a • s) = s * t :=
 Union_image_right _
@@ -410,6 +410,17 @@ image_comm
   f '' (a • s) = f a • f '' s :=
 image_comm $ map_mul _ _
 
+section has_smul
+variables[has_smul αᵐᵒᵖ β] [has_smul β γ] [has_smul α γ]
+
+-- TODO: replace hypothesis and conclusion with a typeclass
+@[to_additive] lemma op_smul_set_smul_eq_smul_smul_set (a : α) (s : set β) (t : set γ)
+  (h : ∀ (a : α) (b : β) (c : γ), (op a • b) • c = b • a • c) :
+  (op a • s) • t = s • a • t :=
+by { ext, simp [mem_smul, mem_smul_set, h] }
+
+end has_smul
+
 section smul_with_zero
 variables [has_zero α] [has_zero β] [smul_with_zero α β] {s : set α} {t : set β}
 
@@ -466,9 +477,9 @@ end smul_with_zero
 section semigroup
 variables [semigroup α]
 
-@[to_additive] lemma op_smul_set_mul_eq_mul_smul_set (s : set α) (a : α) (t : set α) :
+@[to_additive] lemma op_smul_set_mul_eq_mul_smul_set (a : α) (s : set α) (t : set α) :
   (op a • s) * t = s * a • t :=
-by simpa using mul_assoc s {a} t
+op_smul_set_smul_eq_smul_smul_set _ _ _ $ λ _ _ _, mul_assoc _ _ _
 
 end semigroup
 
@@ -480,16 +491,6 @@ variables [left_cancel_semigroup α] {s t : set α}
 pairwise_disjoint_image_right_iff $ λ _ _, mul_right_injective _
 
 end left_cancel_semigroup
-
-section monoid
-variables [monoid α] [mul_action α β]
-
--- TODO: Generalise so that `s` and `a` are in two different types
-@[to_additive] lemma op_smul_set_smul_eq_smul_smul_set (s : set α) (a : α) (t : set β) :
-  (op a • s) • t = s • a • t :=
-by simpa using mul_smul s {a} t
-
-end monoid
 
 section group
 variables [group α] [mul_action α β] {s t A B : set β} {a : α} {x : β}

--- a/src/data/set/pointwise/smul.lean
+++ b/src/data/set/pointwise/smul.lean
@@ -38,7 +38,7 @@ Appropriate definitions and results are also transported to the additive theory 
 
 -/
 
-open function
+open function mul_opposite
 
 variables {F α β γ : Type*}
 
@@ -108,6 +108,12 @@ attribute [mono] vadd_subset_vadd
 @[to_additive] lemma inter_smul_subset : (s₁ ∩ s₂) • t ⊆ s₁ • t ∩ s₂ • t := image2_inter_subset_left
 @[to_additive] lemma smul_inter_subset : s • (t₁ ∩ t₂) ⊆ s • t₁ ∩ s • t₂ :=
 image2_inter_subset_right
+@[to_additive] lemma inter_smul_union_subset_union :
+  (s₁ ∩ s₂) • (t₁ ∪ t₂) ⊆ (s₁ • t₁) ∪ (s₂ • t₂) :=
+image2_inter_union_subset_union
+@[to_additive] lemma union_smul_inter_subset_union :
+  (s₁ ∪ s₂) • (t₁ ∩ t₂) ⊆ (s₁ • t₁) ∪ (s₂ • t₂) :=
+image2_union_inter_subset_union
 
 @[to_additive] lemma Union_smul_left_image : (⋃ a ∈ s, a • t) = s • t := Union_image_left _
 @[to_additive] lemma Union_smul_right_image : (⋃ a ∈ t, (• a) '' s) = s • t := Union_image_right _
@@ -142,6 +148,9 @@ image2_Inter₂_subset_left _ _ _
 lemma smul_Inter₂_subset (s : set α) (t : Π i, κ i → set β) :
   s • (⋂ i j, t i j) ⊆ ⋂ i j, s • t i j :=
 image2_Inter₂_subset_right _ _ _
+
+@[to_additive] lemma smul_set_subset_smul {s : set α} : a ∈ s → a • t ⊆ s • t :=
+image_subset_image2_right
 
 @[simp, to_additive] lemma bUnion_smul_set (s : set α) (t : set β) :
   (⋃ a ∈ s, a • t) = s • t :=
@@ -192,11 +201,21 @@ image_Inter₂_subset _ _
 
 end has_smul_set
 
-variables {s s₁ s₂ : set α} {t t₁ t₂ : set β} {a : α} {b : β}
+section has_mul
+variables [has_mul α] {s t u : set α} {a : α}
 
-@[simp, to_additive] lemma bUnion_op_smul_set [has_mul α] (s t : set α) :
-  (⋃ a ∈ t, mul_opposite.op a • s) = s * t :=
+@[to_additive] lemma op_smul_set_subset_smul : a ∈ t → op a • s ⊆ s • t := image_subset_image2_left
+
+@[simp, to_additive] lemma bUnion_op_smul_set (s t : set α) : (⋃ a ∈ t, op a • s) = s * t :=
 Union_image_right _
+
+@[to_additive] lemma mul_subset_iff_left : s * t ⊆ u ↔ ∀ a ∈ s, a • t ⊆ u := image2_subset_iff_left
+@[to_additive] lemma mul_subset_iff_right : s * t ⊆ u ↔ ∀ b ∈ t, op b • s ⊆ u :=
+image2_subset_iff_right
+
+end has_mul
+
+variables {s s₁ s₂ : set α} {t t₁ t₂ : set β} {a : α} {b : β}
 
 @[to_additive]
 theorem range_smul_range {ι κ : Type*} [has_smul α β] (b : ι → α) (c : κ → β) :
@@ -344,6 +363,10 @@ lemma union_vsub : (s₁ ∪ s₂) -ᵥ t = s₁ -ᵥ t ∪ (s₂ -ᵥ t) := ima
 lemma vsub_union : s -ᵥ (t₁ ∪ t₂) = s -ᵥ t₁ ∪ (s -ᵥ t₂) := image2_union_right
 lemma inter_vsub_subset : s₁ ∩ s₂ -ᵥ t ⊆ (s₁ -ᵥ t) ∩ (s₂ -ᵥ t) := image2_inter_subset_left
 lemma vsub_inter_subset : s -ᵥ t₁ ∩ t₂ ⊆ (s -ᵥ t₁) ∩ (s -ᵥ t₂) := image2_inter_subset_right
+lemma inter_vsub_union_subset_union : (s₁ ∩ s₂) -ᵥ (t₁ ∪ t₂) ⊆ (s₁ -ᵥ t₁) ∪ (s₂ -ᵥ t₂) :=
+image2_inter_union_subset_union
+lemma union_vsub_inter_subset_union : (s₁ ∪ s₂) -ᵥ (t₁ ∩ t₂) ⊆ (s₁ -ᵥ t₁) ∪ (s₂ -ᵥ t₂) :=
+image2_union_inter_subset_union
 
 lemma Union_vsub_left_image : (⋃ a ∈ s, ((-ᵥ) a) '' t) = s -ᵥ t := Union_image_left _
 lemma Union_vsub_right_image : (⋃ a ∈ t, (-ᵥ a) '' s) = s -ᵥ t := Union_image_right _
@@ -448,6 +471,19 @@ variables [left_cancel_semigroup α] {s t : set α}
 pairwise_disjoint_image_right_iff $ λ _ _, mul_right_injective _
 
 end left_cancel_semigroup
+
+section monoid
+variables [monoid α] [mul_action α β]
+
+@[to_additive] lemma op_smul_set_smul_eq_smul_smul_set (s : set α) (a : α) (t : set β) :
+  (op a • s) • t = s • a • t :=
+by simpa using mul_smul s {a} t
+
+@[to_additive] lemma op_smul_set_mul_eq_mul_smul_set (s : set α) (a : α) (t : set α) :
+  (op a • s) * t = s * a • t :=
+op_smul_set_smul_eq_smul_smul_set _ _ _
+
+end monoid
 
 section group
 variables [group α] [mul_action α β] {s t A B : set β} {a : α} {x : β}

--- a/src/data/set/pointwise/smul.lean
+++ b/src/data/set/pointwise/smul.lean
@@ -463,6 +463,15 @@ end
 
 end smul_with_zero
 
+section semigroup
+variables [semigroup α]
+
+@[to_additive] lemma op_smul_set_mul_eq_mul_smul_set (s : set α) (a : α) (t : set α) :
+  (op a • s) * t = s * a • t :=
+by simpa using mul_assoc s {a} t
+
+end semigroup
+
 section left_cancel_semigroup
 variables [left_cancel_semigroup α] {s t : set α}
 
@@ -475,13 +484,10 @@ end left_cancel_semigroup
 section monoid
 variables [monoid α] [mul_action α β]
 
+-- TODO: Generalise so that `s` and `a` are in two different types
 @[to_additive] lemma op_smul_set_smul_eq_smul_smul_set (s : set α) (a : α) (t : set β) :
   (op a • s) • t = s • a • t :=
 by simpa using mul_smul s {a} t
-
-@[to_additive] lemma op_smul_set_mul_eq_mul_smul_set (s : set α) (a : α) (t : set α) :
-  (op a • s) * t = s * a • t :=
-op_smul_set_smul_eq_smul_smul_set _ _ _
 
 end monoid
 


### PR DESCRIPTION
Eta expansion in the lemma statements is deliberate, to make the left and right lemmas more similar and allow further rewrites.

Also additivise `finset.bUnion_smul_finset`, fix the name of `finset.smul_finset_mem_smul_finset` to `finset.smul_mem_smul_finset`, move `image2_swap`/`image₂_swap` further up the file to let them be used in earlier proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
