### PR TITLE
[Merged by Bors] - feat(linear_algebra/dimension): free generalizations

### DIFF
--- a/src/algebra/linear_recurrence.lean
+++ b/src/algebra/linear_recurrence.lean
@@ -167,15 +167,20 @@ def tuple_succ : (fin E.order → α) →ₗ[α] (fin E.order → α) :=
 
 end comm_semiring
 
-section field
+section strong_rank_condition
 
-variables {α : Type*} [field α] (E : linear_recurrence α)
+-- note: `strong_rank_condition` is the same as `nontrivial` on `comm_ring`s, but that result,
+-- `comm_ring_strong_rank_condition`, is in a much later file.
+variables {α : Type*} [comm_ring α] [strong_rank_condition α] (E : linear_recurrence α)
 
 /-- The dimension of `E.sol_space` is `E.order`. -/
 lemma sol_space_dim : module.rank α E.sol_space = E.order :=
-@dim_fin_fun α _ E.order ▸ E.to_init.dim_eq
+begin
+  letI := nontrivial_of_invariant_basis_number α,
+  exact @dim_fin_fun α _ _ _ E.order ▸ E.to_init.dim_eq
+end
 
-end field
+end strong_rank_condition
 
 section comm_ring
 


### PR DESCRIPTION
Generalizes many results about `module.rank` from `[division_ring K]` to `[ring K] [strong_rank_condition K] [module.free K V]`.

Some lemmas have been moved around in the file to make use of existing `variables` groupings.
There are some lemmas about division rings that I wasn't able to weaken the assumptions on.

I'll make the corresponding generalizations to `finrank` in a follow-up PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text
-->

- [x] depends on: #18717

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
