### PR TITLE
[Merged by Bors] - chore(linear_algebra/dimension): deduplicate lemmas

### DIFF
--- a/src/field_theory/finite/polynomial.lean
+++ b/src/field_theory/finite/polynomial.lean
@@ -182,8 +182,7 @@ calc module.rank K (R σ K) =
   module.rank K (↥{s : σ →₀ ℕ | ∀ (n : σ), s n ≤ fintype.card K - 1} →₀ K) :
     linear_equiv.rank_eq
       (finsupp.supported_equiv_finsupp {s : σ →₀ ℕ | ∀n:σ, s n ≤ fintype.card K - 1 })
-  ... = #{s : σ →₀ ℕ | ∀ (n : σ), s n ≤ fintype.card K - 1} :
-    by rw [finsupp.rank_eq, rank_self, mul_one]
+  ... = #{s : σ →₀ ℕ | ∀ (n : σ), s n ≤ fintype.card K - 1} : by rw [rank_finsupp_self']
   ... = #{s : σ → ℕ | ∀ (n : σ), s n < fintype.card K } :
   begin
     refine quotient.sound ⟨equiv.subtype_equiv finsupp.equiv_fun_on_finite $ assume f, _⟩,

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -942,6 +942,19 @@ variables [add_comm_group V'] [module K V'] [module.free K V']
 variables [add_comm_group V₁] [module K V₁] [module.free K V₁]
 variables {K V}
 
+
+namespace module.free
+variables (K V)
+
+/-- The rank of a free module `M` over `R` is the cardinality of `choose_basis_index R M`. -/
+lemma rank_eq_card_choose_basis_index : module.rank K V = #(choose_basis_index K V) :=
+(choose_basis K V).mk_eq_rank''.symm
+
+end module.free
+
+open module.free
+open cardinal
+
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
 theorem nonempty_linear_equiv_of_lift_rank_eq
   (cond : cardinal.lift.{v'} (module.rank K V) = cardinal.lift.{v} (module.rank K V')) :
@@ -987,35 +1000,31 @@ theorem linear_equiv.nonempty_equiv_iff_rank_eq :
   nonempty (V ≃ₗ[K] V₁) ↔ module.rank K V = module.rank K V₁ :=
 ⟨λ ⟨h⟩, linear_equiv.rank_eq h, λ h, nonempty_linear_equiv_of_rank_eq h⟩
 
-theorem rank_prod : module.rank K (V × V₁) = module.rank K V + module.rank K V₁ :=
-begin
-  obtain ⟨⟨_, b⟩⟩ := module.free.exists_basis K V,
-  obtain ⟨⟨_, c⟩⟩ := module.free.exists_basis K V₁,
-  rw [← cardinal.lift_inj,
-      ← (basis.prod b c).mk_eq_rank,
-      cardinal.lift_add, ← cardinal.mk_ulift,
-      ← b.mk_eq_rank, ← c.mk_eq_rank,
-      ← cardinal.mk_ulift, ← cardinal.mk_ulift,
-      cardinal.add_def (ulift _)],
-  exact cardinal.lift_inj.1 (cardinal.lift_mk_eq.2
-      ⟨equiv.ulift.trans (equiv.sum_congr equiv.ulift equiv.ulift).symm ⟩),
-end
+/-- The rank of `M × N` is `(module.rank R M).lift + (module.rank R N).lift`. -/
+@[simp] lemma rank_prod :
+  module.rank K (V × V') =
+    cardinal.lift.{v'} (module.rank K V) + cardinal.lift.{v v'} (module.rank K V') :=
+by simpa [rank_eq_card_choose_basis_index K V, rank_eq_card_choose_basis_index K V',
+  lift_umax, lift_umax'] using ((choose_basis K V).prod (choose_basis K V')).mk_eq_rank.symm
+
+/-- If `M` and `N` lie in the same universe, the rank of `M × N` is
+  `(module.rank R M) + (module.rank R N)`. -/
+theorem rank_prod' : module.rank K (V × V₁) = module.rank K V + module.rank K V₁ :=
+by simp
 
 section fintype
 variables [∀i, add_comm_group (φ i)] [∀i, module K (φ i)] [∀i, module.free K (φ i)]
 
 open linear_map
 
-lemma rank_pi [finite η] :
+/-- The rank of a finite product is the sum of the ranks. -/
+@[simp] lemma rank_pi [finite η] :
   module.rank K (Πi, φ i) = cardinal.sum (λi, module.rank K (φ i)) :=
 begin
-  haveI := nontrivial_of_invariant_basis_number K,
   casesI nonempty_fintype η,
-  let b := λ i, (module.free.exists_basis K (φ i)).some.2,
-  let this : basis (Σ j, _) K (Π j, φ j) := pi.basis b,
-  rw [← cardinal.lift_inj, ← this.mk_eq_rank],
-  simp_rw [cardinal.mk_sigma, cardinal.lift_sum, ←(b _).mk_range_eq_rank,
-    cardinal.mk_range_eq _ (b _).injective],
+  let B := λ i, choose_basis K (φ i),
+  let b : basis _ K (Π i, φ i) := pi.basis (λ i, B i),
+  simp [← b.mk_eq_rank'', λ i, (B i).mk_eq_rank''],
 end
 
 variable [fintype η]
@@ -1037,13 +1046,6 @@ lemma rank_fin_fun (n : ℕ) : module.rank K (fin n → K) = n :=
 by simp [rank_fun']
 
 end fintype
-
-lemma finsupp.rank_eq {ι : Type v} : module.rank K (ι →₀ V) = #ι * module.rank K V :=
-begin
-  obtain ⟨⟨_, bs⟩⟩ := module.free.exists_basis K V,
-  rw [← bs.mk_eq_rank'', ← (finsupp.basis (λa:ι, bs)).mk_eq_rank'',
-    cardinal.mk_sigma, cardinal.sum_const']
-end
 
 -- TODO: merge with the `finrank` content
 /-- An `n`-dimensional `K`-vector space is equivalent to `fin n → K`. -/
@@ -1092,7 +1094,7 @@ calc module.rank K (span K (↑s : set V)) ≤ #(↑s : set V) : rank_span_le �
 
 theorem rank_quotient_add_rank (p : submodule K V) :
   module.rank K (V ⧸ p) + module.rank K p = module.rank K V :=
-by classical; exact let ⟨f⟩ := quotient_prod_linear_equiv p in rank_prod.symm.trans f.rank_eq
+by classical; exact let ⟨f⟩ := quotient_prod_linear_equiv p in rank_prod'.symm.trans f.rank_eq
 
 /-- rank-nullity theorem -/
 theorem rank_range_add_rank_ker (f : V →ₗ[K] V₁) :
@@ -1122,7 +1124,7 @@ lemma rank_add_rank_split
 have hf : surjective (coprod db eb),
 by rwa [←range_eq_top, range_coprod, eq_top_iff],
 begin
-  conv {to_rhs, rw [← rank_prod, rank_eq_of_surjective _ hf] },
+  conv {to_rhs, rw [← rank_prod', rank_eq_of_surjective _ hf] },
   congr' 1,
   apply linear_equiv.rank_eq,
   refine linear_equiv.of_bijective _ ⟨_, _⟩,

--- a/src/linear_algebra/free_module/finite/rank.lean
+++ b/src/linear_algebra/free_module/finite/rank.lean
@@ -57,7 +57,7 @@ end
 
 /-- The finrank of `(ι →₀ R)` is `fintype.card ι`. -/
 @[simp] lemma finrank_finsupp {ι : Type v} [fintype ι] : finrank R (ι →₀ R) = card ι :=
-by { rw [finrank, rank_finsupp'', ← mk_to_nat_eq_card, to_nat_lift] }
+by { rw [finrank, rank_finsupp_self, ← mk_to_nat_eq_card, to_nat_lift] }
 
 /-- The finrank of `(ι → R)` is `fintype.card ι`. -/
 lemma finrank_pi {ι : Type v} [fintype ι] : finrank R (ι → R) = card ι :=

--- a/src/linear_algebra/free_module/finite/rank.lean
+++ b/src/linear_algebra/free_module/finite/rank.lean
@@ -57,7 +57,7 @@ end
 
 /-- The finrank of `(ι →₀ R)` is `fintype.card ι`. -/
 @[simp] lemma finrank_finsupp {ι : Type v} [fintype ι] : finrank R (ι →₀ R) = card ι :=
-by { rw [finrank, rank_finsupp, ← mk_to_nat_eq_card, to_nat_lift] }
+by { rw [finrank, rank_finsupp'', ← mk_to_nat_eq_card, to_nat_lift] }
 
 /-- The finrank of `(ι → R)` is `fintype.card ι`. -/
 lemma finrank_pi {ι : Type v} [fintype ι] : finrank R (ι → R) = card ι :=
@@ -84,7 +84,7 @@ lemma finrank_pi_fintype {ι : Type v} [fintype ι] {M : ι → Type w}
   [Π (i : ι), module.finite R (M i)] : finrank R (Π i, M i) = ∑ i, finrank R (M i) :=
 begin
   letI := nontrivial_of_invariant_basis_number R,
-  simp only [finrank, λ i, rank_eq_card_choose_basis_index R (M i), rank_pi_finite,
+  simp only [finrank, λ i, rank_eq_card_choose_basis_index R (M i), rank_pi,
     ← mk_sigma, mk_to_nat_eq_card, card_sigma],
 end
 

--- a/src/linear_algebra/free_module/rank.lean
+++ b/src/linear_algebra/free_module/rank.lean
@@ -5,14 +5,12 @@ Authors: Riccardo Brasca
 -/
 
 import linear_algebra.dimension
-import linear_algebra.free_module.basic
-import linear_algebra.invariant_basis_number
 
 /-!
 
-# Rank of free modules
+# Extra results about `module.rank`
 
-This is a basic API for the rank of free modules.
+This file contains some extra results not in `linear_algebra.dimension`.
 
 -/
 
@@ -24,36 +22,31 @@ open_locale tensor_product direct_sum big_operators cardinal
 
 open cardinal
 
-namespace module.free
-
 section ring
 
 variables [ring R] [strong_rank_condition R]
 variables [add_comm_group M] [module R M] [module.free R M]
 variables [add_comm_group N] [module R N] [module.free R N]
 
-/-- The rank of a free module `M` over `R` is the cardinality of `choose_basis_index R M`. -/
-lemma rank_eq_card_choose_basis_index : module.rank R M = #(choose_basis_index R M) :=
-(choose_basis R M).mk_eq_rank''.symm
+open module.free
+
+@[simp] lemma rank_finsupp (ι : Type w) :
+  module.rank R (ι →₀ M) = cardinal.lift.{v} #ι * cardinal.lift.{w} (module.rank R M) :=
+begin
+  obtain ⟨⟨_, bs⟩⟩ := module.free.exists_basis R M,
+  rw [← bs.mk_eq_rank'', ← (finsupp.basis (λa:ι, bs)).mk_eq_rank'',
+    cardinal.mk_sigma, cardinal.sum_const]
+end
+
+lemma rank_finsupp' (ι : Type v) : module.rank R (ι →₀ M) = #ι * module.rank R M :=
+by simp [rank_finsupp]
 
 /-- The rank of `(ι →₀ R)` is `(# ι).lift`. -/
-@[simp] lemma rank_finsupp {ι : Type v} : module.rank R (ι →₀ R) = (# ι).lift :=
-by simpa [lift_id', lift_umax] using
-  (basis.of_repr (linear_equiv.refl _ (ι →₀ R))).mk_eq_rank.symm
+@[simp] lemma rank_finsupp_self (ι : Type w) : module.rank R (ι →₀ R) = (# ι).lift :=
+by simp [rank_finsupp]
 
 /-- If `R` and `ι` lie in the same universe, the rank of `(ι →₀ R)` is `# ι`. -/
-lemma rank_finsupp' {ι : Type u} : module.rank R (ι →₀ R) = # ι := by simp
-
-/-- The rank of `M × N` is `(module.rank R M).lift + (module.rank R N).lift`. -/
-@[simp] lemma rank_prod :
-  module.rank R (M × N) = lift.{w v} (module.rank R M) + lift.{v w} (module.rank R N) :=
-by simpa [rank_eq_card_choose_basis_index R M, rank_eq_card_choose_basis_index R N,
-  lift_umax, lift_umax'] using ((choose_basis R M).prod (choose_basis R N)).mk_eq_rank.symm
-
-/-- If `M` and `N` lie in the same universe, the rank of `M × N` is
-  `(module.rank R M) + (module.rank R N)`. -/
-lemma rank_prod' (N : Type v) [add_comm_group N] [module R N] [module.free R N] :
-  module.rank R (M × N) = (module.rank R M) + (module.rank R N) := by simp
+lemma rank_finsupp_self' {ι : Type u} : module.rank R (ι →₀ R) = # ι := by simp
 
 /-- The rank of the direct sum is the sum of the ranks. -/
 @[simp] lemma rank_direct_sum  {ι : Type v} (M : ι → Type w) [Π (i : ι), add_comm_group (M i)]
@@ -64,13 +57,6 @@ begin
   let b : basis _ R (⨁ i, M i) := dfinsupp.basis (λ i, B i),
   simp [← b.mk_eq_rank'', λ i, (B i).mk_eq_rank''],
 end
-
-/-- The rank of a finite product is the sum of the ranks. -/
-@[simp] lemma rank_pi_finite {ι : Type v} [finite ι] {M : ι → Type w}
-  [Π (i : ι), add_comm_group (M i)] [Π (i : ι), module R (M i)] [Π (i : ι), module.free R (M i)] :
-  module.rank R (Π i, M i) = cardinal.sum (λ i, module.rank R (M i)) :=
-by { casesI nonempty_fintype ι,
-  rw [←(direct_sum.linear_equiv_fun_on_fintype _ _ M).rank_eq, rank_direct_sum] }
 
 /-- If `m` and `n` are `fintype`, the rank of `m × n` matrices is `(# m).lift * (# n).lift`. -/
 @[simp] lemma rank_matrix (m : Type v) (n : Type w) [finite m] [finite n] :
@@ -102,6 +88,8 @@ variables [comm_ring R] [strong_rank_condition R]
 variables [add_comm_group M] [module R M] [module.free R M]
 variables [add_comm_group N] [module R N] [module.free R N]
 
+open module.free
+
 /-- The rank of `M ⊗[R] N` is `(module.rank R M).lift * (module.rank R N).lift`. -/
 @[simp] lemma rank_tensor_product : module.rank R (M ⊗[R] N) = lift.{w v} (module.rank R M) *
   lift.{v w} (module.rank R N) :=
@@ -121,5 +109,3 @@ lemma rank_tensor_product' (N : Type v) [add_comm_group N] [module R N] [module.
   module.rank R (M ⊗[R] N) = (module.rank R M) * (module.rank R N) := by simp
 
 end comm_ring
-
-end module.free


### PR DESCRIPTION
We have some lemmas in the `module.free` namespace which duplicate lemmas in the root namespace. This moves all the remaining `rank` lemmas in this namespace into the root namespace, and cleans up the overlapping lemmas this creates.

The changes are:
* `module.free.rank_eq_card_choose_basis_index`: unchanged but moved to an earlier file
* `rank_prod` → `rank_prod'` (the non-universe polymorphic version)
* `module.free.rank_prod` → `rank_prod`
* none → `rank_finsupp` (new lemma)
* `finsupp.rank_eq` → `rank_finsupp'` (the non-universe polymorphic version)
* `module.free.rank_finsupp` → `rank_finsupp_self`
* `module.free.rank_finsupp'` → `rank_finsupp_self'` (the non-universe polymorphic version)
* `module.free.rank_pi_finite` → `rank_pi` (these were duplicates)
* For everything else, `module.free.rank_*` → `rank_*`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
