### PR TITLE
refactor(linear_algebra/dimension): use `rank` in lemma names instead of `dim`

### DIFF
--- a/archive/sensitivity.lean
+++ b/archive/sensitivity.lean
@@ -230,7 +230,7 @@ since this cardinal is finite, as a natural number in `finrank_V` -/
 
 lemma dim_V : module.rank ℝ (V n) = 2^n :=
 have module.rank ℝ (V n) = (2^n : ℕ),
-  by { rw [dim_eq_card_basis (dual_bases_e_ε _).basis, Q.card]; apply_instance },
+  by { rw [rank_eq_card_basis (dual_bases_e_ε _).basis, Q.card]; apply_instance },
 by assumption_mod_cast
 
 instance : finite_dimensional ℝ (V n) :=
@@ -238,7 +238,7 @@ finite_dimensional.of_fintype_basis (dual_bases_e_ε _).basis
 
 lemma finrank_V : finrank ℝ (V n) = 2^n :=
 have _ := @dim_V n,
-by rw ←finrank_eq_dim at this; assumption_mod_cast
+by rw ←finrank_eq_rank at this; assumption_mod_cast
 
 /-! ### The linear map -/
 
@@ -359,25 +359,25 @@ begin
   let img := (g m).range,
   suffices : 0 < dim (W ⊓ img),
   { simp only [exists_prop],
-    exact_mod_cast exists_mem_ne_zero_of_dim_pos this },
+    exact_mod_cast exists_mem_ne_zero_of_rank_pos this },
   have dim_le : dim (W ⊔ img) ≤ 2^(m + 1),
-  { convert ← dim_submodule_le (W ⊔ img),
+  { convert ← rank_submodule_le (W ⊔ img),
     apply dim_V },
   have dim_add : dim (W ⊔ img) + dim (W ⊓ img) = dim W + 2^m,
-  { convert ← dim_sup_add_dim_inf_eq W img,
-    rw ← dim_eq_of_injective (g m) g_injective,
+  { convert ← rank_sup_add_rank_inf_eq W img,
+    rw ← rank_eq_of_injective (g m) g_injective,
     apply dim_V },
   have dimW : dim W = card H,
   { have li : linear_independent ℝ (H.restrict e),
     { convert (dual_bases_e_ε _).basis.linear_independent.comp _ subtype.val_injective,
       rw (dual_bases_e_ε _).coe_basis },
-    have hdW := dim_span li,
+    have hdW := rank_span li,
     rw set.range_restrict at hdW,
     convert hdW,
     rw [← (dual_bases_e_ε _).coe_basis, cardinal.mk_image_eq (dual_bases_e_ε _).basis.injective,
         cardinal.mk_fintype] },
-  rw ← finrank_eq_dim ℝ at ⊢ dim_le dim_add dimW,
-  rw [← finrank_eq_dim ℝ, ← finrank_eq_dim ℝ] at dim_add,
+  rw ← finrank_eq_rank ℝ at ⊢ dim_le dim_add dimW,
+  rw [← finrank_eq_rank ℝ, ← finrank_eq_rank ℝ] at dim_add,
   norm_cast at ⊢ dim_le dim_add dimW,
   rw pow_succ' at dim_le,
   rw set.to_finset_card at hH,

--- a/src/algebra/linear_recurrence.lean
+++ b/src/algebra/linear_recurrence.lean
@@ -174,10 +174,10 @@ section strong_rank_condition
 variables {α : Type*} [comm_ring α] [strong_rank_condition α] (E : linear_recurrence α)
 
 /-- The dimension of `E.sol_space` is `E.order`. -/
-lemma sol_space_dim : module.rank α E.sol_space = E.order :=
+lemma sol_space_rank : module.rank α E.sol_space = E.order :=
 begin
   letI := nontrivial_of_invariant_basis_number α,
-  exact @dim_fin_fun α _ _ E.order ▸ E.to_init.dim_eq
+  exact @rank_fin_fun α _ _ E.order ▸ E.to_init.rank_eq
 end
 
 end strong_rank_condition

--- a/src/algebra/quaternion.lean
+++ b/src/algebra/quaternion.lean
@@ -309,13 +309,13 @@ basis.of_equiv_fun $ linear_equiv_tuple c₁ c₂
 instance : module.finite R ℍ[R, c₁, c₂] := module.finite.of_basis (basis_one_i_j_k c₁ c₂)
 instance : module.free R ℍ[R, c₁, c₂] := module.free.of_basis (basis_one_i_j_k c₁ c₂)
 
-lemma dim_eq_four [strong_rank_condition R] : module.rank R ℍ[R, c₁, c₂] = 4 :=
-by { rw [dim_eq_card_basis (basis_one_i_j_k c₁ c₂), fintype.card_fin], norm_num }
+lemma rank_eq_four [strong_rank_condition R] : module.rank R ℍ[R, c₁, c₂] = 4 :=
+by { rw [rank_eq_card_basis (basis_one_i_j_k c₁ c₂), fintype.card_fin], norm_num }
 
 lemma finrank_eq_four [strong_rank_condition R] : finite_dimensional.finrank R ℍ[R, c₁, c₂] = 4 :=
 have cardinal.to_nat 4 = 4,
   by rw [←cardinal.to_nat_cast 4, nat.cast_bit0, nat.cast_bit0, nat.cast_one],
-by rw [finite_dimensional.finrank, dim_eq_four, this]
+by rw [finite_dimensional.finrank, rank_eq_four, this]
 
 end
 
@@ -631,8 +631,8 @@ lemma smul_coe : x • (y : ℍ[R]) = ↑(x * y) := quaternion_algebra.smul_coe 
 instance : module.finite R ℍ[R] := quaternion_algebra.module.finite _ _
 instance : module.free R ℍ[R] := quaternion_algebra.module.free _ _
 
-lemma dim_eq_four [strong_rank_condition R] : module.rank R ℍ[R] = 4 :=
-quaternion_algebra.dim_eq_four _ _
+lemma rank_eq_four [strong_rank_condition R] : module.rank R ℍ[R] = 4 :=
+quaternion_algebra.rank_eq_four _ _
 
 lemma finrank_eq_four [strong_rank_condition R] : finite_dimensional.finrank R ℍ[R] = 4 :=
 quaternion_algebra.finrank_eq_four _ _

--- a/src/analysis/inner_product_space/projection.lean
+++ b/src/analysis/inner_product_space/projection.lean
@@ -1030,7 +1030,7 @@ lemma submodule.finrank_add_inf_finrank_orthogonal {K₁ K₂ : submodule 𝕜 E
 begin
   haveI := submodule.finite_dimensional_of_le h,
   haveI := proper_is_R_or_C 𝕜 K₁,
-  have hd := submodule.dim_sup_add_dim_inf_eq K₁ (K₁ᗮ ⊓ K₂),
+  have hd := submodule.rank_sup_add_rank_inf_eq K₁ (K₁ᗮ ⊓ K₂),
   rw [←inf_assoc, (submodule.orthogonal_disjoint K₁).eq_bot, bot_inf_eq, finrank_bot,
       submodule.sup_orthogonal_inf_of_complete_space h] at hd,
   rw add_zero at hd,

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -157,11 +157,11 @@ instance : finite_dimensional ℝ ℂ := of_fintype_basis basis_one_I
 @[simp] lemma finrank_real_complex : finite_dimensional.finrank ℝ ℂ = 2 :=
 by rw [finrank_eq_card_basis basis_one_I, fintype.card_fin]
 
-@[simp] lemma dim_real_complex : module.rank ℝ ℂ = 2 :=
-by simp [← finrank_eq_dim, finrank_real_complex]
+@[simp] lemma rank_real_complex : module.rank ℝ ℂ = 2 :=
+by simp [← finrank_eq_rank, finrank_real_complex]
 
-lemma {u} dim_real_complex' : cardinal.lift.{u} (module.rank ℝ ℂ) = 2 :=
-by simp [← finrank_eq_dim, finrank_real_complex, bit0]
+lemma {u} rank_real_complex' : cardinal.lift.{u} (module.rank ℝ ℂ) = 2 :=
+by simp [← finrank_eq_rank, finrank_real_complex, bit0]
 
 /-- `fact` version of the dimension of `ℂ` over `ℝ`, locally useful in the definition of the
 circle. -/
@@ -199,10 +199,10 @@ instance finite_dimensional.complex_to_real (E : Type*) [add_comm_group E] [modu
   [finite_dimensional ℂ E] : finite_dimensional ℝ E :=
 finite_dimensional.trans ℝ ℂ E
 
-lemma dim_real_of_complex (E : Type*) [add_comm_group E] [module ℂ E] :
+lemma rank_real_of_complex (E : Type*) [add_comm_group E] [module ℂ E] :
   module.rank ℝ E = 2 * module.rank ℂ E :=
 cardinal.lift_inj.1 $
-  by { rw [← dim_mul_dim' ℝ ℂ E, complex.dim_real_complex], simp [bit0] }
+  by { rw [← rank_mul_rank' ℝ ℂ E, complex.rank_real_complex], simp [bit0] }
 
 lemma finrank_real_of_complex (E : Type*) [add_comm_group E] [module ℂ E] :
   finite_dimensional.finrank ℝ E = 2 * finite_dimensional.finrank ℂ E :=

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -19,7 +19,7 @@ For example, `algebra.adjoin K {x}` might not include `x⁻¹`.
 ## Main results
 
 - `adjoin_adjoin_left`: adjoining S and then T is the same as adjoining `S ∪ T`.
-- `bot_eq_top_of_dim_adjoin_eq_one`: if `F⟮x⟯` has dimension `1` over `F` for every `x`
+- `bot_eq_top_of_rank_adjoin_eq_one`: if `F⟮x⟯` has dimension `1` over `F` for every `x`
   in `E` then `F = E`
 
 ## Notation
@@ -528,30 +528,30 @@ adjoin_simple_eq_bot_iff.mpr (coe_int_mem ⊥ n)
 @[simp] lemma adjoin_nat (n : ℕ) : F⟮(n : E)⟯ = ⊥ :=
 adjoin_simple_eq_bot_iff.mpr (coe_nat_mem ⊥ n)
 
-section adjoin_dim
+section adjoin_rank
 open finite_dimensional module
 
 variables {K L : intermediate_field F E}
 
-@[simp] lemma dim_eq_one_iff : module.rank F K = 1 ↔ K = ⊥ :=
-by rw [← to_subalgebra_eq_iff, ← dim_eq_dim_subalgebra,
-  subalgebra.dim_eq_one_iff, bot_to_subalgebra]
+@[simp] lemma rank_eq_one_iff : module.rank F K = 1 ↔ K = ⊥ :=
+by rw [← to_subalgebra_eq_iff, ← rank_eq_rank_subalgebra,
+  subalgebra.rank_eq_one_iff, bot_to_subalgebra]
 
 @[simp] lemma finrank_eq_one_iff : finrank F K = 1 ↔ K = ⊥ :=
 by rw [← to_subalgebra_eq_iff, ← finrank_eq_finrank_subalgebra,
   subalgebra.finrank_eq_one_iff, bot_to_subalgebra]
 
-@[simp] lemma dim_bot : module.rank F (⊥ : intermediate_field F E) = 1 :=
-by rw dim_eq_one_iff
+@[simp] lemma rank_bot : module.rank F (⊥ : intermediate_field F E) = 1 :=
+by rw rank_eq_one_iff
 
 @[simp] lemma finrank_bot : finrank F (⊥ : intermediate_field F E) = 1 :=
 by rw finrank_eq_one_iff
 
-lemma dim_adjoin_eq_one_iff : module.rank F (adjoin F S) = 1 ↔ S ⊆ (⊥ : intermediate_field F E) :=
-iff.trans dim_eq_one_iff adjoin_eq_bot_iff
+lemma rank_adjoin_eq_one_iff : module.rank F (adjoin F S) = 1 ↔ S ⊆ (⊥ : intermediate_field F E) :=
+iff.trans rank_eq_one_iff adjoin_eq_bot_iff
 
-lemma dim_adjoin_simple_eq_one_iff : module.rank F F⟮α⟯ = 1 ↔ α ∈ (⊥ : intermediate_field F E) :=
-by { rw dim_adjoin_eq_one_iff, exact set.singleton_subset_iff }
+lemma rank_adjoin_simple_eq_one_iff : module.rank F F⟮α⟯ = 1 ↔ α ∈ (⊥ : intermediate_field F E) :=
+by { rw rank_adjoin_eq_one_iff, exact set.singleton_subset_iff }
 
 lemma finrank_adjoin_eq_one_iff : finrank F (adjoin F S) = 1 ↔ S ⊆ (⊥ : intermediate_field F E) :=
 iff.trans finrank_eq_one_iff adjoin_eq_bot_iff
@@ -560,12 +560,12 @@ lemma finrank_adjoin_simple_eq_one_iff : finrank F F⟮α⟯ = 1 ↔ α ∈ (⊥
 by { rw [finrank_adjoin_eq_one_iff], exact set.singleton_subset_iff }
 
 /-- If `F⟮x⟯` has dimension `1` over `F` for every `x ∈ E` then `F = E`. -/
-lemma bot_eq_top_of_dim_adjoin_eq_one (h : ∀ x : E, module.rank F F⟮x⟯ = 1) :
+lemma bot_eq_top_of_rank_adjoin_eq_one (h : ∀ x : E, module.rank F F⟮x⟯ = 1) :
   (⊥ : intermediate_field F E) = ⊤ :=
 begin
   ext,
   rw iff_true_right intermediate_field.mem_top,
-  exact dim_adjoin_simple_eq_one_iff.mp (h x),
+  exact rank_adjoin_simple_eq_one_iff.mp (h x),
 end
 
 lemma bot_eq_top_of_finrank_adjoin_eq_one (h : ∀ x : E, finrank F F⟮x⟯ = 1) :
@@ -576,9 +576,9 @@ begin
   exact finrank_adjoin_simple_eq_one_iff.mp (h x),
 end
 
-lemma subsingleton_of_dim_adjoin_eq_one (h : ∀ x : E, module.rank F F⟮x⟯ = 1) :
+lemma subsingleton_of_rank_adjoin_eq_one (h : ∀ x : E, module.rank F F⟮x⟯ = 1) :
   subsingleton (intermediate_field F E) :=
-subsingleton_of_bot_eq_top (bot_eq_top_of_dim_adjoin_eq_one h)
+subsingleton_of_bot_eq_top (bot_eq_top_of_rank_adjoin_eq_one h)
 
 lemma subsingleton_of_finrank_adjoin_eq_one (h : ∀ x : E, finrank F F⟮x⟯ = 1) :
   subsingleton (intermediate_field F E) :=
@@ -596,7 +596,7 @@ lemma subsingleton_of_finrank_adjoin_le_one [finite_dimensional F E]
   (h : ∀ x : E, finrank F F⟮x⟯ ≤ 1) : subsingleton (intermediate_field F E) :=
 subsingleton_of_bot_eq_top (bot_eq_top_of_finrank_adjoin_le_one h)
 
-end adjoin_dim
+end adjoin_rank
 end adjoin_intermediate_field_lattice
 
 section adjoin_integral_element

--- a/src/field_theory/finite/polynomial.lean
+++ b/src/field_theory/finite/polynomial.lean
@@ -199,8 +199,9 @@ calc module.rank K (R σ K) =
   ... = fintype.card (σ → K) : cardinal.mk_fintype _
 
 instance [finite σ] : finite_dimensional K (R σ K) :=
-by { casesI nonempty_fintype σ, exact is_noetherian.iff_fg.1 (is_noetherian.iff_rank_lt_aleph_0.mpr $
-  by simpa only [rank_R] using cardinal.nat_lt_aleph_0 (fintype.card (σ → K))) }
+by { casesI nonempty_fintype σ,
+  exact is_noetherian.iff_fg.1 (is_noetherian.iff_rank_lt_aleph_0.mpr $
+    by simpa only [rank_R] using cardinal.nat_lt_aleph_0 (fintype.card (σ → K))) }
 
 lemma finrank_R [fintype σ] : finite_dimensional.finrank K (R σ K) = fintype.card (σ → K) :=
 finite_dimensional.finrank_eq_of_rank_eq (rank_R σ K)

--- a/src/field_theory/finite/polynomial.lean
+++ b/src/field_theory/finite/polynomial.lean
@@ -177,13 +177,13 @@ end comm_ring
 
 variables [field K]
 
-lemma dim_R [fintype σ] : module.rank K (R σ K) = fintype.card (σ → K) :=
+lemma rank_R [fintype σ] : module.rank K (R σ K) = fintype.card (σ → K) :=
 calc module.rank K (R σ K) =
   module.rank K (↥{s : σ →₀ ℕ | ∀ (n : σ), s n ≤ fintype.card K - 1} →₀ K) :
-    linear_equiv.dim_eq
+    linear_equiv.rank_eq
       (finsupp.supported_equiv_finsupp {s : σ →₀ ℕ | ∀n:σ, s n ≤ fintype.card K - 1 })
   ... = #{s : σ →₀ ℕ | ∀ (n : σ), s n ≤ fintype.card K - 1} :
-    by rw [finsupp.dim_eq, dim_self, mul_one]
+    by rw [finsupp.rank_eq, rank_self, mul_one]
   ... = #{s : σ → ℕ | ∀ (n : σ), s n < fintype.card K } :
   begin
     refine quotient.sound ⟨equiv.subtype_equiv finsupp.equiv_fun_on_finite $ assume f, _⟩,
@@ -199,11 +199,11 @@ calc module.rank K (R σ K) =
   ... = fintype.card (σ → K) : cardinal.mk_fintype _
 
 instance [finite σ] : finite_dimensional K (R σ K) :=
-by { casesI nonempty_fintype σ, exact is_noetherian.iff_fg.1 (is_noetherian.iff_dim_lt_aleph_0.mpr $
-  by simpa only [dim_R] using cardinal.nat_lt_aleph_0 (fintype.card (σ → K))) }
+by { casesI nonempty_fintype σ, exact is_noetherian.iff_fg.1 (is_noetherian.iff_rank_lt_aleph_0.mpr $
+  by simpa only [rank_R] using cardinal.nat_lt_aleph_0 (fintype.card (σ → K))) }
 
 lemma finrank_R [fintype σ] : finite_dimensional.finrank K (R σ K) = fintype.card (σ → K) :=
-finite_dimensional.finrank_eq_of_dim_eq (dim_R σ K)
+finite_dimensional.finrank_eq_of_rank_eq (rank_R σ K)
 
 lemma range_evalᵢ [finite σ] : (evalᵢ σ K).range = ⊤ :=
 begin

--- a/src/field_theory/finiteness.lean
+++ b/src/field_theory/finiteness.lean
@@ -24,10 +24,10 @@ variables {K : Type u} {V : Type v} [division_ring K] [add_comm_group V] [module
 A module over a division ring is noetherian if and only if
 its dimension (as a cardinal) is strictly less than the first infinite cardinal `ℵ₀`.
 -/
-lemma iff_dim_lt_aleph_0 : is_noetherian K V ↔ module.rank K V < ℵ₀ :=
+lemma iff_rank_lt_aleph_0 : is_noetherian K V ↔ module.rank K V < ℵ₀ :=
 begin
   let b := basis.of_vector_space K V,
-  rw [← b.mk_eq_dim'', lt_aleph_0_iff_set_finite],
+  rw [← b.mk_eq_rank'', lt_aleph_0_iff_set_finite],
   split,
   { introI,
     exact finite_of_linear_independent (basis.of_vector_space_index.linear_independent K V) },
@@ -42,15 +42,15 @@ variables (K V)
 
 /-- The dimension of a noetherian module over a division ring, as a cardinal,
 is strictly less than the first infinite cardinal `ℵ₀`. -/
-lemma dim_lt_aleph_0 : ∀ [is_noetherian K V], module.rank K V < ℵ₀ :=
-is_noetherian.iff_dim_lt_aleph_0.1
+lemma rank_lt_aleph_0 : ∀ [is_noetherian K V], module.rank K V < ℵ₀ :=
+is_noetherian.iff_rank_lt_aleph_0.1
 
 variables {K V}
 
 /-- In a noetherian module over a division ring, all bases are indexed by a finite type. -/
 noncomputable def fintype_basis_index {ι : Type*} [is_noetherian K V] (b : basis ι K V) :
   fintype ι :=
-b.fintype_index_of_dim_lt_aleph_0 (dim_lt_aleph_0 K V)
+b.fintype_index_of_rank_lt_aleph_0 (rank_lt_aleph_0 K V)
 
 /-- In a noetherian module over a division ring,
 `basis.of_vector_space` is indexed by a finite type. -/
@@ -61,7 +61,7 @@ fintype_basis_index (basis.of_vector_space K V)
 if a basis is indexed by a set, that set is finite. -/
 lemma finite_basis_index {ι : Type*} {s : set ι} [is_noetherian K V] (b : basis s K V) :
   s.finite :=
-b.finite_index_of_dim_lt_aleph_0 (dim_lt_aleph_0 K V)
+b.finite_index_of_rank_lt_aleph_0 (rank_lt_aleph_0 K V)
 
 variables (K V)
 
@@ -103,8 +103,8 @@ begin
   { introI h,
     exact ⟨⟨finset_basis_index K V, by { convert (finset_basis K V).span_eq, simp }⟩⟩ },
   { rintros ⟨s, hs⟩,
-    rw [is_noetherian.iff_dim_lt_aleph_0, ← dim_top, ← hs],
-    exact lt_of_le_of_lt (dim_span_le _) s.finite_to_set.lt_aleph_0 }
+    rw [is_noetherian.iff_rank_lt_aleph_0, ← rank_top, ← hs],
+    exact lt_of_le_of_lt (rank_span_le _) s.finite_to_set.lt_aleph_0 }
 end
 
 end is_noetherian

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -232,10 +232,10 @@ theorem minpoly_eq_minpoly :
 minpoly.eq_of_irreducible_of_monic (minpoly.irreducible G F x)
   (minpoly.eval₂ G F x) (minpoly.monic G F x)
 
-lemma dim_le_card : module.rank (fixed_points.subfield G F) F ≤ fintype.card G :=
-dim_le $ λ s hs, by simpa only [dim_fun', cardinal.mk_coe_finset, finset.coe_sort_coe,
+lemma rank_le_card : module.rank (fixed_points.subfield G F) F ≤ fintype.card G :=
+rank_le $ λ s hs, by simpa only [rank_fun', cardinal.mk_coe_finset, finset.coe_sort_coe,
   cardinal.lift_nat_cast, cardinal.nat_cast_le]
-  using cardinal_lift_le_dim_of_linear_independent'
+  using cardinal_lift_le_rank_of_linear_independent'
     (linear_independent_smul_of_linear_independent G F hs)
 
 end fintype
@@ -262,15 +262,15 @@ instance separable : is_separable (fixed_points.subfield G F) F :=
   exact polynomial.separable_prod_X_sub_C_iff.2 (injective_of_quotient_stabilizer G x) }⟩
 
 instance : finite_dimensional (subfield G F) F :=
-by { casesI nonempty_fintype G, exact is_noetherian.iff_fg.1 (is_noetherian.iff_dim_lt_aleph_0.2 $
-  (dim_le_card G F).trans_lt $ cardinal.nat_lt_aleph_0 _) }
+by { casesI nonempty_fintype G, exact is_noetherian.iff_fg.1 (is_noetherian.iff_rank_lt_aleph_0.2 $
+  (rank_le_card G F).trans_lt $ cardinal.nat_lt_aleph_0 _) }
 
 end finite
 
 lemma finrank_le_card [fintype G] : finrank (subfield G F) F ≤ fintype.card G :=
 begin
-  rw [← cardinal.nat_cast_le, finrank_eq_dim],
-  apply dim_le_card,
+  rw [← cardinal.nat_cast_le, finrank_eq_rank],
+  apply rank_le_card,
 end
 
 end fixed_points

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -472,7 +472,7 @@ left K F L
 instance finite_dimensional_right [finite_dimensional K L] : finite_dimensional F L :=
 right K F L
 
-@[simp] lemma dim_eq_dim_subalgebra :
+@[simp] lemma rank_eq_rank_subalgebra :
   module.rank K F.to_subalgebra = module.rank K F := rfl
 
 @[simp] lemma finrank_eq_finrank_subalgebra :

--- a/src/field_theory/krull_topology.lean
+++ b/src/field_theory/krull_topology.lean
@@ -88,7 +88,7 @@ intermediate_field.fixing_subgroup '' (finite_exts K L)
 /-- For an field extension `L/K`, the intermediate field `K` is finite-dimensional over `K` -/
 lemma intermediate_field.finite_dimensional_bot (K L : Type*) [field K]
   [field L] [algebra K L] : finite_dimensional K (⊥ : intermediate_field K L) :=
-finite_dimensional_of_dim_eq_one intermediate_field.dim_bot
+finite_dimensional_of_rank_eq_one intermediate_field.rank_bot
 
 /-- This lemma says that `Gal(L/K) = L ≃ₐ[K] L` -/
 lemma intermediate_field.fixing_subgroup.bot {K L : Type*} [field K]

--- a/src/field_theory/mv_polynomial.lean
+++ b/src/field_theory/mv_polynomial.lean
@@ -50,7 +50,7 @@ variables {σ : Type u} {K : Type u} [field K]
 
 open_locale classical
 
-lemma dim_mv_polynomial : module.rank K (mv_polynomial σ K) = cardinal.mk (σ →₀ ℕ) :=
-by rw [← cardinal.lift_inj, ← (basis_monomials σ K).mk_eq_dim]
+lemma rank_mv_polynomial : module.rank K (mv_polynomial σ K) = cardinal.mk (σ →₀ ℕ) :=
+by rw [← cardinal.lift_inj, ← (basis_monomials σ K).mk_eq_rank]
 
 end mv_polynomial

--- a/src/field_theory/tower.lean
+++ b/src/field_theory/tower.lean
@@ -44,21 +44,21 @@ variables [algebra F K] [module K A] [module F A] [is_scalar_tower F K A]
 
 /-- Tower law: if `A` is a `K`-vector space and `K` is a field extension of `F` then
 `dim_F(A) = dim_F(K) * dim_K(A)`. -/
-theorem dim_mul_dim' :
+theorem rank_mul_rank' :
   (cardinal.lift.{w} (module.rank F K) * cardinal.lift.{v} (module.rank K A)) =
   cardinal.lift.{v} (module.rank F A) :=
 let b := basis.of_vector_space F K, c := basis.of_vector_space K A in
-by rw [← (module.rank F K).lift_id, ← b.mk_eq_dim,
-    ← (module.rank K A).lift_id, ← c.mk_eq_dim,
-    ← lift_umax.{w v}, ← (b.smul c).mk_eq_dim, mk_prod, lift_mul,
+by rw [← (module.rank F K).lift_id, ← b.mk_eq_rank,
+    ← (module.rank K A).lift_id, ← c.mk_eq_rank,
+    ← lift_umax.{w v}, ← (b.smul c).mk_eq_rank, mk_prod, lift_mul,
     lift_lift, lift_lift, lift_lift, lift_lift, lift_umax]
 
 /-- Tower law: if `A` is a `K`-vector space and `K` is a field extension of `F` then
 `dim_F(A) = dim_F(K) * dim_K(A)`. -/
-theorem dim_mul_dim (F : Type u) (K A : Type v) [field F] [field K] [add_comm_group A]
+theorem rank_mul_rank (F : Type u) (K A : Type v) [field F] [field K] [add_comm_group A]
   [algebra F K] [module K A] [module F A] [is_scalar_tower F K A] :
   module.rank F K * module.rank K A = module.rank F A :=
-by convert dim_mul_dim' F K A; rw lift_id
+by convert rank_mul_rank' F K A; rw lift_id
 
 namespace finite_dimensional
 

--- a/src/linear_algebra/affine_space/finite_dimensional.lean
+++ b/src/linear_algebra/affine_space/finite_dimensional.lean
@@ -68,7 +68,7 @@ instance finite_dimensional_direction_affine_span_image_of_finite [_root_.finite
 finite_dimensional_direction_affine_span_of_finite k (set.to_finite _)
 
 /-- An affine-independent family of points in a finite-dimensional affine space is finite. -/
-lemma finite_of_fin_rank_affine_independent [finite_dimensional k V] {p : ι → P}
+lemma finite_of_fin_dim_affine_independent [finite_dimensional k V] {p : ι → P}
   (hi : affine_independent k p) : _root_.finite ι :=
 begin
   nontriviality ι, inhabit ι,
@@ -79,9 +79,9 @@ begin
 end
 
 /-- An affine-independent subset of a finite-dimensional affine space is finite. -/
-lemma finite_set_of_fin_rank_affine_independent [finite_dimensional k V] {s : set ι} {f : s → P}
+lemma finite_set_of_fin_dim_affine_independent [finite_dimensional k V] {s : set ι} {f : s → P}
   (hi : affine_independent k f) : s.finite :=
-@set.to_finite _ s (finite_of_fin_rank_affine_independent k hi)
+@set.to_finite _ s (finite_of_fin_dim_affine_independent k hi)
 
 open_locale classical
 variables {k}
@@ -750,11 +750,11 @@ protected lemma finite_dimensional [finite ι] (b : affine_basis ι k P) : finit
 let ⟨i⟩ := b.nonempty in finite_dimensional.of_fintype_basis (b.basis_of i)
 
 protected lemma finite [finite_dimensional k V] (b : affine_basis ι k P) : finite ι :=
-finite_of_fin_rank_affine_independent k b.ind
+finite_of_fin_dim_affine_independent k b.ind
 
 protected lemma finite_set [finite_dimensional k V] {s : set ι} (b : affine_basis s k P) :
   s.finite :=
-finite_set_of_fin_rank_affine_independent k b.ind
+finite_set_of_fin_dim_affine_independent k b.ind
 
 lemma card_eq_finrank_add_one [fintype ι] (b : affine_basis ι k P) :
   fintype.card ι = finite_dimensional.finrank k V + 1 :=

--- a/src/linear_algebra/affine_space/finite_dimensional.lean
+++ b/src/linear_algebra/affine_space/finite_dimensional.lean
@@ -68,7 +68,7 @@ instance finite_dimensional_direction_affine_span_image_of_finite [_root_.finite
 finite_dimensional_direction_affine_span_of_finite k (set.to_finite _)
 
 /-- An affine-independent family of points in a finite-dimensional affine space is finite. -/
-lemma finite_of_fin_dim_affine_independent [finite_dimensional k V] {p : ι → P}
+lemma finite_of_fin_rank_affine_independent [finite_dimensional k V] {p : ι → P}
   (hi : affine_independent k p) : _root_.finite ι :=
 begin
   nontriviality ι, inhabit ι,
@@ -79,9 +79,9 @@ begin
 end
 
 /-- An affine-independent subset of a finite-dimensional affine space is finite. -/
-lemma finite_set_of_fin_dim_affine_independent [finite_dimensional k V] {s : set ι} {f : s → P}
+lemma finite_set_of_fin_rank_affine_independent [finite_dimensional k V] {s : set ι} {f : s → P}
   (hi : affine_independent k f) : s.finite :=
-@set.to_finite _ s (finite_of_fin_dim_affine_independent k hi)
+@set.to_finite _ s (finite_of_fin_rank_affine_independent k hi)
 
 open_locale classical
 variables {k}
@@ -313,7 +313,7 @@ at most `1`. -/
 def collinear (s : set P) : Prop := module.rank k (vector_span k s) ≤ 1
 
 /-- The definition of `collinear`. -/
-lemma collinear_iff_dim_le_one (s : set P) : collinear k s ↔ module.rank k (vector_span k s) ≤ 1 :=
+lemma collinear_iff_rank_le_one (s : set P) : collinear k s ↔ module.rank k (vector_span k s) ≤ 1 :=
 iff.rfl
 
 variables {k}
@@ -324,8 +324,8 @@ collinear if and only if their `vector_span` has dimension at most
 lemma collinear_iff_finrank_le_one {s : set P} [finite_dimensional k (vector_span k s)] :
   collinear k s ↔ finrank k (vector_span k s) ≤ 1 :=
 begin
-  have h := collinear_iff_dim_le_one k s,
-  rw ←finrank_eq_dim at h,
+  have h := collinear_iff_rank_le_one k s,
+  rw ←finrank_eq_rank at h,
   exact_mod_cast h
 end
 
@@ -333,13 +333,13 @@ alias collinear_iff_finrank_le_one ↔ collinear.finrank_le_one _
 
 /-- A subset of a collinear set is collinear. -/
 lemma collinear.subset {s₁ s₂ : set P} (hs : s₁ ⊆ s₂) (h : collinear k s₂) : collinear k s₁ :=
-(dim_le_of_submodule (vector_span k s₁) (vector_span k s₂) (vector_span_mono k hs)).trans h
+(rank_le_of_submodule (vector_span k s₁) (vector_span k s₂) (vector_span_mono k hs)).trans h
 
 /-- The `vector_span` of collinear points is finite-dimensional. -/
 lemma collinear.finite_dimensional_vector_span {s : set P} (h : collinear k s) :
   finite_dimensional k (vector_span k s) :=
 is_noetherian.iff_fg.1
-  (is_noetherian.iff_dim_lt_aleph_0.2 (lt_of_le_of_lt h cardinal.one_lt_aleph_0))
+  (is_noetherian.iff_rank_lt_aleph_0.2 (lt_of_le_of_lt h cardinal.one_lt_aleph_0))
 
 /-- The direction of the affine span of collinear points is finite-dimensional. -/
 lemma collinear.finite_dimensional_direction_affine_span {s : set P} (h : collinear k s) :
@@ -351,7 +351,7 @@ variables (k P)
 /-- The empty set is collinear. -/
 lemma collinear_empty : collinear k (∅ : set P) :=
 begin
-  rw [collinear_iff_dim_le_one, vector_span_empty],
+  rw [collinear_iff_rank_le_one, vector_span_empty],
   simp
 end
 
@@ -360,7 +360,7 @@ variables {P}
 /-- A single point is collinear. -/
 lemma collinear_singleton (p : P) : collinear k ({p} : set P) :=
 begin
-  rw [collinear_iff_dim_le_one, vector_span_singleton],
+  rw [collinear_iff_rank_le_one, vector_span_singleton],
   simp
 end
 
@@ -372,7 +372,7 @@ vector, added to `p₀`. -/
 lemma collinear_iff_of_mem {s : set P} {p₀ : P} (h : p₀ ∈ s) :
   collinear k s ↔ ∃ v : V, ∀ p ∈ s, ∃ r : k, p = r • v +ᵥ p₀ :=
 begin
-  simp_rw [collinear_iff_dim_le_one, dim_submodule_le_one_iff', submodule.le_span_singleton_iff],
+  simp_rw [collinear_iff_rank_le_one, rank_submodule_le_one_iff', submodule.le_span_singleton_iff],
   split,
   { rintro ⟨v₀, hv⟩,
     use v₀,
@@ -594,7 +594,7 @@ variables {k}
 lemma coplanar.finite_dimensional_vector_span {s : set P} (h : coplanar k s) :
   finite_dimensional k (vector_span k s) :=
 begin
-  refine is_noetherian.iff_fg.1 (is_noetherian.iff_dim_lt_aleph_0.2 (lt_of_le_of_lt h _)),
+  refine is_noetherian.iff_fg.1 (is_noetherian.iff_rank_lt_aleph_0.2 (lt_of_le_of_lt h _)),
   simp,
 end
 
@@ -609,7 +609,7 @@ lemma coplanar_iff_finrank_le_two {s : set P} [finite_dimensional k (vector_span
   coplanar k s ↔ finrank k (vector_span k s) ≤ 2 :=
 begin
   have h : coplanar k s ↔ module.rank k (vector_span k s) ≤ 2 := iff.rfl,
-  rw ←finrank_eq_dim at h,
+  rw ←finrank_eq_rank at h,
   exact_mod_cast h
 end
 
@@ -617,7 +617,7 @@ alias coplanar_iff_finrank_le_two ↔ coplanar.finrank_le_two _
 
 /-- A subset of a coplanar set is coplanar. -/
 lemma coplanar.subset {s₁ s₂ : set P} (hs : s₁ ⊆ s₂) (h : coplanar k s₂) : coplanar k s₁ :=
-(dim_le_of_submodule (vector_span k s₁) (vector_span k s₂) (vector_span_mono k hs)).trans h
+(rank_le_of_submodule (vector_span k s₁) (vector_span k s₂) (vector_span_mono k hs)).trans h
 
 /-- Collinear points are coplanar. -/
 lemma collinear.coplanar {s : set P} (h : collinear k s) : coplanar k s :=
@@ -681,7 +681,7 @@ begin
     convert rfl;
       simp },
   { rw [affine_span_coe, direction_affine_span_insert hp₀, add_comm],
-    refine (submodule.dim_add_le_dim_add_dim _ _).trans (add_le_add_right _ _),
+    refine (submodule.rank_add_le_rank_add_rank _ _).trans (add_le_add_right _ _),
     refine finrank_le_one ⟨p -ᵥ p₀, submodule.mem_span_singleton_self _⟩ (λ v, _),
     have h := v.property,
     rw submodule.mem_span_singleton at h,
@@ -750,11 +750,11 @@ protected lemma finite_dimensional [finite ι] (b : affine_basis ι k P) : finit
 let ⟨i⟩ := b.nonempty in finite_dimensional.of_fintype_basis (b.basis_of i)
 
 protected lemma finite [finite_dimensional k V] (b : affine_basis ι k P) : finite ι :=
-finite_of_fin_dim_affine_independent k b.ind
+finite_of_fin_rank_affine_independent k b.ind
 
 protected lemma finite_set [finite_dimensional k V] {s : set ι} (b : affine_basis s k P) :
   s.finite :=
-finite_set_of_fin_dim_affine_independent k b.ind
+finite_set_of_fin_rank_affine_independent k b.ind
 
 lemma card_eq_finrank_add_one [fintype ι] (b : affine_basis ι k P) :
   fintype.card ι = finite_dimensional.finrank k V + 1 :=

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1204,7 +1204,7 @@ begin
     exact hx₂ n hn },
   refine is_compl.of_eq this (eq_top_of_finrank_eq $ (submodule.finrank_le _).antisymm _),
   conv_rhs { rw ← add_zero (finrank K _) },
-  rw [← finrank_bot K V, ← this, submodule.dim_sup_add_dim_inf_eq,
+  rw [← finrank_bot K V, ← this, submodule.rank_sup_add_rank_inf_eq,
       finrank_add_finrank_orthogonal b₁],
   exact le_self_add,
 end

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -1047,7 +1047,7 @@ end
 
 -- TODO: merge with the `finrank` content
 /-- An `n`-dimensional `K`-vector space is equivalent to `fin n → K`. -/
-def fin_rank_vectorspace_equiv (n : ℕ)
+def fin_dim_vectorspace_equiv (n : ℕ)
   (hn : (module.rank K V) = n) : V ≃ₗ[K] (fin n → K) :=
 begin
   haveI := nontrivial_of_invariant_basis_number K,

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -23,9 +23,9 @@ import set_theory.cardinal.cofinality
 
 ## Main statements
 
-* `linear_map.dim_le_of_injective`: the source of an injective linear map has dimension
+* `linear_map.rank_le_of_injective`: the source of an injective linear map has dimension
   at most that of the target.
-* `linear_map.dim_le_of_surjective`: the target of a surjective linear map has dimension
+* `linear_map.rank_le_of_surjective`: the target of a surjective linear map has dimension
   at most that of that source.
 * `basis_fintype_of_finite_spans`:
   the existence of a finite spanning set implies that any basis is finite.
@@ -58,15 +58,15 @@ For modules over rings with invariant basis number
 
 For vector spaces (i.e. modules over a field), we have
 
-* `dim_quotient_add_dim`: if `V₁` is a submodule of `V`, then
+* `rank_quotient_add_rank`: if `V₁` is a submodule of `V`, then
   `module.rank (V/V₁) + module.rank V₁ = module.rank V`.
-* `dim_range_add_dim_ker`: the rank-nullity theorem.
+* `rank_range_add_rank_ker`: the rank-nullity theorem.
 
 ## Implementation notes
 
-There is a naming discrepancy: most of the theorem names refer to `dim`,
+There is a naming discrepancy: most of the theorem names refer to `rank`,
 even though the definition is of `module.rank`.
-This reflects that `module.rank` was originally called `dim`, and only defined for vector spaces.
+This reflects that `module.rank` was originally called `rank`, and only defined for vector spaces.
 
 Many theorems in this file are not universe-generic when they relate dimensions
 in different universes. They should be as general as they can be without
@@ -117,7 +117,7 @@ variables {M : Type v} [add_comm_group M] [module R M]
 variables {M' : Type v'} [add_comm_group M'] [module R M']
 variables {M₁ : Type v} [add_comm_group M₁] [module R M₁]
 
-theorem linear_map.lift_dim_le_of_injective (f : M →ₗ[R] M') (i : injective f) :
+theorem linear_map.lift_rank_le_of_injective (f : M →ₗ[R] M') (i : injective f) :
   cardinal.lift.{v'} (module.rank R M) ≤ cardinal.lift.{v} (module.rank R M') :=
 begin
   dsimp [module.rank],
@@ -129,11 +129,11 @@ begin
   exact (li.map' _ $ linear_map.ker_eq_bot.mpr i).image,
 end
 
-theorem linear_map.dim_le_of_injective (f : M →ₗ[R] M₁) (i : injective f) :
+theorem linear_map.rank_le_of_injective (f : M →ₗ[R] M₁) (i : injective f) :
   module.rank R M ≤ module.rank R M₁ :=
-cardinal.lift_le.1 (f.lift_dim_le_of_injective i)
+cardinal.lift_le.1 (f.lift_rank_le_of_injective i)
 
-theorem dim_le {n : ℕ}
+theorem rank_le {n : ℕ}
   (H : ∀ s : finset M, linear_independent R (λ i : s, (i : M)) → s.card ≤ n) :
   module.rank R M ≤ n :=
 begin
@@ -143,7 +143,7 @@ begin
   exact linear_independent_bounded_of_finset_linear_independent_bounded H _ li,
 end
 
-lemma lift_dim_range_le (f : M →ₗ[R] M') :
+lemma lift_rank_range_le (f : M →ₗ[R] M') :
   cardinal.lift.{v} (module.rank R f.range) ≤ cardinal.lift.{v'} (module.rank R M) :=
 begin
   dsimp [module.rank],
@@ -159,82 +159,82 @@ begin
   { exact (cardinal.lift_mk_eq'.mpr ⟨equiv.set.range_splitting_image_equiv f s⟩).ge, },
 end
 
-lemma dim_range_le (f : M →ₗ[R] M₁) : module.rank R f.range ≤ module.rank R M :=
-by simpa using lift_dim_range_le f
+lemma rank_range_le (f : M →ₗ[R] M₁) : module.rank R f.range ≤ module.rank R M :=
+by simpa using lift_rank_range_le f
 
-lemma lift_dim_map_le (f : M →ₗ[R] M') (p : submodule R M) :
+lemma lift_rank_map_le (f : M →ₗ[R] M') (p : submodule R M) :
   cardinal.lift.{v} (module.rank R (p.map f)) ≤ cardinal.lift.{v'} (module.rank R p) :=
 begin
-  have h := lift_dim_range_le (f.comp (submodule.subtype p)),
+  have h := lift_rank_range_le (f.comp (submodule.subtype p)),
   rwa [linear_map.range_comp, range_subtype] at h,
 end
 
-lemma dim_map_le (f : M →ₗ[R] M₁) (p : submodule R M) : module.rank R (p.map f) ≤ module.rank R p :=
-by simpa using lift_dim_map_le f p
+lemma rank_map_le (f : M →ₗ[R] M₁) (p : submodule R M) : module.rank R (p.map f) ≤ module.rank R p :=
+by simpa using lift_rank_map_le f p
 
-lemma dim_le_of_submodule (s t : submodule R M) (h : s ≤ t) :
+lemma rank_le_of_submodule (s t : submodule R M) (h : s ≤ t) :
   module.rank R s ≤ module.rank R t :=
-(of_le h).dim_le_of_injective $ assume ⟨x, hx⟩ ⟨y, hy⟩ eq,
+(of_le h).rank_le_of_injective $ assume ⟨x, hx⟩ ⟨y, hy⟩ eq,
   subtype.eq $ show x = y, from subtype.ext_iff_val.1 eq
 
 /-- Two linearly equivalent vector spaces have the same dimension, a version with different
 universes. -/
-theorem linear_equiv.lift_dim_eq (f : M ≃ₗ[R] M') :
+theorem linear_equiv.lift_rank_eq (f : M ≃ₗ[R] M') :
   cardinal.lift.{v'} (module.rank R M) = cardinal.lift.{v} (module.rank R M') :=
 begin
   apply le_antisymm,
-  { exact f.to_linear_map.lift_dim_le_of_injective f.injective, },
-  { exact f.symm.to_linear_map.lift_dim_le_of_injective f.symm.injective, },
+  { exact f.to_linear_map.lift_rank_le_of_injective f.injective, },
+  { exact f.symm.to_linear_map.lift_rank_le_of_injective f.symm.injective, },
 end
 
 /-- Two linearly equivalent vector spaces have the same dimension. -/
-theorem linear_equiv.dim_eq (f : M ≃ₗ[R] M₁) :
+theorem linear_equiv.rank_eq (f : M ≃ₗ[R] M₁) :
   module.rank R M = module.rank R M₁ :=
-cardinal.lift_inj.1 f.lift_dim_eq
+cardinal.lift_inj.1 f.lift_rank_eq
 
-lemma dim_eq_of_injective (f : M →ₗ[R] M₁) (h : injective f) :
+lemma rank_eq_of_injective (f : M →ₗ[R] M₁) (h : injective f) :
   module.rank R M = module.rank R f.range :=
-(linear_equiv.of_injective f h).dim_eq
+(linear_equiv.of_injective f h).rank_eq
 
 /-- Pushforwards of submodules along a `linear_equiv` have the same dimension. -/
-lemma linear_equiv.dim_map_eq (f : M ≃ₗ[R] M₁) (p : submodule R M) :
+lemma linear_equiv.rank_map_eq (f : M ≃ₗ[R] M₁) (p : submodule R M) :
   module.rank R (p.map (f : M →ₗ[R] M₁)) = module.rank R p :=
-(f.submodule_map p).dim_eq.symm
+(f.submodule_map p).rank_eq.symm
 
 variables (R M)
 
-@[simp] lemma dim_top : module.rank R (⊤ : submodule R M) = module.rank R M :=
+@[simp] lemma rank_top : module.rank R (⊤ : submodule R M) = module.rank R M :=
 begin
   have : (⊤ : submodule R M) ≃ₗ[R] M := linear_equiv.of_top ⊤ rfl,
-  rw this.dim_eq,
+  rw this.rank_eq,
 end
 
 variables {R M}
 
-lemma dim_range_of_surjective (f : M →ₗ[R] M') (h : surjective f) :
+lemma rank_range_of_surjective (f : M →ₗ[R] M') (h : surjective f) :
   module.rank R f.range = module.rank R M' :=
-by rw [linear_map.range_eq_top.2 h, dim_top]
+by rw [linear_map.range_eq_top.2 h, rank_top]
 
-lemma dim_submodule_le (s : submodule R M) : module.rank R s ≤ module.rank R M :=
+lemma rank_submodule_le (s : submodule R M) : module.rank R s ≤ module.rank R M :=
 begin
-  rw ←dim_top R M,
-  exact dim_le_of_submodule _ _ le_top,
+  rw ←rank_top R M,
+  exact rank_le_of_submodule _ _ le_top,
 end
 
-lemma linear_map.dim_le_of_surjective (f : M →ₗ[R] M₁) (h : surjective f) :
+lemma linear_map.rank_le_of_surjective (f : M →ₗ[R] M₁) (h : surjective f) :
   module.rank R M₁ ≤ module.rank R M :=
 begin
-  rw ←dim_range_of_surjective f h,
-  apply dim_range_le,
+  rw ←rank_range_of_surjective f h,
+  apply rank_range_le,
 end
 
-theorem dim_quotient_le (p : submodule R M) :
+theorem rank_quotient_le (p : submodule R M) :
   module.rank R (M ⧸ p) ≤ module.rank R M :=
-(mkq p).dim_le_of_surjective (surjective_quot_mk _)
+(mkq p).rank_le_of_surjective (surjective_quot_mk _)
 
 variables [nontrivial R]
 
-lemma {m} cardinal_lift_le_dim_of_linear_independent
+lemma {m} cardinal_lift_le_rank_of_linear_independent
   {ι : Type w} {v : ι → M} (hv : linear_independent R v) :
   cardinal.lift.{max v m} (#ι) ≤ cardinal.lift.{max w m} (module.rank R M) :=
 begin
@@ -248,24 +248,24 @@ begin
     exact le_rfl, },
 end
 
-lemma cardinal_lift_le_dim_of_linear_independent'
+lemma cardinal_lift_le_rank_of_linear_independent'
   {ι : Type w} {v : ι → M} (hv : linear_independent R v) :
   cardinal.lift.{v} (#ι) ≤ cardinal.lift.{w} (module.rank R M) :=
-cardinal_lift_le_dim_of_linear_independent.{u v w 0} hv
+cardinal_lift_le_rank_of_linear_independent.{u v w 0} hv
 
-lemma cardinal_le_dim_of_linear_independent
+lemma cardinal_le_rank_of_linear_independent
   {ι : Type v} {v : ι → M} (hv : linear_independent R v) :
   #ι ≤ module.rank R M :=
-by simpa using cardinal_lift_le_dim_of_linear_independent hv
+by simpa using cardinal_lift_le_rank_of_linear_independent hv
 
-lemma cardinal_le_dim_of_linear_independent'
+lemma cardinal_le_rank_of_linear_independent'
   {s : set M} (hs : linear_independent R (λ x, x : s → M)) :
   #s ≤ module.rank R M :=
-cardinal_le_dim_of_linear_independent hs
+cardinal_le_rank_of_linear_independent hs
 
 variables (R M)
 
-@[simp] lemma dim_punit : module.rank R punit = 0 :=
+@[simp] lemma rank_punit : module.rank R punit = 0 :=
 begin
   apply le_bot_iff.mp,
   rw module.rank,
@@ -279,17 +279,17 @@ begin
   simpa using linear_independent.ne_zero (⟨a, ha⟩ : s) li,
 end
 
-@[simp] lemma dim_bot : module.rank R (⊥ : submodule R M) = 0 :=
+@[simp] lemma rank_bot : module.rank R (⊥ : submodule R M) = 0 :=
 begin
   have : (⊥ : submodule R M) ≃ₗ[R] punit := bot_equiv_punit,
-  rw [this.dim_eq, dim_punit],
+  rw [this.rank_eq, rank_punit],
 end
 
 variables {R M}
 
-lemma exists_mem_ne_zero_of_dim_pos {s : submodule R M} (h : 0 < module.rank R s) :
+lemma exists_mem_ne_zero_of_rank_pos {s : submodule R M} (h : 0 < module.rank R s) :
   ∃ b : M, b ∈ s ∧ b ≠ 0 :=
-exists_mem_ne_zero_of_ne_bot $ assume eq, by rw [eq, dim_bot] at h; exact lt_irrefl _ h
+exists_mem_ne_zero_of_ne_bot $ assume eq, by rw [eq, rank_bot] at h; exact lt_irrefl _ h
 
 /-- A linearly-independent family of vectors in a module over a non-trivial ring must be finite if
 the module is Noetherian. -/
@@ -460,7 +460,7 @@ begin
   choose v hvV hv using hI,
   have : linear_independent R v,
   { exact (hV.comp subtype.coe_injective).linear_independent _ hvV hv },
-  exact cardinal_lift_le_dim_of_linear_independent' this
+  exact cardinal_lift_le_rank_of_linear_independent' this
 end
 
 end
@@ -470,7 +470,7 @@ section rank_zero
 variables {R : Type u} {M : Type v}
 variables [ring R] [add_comm_group M] [module R M]
 
-@[simp] lemma dim_subsingleton [subsingleton R] : module.rank R M = 1 :=
+@[simp] lemma rank_subsingleton [subsingleton R] : module.rank R M = 1 :=
 begin
   haveI := module.subsingleton R M,
   haveI : nonempty {s : set M // linear_independent R (coe : s → M)},
@@ -489,43 +489,43 @@ end
 
 variables [no_zero_smul_divisors R M]
 
-lemma dim_pos [nontrivial M] : 0 < module.rank R M :=
+lemma rank_pos [nontrivial M] : 0 < module.rank R M :=
 begin
   obtain ⟨x, hx⟩ := exists_ne (0 : M),
   suffices : 1 ≤ module.rank R M,
   { exact zero_lt_one.trans_le this },
   letI := module.nontrivial R M,
   suffices : linear_independent R (λ (y : ({x} : set M)), ↑y),
-  { simpa using (cardinal_le_dim_of_linear_independent this), },
+  { simpa using (cardinal_le_rank_of_linear_independent this), },
   exact linear_independent_singleton hx
 end
 
 variables [nontrivial R]
 
-lemma dim_zero_iff_forall_zero : module.rank R M = 0 ↔ ∀ x : M, x = 0 :=
+lemma rank_zero_iff_forall_zero : module.rank R M = 0 ↔ ∀ x : M, x = 0 :=
 begin
   refine ⟨λ h, _, λ h, _⟩,
   { contrapose! h,
     obtain ⟨x, hx⟩ := h,
     letI : nontrivial M := nontrivial_of_ne _ _ hx,
-    exact dim_pos.ne' },
+    exact rank_pos.ne' },
   { have : (⊤ : submodule R M) = ⊥,
     { ext x, simp [h x] },
-    rw [←dim_top, this, dim_bot] }
+    rw [←rank_top, this, rank_bot] }
 end
 
-/-- See `dim_subsingleton` for the reason that `nontrivial R` is needed. -/
-lemma dim_zero_iff : module.rank R M = 0 ↔ subsingleton M :=
-dim_zero_iff_forall_zero.trans (subsingleton_iff_forall_eq 0).symm
+/-- See `rank_subsingleton` for the reason that `nontrivial R` is needed. -/
+lemma rank_zero_iff : module.rank R M = 0 ↔ subsingleton M :=
+rank_zero_iff_forall_zero.trans (subsingleton_iff_forall_eq 0).symm
 
-lemma dim_pos_iff_exists_ne_zero : 0 < module.rank R M ↔ ∃ x : M, x ≠ 0 :=
+lemma rank_pos_iff_exists_ne_zero : 0 < module.rank R M ↔ ∃ x : M, x ≠ 0 :=
 begin
   rw ←not_iff_not,
-  simpa using dim_zero_iff_forall_zero
+  simpa using rank_zero_iff_forall_zero
 end
 
-lemma dim_pos_iff_nontrivial : 0 < module.rank R M ↔ nontrivial M :=
-dim_pos_iff_exists_ne_zero.trans (nontrivial_iff_exists_ne 0).symm
+lemma rank_pos_iff_nontrivial : 0 < module.rank R M ↔ nontrivial M :=
+rank_pos_iff_exists_ne_zero.trans (nontrivial_iff_exists_ne 0).symm
 
 end rank_zero
 
@@ -805,7 +805,7 @@ begin
     exact infinite_basis_le_maximal_linear_independent b v i m, }
 end
 
-theorem basis.mk_eq_dim'' {ι : Type v} (v : basis ι R M) :
+theorem basis.mk_eq_rank'' {ι : Type v} (v : basis ι R M) :
   #ι = module.rank R M :=
 begin
   haveI := nontrivial_of_invariant_basis_number R,
@@ -821,24 +821,24 @@ begin
     apply linear_independent_le_basis v _ li, },
 end
 
-theorem basis.mk_range_eq_dim (v : basis ι R M) :
+theorem basis.mk_range_eq_rank (v : basis ι R M) :
   #(range v) = module.rank R M :=
-v.reindex_range.mk_eq_dim''
+v.reindex_range.mk_eq_rank''
 
 /-- If a vector space has a finite basis, then its dimension (seen as a cardinal) is equal to the
 cardinality of the basis. -/
-lemma dim_eq_card_basis {ι : Type w} [fintype ι] (h : basis ι R M) :
+lemma rank_eq_card_basis {ι : Type w} [fintype ι] (h : basis ι R M) :
   module.rank R M = fintype.card ι :=
 by {haveI := nontrivial_of_invariant_basis_number R,
-  rw [←h.mk_range_eq_dim, cardinal.mk_fintype, set.card_range_of_injective h.injective] }
+  rw [←h.mk_range_eq_rank, cardinal.mk_fintype, set.card_range_of_injective h.injective] }
 
 lemma basis.card_le_card_of_linear_independent {ι : Type*} [fintype ι]
   (b : basis ι R M) {ι' : Type*} [fintype ι'] {v : ι' → M} (hv : linear_independent R v) :
   fintype.card ι' ≤ fintype.card ι :=
 begin
   letI := nontrivial_of_invariant_basis_number R,
-  simpa [dim_eq_card_basis b, cardinal.mk_fintype] using
-    cardinal_lift_le_dim_of_linear_independent' hv
+  simpa [rank_eq_card_basis b, cardinal.mk_fintype] using
+    cardinal_lift_le_rank_of_linear_independent' hv
 end
 
 lemma basis.card_le_card_of_submodule (N : submodule R M) [fintype ι] (b : basis ι R M)
@@ -851,49 +851,49 @@ lemma basis.card_le_card_of_le
 b.card_le_card_of_linear_independent
   (b'.linear_independent.map' (submodule.of_le hNO) (N.ker_of_le O _))
 
-theorem basis.mk_eq_dim (v : basis ι R M) :
+theorem basis.mk_eq_rank (v : basis ι R M) :
   cardinal.lift.{v} (#ι) = cardinal.lift.{w} (module.rank R M) :=
 begin
   haveI := nontrivial_of_invariant_basis_number R,
-  rw [←v.mk_range_eq_dim, cardinal.mk_range_eq_of_injective v.injective]
+  rw [←v.mk_range_eq_rank, cardinal.mk_range_eq_of_injective v.injective]
 end
 
-theorem {m} basis.mk_eq_dim' (v : basis ι R M) :
+theorem {m} basis.mk_eq_rank' (v : basis ι R M) :
   cardinal.lift.{max v m} (#ι) = cardinal.lift.{max w m} (module.rank R M) :=
-by simpa using v.mk_eq_dim
+by simpa using v.mk_eq_rank
 
 /-- If a module has a finite dimension, all bases are indexed by a finite type. -/
-lemma basis.nonempty_fintype_index_of_dim_lt_aleph_0 {ι : Type*}
+lemma basis.nonempty_fintype_index_of_rank_lt_aleph_0 {ι : Type*}
   (b : basis ι R M) (h : module.rank R M < ℵ₀) :
   nonempty (fintype ι) :=
-by rwa [← cardinal.lift_lt, ← b.mk_eq_dim,
+by rwa [← cardinal.lift_lt, ← b.mk_eq_rank,
         -- ensure `aleph_0` has the correct universe
         cardinal.lift_aleph_0, ← cardinal.lift_aleph_0.{u_1 v},
         cardinal.lift_lt, cardinal.lt_aleph_0_iff_fintype] at h
 
 /-- If a module has a finite dimension, all bases are indexed by a finite type. -/
-noncomputable def basis.fintype_index_of_dim_lt_aleph_0 {ι : Type*}
+noncomputable def basis.fintype_index_of_rank_lt_aleph_0 {ι : Type*}
   (b : basis ι R M) (h : module.rank R M < ℵ₀) :
   fintype ι :=
-classical.choice (b.nonempty_fintype_index_of_dim_lt_aleph_0 h)
+classical.choice (b.nonempty_fintype_index_of_rank_lt_aleph_0 h)
 
 /-- If a module has a finite dimension, all bases are indexed by a finite set. -/
-lemma basis.finite_index_of_dim_lt_aleph_0 {ι : Type*} {s : set ι}
+lemma basis.finite_index_of_rank_lt_aleph_0 {ι : Type*} {s : set ι}
   (b : basis s R M) (h : module.rank R M < ℵ₀) :
   s.finite :=
-finite_def.2 (b.nonempty_fintype_index_of_dim_lt_aleph_0 h)
+finite_def.2 (b.nonempty_fintype_index_of_rank_lt_aleph_0 h)
 
-lemma dim_span {v : ι → M} (hv : linear_independent R v) :
+lemma rank_span {v : ι → M} (hv : linear_independent R v) :
   module.rank R ↥(span R (range v)) = #(range v) :=
 begin
   haveI := nontrivial_of_invariant_basis_number R,
-  rw [←cardinal.lift_inj, ← (basis.span hv).mk_eq_dim,
+  rw [←cardinal.lift_inj, ← (basis.span hv).mk_eq_rank,
     cardinal.mk_range_eq_of_injective (@linear_independent.injective ι R M v _ _ _ _ hv)]
 end
 
-lemma dim_span_set {s : set M} (hs : linear_independent R (λ x, x : s → M)) :
+lemma rank_span_set {s : set M} (hs : linear_independent R (λ x, x : s → M)) :
   module.rank R ↥(span R s) = #s :=
-by { rw [← @set_of_mem_eq _ s, ← subtype.range_coe_subtype], exact dim_span hs }
+by { rw [← @set_of_mem_eq _ s, ← subtype.range_coe_subtype], exact rank_span hs }
 
 /-- If `N` is a submodule in a free, finitely generated module,
 do induction on adjoining a linear independent element to a submodule. -/
@@ -929,8 +929,8 @@ end
 
 variables (R)
 
-@[simp] lemma dim_self : module.rank R R = 1 :=
-by rw [←cardinal.lift_inj, ← (basis.singleton punit R).mk_eq_dim, cardinal.mk_punit]
+@[simp] lemma rank_self : module.rank R R = 1 :=
+by rw [←cardinal.lift_inj, ← (basis.singleton punit R).mk_eq_rank, cardinal.mk_punit]
 
 end strong_rank_condition
 
@@ -942,58 +942,58 @@ variables [add_comm_group V₁] [module K V₁] [module.free K V₁]
 variables {K V}
 
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
-theorem nonempty_linear_equiv_of_lift_dim_eq
+theorem nonempty_linear_equiv_of_lift_rank_eq
   (cond : cardinal.lift.{v'} (module.rank K V) = cardinal.lift.{v} (module.rank K V')) :
   nonempty (V ≃ₗ[K] V') :=
 begin
   obtain ⟨⟨_, B⟩⟩ := module.free.exists_basis K V,
   obtain ⟨⟨_, B'⟩⟩ := module.free.exists_basis K V',
   have : cardinal.lift.{v' v} (#_) = cardinal.lift.{v v'} (#_),
-    by rw [B.mk_eq_dim'', cond, B'.mk_eq_dim''],
+    by rw [B.mk_eq_rank'', cond, B'.mk_eq_rank''],
   exact (cardinal.lift_mk_eq.{v v' 0}.1 this).map (B.equiv B')
 end
 
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
-theorem nonempty_linear_equiv_of_dim_eq
+theorem nonempty_linear_equiv_of_rank_eq
   (cond : module.rank K V = module.rank K V₁) :
   nonempty (V ≃ₗ[K] V₁) :=
-nonempty_linear_equiv_of_lift_dim_eq $ congr_arg _ cond
+nonempty_linear_equiv_of_lift_rank_eq $ congr_arg _ cond
 
 section
 
 variables (V V' V₁)
 
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
-def linear_equiv.of_lift_dim_eq
+def linear_equiv.of_lift_rank_eq
   (cond : cardinal.lift.{v'} (module.rank K V) = cardinal.lift.{v} (module.rank K V')) :
   V ≃ₗ[K] V' :=
-classical.choice (nonempty_linear_equiv_of_lift_dim_eq cond)
+classical.choice (nonempty_linear_equiv_of_lift_rank_eq cond)
 
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
-def linear_equiv.of_dim_eq (cond : module.rank K V = module.rank K V₁) : V ≃ₗ[K] V₁ :=
-classical.choice (nonempty_linear_equiv_of_dim_eq cond)
+def linear_equiv.of_rank_eq (cond : module.rank K V = module.rank K V₁) : V ≃ₗ[K] V₁ :=
+classical.choice (nonempty_linear_equiv_of_rank_eq cond)
 
 end
 
 /-- Two vector spaces are isomorphic if and only if they have the same dimension. -/
-theorem linear_equiv.nonempty_equiv_iff_lift_dim_eq :
+theorem linear_equiv.nonempty_equiv_iff_lift_rank_eq :
   nonempty (V ≃ₗ[K] V') ↔
     cardinal.lift.{v'} (module.rank K V) = cardinal.lift.{v} (module.rank K V') :=
-⟨λ ⟨h⟩, linear_equiv.lift_dim_eq h, λ h, nonempty_linear_equiv_of_lift_dim_eq h⟩
+⟨λ ⟨h⟩, linear_equiv.lift_rank_eq h, λ h, nonempty_linear_equiv_of_lift_rank_eq h⟩
 
 /-- Two vector spaces are isomorphic if and only if they have the same dimension. -/
-theorem linear_equiv.nonempty_equiv_iff_dim_eq :
+theorem linear_equiv.nonempty_equiv_iff_rank_eq :
   nonempty (V ≃ₗ[K] V₁) ↔ module.rank K V = module.rank K V₁ :=
-⟨λ ⟨h⟩, linear_equiv.dim_eq h, λ h, nonempty_linear_equiv_of_dim_eq h⟩
+⟨λ ⟨h⟩, linear_equiv.rank_eq h, λ h, nonempty_linear_equiv_of_rank_eq h⟩
 
-theorem dim_prod : module.rank K (V × V₁) = module.rank K V + module.rank K V₁ :=
+theorem rank_prod : module.rank K (V × V₁) = module.rank K V + module.rank K V₁ :=
 begin
   obtain ⟨⟨_, b⟩⟩ := module.free.exists_basis K V,
   obtain ⟨⟨_, c⟩⟩ := module.free.exists_basis K V₁,
   rw [← cardinal.lift_inj,
-      ← (basis.prod b c).mk_eq_dim,
+      ← (basis.prod b c).mk_eq_rank,
       cardinal.lift_add, ← cardinal.mk_ulift,
-      ← b.mk_eq_dim, ← c.mk_eq_dim,
+      ← b.mk_eq_rank, ← c.mk_eq_rank,
       ← cardinal.mk_ulift, ← cardinal.mk_ulift,
       cardinal.add_def (ulift _)],
   exact cardinal.lift_inj.1 (cardinal.lift_mk_eq.2
@@ -1005,48 +1005,48 @@ variables [∀i, add_comm_group (φ i)] [∀i, module K (φ i)] [∀i, module.fr
 
 open linear_map
 
-lemma dim_pi [finite η] :
+lemma rank_pi [finite η] :
   module.rank K (Πi, φ i) = cardinal.sum (λi, module.rank K (φ i)) :=
 begin
   haveI := nontrivial_of_invariant_basis_number K,
   casesI nonempty_fintype η,
   let b := λ i, (module.free.exists_basis K (φ i)).some.2,
   let this : basis (Σ j, _) K (Π j, φ j) := pi.basis b,
-  rw [← cardinal.lift_inj, ← this.mk_eq_dim],
-  simp_rw [cardinal.mk_sigma, cardinal.lift_sum, ←(b _).mk_range_eq_dim,
+  rw [← cardinal.lift_inj, ← this.mk_eq_rank],
+  simp_rw [cardinal.mk_sigma, cardinal.lift_sum, ←(b _).mk_range_eq_rank,
     cardinal.mk_range_eq _ (b _).injective],
 end
 
 variable [fintype η]
 
-lemma dim_fun {V η : Type u} [fintype η] [add_comm_group V] [module K V]
+lemma rank_fun {V η : Type u} [fintype η] [add_comm_group V] [module K V]
   [module.free K V] :
   module.rank K (η → V) = fintype.card η * module.rank K V :=
-by rw [dim_pi, cardinal.sum_const', cardinal.mk_fintype]
+by rw [rank_pi, cardinal.sum_const', cardinal.mk_fintype]
 
-lemma dim_fun_eq_lift_mul :
+lemma rank_fun_eq_lift_mul :
   module.rank K (η → V) = (fintype.card η : cardinal.{max u₁' v}) *
     cardinal.lift.{u₁'} (module.rank K V) :=
-by rw [dim_pi, cardinal.sum_const, cardinal.mk_fintype, cardinal.lift_nat_cast]
+by rw [rank_pi, cardinal.sum_const, cardinal.mk_fintype, cardinal.lift_nat_cast]
 
-lemma dim_fun' : module.rank K (η → K) = fintype.card η :=
-by rw [dim_fun_eq_lift_mul, dim_self, cardinal.lift_one, mul_one, cardinal.nat_cast_inj]
+lemma rank_fun' : module.rank K (η → K) = fintype.card η :=
+by rw [rank_fun_eq_lift_mul, rank_self, cardinal.lift_one, mul_one, cardinal.nat_cast_inj]
 
-lemma dim_fin_fun (n : ℕ) : module.rank K (fin n → K) = n :=
-by simp [dim_fun']
+lemma rank_fin_fun (n : ℕ) : module.rank K (fin n → K) = n :=
+by simp [rank_fun']
 
 end fintype
 
-lemma finsupp.dim_eq {ι : Type v} : module.rank K (ι →₀ V) = #ι * module.rank K V :=
+lemma finsupp.rank_eq {ι : Type v} : module.rank K (ι →₀ V) = #ι * module.rank K V :=
 begin
   obtain ⟨⟨_, bs⟩⟩ := module.free.exists_basis K V,
-  rw [← bs.mk_eq_dim'', ← (finsupp.basis (λa:ι, bs)).mk_eq_dim'',
+  rw [← bs.mk_eq_rank'', ← (finsupp.basis (λa:ι, bs)).mk_eq_rank'',
     cardinal.mk_sigma, cardinal.sum_const']
 end
 
 -- TODO: merge with the `finrank` content
 /-- An `n`-dimensional `K`-vector space is equivalent to `fin n → K`. -/
-def fin_dim_vectorspace_equiv (n : ℕ)
+def fin_rank_vectorspace_equiv (n : ℕ)
   (hn : (module.rank K V) = n) : V ≃ₗ[K] (fin n → K) :=
 begin
   haveI := nontrivial_of_invariant_basis_number K,
@@ -1054,9 +1054,9 @@ begin
     by simp,
   have hn := cardinal.lift_inj.{v u}.2 hn,
   rw this at hn,
-  rw ←@dim_fin_fun K _ _ n at hn,
+  rw ←@rank_fin_fun K _ _ n at hn,
   haveI : module.free K (fin n → K) := module.free.pi _ _,
-  exact classical.choice (nonempty_linear_equiv_of_lift_dim_eq hn),
+  exact classical.choice (nonempty_linear_equiv_of_lift_rank_eq hn),
 end
 
 end free
@@ -1069,49 +1069,49 @@ variables [add_comm_group V₁] [module K V₁]
 variables {K V}
 
 /-- If a vector space has a finite dimension, the index set of `basis.of_vector_space` is finite. -/
-lemma basis.finite_of_vector_space_index_of_dim_lt_aleph_0 (h : module.rank K V < ℵ₀) :
+lemma basis.finite_of_vector_space_index_of_rank_lt_aleph_0 (h : module.rank K V < ℵ₀) :
   (basis.of_vector_space_index K V).finite :=
-finite_def.2 $ (basis.of_vector_space K V).nonempty_fintype_index_of_dim_lt_aleph_0 h
+finite_def.2 $ (basis.of_vector_space K V).nonempty_fintype_index_of_rank_lt_aleph_0 h
 
 -- TODO how far can we generalise this?
 -- When `s` is finite, we could prove this for any ring satisfying the strong rank condition
 -- using `linear_independent_le_span'`
-lemma dim_span_le (s : set V) : module.rank K (span K s) ≤ #s :=
+lemma rank_span_le (s : set V) : module.rank K (span K s) ≤ #s :=
 begin
   obtain ⟨b, hb, hsab, hlib⟩ := exists_linear_independent K s,
   convert cardinal.mk_le_mk_of_subset hb,
-  rw [← hsab, dim_span_set hlib]
+  rw [← hsab, rank_span_set hlib]
 end
 
-lemma dim_span_of_finset (s : finset V) :
+lemma rank_span_of_finset (s : finset V) :
   module.rank K (span K (↑s : set V)) < ℵ₀ :=
-calc module.rank K (span K (↑s : set V)) ≤ #(↑s : set V) : dim_span_le ↑s
+calc module.rank K (span K (↑s : set V)) ≤ #(↑s : set V) : rank_span_le ↑s
                              ... = s.card : by rw [finset.coe_sort_coe, cardinal.mk_coe_finset]
                              ... < ℵ₀ : cardinal.nat_lt_aleph_0 _
 
-theorem dim_quotient_add_dim (p : submodule K V) :
+theorem rank_quotient_add_rank (p : submodule K V) :
   module.rank K (V ⧸ p) + module.rank K p = module.rank K V :=
-by classical; exact let ⟨f⟩ := quotient_prod_linear_equiv p in dim_prod.symm.trans f.dim_eq
+by classical; exact let ⟨f⟩ := quotient_prod_linear_equiv p in rank_prod.symm.trans f.rank_eq
 
 /-- rank-nullity theorem -/
-theorem dim_range_add_dim_ker (f : V →ₗ[K] V₁) :
+theorem rank_range_add_rank_ker (f : V →ₗ[K] V₁) :
   module.rank K f.range + module.rank K f.ker = module.rank K V :=
 begin
   haveI := λ (p : submodule K V), classical.dec_eq (V ⧸ p),
-  rw [← f.quot_ker_equiv_range.dim_eq, dim_quotient_add_dim]
+  rw [← f.quot_ker_equiv_range.rank_eq, rank_quotient_add_rank]
 end
 
-lemma dim_eq_of_surjective (f : V →ₗ[K] V₁) (h : surjective f) :
+lemma rank_eq_of_surjective (f : V →ₗ[K] V₁) (h : surjective f) :
   module.rank K V = module.rank K V₁ + module.rank K f.ker :=
-by rw [← dim_range_add_dim_ker f, ← dim_range_of_surjective f h]
+by rw [← rank_range_add_rank_ker f, ← rank_range_of_surjective f h]
 
 section
 variables [add_comm_group V₂] [module K V₂]
 variables [add_comm_group V₃] [module K V₃]
 open linear_map
 
-/-- This is mostly an auxiliary lemma for `dim_sup_add_dim_inf_eq`. -/
-lemma dim_add_dim_split
+/-- This is mostly an auxiliary lemma for `rank_sup_add_rank_inf_eq`. -/
+lemma rank_add_rank_split
   (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd : V₁ →ₗ[K] V₂) (ce : V₁ →ₗ[K] V₃)
   (hde : ⊤ ≤ db.range ⊔ eb.range)
   (hgd : ker cd = ⊥)
@@ -1121,9 +1121,9 @@ lemma dim_add_dim_split
 have hf : surjective (coprod db eb),
 by rwa [←range_eq_top, range_coprod, eq_top_iff],
 begin
-  conv {to_rhs, rw [← dim_prod, dim_eq_of_surjective _ hf] },
+  conv {to_rhs, rw [← rank_prod, rank_eq_of_surjective _ hf] },
   congr' 1,
-  apply linear_equiv.dim_eq,
+  apply linear_equiv.rank_eq,
   refine linear_equiv.of_bijective _ ⟨_, _⟩,
   { refine cod_restrict _ (prod cd (- ce)) _,
     { assume c,
@@ -1143,10 +1143,10 @@ begin
     rw [h₂, _root_.neg_neg] }
 end
 
-lemma dim_sup_add_dim_inf_eq (s t : submodule K V) :
+lemma rank_sup_add_rank_inf_eq (s t : submodule K V) :
   module.rank K (s ⊔ t : submodule K V) + module.rank K (s ⊓ t : submodule K V) =
     module.rank K s + module.rank K t :=
-dim_add_dim_split (of_le le_sup_left) (of_le le_sup_right) (of_le inf_le_left) (of_le inf_le_right)
+rank_add_rank_split (of_le le_sup_left) (of_le le_sup_right) (of_le inf_le_left) (of_le inf_le_right)
   begin
     rw [← map_le_map_iff' (ker_subtype $ s ⊔ t), submodule.map_sup, submodule.map_top,
       ← linear_map.range_comp, ← linear_map.range_comp, subtype_comp_of_le, subtype_comp_of_le,
@@ -1161,9 +1161,9 @@ dim_add_dim_split (of_le le_sup_left) (of_le le_sup_right) (of_le inf_le_left) (
     exact ⟨⟨b₁, hb₁, hb₂⟩, rfl, rfl⟩
   end
 
-lemma dim_add_le_dim_add_dim (s t : submodule K V) :
+lemma rank_add_le_rank_add_rank (s t : submodule K V) :
   module.rank K (s ⊔ t : submodule K V) ≤ module.rank K s + module.rank K t :=
-by { rw [← dim_sup_add_dim_inf_eq], exact self_le_add_right _ _ }
+by { rw [← rank_sup_add_rank_inf_eq], exact self_le_add_right _ _ }
 
 end
 
@@ -1177,36 +1177,36 @@ variables [add_comm_group V'] [module K V']
 
 See also `finite_dimensional.fin_basis`.
 -/
-def basis.of_dim_eq_zero {ι : Type*} [is_empty ι] (hV : module.rank K V = 0) :
+def basis.of_rank_eq_zero {ι : Type*} [is_empty ι] (hV : module.rank K V = 0) :
   basis ι K V :=
 begin
-  haveI : subsingleton V := dim_zero_iff.1 hV,
+  haveI : subsingleton V := rank_zero_iff.1 hV,
   exact basis.empty _
 end
 
-@[simp] lemma basis.of_dim_eq_zero_apply {ι : Type*} [is_empty ι]
+@[simp] lemma basis.of_rank_eq_zero_apply {ι : Type*} [is_empty ι]
   (hV : module.rank K V = 0) (i : ι) :
-  basis.of_dim_eq_zero hV i = 0 :=
+  basis.of_rank_eq_zero hV i = 0 :=
 rfl
 
-lemma le_dim_iff_exists_linear_independent {c : cardinal} :
+lemma le_rank_iff_exists_linear_independent {c : cardinal} :
   c ≤ module.rank K V ↔ ∃ s : set V, #s = c ∧ linear_independent K (coe : s → V) :=
 begin
   split,
   { intro h,
     let t := basis.of_vector_space K V,
-    rw [← t.mk_eq_dim'', cardinal.le_mk_iff_exists_subset] at h,
+    rw [← t.mk_eq_rank'', cardinal.le_mk_iff_exists_subset] at h,
     rcases h with ⟨s, hst, hsc⟩,
     exact ⟨s, hsc, (of_vector_space_index.linear_independent K V).mono hst⟩ },
   { rintro ⟨s, rfl, si⟩,
-    exact cardinal_le_dim_of_linear_independent si }
+    exact cardinal_le_rank_of_linear_independent si }
 end
 
-lemma le_dim_iff_exists_linear_independent_finset {n : ℕ} :
+lemma le_rank_iff_exists_linear_independent_finset {n : ℕ} :
   ↑n ≤ module.rank K V ↔
     ∃ s : finset V, s.card = n ∧ linear_independent K (coe : (s : set V) → V) :=
 begin
-  simp only [le_dim_iff_exists_linear_independent, cardinal.mk_set_eq_nat_iff_finset],
+  simp only [le_rank_iff_exists_linear_independent, cardinal.mk_set_eq_nat_iff_finset],
   split,
   { rintro ⟨s, ⟨t, rfl, rfl⟩, si⟩,
     exact ⟨t, rfl, si⟩ },
@@ -1216,12 +1216,12 @@ end
 
 /-- A vector space has dimension at most `1` if and only if there is a
 single vector of which all vectors are multiples. -/
-lemma dim_le_one_iff : module.rank K V ≤ 1 ↔ ∃ v₀ : V, ∀ v, ∃ r : K, r • v₀ = v :=
+lemma rank_le_one_iff : module.rank K V ≤ 1 ↔ ∃ v₀ : V, ∀ v, ∃ r : K, r • v₀ = v :=
 begin
   let b := basis.of_vector_space K V,
   split,
   { intro hd,
-    rw [← b.mk_eq_dim'', cardinal.le_one_iff_subsingleton, subsingleton_coe] at hd,
+    rw [← b.mk_eq_rank'', cardinal.le_one_iff_subsingleton, subsingleton_coe] at hd,
     rcases eq_empty_or_nonempty (of_vector_space_index K V) with hb | ⟨⟨v₀, hv₀⟩⟩,
     { use 0,
       have h' : ∀ v : V, v = 0, { simpa [hb, submodule.eq_bot_iff] using b.span_eq.symm },
@@ -1235,17 +1235,17 @@ begin
   { rintros ⟨v₀, hv₀⟩,
     have h : (K ∙ v₀) = ⊤,
     { ext, simp [mem_span_singleton, hv₀] },
-    rw [←dim_top, ←h],
-    refine (dim_span_le _).trans_eq _,
+    rw [←rank_top, ←h],
+    refine (rank_span_le _).trans_eq _,
     simp }
 end
 
 /-- A submodule has dimension at most `1` if and only if there is a
 single vector in the submodule such that the submodule is contained in
 its span. -/
-lemma dim_submodule_le_one_iff (s : submodule K V) : module.rank K s ≤ 1 ↔ ∃ v₀ ∈ s, s ≤ K ∙ v₀ :=
+lemma rank_submodule_le_one_iff (s : submodule K V) : module.rank K s ≤ 1 ↔ ∃ v₀ ∈ s, s ≤ K ∙ v₀ :=
 begin
-  simp_rw [dim_le_one_iff, le_span_singleton_iff],
+  simp_rw [rank_le_one_iff, le_span_singleton_iff],
   split,
   { rintro ⟨⟨v₀, hv₀⟩, h⟩,
     use [v₀, hv₀],
@@ -1266,9 +1266,9 @@ end
 /-- A submodule has dimension at most `1` if and only if there is a
 single vector, not necessarily in the submodule, such that the
 submodule is contained in its span. -/
-lemma dim_submodule_le_one_iff' (s : submodule K V) : module.rank K s ≤ 1 ↔ ∃ v₀, s ≤ K ∙ v₀ :=
+lemma rank_submodule_le_one_iff' (s : submodule K V) : module.rank K s ≤ 1 ↔ ∃ v₀, s ≤ K ∙ v₀ :=
 begin
-  rw dim_submodule_le_one_iff,
+  rw rank_submodule_le_one_iff,
   split,
   { rintros ⟨v₀, hv₀, h⟩,
     exact ⟨v₀, h⟩ },
@@ -1289,7 +1289,7 @@ end
 lemma submodule.rank_le_one_iff_is_principal (W : submodule K V) :
   module.rank K W ≤ 1 ↔ W.is_principal :=
 begin
-  simp only [dim_le_one_iff, submodule.is_principal_iff, le_antisymm_iff,
+  simp only [rank_le_one_iff, submodule.is_principal_iff, le_antisymm_iff,
     le_span_singleton_iff, span_singleton_le_iff_mem],
   split,
   { rintro ⟨⟨m, hm⟩, hm'⟩,
@@ -1302,7 +1302,7 @@ end
 
 lemma module.rank_le_one_iff_top_is_principal :
   module.rank K V ≤ 1 ↔ (⊤ : submodule K V).is_principal :=
-by rw [← submodule.rank_le_one_iff_is_principal, dim_top]
+by rw [← submodule.rank_le_one_iff_is_principal, rank_top]
 
 end division_ring
 
@@ -1320,16 +1320,16 @@ variables [add_comm_group V'] [module K V']
 def rank (f : V →ₗ[K] V') : cardinal := module.rank K f.range
 
 lemma rank_le_range (f : V →ₗ[K] V₁) : rank f ≤ module.rank K V₁ :=
-dim_submodule_le _
+rank_submodule_le _
 
 @[simp] lemma rank_zero [nontrivial K] : rank (0 : V →ₗ[K] V') = 0 :=
-by rw [rank, linear_map.range_zero, dim_bot]
+by rw [rank, linear_map.range_zero, rank_bot]
 
 variables [add_comm_group V''] [module K V'']
 
 lemma rank_comp_le1 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'') : rank (f.comp g) ≤ rank f :=
 begin
-  refine dim_le_of_submodule _ _ _,
+  refine rank_le_of_submodule _ _ _,
   rw [linear_map.range_comp],
   exact linear_map.map_le_range,
 end
@@ -1337,7 +1337,7 @@ end
 variables [add_comm_group V'₁] [module K V'₁]
 
 lemma rank_comp_le2 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'₁) : rank (f.comp g) ≤ rank g :=
-by rw [rank, rank, linear_map.range_comp]; exact dim_map_le _ _
+by rw [rank, rank, linear_map.range_comp]; exact rank_map_le _ _
 
 end ring
 
@@ -1346,17 +1346,17 @@ variables [division_ring K] [add_comm_group V] [module K V] [add_comm_group V₁
 variables [add_comm_group V'] [module K V']
 
 lemma rank_le_domain (f : V →ₗ[K] V₁) : rank f ≤ module.rank K V :=
-by { rw [← dim_range_add_dim_ker f], exact self_le_add_right _ _ }
+by { rw [← rank_range_add_rank_ker f], exact self_le_add_right _ _ }
 
 lemma rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=
 calc rank (f + g) ≤ module.rank K (f.range ⊔ g.range : submodule K V') :
   begin
-    refine dim_le_of_submodule _ _ _,
+    refine rank_le_of_submodule _ _ _,
     exact (linear_map.range_le_iff_comap.2 $ eq_top_iff'.2 $
       assume x, show f x + g x ∈ (f.range ⊔ g.range : submodule K V'), from
         mem_sup.2 ⟨_, ⟨x, rfl⟩, _, ⟨x, rfl⟩, rfl⟩)
   end
-  ... ≤ rank f + rank g : dim_add_le_dim_add_dim _ _
+  ... ≤ rank f + rank g : rank_add_le_rank_add_rank _ _
 
 lemma rank_finset_sum_le {η} (s : finset η) (f : η → V →ₗ[K] V') :
   rank (∑ d in s, f d) ≤ ∑ d in s, rank (f d) :=
@@ -1371,7 +1371,7 @@ begin
   rcases f.range_restrict.exists_right_inverse_of_surjective f.range_range_restrict with ⟨g, hg⟩,
   have fg : left_inverse f.range_restrict g, from linear_map.congr_fun hg,
   refine ⟨λ h, _, _⟩,
-  { rcases le_dim_iff_exists_linear_independent.1 h with ⟨s, rfl, si⟩,
+  { rcases le_rank_iff_exists_linear_independent.1 h with ⟨s, rfl, si⟩,
     refine ⟨g '' s, cardinal.mk_image_eq_lift _ _ fg.injective, _⟩,
     replace fg : ∀ x, f (g x) = x, by { intro x, convert congr_arg subtype.val (fg x) },
     replace si : linear_independent K (λ x : s, f (g x)),
@@ -1380,7 +1380,7 @@ begin
   { rintro ⟨s, hsc, si⟩,
     have : linear_independent K (λ x : s, f.range_restrict x),
       from linear_independent.of_comp (f.range.subtype) (by convert si),
-    convert cardinal_le_dim_of_linear_independent this.image,
+    convert cardinal_le_rank_of_linear_independent this.image,
     rw [← cardinal.lift_inj, ← hsc, cardinal.mk_image_eq_of_inj_on_lift],
     exact inj_on_iff_injective.2 this.injective }
 end

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -169,7 +169,8 @@ begin
   rwa [linear_map.range_comp, range_subtype] at h,
 end
 
-lemma rank_map_le (f : M →ₗ[R] M₁) (p : submodule R M) : module.rank R (p.map f) ≤ module.rank R p :=
+lemma rank_map_le (f : M →ₗ[R] M₁) (p : submodule R M) :
+  module.rank R (p.map f) ≤ module.rank R p :=
 by simpa using lift_rank_map_le f p
 
 lemma rank_le_of_submodule (s t : submodule R M) (h : s ≤ t) :
@@ -1146,7 +1147,8 @@ end
 lemma rank_sup_add_rank_inf_eq (s t : submodule K V) :
   module.rank K (s ⊔ t : submodule K V) + module.rank K (s ⊓ t : submodule K V) =
     module.rank K s + module.rank K t :=
-rank_add_rank_split (of_le le_sup_left) (of_le le_sup_right) (of_le inf_le_left) (of_le inf_le_right)
+rank_add_rank_split
+  (of_le le_sup_left) (of_le le_sup_right) (of_le inf_le_left) (of_le inf_le_right)
   begin
     rw [← map_le_map_iff' (ker_subtype $ s ⊔ t), submodule.map_sup, submodule.map_top,
       ← linear_map.range_comp, ← linear_map.range_comp, subtype_comp_of_le, subtype_comp_of_le,

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -422,13 +422,13 @@ end comm_ring
   finsupp.total ι (dual R M) R b.coord f (b i) = f i :=
 by { haveI := classical.dec_eq ι, rw [← coe_dual_basis, total_dual_basis] }
 
-lemma dual_dim_eq [comm_ring K] [add_comm_group V] [module K V] [_root_.finite ι]
+lemma dual_rank_eq [comm_ring K] [add_comm_group V] [module K V] [_root_.finite ι]
   (b : basis ι K V) :
   cardinal.lift (module.rank K V) = module.rank K (dual K V) :=
 begin
   classical,
   casesI nonempty_fintype ι,
-  have := linear_equiv.lift_dim_eq b.to_dual_equiv,
+  have := linear_equiv.lift_rank_eq b.to_dual_equiv,
   simp only [cardinal.lift_umax] at this,
   rw [this, ← cardinal.lift_umax],
   apply cardinal.lift_id,
@@ -479,9 +479,9 @@ by { rw [← eval_apply_eq_zero_iff K v, linear_map.ext_iff], refl }
 end
 
 -- TODO(jmc): generalize to rings, once `module.rank` is generalized
-theorem dual_dim_eq [finite_dimensional K V] :
+theorem dual_rank_eq [finite_dimensional K V] :
   cardinal.lift (module.rank K V) = module.rank K (dual K V) :=
-(basis.of_vector_space K V).dual_dim_eq
+(basis.of_vector_space K V).dual_rank_eq
 
 lemma erange_coe [finite_dimensional K V] : (eval K V).range = ⊤ :=
 begin

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -157,7 +157,8 @@ instance finite_dimensional_submodule [finite_dimensional K V] (S : submodule K 
 begin
   letI : is_noetherian K V := iff_fg.2 _,
   exact iff_fg.1
-    (is_noetherian.iff_rank_lt_aleph_0.2 (lt_of_le_of_lt (rank_submodule_le _) (rank_lt_aleph_0 K V))),
+    (is_noetherian.iff_rank_lt_aleph_0.2
+      (lt_of_le_of_lt (rank_submodule_le _) (rank_lt_aleph_0 K V))),
   apply_instance,
 end
 
@@ -582,7 +583,8 @@ variables [division_ring K] [add_comm_group V] [module K V]
 
 open finite_dimensional
 
-lemma finite_dimensional_of_rank_eq_nat {n : ℕ} (h : module.rank K V = n) : finite_dimensional K V :=
+lemma finite_dimensional_of_rank_eq_nat {n : ℕ} (h : module.rank K V = n) :
+  finite_dimensional K V :=
 begin
   rw [finite_dimensional, ← is_noetherian.iff_fg, is_noetherian.iff_rank_lt_aleph_0, h],
   exact nat_lt_aleph_0 n,

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -157,7 +157,7 @@ instance finite_dimensional_submodule [finite_dimensional K V] (S : submodule K 
 begin
   letI : is_noetherian K V := iff_fg.2 _,
   exact iff_fg.1
-    (is_noetherian.iff_dim_lt_aleph_0.2 (lt_of_le_of_lt (dim_submodule_le _) (dim_lt_aleph_0 K V))),
+    (is_noetherian.iff_rank_lt_aleph_0.2 (lt_of_le_of_lt (rank_submodule_le _) (rank_lt_aleph_0 K V))),
   apply_instance,
 end
 
@@ -169,13 +169,13 @@ module.finite.of_surjective (submodule.mkq S) $ surjective_quot_mk _
 variables (K V)
 /-- In a finite-dimensional space, its dimension (seen as a cardinal) coincides with its
 `finrank`. This is a copy of `finrank_eq_rank _ _` which creates easier typeclass searches. -/
-lemma finrank_eq_dim [finite_dimensional K V] :
+lemma finrank_eq_rank' [finite_dimensional K V] :
   (finrank K V : cardinal.{v}) = module.rank K V :=
 finrank_eq_rank _ _
 variables {K V}
 
 lemma finrank_of_infinite_dimensional (h : ¬finite_dimensional K V) : finrank K V = 0 :=
-dif_neg $ mt is_noetherian.iff_dim_lt_aleph_0.2 $ (not_iff_not.2 iff_fg).2 h
+dif_neg $ mt is_noetherian.iff_rank_lt_aleph_0.2 $ (not_iff_not.2 iff_fg).2 h
 
 lemma finite_dimensional_of_finrank (h : 0 < finrank K V) : finite_dimensional K V :=
 by { contrapose h, simp [finrank_of_infinite_dimensional h] }
@@ -193,7 +193,7 @@ finite_dimensional_of_finrank $ by convert nat.succ_pos n; apply fact.out
 lemma finite_dimensional_iff_of_rank_eq_nsmul {W} [add_comm_group W] [module K W]
   {n : ℕ} (hn : n ≠ 0) (hVW : module.rank K V = n • module.rank K W) :
   finite_dimensional K V ↔ finite_dimensional K W :=
-by simp only [finite_dimensional, ← is_noetherian.iff_fg, is_noetherian.iff_dim_lt_aleph_0, hVW,
+by simp only [finite_dimensional, ← is_noetherian.iff_fg, is_noetherian.iff_rank_lt_aleph_0, hVW,
   cardinal.nsmul_lt_aleph_0_iff_of_ne_zero hn]
 
 /-- If a vector space is finite-dimensional, then the cardinality of any basis is equal to its
@@ -249,8 +249,8 @@ lemma cardinal_mk_le_finrank_of_linear_independent
   #ι ≤ finrank K V :=
 begin
   rw ← lift_le.{_ (max v w)},
-  simpa [← finrank_eq_dim, -finrank_eq_rank] using
-    cardinal_lift_le_dim_of_linear_independent.{_ _ _ (max v w)} h
+  simpa [← finrank_eq_rank', -finrank_eq_rank] using
+    cardinal_lift_le_rank_of_linear_independent.{_ _ _ (max v w)} h
 end
 
 lemma fintype_card_le_finrank_of_linear_independent
@@ -272,8 +272,8 @@ lemma lt_aleph_0_of_linear_independent {ι : Type w} [finite_dimensional K V]
 begin
   apply cardinal.lift_lt.1,
   apply lt_of_le_of_lt,
-  apply cardinal_lift_le_dim_of_linear_independent h,
-  rw [←finrank_eq_dim, cardinal.lift_aleph_0, cardinal.lift_nat_cast],
+  apply cardinal_lift_le_rank_of_linear_independent h,
+  rw [←finrank_eq_rank, cardinal.lift_aleph_0, cardinal.lift_nat_cast],
   apply cardinal.nat_lt_aleph_0,
 end
 
@@ -292,21 +292,21 @@ end
 
 /-- A finite dimensional space has positive `finrank` iff it has a nonzero element. -/
 lemma finrank_pos_iff_exists_ne_zero [finite_dimensional K V] : 0 < finrank K V ↔ ∃ x : V, x ≠ 0 :=
-iff.trans (by { rw ← finrank_eq_dim, norm_cast }) (@dim_pos_iff_exists_ne_zero K V _ _ _ _ _)
+iff.trans (by { rw ← finrank_eq_rank, norm_cast }) (@rank_pos_iff_exists_ne_zero K V _ _ _ _ _)
 
 /-- A finite dimensional space has positive `finrank` iff it is nontrivial. -/
 lemma finrank_pos_iff [finite_dimensional K V] : 0 < finrank K V ↔ nontrivial V :=
-iff.trans (by { rw ← finrank_eq_dim, norm_cast }) (@dim_pos_iff_nontrivial K V _ _ _ _ _)
+iff.trans (by { rw ← finrank_eq_rank, norm_cast }) (@rank_pos_iff_nontrivial K V _ _ _ _ _)
 
 /-- A nontrivial finite dimensional space has positive `finrank`. -/
 lemma finrank_pos [finite_dimensional K V] [h : nontrivial V] : 0 < finrank K V :=
 finrank_pos_iff.mpr h
 
 /-- A finite dimensional space has zero `finrank` iff it is a subsingleton.
-This is the `finrank` version of `dim_zero_iff`. -/
+This is the `finrank` version of `rank_zero_iff`. -/
 lemma finrank_zero_iff [finite_dimensional K V] :
   finrank K V = 0 ↔ subsingleton V :=
-iff.trans (by { rw ← finrank_eq_dim, norm_cast }) (@dim_zero_iff K V _ _ _ _ _)
+iff.trans (by { rw ← finrank_eq_rank, norm_cast }) (@rank_zero_iff K V _ _ _ _ _)
 
 /-- If a submodule has maximal dimension in a finite dimensional space, then it is equal to the
 whole space. -/
@@ -358,17 +358,17 @@ span_of_finite K $ s.finite_to_set
 instance (f : V →ₗ[K] V₂) (p : submodule K V) [h : finite_dimensional K p] :
   finite_dimensional K (p.map f) :=
 begin
-  unfreezingI { rw [finite_dimensional, ← iff_fg, is_noetherian.iff_dim_lt_aleph_0] at h ⊢ },
+  unfreezingI { rw [finite_dimensional, ← iff_fg, is_noetherian.iff_rank_lt_aleph_0] at h ⊢ },
   rw [← cardinal.lift_lt.{v' v}],
   rw [← cardinal.lift_lt.{v v'}] at h,
   rw [cardinal.lift_aleph_0] at h ⊢,
-  exact (lift_dim_map_le f p).trans_lt h
+  exact (lift_rank_map_le f p).trans_lt h
 end
 
 /-- Pushforwards of finite-dimensional submodules have a smaller finrank. -/
 lemma finrank_map_le (f : V →ₗ[K] V₂) (p : submodule K V) [finite_dimensional K p] :
   finrank K (p.map f) ≤ finrank K p :=
-by simpa [← finrank_eq_dim, -finrank_eq_rank] using lift_dim_map_le f p
+by simpa [← finrank_eq_rank', -finrank_eq_rank] using lift_rank_map_le f p
 
 variable {K}
 
@@ -380,7 +380,7 @@ begin
   { rwa cardinal.lift_le at this },
   calc cardinal.lift.{v} (# {i // p i ≠ ⊥})
       ≤ cardinal.lift.{w} (module.rank K V) : hp.subtype_ne_bot_le_rank
-  ... = cardinal.lift.{w} (finrank K V : cardinal.{v}) : by rw finrank_eq_dim
+  ... = cardinal.lift.{w} (finrank K V : cardinal.{v}) : by rw finrank_eq_rank
   ... = cardinal.lift.{v} (finrank K V : cardinal.{w}) : by simp
 end
 
@@ -417,7 +417,7 @@ open finset
 If a finset has cardinality larger than the dimension of the space,
 then there is a nontrivial linear relation amongst its elements.
 -/
-lemma exists_nontrivial_relation_of_dim_lt_card
+lemma exists_nontrivial_relation_of_rank_lt_card
   [finite_dimensional K V] {t : finset V} (h : finrank K V < t.card) :
   ∃ f : V → K, ∑ e in t, f e • e = 0 ∧ ∃ x ∈ t, f x ≠ 0 :=
 begin
@@ -452,7 +452,7 @@ If a finset has cardinality larger than `finrank + 1`,
 then there is a nontrivial linear relation amongst its elements,
 such that the coefficients of the relation sum to zero.
 -/
-lemma exists_nontrivial_relation_sum_zero_of_dim_succ_lt_card
+lemma exists_nontrivial_relation_sum_zero_of_rank_succ_lt_card
   [finite_dimensional K V] {t : finset V} (h : finrank K V + 1 < t.card) :
   ∃ f : V → K, ∑ e in t, f e • e = 0 ∧ ∑ e in t, f e = 0 ∧ ∃ x ∈ t, f x ≠ 0 :=
 begin
@@ -466,7 +466,7 @@ begin
   { simp only [t', card_map, finset.card_erase_of_mem m],
     exact nat.lt_pred_iff.mpr h, },
   -- to obtain a function `g`.
-  obtain ⟨g, gsum, x₁, x₁_mem, nz⟩ := exists_nontrivial_relation_of_dim_lt_card h',
+  obtain ⟨g, gsum, x₁, x₁_mem, nz⟩ := exists_nontrivial_relation_of_rank_lt_card h',
   -- Then obtain `f` by translating back by `x₀`,
   -- and setting the value of `f` at `x₀` to ensure `∑ e in t, f e = 0`.
   let f : V → K := λ z, if z = x₀ then - ∑ z in (t.erase x₀), g (z - x₀) else g (z - x₀),
@@ -518,15 +518,15 @@ variables {L : Type*} [linear_ordered_field L]
 variables {W : Type v} [add_comm_group W] [module L W]
 
 /--
-A slight strengthening of `exists_nontrivial_relation_sum_zero_of_dim_succ_lt_card`
+A slight strengthening of `exists_nontrivial_relation_sum_zero_of_rank_succ_lt_card`
 available when working over an ordered field:
 we can ensure a positive coefficient, not just a nonzero coefficient.
 -/
-lemma exists_relation_sum_zero_pos_coefficient_of_dim_succ_lt_card
+lemma exists_relation_sum_zero_pos_coefficient_of_rank_succ_lt_card
   [finite_dimensional L W] {t : finset W} (h : finrank L W + 1 < t.card) :
   ∃ f : W → L, ∑ e in t, f e • e = 0 ∧ ∑ e in t, f e = 0 ∧ ∃ x ∈ t, 0 < f x :=
 begin
-  obtain ⟨f, sum, total, nonzero⟩ := exists_nontrivial_relation_sum_zero_of_dim_succ_lt_card h,
+  obtain ⟨f, sum, total, nonzero⟩ := exists_nontrivial_relation_sum_zero_of_rank_succ_lt_card h,
   exact ⟨f, sum, total, exists_pos_of_sum_zero_of_exists_nonzero f total nonzero⟩,
 end
 
@@ -576,56 +576,56 @@ end finite_dimensional
 
 variables {K V}
 
-section zero_dim
+section zero_rank
 
 variables [division_ring K] [add_comm_group V] [module K V]
 
 open finite_dimensional
 
-lemma finite_dimensional_of_dim_eq_nat {n : ℕ} (h : module.rank K V = n) : finite_dimensional K V :=
+lemma finite_dimensional_of_rank_eq_nat {n : ℕ} (h : module.rank K V = n) : finite_dimensional K V :=
 begin
-  rw [finite_dimensional, ← is_noetherian.iff_fg, is_noetherian.iff_dim_lt_aleph_0, h],
+  rw [finite_dimensional, ← is_noetherian.iff_fg, is_noetherian.iff_rank_lt_aleph_0, h],
   exact nat_lt_aleph_0 n,
 end
 /- TODO: generalize to free modules over general rings. -/
 
-lemma finite_dimensional_of_dim_eq_zero (h : module.rank K V = 0) : finite_dimensional K V :=
-finite_dimensional_of_dim_eq_nat $ h.trans nat.cast_zero.symm
+lemma finite_dimensional_of_rank_eq_zero (h : module.rank K V = 0) : finite_dimensional K V :=
+finite_dimensional_of_rank_eq_nat $ h.trans nat.cast_zero.symm
 
-lemma finite_dimensional_of_dim_eq_one (h : module.rank K V = 1) : finite_dimensional K V :=
-finite_dimensional_of_dim_eq_nat $ h.trans nat.cast_one.symm
+lemma finite_dimensional_of_rank_eq_one (h : module.rank K V = 1) : finite_dimensional K V :=
+finite_dimensional_of_rank_eq_nat $ h.trans nat.cast_one.symm
 
-lemma finrank_eq_zero_of_dim_eq_zero [finite_dimensional K V] (h : module.rank K V = 0) :
+lemma finrank_eq_zero_of_rank_eq_zero [finite_dimensional K V] (h : module.rank K V = 0) :
   finrank K V = 0 :=
 begin
-  convert finrank_eq_dim K V,
+  convert finrank_eq_rank K V,
   rw h, norm_cast
 end
 
 variables (K V)
 
 instance finite_dimensional_bot : finite_dimensional K (⊥ : submodule K V) :=
-finite_dimensional_of_dim_eq_zero $ by simp
+finite_dimensional_of_rank_eq_zero $ by simp
 
 variables {K V}
 
-lemma bot_eq_top_of_dim_eq_zero (h : module.rank K V = 0) : (⊥ : submodule K V) = ⊤ :=
+lemma bot_eq_top_of_rank_eq_zero (h : module.rank K V = 0) : (⊥ : submodule K V) = ⊤ :=
 begin
-  haveI := finite_dimensional_of_dim_eq_zero h,
+  haveI := finite_dimensional_of_rank_eq_zero h,
   apply eq_top_of_finrank_eq,
-  rw [finrank_bot, finrank_eq_zero_of_dim_eq_zero h]
+  rw [finrank_bot, finrank_eq_zero_of_rank_eq_zero h]
 end
 
-@[simp] theorem dim_eq_zero {S : submodule K V} : module.rank K S = 0 ↔ S = ⊥ :=
+@[simp] theorem rank_eq_zero {S : submodule K V} : module.rank K S = 0 ↔ S = ⊥ :=
 ⟨λ h, (submodule.eq_bot_iff _).2 $ λ x hx, congr_arg subtype.val $
-  ((submodule.eq_bot_iff _).1 $ eq.symm $ bot_eq_top_of_dim_eq_zero h) ⟨x, hx⟩ submodule.mem_top,
-λ h, by rw [h, dim_bot]⟩
+  ((submodule.eq_bot_iff _).1 $ eq.symm $ bot_eq_top_of_rank_eq_zero h) ⟨x, hx⟩ submodule.mem_top,
+λ h, by rw [h, rank_bot]⟩
 
 @[simp] theorem finrank_eq_zero {S : submodule K V} [finite_dimensional K S] :
   finrank K S = 0 ↔ S = ⊥ :=
-by rw [← dim_eq_zero, ← finrank_eq_dim, ← @nat.cast_zero cardinal, cardinal.nat_cast_inj]
+by rw [← rank_eq_zero, ← finrank_eq_rank, ← @nat.cast_zero cardinal, cardinal.nat_cast_inj]
 
-end zero_dim
+end zero_rank
 
 namespace submodule
 open is_noetherian finite_dimensional
@@ -644,8 +644,8 @@ lemma finite_dimensional_of_le {S₁ S₂ : submodule K V} [finite_dimensional K
   finite_dimensional K S₁ :=
 begin
   haveI : is_noetherian K S₂ := iff_fg.2 infer_instance,
-  exact iff_fg.1 (is_noetherian.iff_dim_lt_aleph_0.2
-    (lt_of_le_of_lt (dim_le_of_submodule _ _ h) (dim_lt_aleph_0 K S₂))),
+  exact iff_fg.1 (is_noetherian.iff_rank_lt_aleph_0.2
+    (lt_of_le_of_lt (rank_le_of_submodule _ _ h) (finite_dimensional.rank_lt_aleph_0 K S₂))),
 end
 
 /-- The inf of two submodules, the first finite-dimensional, is
@@ -696,22 +696,22 @@ end
 
 /-- The dimension of a submodule is bounded by the dimension of the ambient space. -/
 lemma finrank_le [finite_dimensional K V] (s : submodule K V) : finrank K s ≤ finrank K V :=
-by simpa only [cardinal.nat_cast_le, ←finrank_eq_dim] using
-  s.subtype.dim_le_of_injective (injective_subtype s)
+by simpa only [cardinal.nat_cast_le, ←finrank_eq_rank] using
+  s.subtype.rank_le_of_injective (injective_subtype s)
 
 /-- The dimension of a quotient is bounded by the dimension of the ambient space. -/
 lemma finrank_quotient_le [finite_dimensional K V] (s : submodule K V) :
   finrank K (V ⧸ s) ≤ finrank K V :=
-by simpa only [cardinal.nat_cast_le, ←finrank_eq_dim] using
-  (mkq s).dim_le_of_surjective (surjective_quot_mk _)
+by simpa only [cardinal.nat_cast_le, ←finrank_eq_rank] using
+  (mkq s).rank_le_of_surjective (surjective_quot_mk _)
 
 /-- In a finite-dimensional vector space, the dimensions of a submodule and of the corresponding
 quotient add up to the dimension of the space. -/
 theorem finrank_quotient_add_finrank [finite_dimensional K V] (s : submodule K V) :
   finrank K (V ⧸ s) + finrank K s = finrank K V :=
 begin
-  have := dim_quotient_add_dim s,
-  rw [← finrank_eq_dim, ← finrank_eq_dim, ← finrank_eq_dim] at this,
+  have := rank_quotient_add_rank s,
+  rw [← finrank_eq_rank, ← finrank_eq_rank, ← finrank_eq_rank] at this,
   exact_mod_cast this
 end
 
@@ -725,21 +725,21 @@ begin
 end
 
 /-- The sum of the dimensions of s + t and s ∩ t is the sum of the dimensions of s and t -/
-theorem dim_sup_add_dim_inf_eq (s t : submodule K V)
+theorem rank_sup_add_rank_inf_eq (s t : submodule K V)
   [finite_dimensional K s] [finite_dimensional K t] :
   finrank K ↥(s ⊔ t) + finrank K ↥(s ⊓ t) = finrank K ↥s + finrank K ↥t :=
 begin
   have key : module.rank K ↥(s ⊔ t) + module.rank K ↥(s ⊓ t) =
-    module.rank K s + module.rank K t := dim_sup_add_dim_inf_eq s t,
-  repeat { rw ←finrank_eq_dim at key },
+    module.rank K s + module.rank K t := rank_sup_add_rank_inf_eq s t,
+  repeat { rw ←finrank_eq_rank at key },
   norm_cast at key,
   exact key
 end
 
-lemma dim_add_le_dim_add_dim (s t : submodule K V)
+lemma rank_add_le_rank_add_rank (s t : submodule K V)
   [finite_dimensional K s] [finite_dimensional K t] :
   finrank K (s ⊔ t : submodule K V) ≤ finrank K s + finrank K t :=
-by { rw [← dim_sup_add_dim_inf_eq], exact self_le_add_right _ _ }
+by { rw [← rank_sup_add_rank_inf_eq], exact self_le_add_right _ _ }
 
 lemma eq_top_of_disjoint [finite_dimensional K V] (s t : submodule K V)
   (hdim : finrank K s + finrank K t = finrank K V)
@@ -750,7 +750,7 @@ begin
     rw [hdisjoint, finrank_bot] },
   apply eq_top_of_finrank_eq,
   rw ←hdim,
-  convert s.dim_sup_add_dim_inf_eq t,
+  convert s.rank_sup_add_rank_inf_eq t,
   rw h_finrank_inf,
   refl,
 end
@@ -795,7 +795,7 @@ Two finite-dimensional vector spaces are isomorphic if they have the same (finit
 -/
 theorem nonempty_linear_equiv_of_finrank_eq [finite_dimensional K V] [finite_dimensional K V₂]
   (cond : finrank K V = finrank K V₂) : nonempty (V ≃ₗ[K] V₂) :=
-nonempty_linear_equiv_of_lift_dim_eq $ by simp only [← finrank_eq_dim, cond, lift_nat_cast]
+nonempty_linear_equiv_of_lift_rank_eq $ by simp only [← finrank_eq_rank, cond, lift_nat_cast]
 
 /--
 Two finite-dimensional vector spaces are isomorphic if and only if they have the same (finite)
@@ -871,8 +871,8 @@ variables [division_ring K] [add_comm_group V] [module K V]
 lemma surjective_of_injective [finite_dimensional K V] {f : V →ₗ[K] V}
   (hinj : injective f) : surjective f :=
 begin
-  have h := dim_eq_of_injective _ hinj,
-  rw [← finrank_eq_dim, ← finrank_eq_dim, nat_cast_inj] at h,
+  have h := rank_eq_of_injective _ hinj,
+  rw [← finrank_eq_rank, ← finrank_eq_rank, nat_cast_inj] at h,
   exact range_eq_top.1 (eq_top_of_finrank_eq h.symm)
 end
 
@@ -1092,7 +1092,7 @@ lemma finrank_add_eq_of_is_compl
   [finite_dimensional K V] {U W : submodule K V} (h : is_compl U W) :
   finrank K U + finrank K W = finrank K V :=
 begin
-  rw [← dim_sup_add_dim_inf_eq, h.codisjoint.eq_top, h.disjoint.eq_bot, finrank_bot, add_zero],
+  rw [← rank_sup_add_rank_inf_eq, h.codisjoint.eq_top, h.disjoint.eq_bot, finrank_bot, add_zero],
   exact finrank_top
 end
 
@@ -1138,7 +1138,7 @@ begin
     symmetry,
     replace fin := (not_iff_not.2 is_noetherian.iff_fg).2 fin,
     calc fintype.card ι = finrank K V : card_eq
-                    ... = 0 : dif_neg (mt is_noetherian.iff_dim_lt_aleph_0.mpr fin) }
+                    ... = 0 : dif_neg (mt is_noetherian.iff_rank_lt_aleph_0.mpr fin) }
 end
 
 /-- A linear independent family of `finrank K V` vectors forms a basis. -/
@@ -1260,11 +1260,11 @@ end
 
 lemma submodule.finrank_le_one_iff_is_principal (W : submodule K V) [finite_dimensional K W] :
   finrank K W ≤ 1 ↔ W.is_principal :=
-by rw [← W.rank_le_one_iff_is_principal, ← finrank_eq_dim, ← cardinal.nat_cast_le, nat.cast_one]
+by rw [← W.rank_le_one_iff_is_principal, ← finrank_eq_rank, ← cardinal.nat_cast_le, nat.cast_one]
 
 lemma module.finrank_le_one_iff_top_is_principal [finite_dimensional K V] :
   finrank K V ≤ 1 ↔ (⊤ : submodule K V).is_principal :=
-by rw [← module.rank_le_one_iff_top_is_principal, ← finrank_eq_dim,
+by rw [← module.rank_le_one_iff_top_is_principal, ← finrank_eq_rank,
   ← cardinal.nat_cast_le, nat.cast_one]
 
 -- We use the `linear_map.compatible_smul` typeclass here, to encompass two situations:
@@ -1297,7 +1297,7 @@ end finrank_eq_one
 
 end division_ring
 
-section subalgebra_dim
+section subalgebra_rank
 open module
 variables {F E : Type*} [field F] [ring E] [algebra F E]
 
@@ -1313,46 +1313,46 @@ instance finite_dimensional.finite_dimensional_subalgebra [finite_dimensional F 
 finite_dimensional.of_subalgebra_to_submodule infer_instance
 
 instance subalgebra.finite_dimensional_bot : finite_dimensional F (⊥ : subalgebra F E) :=
-by { nontriviality E, exact finite_dimensional_of_dim_eq_one subalgebra.dim_bot }
+by { nontriviality E, exact finite_dimensional_of_rank_eq_one subalgebra.rank_bot }
 
-lemma subalgebra.eq_bot_of_dim_le_one {S : subalgebra F E} (h : module.rank F S ≤ 1) : S = ⊥ :=
+lemma subalgebra.eq_bot_of_rank_le_one {S : subalgebra F E} (h : module.rank F S ≤ 1) : S = ⊥ :=
 begin
   nontriviality E,
   obtain ⟨m, hm, he⟩ := cardinal.exists_nat_eq_of_le_nat (h.trans_eq nat.cast_one.symm),
-  haveI := finite_dimensional_of_dim_eq_nat he,
+  haveI := finite_dimensional_of_rank_eq_nat he,
   rw [← not_bot_lt_iff, ← subalgebra.to_submodule.lt_iff_lt],
   haveI := (S.to_submodule_equiv).symm.finite_dimensional,
   refine λ hl, (submodule.finrank_lt_finrank_of_lt hl).not_le (nat_cast_le.1 _),
-  iterate 2 { rw [subalgebra.finrank_to_submodule, finrank_eq_dim] },
-  exact h.trans_eq subalgebra.dim_bot.symm,
+  iterate 2 { rw [subalgebra.finrank_to_submodule, finrank_eq_rank] },
+  exact h.trans_eq subalgebra.rank_bot.symm,
 end
 
 lemma subalgebra.eq_bot_of_finrank_one {S : subalgebra F E} (h : finrank F S = 1) : S = ⊥ :=
-subalgebra.eq_bot_of_dim_le_one $
-  by { haveI := finite_dimensional_of_finrank_eq_succ h, rw [← finrank_eq_dim, h, nat.cast_one] }
+subalgebra.eq_bot_of_rank_le_one $
+  by { haveI := finite_dimensional_of_finrank_eq_succ h, rw [← finrank_eq_rank, h, nat.cast_one] }
 
 @[simp]
-theorem subalgebra.dim_eq_one_iff [nontrivial E] {S : subalgebra F E} :
+theorem subalgebra.rank_eq_one_iff [nontrivial E] {S : subalgebra F E} :
   module.rank F S = 1 ↔ S = ⊥ :=
-⟨λ h, subalgebra.eq_bot_of_dim_le_one h.le, λ h, h.symm ▸ subalgebra.dim_bot⟩
+⟨λ h, subalgebra.eq_bot_of_rank_le_one h.le, λ h, h.symm ▸ subalgebra.rank_bot⟩
 
 @[simp]
 theorem subalgebra.finrank_eq_one_iff [nontrivial E] {S : subalgebra F E} :
   finrank F S = 1 ↔ S = ⊥ :=
 ⟨subalgebra.eq_bot_of_finrank_one, λ h, h.symm ▸ subalgebra.finrank_bot⟩
 
-lemma subalgebra.bot_eq_top_iff_dim_eq_one [nontrivial E] :
+lemma subalgebra.bot_eq_top_iff_rank_eq_one [nontrivial E] :
   (⊥ : subalgebra F E) = ⊤ ↔ module.rank F E = 1 :=
-by rw [← dim_top, ← subalgebra_top_dim_eq_submodule_top_dim, subalgebra.dim_eq_one_iff, eq_comm]
+by rw [← rank_top, ← subalgebra_top_rank_eq_submodule_top_rank, subalgebra.rank_eq_one_iff, eq_comm]
 
 lemma subalgebra.bot_eq_top_iff_finrank_eq_one [nontrivial E] :
   (⊥ : subalgebra F E) = ⊤ ↔ finrank F E = 1 :=
 by rw [← finrank_top, ← subalgebra_top_finrank_eq_submodule_top_finrank,
        subalgebra.finrank_eq_one_iff, eq_comm]
 
-alias subalgebra.bot_eq_top_iff_dim_eq_one ↔ _ subalgebra.bot_eq_top_of_dim_eq_one
+alias subalgebra.bot_eq_top_iff_rank_eq_one ↔ _ subalgebra.bot_eq_top_of_rank_eq_one
 alias subalgebra.bot_eq_top_iff_finrank_eq_one ↔ _ subalgebra.bot_eq_top_of_finrank_eq_one
-attribute [simp] subalgebra.bot_eq_top_of_finrank_eq_one subalgebra.bot_eq_top_of_dim_eq_one
+attribute [simp] subalgebra.bot_eq_top_of_finrank_eq_one subalgebra.bot_eq_top_of_rank_eq_one
 
 lemma subalgebra.is_simple_order_of_finrank (hr : finrank F E = 2) :
   is_simple_order (subalgebra F E) :=
@@ -1374,7 +1374,7 @@ let i := nontrivial_of_finrank_pos (zero_lt_two.trans_eq hr.symm) in by exactI
       exact submodule.eq_top_of_finrank_eq h, },
   end }
 
-end subalgebra_dim
+end subalgebra_rank
 
 namespace module
 namespace End
@@ -1457,7 +1457,7 @@ open module
 
 open_locale cardinal
 
-lemma cardinal_mk_eq_cardinal_mk_field_pow_dim
+lemma cardinal_mk_eq_cardinal_mk_field_pow_rank
   (K V : Type u) [division_ring K] [add_comm_group V] [module K V] [finite_dimensional K V] :
   #V = #K ^ module.rank K V :=
 begin
@@ -1465,7 +1465,7 @@ begin
   let hs := basis.of_vector_space K V,
   calc #V = #(s →₀ K) : quotient.sound ⟨hs.repr.to_equiv⟩
     ... = #(s → K) : quotient.sound ⟨finsupp.equiv_fun_on_finite⟩
-    ... = _ : by rw [← cardinal.lift_inj.1 hs.mk_eq_dim, cardinal.power_def]
+    ... = _ : by rw [← cardinal.lift_inj.1 hs.mk_eq_rank, cardinal.power_def]
 end
 
 lemma cardinal_lt_aleph_0_of_finite_dimensional
@@ -1474,9 +1474,9 @@ lemma cardinal_lt_aleph_0_of_finite_dimensional
   #V < ℵ₀ :=
 begin
   letI : is_noetherian K V := is_noetherian.iff_fg.2 infer_instance,
-  rw cardinal_mk_eq_cardinal_mk_field_pow_dim K V,
+  rw cardinal_mk_eq_cardinal_mk_field_pow_rank K V,
   exact cardinal.power_lt_aleph_0 (cardinal.lt_aleph_0_of_finite K)
-    (is_noetherian.dim_lt_aleph_0 K V),
+    (is_noetherian.rank_lt_aleph_0 K V),
 end
 
 end module

--- a/src/linear_algebra/finrank.lean
+++ b/src/linear_algebra/finrank.lean
@@ -56,28 +56,28 @@ noncomputable def finrank (R V : Type*) [semiring R]
   [add_comm_group V] [module R V] : ℕ :=
 (module.rank R V).to_nat
 
-lemma finrank_eq_of_dim_eq {n : ℕ} (h : module.rank K V = ↑ n) : finrank K V = n :=
+lemma finrank_eq_of_rank_eq {n : ℕ} (h : module.rank K V = ↑ n) : finrank K V = n :=
 begin
   apply_fun to_nat at h,
   rw to_nat_cast at h,
   exact_mod_cast h,
 end
 
-lemma finrank_le_of_dim_le {n : ℕ} (h : module.rank K V ≤ ↑ n) : finrank K V ≤ n :=
+lemma finrank_le_of_rank_le {n : ℕ} (h : module.rank K V ≤ ↑ n) : finrank K V ≤ n :=
 begin
   rwa [← cardinal.to_nat_le_iff_le_of_lt_aleph_0, to_nat_cast] at h,
   { exact h.trans_lt (nat_lt_aleph_0 n) },
   { exact nat_lt_aleph_0 n },
 end
 
-lemma finrank_lt_of_dim_lt {n : ℕ} (h : module.rank K V < ↑ n) : finrank K V < n :=
+lemma finrank_lt_of_rank_lt {n : ℕ} (h : module.rank K V < ↑ n) : finrank K V < n :=
 begin
   rwa [← cardinal.to_nat_lt_iff_lt_of_lt_aleph_0, to_nat_cast] at h,
   { exact h.trans (nat_lt_aleph_0 n) },
   { exact nat_lt_aleph_0 n },
 end
 
-lemma dim_lt_of_finrank_lt {n : ℕ} (h : n < finrank K V) : ↑n < module.rank K V :=
+lemma rank_lt_of_finrank_lt {n : ℕ} (h : n < finrank K V) : ↑n < module.rank K V :=
 begin
   rwa [← cardinal.to_nat_lt_iff_lt_of_lt_aleph_0, to_nat_cast],
   { exact nat_lt_aleph_0 n },
@@ -90,7 +90,7 @@ end
 basis. -/
 lemma finrank_eq_card_basis {ι : Type w} [fintype ι] (h : basis ι K V) :
   finrank K V = fintype.card ι :=
-finrank_eq_of_dim_eq (dim_eq_card_basis h)
+finrank_eq_of_rank_eq (rank_eq_card_basis h)
 
 /-- If a vector space has a finite basis, then its dimension is equal to the cardinality of the
 basis. This lemma uses a `finset` instead of indexed types. -/
@@ -101,7 +101,7 @@ by rw [finrank_eq_card_basis h, fintype.card_coe]
 
 /-- A finite dimensional space is nontrivial if it has positive `finrank`. -/
 lemma nontrivial_of_finrank_pos (h : 0 < finrank K V) : nontrivial V :=
-dim_pos_iff_nontrivial.mp (dim_lt_of_finrank_lt h)
+rank_pos_iff_nontrivial.mp (rank_lt_of_finrank_lt h)
 
 /-- A finite dimensional space is nontrivial if it has `finrank` equal to the successor of a
 natural number. -/
@@ -124,12 +124,12 @@ hs.subset_extend _
 variable (K)
 /-- A division_ring is one-dimensional as a vector space over itself. -/
 @[simp] lemma finrank_self : finrank K K = 1 :=
-finrank_eq_of_dim_eq (by simp)
+finrank_eq_of_rank_eq (by simp)
 
 /-- The vector space of functions on a fintype ι has finrank equal to the cardinality of ι. -/
 @[simp] lemma finrank_fintype_fun_eq_card {ι : Type v} [fintype ι] :
   finrank K (ι → K) = fintype.card ι :=
-finrank_eq_of_dim_eq dim_fun'
+finrank_eq_of_rank_eq rank_fun'
 
 /-- The vector space of functions on `fin n` has finrank equal to `n`. -/
 @[simp] lemma finrank_fin_fun {n : ℕ} : finrank K (fin n → K) = n :=
@@ -141,7 +141,7 @@ end finite_dimensional
 
 variables {K V}
 
-section zero_dim
+section zero_rank
 
 variables [division_ring K] [add_comm_group V] [module K V]
 
@@ -149,8 +149,8 @@ open finite_dimensional
 
 lemma finrank_eq_zero_of_basis_imp_not_finite
   (h : ∀ s : set V, basis.{v} (s : set V) K V → ¬ s.finite) : finrank K V = 0 :=
-dif_neg (λ dim_lt, h _ (basis.of_vector_space K V)
-  ((basis.of_vector_space K V).finite_index_of_dim_lt_aleph_0 dim_lt))
+dif_neg (λ rank_lt, h _ (basis.of_vector_space K V)
+  ((basis.of_vector_space K V).finite_index_of_rank_lt_aleph_0 rank_lt))
 
 lemma finrank_eq_zero_of_basis_imp_false
   (h : ∀ s : finset V, basis.{v} (s : set V) K V → false) : finrank K V = 0 :=
@@ -171,9 +171,9 @@ finrank_eq_zero_of_basis_imp_false (λ s b, h ⟨s, ⟨b⟩⟩)
 variables (K V)
 
 @[simp] lemma finrank_bot : finrank K (⊥ : submodule K V) = 0 :=
-finrank_eq_of_dim_eq (dim_bot _ _)
+finrank_eq_of_rank_eq (rank_bot _ _)
 
-end zero_dim
+end zero_rank
 
 namespace linear_equiv
 open finite_dimensional
@@ -186,7 +186,7 @@ variables [module R M] [module R M₂]
 
 /-- The dimension of a finite dimensional space is preserved under linear equivalence. -/
 theorem finrank_eq (f : M ≃ₗ[R] M₂) : finrank R M = finrank R M₂ :=
-by { unfold finrank, rw [← cardinal.to_nat_lift, f.lift_dim_eq, cardinal.to_nat_lift] }
+by { unfold finrank, rw [← cardinal.to_nat_lift, f.lift_rank_eq, cardinal.to_nat_lift] }
 
 /-- Pushforwards of finite-dimensional submodules along a `linear_equiv` have the same finrank. -/
 lemma finrank_map_eq (f : M ≃ₗ[R] M₂) (p : submodule R M) :
@@ -218,7 +218,7 @@ variables [division_ring K] [add_comm_group V] [module K V]
 
 @[simp]
 theorem finrank_top : finrank K (⊤ : submodule K V) = finrank K V :=
-by { unfold finrank, simp [dim_top] }
+by { unfold finrank, simp [rank_top] }
 
 end
 
@@ -259,7 +259,7 @@ variable {K}
 
 lemma finrank_span_le_card (s : set V) [fintype s] :
   finrank K (span K s) ≤ s.to_finset.card :=
-finrank_le_of_dim_le (by simpa using dim_span_le s)
+finrank_le_of_rank_le (by simpa using rank_span_le s)
 
 lemma finrank_span_finset_le_card (s : finset V)  :
   (s : set V).finrank K ≤ s.card :=
@@ -273,9 +273,9 @@ lemma finrank_range_le_card {ι : Type*} [fintype ι] {b : ι → V} :
 lemma finrank_span_eq_card {ι : Type*} [fintype ι] {b : ι → V}
   (hb : linear_independent K b) :
   finrank K (span K (set.range b)) = fintype.card ι :=
-finrank_eq_of_dim_eq
+finrank_eq_of_rank_eq
 begin
-  have : module.rank K (span K (set.range b)) = #(set.range b) := dim_span hb,
+  have : module.rank K (span K (set.range b)) = #(set.range b) := rank_span hb,
   rwa [←lift_inj, mk_range_eq_of_injective hb.injective, cardinal.mk_fintype, lift_nat_cast,
        lift_eq_nat_iff] at this,
 end
@@ -283,9 +283,9 @@ end
 lemma finrank_span_set_eq_card (s : set V) [fintype s]
   (hs : linear_independent K (coe : s → V)) :
   finrank K (span K s) = s.to_finset.card :=
-finrank_eq_of_dim_eq
+finrank_eq_of_rank_eq
 begin
-  have : module.rank K (span K s) = #s := dim_span_set hs,
+  have : module.rank K (span K s) = #s := rank_span_set hs,
   rwa [cardinal.mk_fintype, ←set.to_finset_card] at this,
 end
 
@@ -456,22 +456,22 @@ end
 
 end finrank_eq_one
 
-section subalgebra_dim
+section subalgebra_rank
 open module
 variables {F E : Type*} [field F] [ring E] [algebra F E]
 
-@[simp] lemma subalgebra.dim_bot [nontrivial E] : module.rank F (⊥ : subalgebra F E) = 1 :=
+@[simp] lemma subalgebra.rank_bot [nontrivial E] : module.rank F (⊥ : subalgebra F E) = 1 :=
 ((subalgebra.to_submodule_equiv (⊥ : subalgebra F E)).symm.trans $
-  linear_equiv.of_eq _ _ algebra.to_submodule_bot).dim_eq.trans $
-  by { rw dim_span_set, exacts [mk_singleton _, linear_independent_singleton one_ne_zero] }
+  linear_equiv.of_eq _ _ algebra.to_submodule_bot).rank_eq.trans $
+  by { rw rank_span_set, exacts [mk_singleton _, linear_independent_singleton one_ne_zero] }
 
-@[simp] lemma subalgebra.dim_to_submodule (S : subalgebra F E) :
+@[simp] lemma subalgebra.rank_to_submodule (S : subalgebra F E) :
   module.rank F S.to_submodule = module.rank F S := rfl
 
 @[simp] lemma subalgebra.finrank_to_submodule (S : subalgebra F E) :
   finrank F S.to_submodule = finrank F S := rfl
 
-lemma subalgebra_top_dim_eq_submodule_top_dim :
+lemma subalgebra_top_rank_eq_submodule_top_rank :
   module.rank F (⊤ : subalgebra F E) = module.rank F (⊤ : submodule F E) :=
 by { rw ← algebra.top_to_submodule, refl }
 
@@ -479,11 +479,11 @@ lemma subalgebra_top_finrank_eq_submodule_top_finrank :
   finrank F (⊤ : subalgebra F E) = finrank F (⊤ : submodule F E) :=
 by { rw ← algebra.top_to_submodule, refl }
 
-lemma subalgebra.dim_top : module.rank F (⊤ : subalgebra F E) = module.rank F E :=
-by { rw subalgebra_top_dim_eq_submodule_top_dim, exact dim_top F E }
+lemma subalgebra.rank_top : module.rank F (⊤ : subalgebra F E) = module.rank F E :=
+by { rw subalgebra_top_rank_eq_submodule_top_rank, exact rank_top F E }
 
 @[simp]
 lemma subalgebra.finrank_bot [nontrivial E] : finrank F (⊥ : subalgebra F E) = 1 :=
-finrank_eq_of_dim_eq (by simp)
+finrank_eq_of_rank_eq (by simp)
 
-end subalgebra_dim
+end subalgebra_rank

--- a/src/linear_algebra/free_algebra.lean
+++ b/src/linear_algebra/free_algebra.lean
@@ -27,8 +27,8 @@ finsupp.basis_single_one.map
   (equiv_monoid_algebra_free_monoid.symm.to_linear_equiv : _ ≃ₗ[R] free_algebra R X)
 
 -- TODO: generalize to `X : Type v`
-lemma dim_eq {K : Type u} {X : Type (max u v)} [field K] :
+lemma rank_eq {K : Type u} {X : Type (max u v)} [field K] :
   module.rank K (free_algebra K X) = cardinal.mk (list X) :=
-(cardinal.lift_inj.mp (basis_free_monoid K X).mk_eq_dim).symm
+(cardinal.lift_inj.mp (basis_free_monoid K X).mk_eq_rank).symm
 
 end free_algebra

--- a/src/linear_algebra/free_module/finite/matrix.lean
+++ b/src/linear_algebra/free_module/finite/matrix.lean
@@ -87,7 +87,7 @@ begin
   letI := nontrivial_of_invariant_basis_number R,
   have h := (linear_map.to_matrix (choose_basis R M) (choose_basis R N)),
   let b := (matrix.std_basis _ _ _).map h.symm,
-  rw [finrank, dim_eq_card_basis b, ← cardinal.mk_fintype, cardinal.mk_to_nat_eq_card, finrank,
+  rw [finrank, rank_eq_card_basis b, ← cardinal.mk_fintype, cardinal.mk_to_nat_eq_card, finrank,
     finrank, rank_eq_card_choose_basis_index, rank_eq_card_choose_basis_index,
     cardinal.mk_to_nat_eq_card, cardinal.mk_to_nat_eq_card, fintype.card_prod, mul_comm]
 end

--- a/src/linear_algebra/free_module/finite/rank.lean
+++ b/src/linear_algebra/free_module/finite/rank.lean
@@ -39,7 +39,7 @@ variables [add_comm_group N] [module R N] [module.free R N] [module.finite R N]
 lemma rank_lt_aleph_0 : module.rank R M < ℵ₀ :=
 begin
   letI := nontrivial_of_invariant_basis_number R,
-  rw [← (choose_basis R M).mk_eq_dim'', lt_aleph_0_iff_fintype],
+  rw [← (choose_basis R M).mk_eq_rank'', lt_aleph_0_iff_fintype],
   exact nonempty.intro infer_instance
 end
 

--- a/src/linear_algebra/free_module/rank.lean
+++ b/src/linear_algebra/free_module/rank.lean
@@ -34,12 +34,12 @@ variables [add_comm_group N] [module R N] [module.free R N]
 
 /-- The rank of a free module `M` over `R` is the cardinality of `choose_basis_index R M`. -/
 lemma rank_eq_card_choose_basis_index : module.rank R M = #(choose_basis_index R M) :=
-(choose_basis R M).mk_eq_dim''.symm
+(choose_basis R M).mk_eq_rank''.symm
 
 /-- The rank of `(ι →₀ R)` is `(# ι).lift`. -/
 @[simp] lemma rank_finsupp {ι : Type v} : module.rank R (ι →₀ R) = (# ι).lift :=
 by simpa [lift_id', lift_umax] using
-  (basis.of_repr (linear_equiv.refl _ (ι →₀ R))).mk_eq_dim.symm
+  (basis.of_repr (linear_equiv.refl _ (ι →₀ R))).mk_eq_rank.symm
 
 /-- If `R` and `ι` lie in the same universe, the rank of `(ι →₀ R)` is `# ι`. -/
 lemma rank_finsupp' {ι : Type u} : module.rank R (ι →₀ R) = # ι := by simp
@@ -48,7 +48,7 @@ lemma rank_finsupp' {ι : Type u} : module.rank R (ι →₀ R) = # ι := by sim
 @[simp] lemma rank_prod :
   module.rank R (M × N) = lift.{w v} (module.rank R M) + lift.{v w} (module.rank R N) :=
 by simpa [rank_eq_card_choose_basis_index R M, rank_eq_card_choose_basis_index R N,
-  lift_umax, lift_umax'] using ((choose_basis R M).prod (choose_basis R N)).mk_eq_dim.symm
+  lift_umax, lift_umax'] using ((choose_basis R M).prod (choose_basis R N)).mk_eq_rank.symm
 
 /-- If `M` and `N` lie in the same universe, the rank of `M × N` is
   `(module.rank R M) + (module.rank R N)`. -/
@@ -62,7 +62,7 @@ lemma rank_prod' (N : Type v) [add_comm_group N] [module R N] [module.free R N] 
 begin
   let B := λ i, choose_basis R (M i),
   let b : basis _ R (⨁ i, M i) := dfinsupp.basis (λ i, B i),
-  simp [← b.mk_eq_dim'', λ i, (B i).mk_eq_dim''],
+  simp [← b.mk_eq_rank'', λ i, (B i).mk_eq_rank''],
 end
 
 /-- The rank of a finite product is the sum of the ranks. -/
@@ -70,7 +70,7 @@ end
   [Π (i : ι), add_comm_group (M i)] [Π (i : ι), module R (M i)] [Π (i : ι), module.free R (M i)] :
   module.rank R (Π i, M i) = cardinal.sum (λ i, module.rank R (M i)) :=
 by { casesI nonempty_fintype ι,
-  rw [←(direct_sum.linear_equiv_fun_on_fintype _ _ M).dim_eq, rank_direct_sum] }
+  rw [←(direct_sum.linear_equiv_fun_on_fintype _ _ M).rank_eq, rank_direct_sum] }
 
 /-- If `m` and `n` are `fintype`, the rank of `m × n` matrices is `(# m).lift * (# n).lift`. -/
 @[simp] lemma rank_matrix (m : Type v) (n : Type w) [finite m] [finite n] :
@@ -78,7 +78,7 @@ by { casesI nonempty_fintype ι,
 begin
   casesI nonempty_fintype m,
   casesI nonempty_fintype n,
-  have h := (matrix.std_basis R m n).mk_eq_dim,
+  have h := (matrix.std_basis R m n).mk_eq_rank,
   rw [← lift_lift.{(max v w u) (max v w)}, lift_inj] at h,
   simpa using h.symm,
 end
@@ -109,9 +109,9 @@ begin
   let ιM := choose_basis_index R M,
   let ιN := choose_basis_index R N,
 
-  have h₁ := linear_equiv.lift_dim_eq (tensor_product.congr (repr R M) (repr R N)),
+  have h₁ := linear_equiv.lift_rank_eq (tensor_product.congr (repr R M) (repr R N)),
   let b : basis (ιM × ιN) R (_ →₀ R) := finsupp.basis_single_one,
-  rw [linear_equiv.dim_eq (finsupp_tensor_finsupp' R ιM ιN), ← b.mk_eq_dim, mk_prod] at h₁,
+  rw [linear_equiv.rank_eq (finsupp_tensor_finsupp' R ιM ιN), ← b.mk_eq_rank, mk_prod] at h₁,
   rw [lift_inj.1 h₁, rank_eq_card_choose_basis_index R M, rank_eq_card_choose_basis_index R N],
 end
 

--- a/src/linear_algebra/matrix/diagonal.lean
+++ b/src/linear_algebra/matrix/diagonal.lean
@@ -77,8 +77,8 @@ begin
   have hd : disjoint {i : m | w i ≠ 0} {i : m | w i = 0} := disjoint_compl_left,
   have B₁ := supr_range_std_basis_eq_infi_ker_proj K (λi:m, K) hd hu (set.to_finite _),
   have B₂ := @infi_ker_proj_equiv K _ _ (λi:m, K) _ _ _ _ (by simp; apply_instance) hd hu,
-  rw [rank, range_diagonal, B₁, ←@dim_fun' K],
-  apply linear_equiv.dim_eq,
+  rw [rank, range_diagonal, B₁, ←@rank_fun' K],
+  apply linear_equiv.rank_eq,
   apply B₂,
 end
 

--- a/src/linear_algebra/matrix/to_lin.lean
+++ b/src/linear_algebra/matrix/to_lin.lean
@@ -349,7 +349,7 @@ begin
   rw [vec_mul_vec_eq, matrix.to_lin'_mul],
   refine le_trans (rank_comp_le1 _ _) _,
   refine (rank_le_domain _).trans_eq _,
-  rw [dim_fun', fintype.card_unit, nat.cast_one]
+  rw [rank_fun', fintype.card_unit, nat.cast_one]
 end
 
 end to_matrix'

--- a/src/number_theory/ramification_inertia.lean
+++ b/src/number_theory/ramification_inertia.lean
@@ -606,44 +606,44 @@ end
 
 /-- Since the inclusion `(P^(i + 1) / P^e) ⊂ (P^i / P^e)` has a kernel isomorphic to `P / S`,
 `[P^i / P^e : R / p] = [P^(i+1) / P^e : R / p] + [P / S : R / p]` -/
-lemma dim_pow_quot_aux [is_domain S] [is_dedekind_domain S] [p.is_maximal] [P.is_prime]
+lemma rank_pow_quot_aux [is_domain S] [is_dedekind_domain S] [p.is_maximal] [P.is_prime]
   (hP0 : P ≠ ⊥) {i : ℕ} (hi : i < e) :
   module.rank (R ⧸ p) (ideal.map (P^e)^.quotient.mk (P ^ i)) =
   module.rank (R ⧸ p) (S ⧸ P) + module.rank (R ⧸ p) (ideal.map (P^e)^.quotient.mk (P ^ (i + 1))) :=
 begin
   letI : field (R ⧸ p) := ideal.quotient.field _,
-  rw [dim_eq_of_injective _ (pow_quot_succ_inclusion_injective f p P i),
-      (quotient_range_pow_quot_succ_inclusion_equiv f p P hP0 hi).symm.dim_eq],
-  exact (dim_quotient_add_dim (linear_map.range (pow_quot_succ_inclusion f p P i))).symm,
+  rw [rank_eq_of_injective _ (pow_quot_succ_inclusion_injective f p P i),
+      (quotient_range_pow_quot_succ_inclusion_equiv f p P hP0 hi).symm.rank_eq],
+  exact (rank_quotient_add_rank (linear_map.range (pow_quot_succ_inclusion f p P i))).symm,
 end
 
-lemma dim_pow_quot [is_domain S] [is_dedekind_domain S] [p.is_maximal] [P.is_prime]
+lemma rank_pow_quot [is_domain S] [is_dedekind_domain S] [p.is_maximal] [P.is_prime]
   (hP0 : P ≠ ⊥) (i : ℕ) (hi : i ≤ e) :
   module.rank (R ⧸ p) (ideal.map (P^e)^.quotient.mk (P ^ i)) =
   (e - i) • module.rank (R ⧸ p) (S ⧸ P) :=
 begin
   refine @nat.decreasing_induction' _ i e (λ j lt_e le_j ih, _) hi _,
-  { rw [dim_pow_quot_aux f p P _ lt_e, ih, ← succ_nsmul, nat.sub_succ, ← nat.succ_eq_add_one,
+  { rw [rank_pow_quot_aux f p P _ lt_e, ih, ← succ_nsmul, nat.sub_succ, ← nat.succ_eq_add_one,
       nat.succ_pred_eq_of_pos (nat.sub_pos_of_lt lt_e)],
     assumption },
   { rw [nat.sub_self, zero_nsmul, map_quotient_self],
-    exact dim_bot (R ⧸ p) (S ⧸ (P^e)) }
+    exact rank_bot (R ⧸ p) (S ⧸ (P^e)) }
 end
 
 omit hfp
 
 /-- If `p` is a maximal ideal of `R`, `S` extends `R` and `P^e` lies over `p`,
 then the dimension `[S/(P^e) : R/p]` is equal to `e * [S/P : R/p]`. -/
-lemma dim_prime_pow_ramification_idx [is_domain S] [is_dedekind_domain S] [p.is_maximal]
+lemma rank_prime_pow_ramification_idx [is_domain S] [is_dedekind_domain S] [p.is_maximal]
   [P.is_prime] (hP0 : P ≠ ⊥) (he : e ≠ 0) :
   module.rank (R ⧸ p) (S ⧸ P^e) =
   e • @module.rank (R ⧸ p) (S ⧸ P) _ _ (@algebra.to_module _ _ _ _ $
     @@quotient.algebra_quotient_of_ramification_idx_ne_zero _ _ _ _ _ ⟨he⟩) :=
 begin
   letI : ne_zero e := ⟨he⟩,
-  have := dim_pow_quot f p P hP0 0 (nat.zero_le e),
+  have := rank_pow_quot f p P hP0 0 (nat.zero_le e),
   rw [pow_zero, nat.sub_zero, ideal.one_eq_top, ideal.map_top] at this,
-  exact (dim_top (R ⧸ p) _).symm.trans this
+  exact (rank_top (R ⧸ p) _).symm.trans this
 end
 
 /-- If `p` is a maximal ideal of `R`, `S` extends `R` and `P^e` lies over `p`,
@@ -657,12 +657,12 @@ begin
   letI : ne_zero e := ⟨he⟩,
   letI : algebra (R ⧸ p) (S ⧸ P) := quotient.algebra_quotient_of_ramification_idx_ne_zero f p P,
   letI := ideal.quotient.field p,
-  have hdim := dim_prime_pow_ramification_idx _ _ _ hP0 he,
+  have hdim := rank_prime_pow_ramification_idx _ _ _ hP0 he,
   by_cases hP : finite_dimensional (R ⧸ p) (S ⧸ P),
   { haveI := hP,
     haveI := (finite_dimensional_iff_of_rank_eq_nsmul he hdim).mpr hP,
     refine cardinal.nat_cast_injective _,
-    rw [finrank_eq_dim, nat.cast_mul, finrank_eq_dim, hdim, nsmul_eq_mul] },
+    rw [finrank_eq_rank', nat.cast_mul, finrank_eq_rank', hdim, nsmul_eq_mul] },
   have hPe := mt (finite_dimensional_iff_of_rank_eq_nsmul he hdim).mp hP,
   simp only [finrank_of_infinite_dimensional hP, finrank_of_infinite_dimensional hPe, mul_zero],
 end


### PR DESCRIPTION
The `dim` name is left from the previous name of the function, `vector_space.dim`. When that was merged with `module.rank` in #7322, we left renaming the existing lemmas as future work.

This commit was made by replacing `(\b|(?<=_))dim(\b|(?=_))` with `rank` in the `dimension` and `finite_dimensional` files, and then manually fixing downstream breakages; it's important not to rename `power_basis.dim` at the same time!

Deciding whether to move some of these to the `module` namespace is left as future work, the diff is already big enough.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

It's possible that some of these names are wrong; but if so, they were wrong before too, and I'd rather fix them in a follow-up that isn't just a find-and-replace.