### PR TITLE
[Merged by Bors] - [Merged by Bors] - fix(data/nat/squarefree): `norm_num` only supports `squarefree` on naturals

### DIFF
--- a/src/data/nat/squarefree.lean
+++ b/src/data/nat/squarefree.lean
@@ -513,7 +513,8 @@ end
 
 /-- Evaluates the `squarefree` predicate on naturals. -/
 @[norm_num] meta def eval_squarefree : expr → tactic (expr × expr)
-| `(@squarefree ℕ _ %%e) := do
+| `(@squarefree ℕ %%inst %%e) := do
+  is_def_eq inst `(nat.monoid),
   n ← e.to_nat,
   match n with
   | 0 := false_intro `(@not_squarefree_zero ℕ _ _)

--- a/src/data/nat/squarefree.lean
+++ b/src/data/nat/squarefree.lean
@@ -513,7 +513,7 @@ end
 
 /-- Evaluates the `squarefree` predicate on naturals. -/
 @[norm_num] meta def eval_squarefree : expr → tactic (expr × expr)
-| `(squarefree (%%e : ℕ)) := do
+| `(@squarefree ℕ _ %%e) := do
   n ← e.to_nat,
   match n with
   | 0 := false_intro `(@not_squarefree_zero ℕ _ _)

--- a/test/norm_num_ext.lean
+++ b/test/norm_num_ext.lean
@@ -250,6 +250,22 @@ begin
   exact irreducible.squarefree (prime.irreducible
     (int.prime_iff_nat_abs_prime.mpr (by norm_num)))
 end
+example : @squarefree ℕ multiplicative.monoid 1 :=
+begin
+  -- `norm_num` should fail on this example, instead of producing an incorrect proof.
+  success_if_fail { norm_num },
+  -- the statement was deliberately wacky, let's fix it
+  change squarefree (multiplicative.of_add 1 : multiplicative ℕ),
+  rintros x ⟨dx, hd⟩,
+  revert x dx,
+  rw multiplicative.of_add.surjective.forall₂,
+  intros x dx h,
+  simp_rw [←of_add_add, multiplicative.of_add.injective.eq_iff] at h,
+  cases x,
+  { simp [is_unit_one], exact is_unit_one },
+  { simp only [nat.succ_add, nat.add_succ] at h,
+    cases h },
+end
 
 example : nat.fib 0 = 0 := by norm_num
 example : nat.fib 1 = 1 := by norm_num

--- a/test/norm_num_ext.lean
+++ b/test/norm_num_ext.lean
@@ -243,6 +243,13 @@ example : squarefree 10 := by norm_num
 example : squarefree (2*3*5*17) := by norm_num
 example : ¬ squarefree (2*3*5*5*17) := by norm_num
 example : squarefree 251 := by norm_num
+example : squarefree (3 : ℤ) :=
+begin
+  -- `norm_num` should fail on this example, instead of producing an incorrect proof.
+  success_if_fail { norm_num },
+  exact irreducible.squarefree (prime.irreducible
+    (int.prime_iff_nat_abs_prime.mpr (by norm_num)))
+end
 
 example : nat.fib 0 = 0 := by norm_num
 example : nat.fib 1 = 1 := by norm_num


### PR DESCRIPTION
We have a `norm_num` extension for proving whether natural numbers are squarefree. This tactic does not work on other rings, like integers, but the check for this case was broken, meaning it returned a proof with a type error instead of skipping the goal.

This PR changes the check to only fire the `norm_num` extension on natural numbers. I've included a small test that checks `norm_num` fails on integers, instead of returning a type-incorrect proof. We'd have to replace this test if `norm_num` gains support for `squarefree` on integers.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
