### PR TITLE
[Merged by Bors] - chore(set_theory/cardinal/basic): missing lemmas about `lift c < ℵ₀` and `ℵ₀ < lift c`

### DIFF
--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -872,6 +872,8 @@ by rwa [← cardinal.lift_lt, ← b.mk_eq_rank,
         cardinal.lift_aleph_0, ← cardinal.lift_aleph_0.{u_1 v},
         cardinal.lift_lt, cardinal.lt_aleph_0_iff_fintype] at h
 
+#exit -- TODO: golf the proof above once CI stops here
+
 /-- If a module has a finite dimension, all bases are indexed by a finite type. -/
 noncomputable def basis.fintype_index_of_rank_lt_aleph_0 {ι : Type*}
   (b : basis ι R M) (h : module.rank R M < ℵ₀) :

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -867,12 +867,8 @@ by simpa using v.mk_eq_rank
 lemma basis.nonempty_fintype_index_of_rank_lt_aleph_0 {ι : Type*}
   (b : basis ι R M) (h : module.rank R M < ℵ₀) :
   nonempty (fintype ι) :=
-by rwa [← cardinal.lift_lt, ← b.mk_eq_rank,
-        -- ensure `aleph_0` has the correct universe
-        cardinal.lift_aleph_0, ← cardinal.lift_aleph_0.{u_1 v},
-        cardinal.lift_lt, cardinal.lt_aleph_0_iff_fintype] at h
-
-#exit -- TODO: golf the proof above once CI stops here
+by rwa [← cardinal.lift_lt, ← b.mk_eq_rank, cardinal.lift_aleph_0, cardinal.lift_lt_aleph_0,
+        cardinal.lt_aleph_0_iff_fintype] at h
 
 /-- If a module has a finite dimension, all bases are indexed by a finite type. -/
 noncomputable def basis.fintype_index_of_rank_lt_aleph_0 {ι : Type*}

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -891,6 +891,12 @@ by rw [←lift_aleph_0, lift_le]
 @[simp] theorem lift_le_aleph_0 {c : cardinal.{u}} : lift.{v} c ≤ ℵ₀ ↔ c ≤ ℵ₀ :=
 by rw [←lift_aleph_0, lift_le]
 
+@[simp] theorem aleph_0_lt_lift {c : cardinal.{u}} : ℵ₀ < lift.{v} c ↔ ℵ₀ < c :=
+by rw [←lift_aleph_0, lift_lt]
+
+@[simp] theorem lift_lt_aleph_0 {c : cardinal.{u}} : lift.{v} c < ℵ₀ ↔ c < ℵ₀ :=
+by rw [←lift_aleph_0, lift_lt]
+
 /-! ### Properties about the cast from `ℕ` -/
 
 @[simp] theorem mk_fin (n : ℕ) : #(fin n) = n := by simp
@@ -1245,9 +1251,9 @@ begin
   apply nat_cast_injective,
   cases lt_or_ge c ℵ₀ with hc hc,
   { rw [cast_to_nat_of_lt_aleph_0, ←lift_nat_cast, cast_to_nat_of_lt_aleph_0 hc],
-    rwa [←lift_aleph_0, lift_lt] },
+    rwa [lift_lt_aleph_0] },
   { rw [cast_to_nat_of_aleph_0_le, ←lift_nat_cast, cast_to_nat_of_aleph_0_le hc, lift_zero],
-    rwa [←lift_aleph_0, lift_le] },
+    rwa [aleph_0_le_lift] },
 end
 
 lemma to_nat_congr {β : Type v} (e : α ≃ β) : (#α).to_nat = (#β).to_nat :=
@@ -1285,8 +1291,8 @@ map_prod to_nat_hom _ _
   (ha : a < ℵ₀) (hb : b < ℵ₀) : ((lift.{v u} a) + (lift.{u v} b)).to_nat = a.to_nat + b.to_nat :=
 begin
   apply cardinal.nat_cast_injective,
-  replace ha : (lift.{v u} a) < ℵ₀ := by { rw ←lift_aleph_0, exact lift_lt.2 ha },
-  replace hb : (lift.{u v} b) < ℵ₀ := by { rw ←lift_aleph_0, exact lift_lt.2 hb },
+  replace ha : (lift.{v u} a) < ℵ₀ := by rwa lift_lt_aleph_0,
+  replace hb : (lift.{u v} b) < ℵ₀ := by rwa lift_lt_aleph_0,
   rw [nat.cast_add, ←to_nat_lift.{v u} a, ←to_nat_lift.{u v} b, cast_to_nat_of_lt_aleph_0 ha,
     cast_to_nat_of_lt_aleph_0 hb, cast_to_nat_of_lt_aleph_0 (add_lt_aleph_0 ha hb)]
 end

--- a/src/set_theory/cardinal/continuum.lean
+++ b/src/set_theory/cardinal/continuum.lean
@@ -39,6 +39,18 @@ by rw [←two_power_aleph_0, lift_two_power, lift_aleph_0, two_power_aleph_0]
 ### Inequalities
 -/
 
+@[simp] lemma continuum_le_lift {c : cardinal.{u}} : 𝔠 ≤ lift.{v} c ↔ 𝔠 ≤ c :=
+by rw [←lift_continuum, lift_le]
+
+@[simp] lemma lift_le_continuum {c : cardinal.{u}} : lift.{v} c ≤ 𝔠 ↔ c ≤ 𝔠 :=
+by rw [←lift_continuum, lift_le]
+
+@[simp] lemma continuum_lt_lift {c : cardinal.{u}} : 𝔠 < lift.{v} c ↔ 𝔠 < c :=
+by rw [←lift_continuum, lift_lt]
+
+@[simp] lemma lift_lt_continuum {c : cardinal.{u}} : lift.{v} c < 𝔠 ↔ c < 𝔠 :=
+by rw [←lift_continuum, lift_lt]
+
 lemma aleph_0_lt_continuum : ℵ₀ < 𝔠 := cantor ℵ₀
 
 lemma aleph_0_le_continuum : ℵ₀ ≤ 𝔠 := aleph_0_lt_continuum.le

--- a/src/set_theory/ordinal/arithmetic.lean
+++ b/src/set_theory/ordinal/arithmetic.lean
@@ -1831,7 +1831,7 @@ open ordinal
 le_antisymm (ord_le.2 $ le_rfl) $
 le_of_forall_lt $ λ o h, begin
   rcases ordinal.lt_lift_iff.1 h with ⟨o, rfl, h'⟩,
-  rw [lt_ord, ←lift_card, ←lift_aleph_0.{0 u}, lift_lt, ←typein_enum (<) h'],
+  rw [lt_ord, ←lift_card, lift_lt_aleph_0, ←typein_enum (<) h'],
   exact lt_aleph_0_iff_fintype.2 ⟨set.fintype_lt_nat _⟩
 end
 


### PR DESCRIPTION
We already had the `le` versions `lift_le_aleph0` and `aleph0_le_lift`, this adds the `lt` ones `lift_lt_aleph0` and `aleph0_lt_lift`.

This turns out to be useful for proving some results about `finrank`, as well as golfing some existing proofs.

Since they're trivial, this adds the same lemmas about `continuum` too.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
