### PR TITLE
[Merged by Bors] - chore(linear_algebra/dimension): fix lemma names

### DIFF
--- a/archive/sensitivity.lean
+++ b/archive/sensitivity.lean
@@ -364,7 +364,7 @@ begin
   { convert ← rank_submodule_le (W ⊔ img),
     apply dim_V },
   have dim_add : dim (W ⊔ img) + dim (W ⊓ img) = dim W + 2^m,
-  { convert ← rank_sup_add_rank_inf_eq W img,
+  { convert ← submodule.rank_sup_add_rank_inf_eq W img,
     rw ← rank_eq_of_injective (g m) g_injective,
     apply dim_V },
   have dimW : dim W = card H,

--- a/src/analysis/inner_product_space/projection.lean
+++ b/src/analysis/inner_product_space/projection.lean
@@ -1047,7 +1047,7 @@ lemma submodule.finrank_add_inf_finrank_orthogonal {K₁ K₂ : submodule 𝕜 E
 begin
   haveI := submodule.finite_dimensional_of_le h,
   haveI := proper_is_R_or_C 𝕜 K₁,
-  have hd := submodule.rank_sup_add_rank_inf_eq K₁ (K₁ᗮ ⊓ K₂),
+  have hd := submodule.finrank_sup_add_finrank_inf_eq K₁ (K₁ᗮ ⊓ K₂),
   rw [←inf_assoc, (submodule.orthogonal_disjoint K₁).eq_bot, bot_inf_eq, finrank_bot,
       submodule.sup_orthogonal_inf_of_complete_space h] at hd,
   rw add_zero at hd,

--- a/src/linear_algebra/affine_space/finite_dimensional.lean
+++ b/src/linear_algebra/affine_space/finite_dimensional.lean
@@ -681,7 +681,7 @@ begin
     convert rfl;
       simp },
   { rw [affine_span_coe, direction_affine_span_insert hp₀, add_comm],
-    refine (submodule.rank_add_le_rank_add_rank _ _).trans (add_le_add_right _ _),
+    refine (submodule.finrank_add_le_finrank_add_finrank _ _).trans (add_le_add_right _ _),
     refine finrank_le_one ⟨p -ᵥ p₀, submodule.mem_span_singleton_self _⟩ (λ v, _),
     have h := v.property,
     rw submodule.mem_span_singleton at h,

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -1204,7 +1204,7 @@ begin
     exact hx₂ n hn },
   refine is_compl.of_eq this (eq_top_of_finrank_eq $ (submodule.finrank_le _).antisymm _),
   conv_rhs { rw ← add_zero (finrank K _) },
-  rw [← finrank_bot K V, ← this, submodule.rank_sup_add_rank_inf_eq,
+  rw [← finrank_bot K V, ← this, submodule.finrank_sup_add_finrank_inf_eq,
       finrank_add_finrank_orthogonal b₁],
   exact le_self_add,
 end

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -1113,7 +1113,7 @@ variables [add_comm_group V₂] [module K V₂]
 variables [add_comm_group V₃] [module K V₃]
 open linear_map
 
-/-- This is mostly an auxiliary lemma for `rank_sup_add_rank_inf_eq`. -/
+/-- This is mostly an auxiliary lemma for `submodule.rank_sup_add_rank_inf_eq`. -/
 lemma rank_add_rank_split
   (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd : V₁ →ₗ[K] V₂) (ce : V₁ →ₗ[K] V₃)
   (hde : ⊤ ≤ db.range ⊔ eb.range)
@@ -1146,7 +1146,7 @@ begin
     rw [h₂, _root_.neg_neg] }
 end
 
-lemma rank_sup_add_rank_inf_eq (s t : submodule K V) :
+lemma submodule.rank_sup_add_rank_inf_eq (s t : submodule K V) :
   module.rank K (s ⊔ t : submodule K V) + module.rank K (s ⊓ t : submodule K V) =
     module.rank K s + module.rank K t :=
 rank_add_rank_split
@@ -1165,9 +1165,9 @@ rank_add_rank_split
     exact ⟨⟨b₁, hb₁, hb₂⟩, rfl, rfl⟩
   end
 
-lemma rank_add_le_rank_add_rank (s t : submodule K V) :
+lemma submodule.rank_add_le_rank_add_rank (s t : submodule K V) :
   module.rank K (s ⊔ t : submodule K V) ≤ module.rank K s + module.rank K t :=
-by { rw [← rank_sup_add_rank_inf_eq], exact self_le_add_right _ _ }
+by { rw [← submodule.rank_sup_add_rank_inf_eq], exact self_le_add_right _ _ }
 
 end
 
@@ -1360,7 +1360,7 @@ calc rank (f + g) ≤ module.rank K (f.range ⊔ g.range : submodule K V') :
       assume x, show f x + g x ∈ (f.range ⊔ g.range : submodule K V'), from
         mem_sup.2 ⟨_, ⟨x, rfl⟩, _, ⟨x, rfl⟩, rfl⟩)
   end
-  ... ≤ rank f + rank g : rank_add_le_rank_add_rank _ _
+  ... ≤ rank f + rank g : submodule.rank_add_le_rank_add_rank _ _
 
 lemma rank_finset_sum_le {η} (s : finset η) (f : η → V →ₗ[K] V') :
   rank (∑ d in s, f d) ≤ ∑ d in s, rank (f d) :=

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -752,7 +752,7 @@ begin
     rw [hdisjoint, finrank_bot] },
   apply eq_top_of_finrank_eq,
   rw ←hdim,
-  convert s.rank_sup_add_rank_inf_eq t,
+  convert s.finrank_sup_add_finrank_inf_eq t,
   rw h_finrank_inf,
   refl,
 end
@@ -1094,7 +1094,8 @@ lemma finrank_add_eq_of_is_compl
   [finite_dimensional K V] {U W : submodule K V} (h : is_compl U W) :
   finrank K U + finrank K W = finrank K V :=
 begin
-  rw [← rank_sup_add_rank_inf_eq, h.codisjoint.eq_top, h.disjoint.eq_bot, finrank_bot, add_zero],
+  rw [← finrank_sup_add_finrank_inf_eq, h.codisjoint.eq_top, h.disjoint.eq_bot, finrank_bot,
+    add_zero],
   exact finrank_top
 end
 

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -727,7 +727,7 @@ begin
 end
 
 /-- The sum of the dimensions of s + t and s ∩ t is the sum of the dimensions of s and t -/
-theorem rank_sup_add_rank_inf_eq (s t : submodule K V)
+theorem finrank_sup_add_finrank_inf_eq (s t : submodule K V)
   [finite_dimensional K s] [finite_dimensional K t] :
   finrank K ↥(s ⊔ t) + finrank K ↥(s ⊓ t) = finrank K ↥s + finrank K ↥t :=
 begin
@@ -738,10 +738,10 @@ begin
   exact key
 end
 
-lemma rank_add_le_rank_add_rank (s t : submodule K V)
+lemma finrank_add_le_finrank_add_finrank (s t : submodule K V)
   [finite_dimensional K s] [finite_dimensional K t] :
   finrank K (s ⊔ t : submodule K V) ≤ finrank K s + finrank K t :=
-by { rw [← rank_sup_add_rank_inf_eq], exact self_le_add_right _ _ }
+by { rw [← finrank_sup_add_finrank_inf_eq], exact self_le_add_right _ _ }
 
 lemma eq_top_of_disjoint [finite_dimensional K V] (s t : submodule K V)
   (hdim : finrank K s + finrank K t = finrank K V)


### PR DESCRIPTION
This fixes some lemma names which use `rank` but are about `finrank`:

* `rank_sup_add_rank_inf_eq` → `submodule.rank_sup_add_rank_inf_eq`
* `rank_add_le_rank_add_rank` → `submodule.rank_add_le_rank_add_rank`
* `submodule.rank_sup_add_rank_inf_eq` → `submodule.finrank_sup_add_finrank_inf_eq`
* `submodule.rank_add_le_rank_add_rank` → `submodule.finrank_add_le_finrank_add_finrank`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
