### PR TITLE
[Merged by Bors] - refactor(linear_algebra): make `module.free` available inside `linear_algebra/dimension`

### DIFF
--- a/src/field_theory/mv_polynomial.lean
+++ b/src/field_theory/mv_polynomial.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 
 import data.mv_polynomial.comm_ring
+import linear_algebra.dimension
 import ring_theory.ideal.quotient
 import ring_theory.mv_polynomial.basic
 

--- a/src/field_theory/mv_polynomial.lean
+++ b/src/field_theory/mv_polynomial.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 
 import data.mv_polynomial.comm_ring
+import ring_theory.ideal.quotient
 import ring_theory.mv_polynomial.basic
 
 /-!

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -1329,30 +1329,15 @@ end division_ring
 
 end module
 
-namespace finsupp
-
-section dim
+section field
 variables [field K] [add_comm_group V] [module K V]
 
-lemma dim_eq {ι : Type v} : module.rank K (ι →₀ V) = #ι * module.rank K V :=
+lemma finsupp.dim_eq {ι : Type v} :  module.rank K (ι →₀ V) = #ι * module.rank K V :=
 begin
   let bs := basis.of_vector_space K V,
   rw [← bs.mk_eq_dim'', ← (finsupp.basis (λa:ι, bs)).mk_eq_dim'',
     cardinal.mk_sigma, cardinal.sum_const']
 end
-
-end dim
-
-end finsupp
-
-section module
-variables [field K]
-variables [add_comm_group V] [module K V]
-variables [add_comm_group V₁] [module K V₁]
-variables [add_comm_group V₂] [module K V₂]
-variables [add_comm_group V'] [module K V']
-
-open module
 
 -- TODO: merge with the `finrank` content
 /-- An `n`-dimensional `K`-vector space is equivalent to `fin n → K`. -/
@@ -1367,4 +1352,4 @@ begin
   exact classical.choice (nonempty_linear_equiv_of_lift_dim_eq hn),
 end
 
-end module
+end field

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -5,11 +5,11 @@ Authors: Mario Carneiro, Johannes Hölzl, Sander Dahmen, Scott Morrison
 -/
 import algebra.module.big_operators
 import linear_algebra.dfinsupp
+import linear_algebra.free_module.basic
 import linear_algebra.invariant_basis_number
 import linear_algebra.isomorphisms
 import linear_algebra.std_basis
 import set_theory.cardinal.cofinality
-import linear_algebra.free_module.basic
 
 /-!
 # Dimension of modules and vector spaces

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -1345,8 +1345,6 @@ end dim
 
 end finsupp
 
-/- TODO: move these to a better location-/
-
 section module
 variables [field K]
 variables [add_comm_group V] [module K V]
@@ -1356,27 +1354,7 @@ variables [add_comm_group V'] [module K V']
 
 open module
 
-lemma equiv_of_dim_eq_lift_dim
-  (h : cardinal.lift.{v'} (module.rank K V) = cardinal.lift.{v} (module.rank K V')) :
-  nonempty (V ≃ₗ[K] V') :=
-begin
-  haveI := classical.dec_eq V,
-  haveI := classical.dec_eq V',
-  let m := basis.of_vector_space K V,
-  let m' := basis.of_vector_space K V',
-  rw [←cardinal.lift_inj.1 m.mk_eq_dim, ←cardinal.lift_inj.1 m'.mk_eq_dim] at h,
-  rcases quotient.exact h with ⟨e⟩,
-  let e := (equiv.ulift.symm.trans e).trans equiv.ulift,
-  exact ⟨(m.repr ≪≫ₗ (finsupp.dom_lcongr e)) ≪≫ₗ m'.repr.symm⟩
-end
-
-/-- Two `K`-vector spaces are equivalent if their dimension is the same. -/
-def equiv_of_dim_eq_dim (h : module.rank K V₁ = module.rank K V₂) : V₁ ≃ₗ[K] V₂ :=
-begin
-  classical,
-  exact classical.choice (equiv_of_dim_eq_lift_dim (cardinal.lift_inj.2 h))
-end
-
+-- TODO: merge with the `finrank` content
 /-- An `n`-dimensional `K`-vector space is equivalent to `fin n → K`. -/
 def fin_dim_vectorspace_equiv (n : ℕ)
   (hn : (module.rank K V) = n) : V ≃ₗ[K] (fin n → K) :=
@@ -1386,7 +1364,7 @@ begin
   have hn := cardinal.lift_inj.{v u}.2 hn,
   rw this at hn,
   rw ←@dim_fin_fun K _ n at hn,
-  exact classical.choice (equiv_of_dim_eq_lift_dim hn),
+  exact classical.choice (nonempty_linear_equiv_of_lift_dim_eq hn),
 end
 
 end module

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -1332,7 +1332,7 @@ end module
 section field
 variables [field K] [add_comm_group V] [module K V]
 
-lemma finsupp.dim_eq {ι : Type v} :  module.rank K (ι →₀ V) = #ι * module.rank K V :=
+lemma finsupp.dim_eq {ι : Type v} : module.rank K (ι →₀ V) = #ι * module.rank K V :=
 begin
   let bs := basis.of_vector_space K V,
   rw [← bs.mk_eq_dim'', ← (finsupp.basis (λa:ι, bs)).mk_eq_dim'',

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 
--- import linear_algebra.dimension
 import linear_algebra.std_basis
 
 /-!
@@ -13,11 +12,6 @@ import linear_algebra.std_basis
 This file contains results on the `R`-module structure on functions of finite support from a type
 `ι` to an `R`-module `M`, in particular in the case that `R` is a field.
 
-Furthermore, it contains some facts about isomorphisms of vector spaces from equality of dimension.
-
-## TODO
-
-Move the second half of this file to more appropriate other files.
 -/
 
 noncomputable theory

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 
-import linear_algebra.dimension
+-- import linear_algebra.dimension
 import linear_algebra.std_basis
 
 /-!
@@ -122,65 +122,7 @@ funext $ λ i, basis.apply_eq_iff.mpr rfl
 
 end semiring
 
-section dim
-variables {K : Type u} {V : Type v} {ι : Type v}
-variables [field K] [add_comm_group V] [module K V]
-
-lemma dim_eq : module.rank K (ι →₀ V) = #ι * module.rank K V :=
-begin
-  let bs := basis.of_vector_space K V,
-  rw [← bs.mk_eq_dim'', ← (finsupp.basis (λa:ι, bs)).mk_eq_dim'',
-    cardinal.mk_sigma, cardinal.sum_const']
-end
-
-end dim
-
 end finsupp
-
-section module
-variables {K : Type u} {V V₁ V₂ : Type v} {V' : Type w}
-variables [field K]
-variables [add_comm_group V] [module K V]
-variables [add_comm_group V₁] [module K V₁]
-variables [add_comm_group V₂] [module K V₂]
-variables [add_comm_group V'] [module K V']
-
-open module
-
-lemma equiv_of_dim_eq_lift_dim
-  (h : cardinal.lift.{w} (module.rank K V) = cardinal.lift.{v} (module.rank K V')) :
-  nonempty (V ≃ₗ[K] V') :=
-begin
-  haveI := classical.dec_eq V,
-  haveI := classical.dec_eq V',
-  let m := basis.of_vector_space K V,
-  let m' := basis.of_vector_space K V',
-  rw [←cardinal.lift_inj.1 m.mk_eq_dim, ←cardinal.lift_inj.1 m'.mk_eq_dim] at h,
-  rcases quotient.exact h with ⟨e⟩,
-  let e := (equiv.ulift.symm.trans e).trans equiv.ulift,
-  exact ⟨(m.repr ≪≫ₗ (finsupp.dom_lcongr e)) ≪≫ₗ m'.repr.symm⟩
-end
-
-/-- Two `K`-vector spaces are equivalent if their dimension is the same. -/
-def equiv_of_dim_eq_dim (h : module.rank K V₁ = module.rank K V₂) : V₁ ≃ₗ[K] V₂ :=
-begin
-  classical,
-  exact classical.choice (equiv_of_dim_eq_lift_dim (cardinal.lift_inj.2 h))
-end
-
-/-- An `n`-dimensional `K`-vector space is equivalent to `fin n → K`. -/
-def fin_dim_vectorspace_equiv (n : ℕ)
-  (hn : (module.rank K V) = n) : V ≃ₗ[K] (fin n → K) :=
-begin
-  have : cardinal.lift.{u} (n : cardinal.{v}) = cardinal.lift.{v} (n : cardinal.{u}),
-    by simp,
-  have hn := cardinal.lift_inj.{v u}.2 hn,
-  rw this at hn,
-  rw ←@dim_fin_fun K _ n at hn,
-  exact classical.choice (equiv_of_dim_eq_lift_dim hn),
-end
-
-end module
 
 namespace basis
 

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -118,6 +118,8 @@ end semiring
 
 end finsupp
 
+/-! TODO: move this section to an earlier file. -/
+
 namespace basis
 
 variables {R M n : Type*}

--- a/src/linear_algebra/free_algebra.lean
+++ b/src/linear_algebra/free_algebra.lean
@@ -5,6 +5,7 @@ Authors: Eric Wieser
 -/
 import linear_algebra.basis
 import algebra.free_algebra
+import linear_algebra.dimension
 import linear_algebra.finsupp_vector_space
 /-!
 # Linear algebra properties of `free_algebra R X`

--- a/src/linear_algebra/free_module/finite/basic.lean
+++ b/src/linear_algebra/free_module/finite/basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
 
+import linear_algebra.dimension
 import linear_algebra.free_module.basic
 import ring_theory.finiteness
 

--- a/src/linear_algebra/free_module/rank.lean
+++ b/src/linear_algebra/free_module/rank.lean
@@ -6,7 +6,6 @@ Authors: Riccardo Brasca
 
 import linear_algebra.dimension
 import linear_algebra.free_module.basic
-import linear_algebra.finsupp_vector_space
 import linear_algebra.invariant_basis_number
 
 /-!

--- a/src/linear_algebra/free_module/rank.lean
+++ b/src/linear_algebra/free_module/rank.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
 
+import linear_algebra.dimension
 import linear_algebra.free_module.basic
 import linear_algebra.finsupp_vector_space
+import linear_algebra.invariant_basis_number
 
 /-!
 


### PR DESCRIPTION
Many of the results here should generalize from `division_ring K` to `module.free K V`, though this PR doesn't bother itself with making them.
This PR just flips around the imports and moves the lemmas that can't stay in the old home, and makes no attempt to actually make this generalization.

This also removes some duplicates:
* `lemma equiv_of_dim_eq_lift_dim` duplicates `nonempty_linear_equiv_of_lift_dim_eq`
* `def equiv_of_dim_eq_dim` duplicates `linear_equiv.of_dim_eq`

A few downstream files now need to directly import `linear_algebra.dimension`, which previously was implied transitively.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
