### PR TITLE
[Merged by Bors] - chore(category_theory/monad/basic): remove some simp lemmas

### DIFF
--- a/src/category_theory/monad/basic.lean
+++ b/src/category_theory/monad/basic.lean
@@ -226,7 +226,6 @@ def monad_to_functor : monad C ⥤ (C ⥤ C) :=
 
 instance : faithful (monad_to_functor C) := {}.
 
-@[simp]
 lemma monad_to_functor_map_iso_monad_iso_mk {M N : monad C} (f : (M : C ⥤ C) ≅ N) (f_η f_μ) :
   (monad_to_functor _).map_iso (monad_iso.mk f f_η f_μ) = f :=
 by { ext, refl }
@@ -249,7 +248,6 @@ def comonad_to_functor : comonad C ⥤ (C ⥤ C) :=
 
 instance : faithful (comonad_to_functor C) := {}.
 
-@[simp]
 lemma comonad_to_functor_map_iso_comonad_iso_mk {M N : comonad C} (f : (M : C ⥤ C) ≅ N) (f_ε f_δ) :
   (comonad_to_functor _).map_iso (comonad_iso.mk f f_ε f_δ) = f :=
 by { ext, refl }


### PR DESCRIPTION
This is a backport from mathlib4, where the simpNF (correctly) linter disapproves of these lemmas. Mostly this PR exists to verify that these are not needed in the simp set.

https://github.com/leanprover-community/mathlib4/pull/2969

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
