### PR TITLE
[Merged by Bors] - chore(category_theory/abelian): backport removal of abelian.has_finite_biproducts instance

### DIFF
--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -258,7 +258,7 @@ variables {C : Type u} [category.{v} C] [abelian C]
 -- but triggers https://github.com/leanprover/lean4/issues/2055
 -- We set it as a local instance instead.
 -- @[priority 100] instance
-def has_finite_biproducts : has_finite_biproducts C :=
+theorem has_finite_biproducts : has_finite_biproducts C :=
 limits.has_finite_biproducts.of_has_finite_products
 
 local attribute [instance] has_finite_biproducts

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -254,9 +254,14 @@ namespace category_theory.abelian
 variables {C : Type u} [category.{v} C] [abelian C]
 
 /-- An abelian category has finite biproducts. -/
-@[priority 100]
-instance has_finite_biproducts : has_finite_biproducts C :=
+-- Porting note: this should be an instance,
+-- but triggers https://github.com/leanprover/lean4/issues/2055
+-- We set it as a local instance instead.
+-- @[priority 100] instance
+def has_finite_biproducts : has_finite_biproducts C :=
 limits.has_finite_biproducts.of_has_finite_products
+
+local attribute [instance] has_finite_biproducts
 
 @[priority 100]
 instance has_binary_biproducts : has_binary_biproducts C :=

--- a/src/category_theory/abelian/opposite.lean
+++ b/src/category_theory/abelian/opposite.lean
@@ -22,6 +22,11 @@ variables (C : Type*) [category C] [abelian C]
 local attribute [instance]
   has_finite_limits_of_has_equalizers_and_finite_products
   has_finite_colimits_of_has_coequalizers_and_finite_coproducts
+  -- Porting note:
+  -- This should have been a global instance,
+  -- but triggers https://github.com/leanprover/lean4/issues/2055
+  -- when ported to mathlib4.
+  abelian.has_finite_biproducts
 
 instance : abelian Cᵒᵖ :=
 { normal_mono_of_mono := λ X Y f m, by exactI


### PR DESCRIPTION
This backports a proposed removal of the `abelian.has_finite_biproducts` global instance, instead enabling it locally in the files that need it.

The reason for removing it is that it triggers the ~~dreaded~~ https://github.com/leanprover/lean4/issues/2055 during the simpNF linter in https://github.com/leanprover-community/mathlib4/pull/2769, the mathlib4 port of `category_theory.abelian.basic`.

This backport verifies that we won't run into further problems downstream if we (hopefully temporarily) remove these instances in mathlib4. 



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
