### PR TITLE
feat(order/well_founded): `well_founded_lt.has_min`, etc.

### DIFF
--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -233,11 +233,17 @@ def to_has_well_founded : has_well_founded α := ⟨r, is_well_founded.wf⟩
 
 end is_well_founded
 
+/-- There are no 2-cycles in a well-founded relation. -/
 theorem well_founded.asymmetric {α : Sort*} {r : α → α → Prop} (h : well_founded r) :
   ∀ ⦃a b⦄, r a b → ¬ r b a
 | a := λ b hab hba, well_founded.asymmetric hba hab
 using_well_founded { rel_tac := λ _ _, `[exact ⟨_, h⟩],
                      dec_tac := tactic.assumption }
+
+/-- There are no 1-cycles in a well-founded relation. -/
+theorem well_founded.irreflexive {α : Sort*} {r : α → α → Prop} (h : well_founded r) :
+  ∀ ⦃a⦄, ¬ r a a :=
+λ a ha, h.asymmetric ha ha
 
 @[priority 100] -- see Note [lower instance priority]
 instance is_well_founded.is_asymm (r : α → α → Prop) [is_well_founded α r] : is_asymm α r :=

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -25,18 +25,6 @@ variables {α : Type*}
 
 namespace well_founded
 
-protected theorem is_asymm {α : Sort*} {r : α → α → Prop} (h : well_founded r) : is_asymm α r :=
-⟨h.asymmetric⟩
-
-instance {α : Sort*} [has_well_founded α] : is_asymm α has_well_founded.r :=
-has_well_founded.wf.is_asymm
-
-protected theorem is_irrefl {α : Sort*} {r : α → α → Prop} (h : well_founded r) : is_irrefl α r :=
-(@is_asymm.is_irrefl α r h.is_asymm)
-
-instance {α : Sort*} [has_well_founded α] : is_irrefl α has_well_founded.r :=
-is_asymm.is_irrefl
-
 /-- If `r` is a well-founded relation, then any nonempty set has a minimal element
 with respect to `r`. -/
 theorem has_min {α} {r : α → α → Prop} (H : well_founded r)
@@ -61,7 +49,7 @@ theorem not_lt_min {r : α → α → Prop} (H : well_founded r)
   (s : set α) (h : s.nonempty) {x} (hx : x ∈ s) : ¬ r x (H.min s h) :=
 let ⟨_, h'⟩ := classical.some_spec (H.has_min s h) in h' _ hx
 
-theorem well_founded_iff_has_min {r : α → α → Prop} : (well_founded r) ↔
+theorem well_founded_iff_has_min {r : α → α → Prop} : well_founded r ↔
   ∀ (s : set α), s.nonempty → ∃ m ∈ s, ∀ x ∈ s, ¬ r x m :=
 begin
   refine ⟨λ h, h.has_min, λ h, ⟨λ x, _⟩⟩,
@@ -73,28 +61,31 @@ begin
 end
 
 open set
+
 /-- The supremum of a bounded, well-founded order -/
 protected noncomputable def sup {r : α → α → Prop} (wf : well_founded r) (s : set α)
   (h : bounded r s) : α :=
-wf.min { x | ∀a ∈ s, r a x } h
+wf.min { x | ∀ a ∈ s, r a x } h
 
 protected lemma lt_sup {r : α → α → Prop} (wf : well_founded r) {s : set α} (h : bounded r s)
   {x} (hx : x ∈ s) : r x (wf.sup s h) :=
-min_mem wf { x | ∀a ∈ s, r a x } h x hx
+min_mem wf { x | ∀ a ∈ s, r a x } h x hx
 
-section
+section classical
 open_locale classical
+
 /-- A successor of an element `x` in a well-founded order is a minimal element `y` such that
 `x < y` if one exists. Otherwise it is `x` itself. -/
 protected noncomputable def succ {r : α → α → Prop} (wf : well_founded r) (x : α) : α :=
-if h : ∃y, r x y then wf.min { y | r x y } h else x
+if h : ∃ y, r x y then wf.min { y | r x y } h else x
 
-protected lemma lt_succ {r : α → α → Prop} (wf : well_founded r) {x : α} (h : ∃y, r x y) :
+protected lemma lt_succ {r : α → α → Prop} (wf : well_founded r) {x : α} (h : ∃ y, r x y) :
   r x (wf.succ x) :=
 by { rw [well_founded.succ, dif_pos h], apply min_mem }
-end
 
-protected lemma lt_succ_iff {r : α → α → Prop} [wo : is_well_order α r] {x : α} (h : ∃y, r x y)
+end classical
+
+protected lemma lt_succ_iff {r : α → α → Prop} [wo : is_well_order α r] {x : α} (h : ∃ y, r x y)
   (y : α) : r y (wo.wf.succ x) ↔ r y x ∨ y = x :=
 begin
   split,

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -64,16 +64,6 @@ variables (r : α → α → Prop) [h : is_well_founded α r]
 with respect to `r`. -/
 theorem has_min : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, ¬ r x a := h.wf.has_min
 
-/-- An arbitrary minimal element of a nonempty set in a well-founded order. -/
-noncomputable def min : Π s : set α, s.nonempty → α :=
-h.wf.min
-
-theorem min_mem : ∀ (s : set α) (hs : s.nonempty), min r s hs ∈ s :=
-h.wf.min_mem
-
-theorem not_lt_min : ∀ (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s), ¬ r x (min r s hs) :=
-h.wf.not_lt_min
-
 theorem is_well_founded_iff_has_min {r : α → α → Prop} : is_well_founded α r ↔
   ∀ s : set α, s.nonempty → ∃ m ∈ s, ∀ x ∈ s, ¬ r x m :=
 by rw [is_well_founded_iff, well_founded.well_founded_iff_has_min]
@@ -84,22 +74,12 @@ namespace well_founded_lt
 section has_lt
 variables [has_lt α] [h : well_founded_lt α]
 
-/-- If `<` is well-founded, then any nonempty set has a minimal element. -/
-theorem has_min' : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, ¬ x < a := h.wf.has_min
-
-/-- A minimal element of a nonempty set in a well-founded order.
+/-- If `<` is well-founded, then any nonempty set has a minimal element.
 
 If you're working with a nonempty linear order, consider defining a
 `conditionally_complete_linear_order_bot` instance via
-`well_founded.conditionally_complete_linear_order_with_bot` and using `Inf` instead. -/
-noncomputable def min : Π s : set α, s.nonempty → α :=
-h.wf.min
-
-theorem min_mem : ∀ (s : set α) (hs : s.nonempty), min s hs ∈ s :=
-h.wf.min_mem
-
-theorem not_lt_min : ∀ (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s), ¬ x < min s hs :=
-h.wf.not_lt_min
+`well_founded.conditionally_complete_linear_order_with_bot` and using `Inf` instead.-/
+theorem has_min' : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, ¬ x < a := h.wf.has_min
 
 theorem well_founded_lt_iff_has_min' {α : Type*} [has_lt α] : well_founded_lt α ↔
   ∀ s : set α, s.nonempty → ∃ m ∈ s, ∀ x ∈ s, ¬ x < m :=
@@ -113,9 +93,6 @@ variables [linear_order α] [well_founded_lt α]
 /-- If `<` is well-founded, then any nonempty set has a minimal element. -/
 theorem has_min : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, a ≤ x :=
 by { simp_rw ←not_lt, exact has_min' }
-
-theorem min_le (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s) : min s hs ≤ x :=
-by { rw ←not_lt, exact not_lt_min s hs hx }
 
 theorem well_founded_lt_iff_has_min {α : Type*} [linear_order α] : well_founded_lt α ↔
   ∀ s : set α, s.nonempty → ∃ m ∈ s, ∀ x ∈ s, m ≤ x :=
@@ -132,16 +109,6 @@ variables [has_lt α] [h : well_founded_gt α]
 theorem has_max' : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, ¬ a < x :=
 h.wf.has_min
 
-/-- A maximal element of a nonempty set in a well-founded order. -/
-noncomputable def max : Π s : set α, s.nonempty → α :=
-h.wf.min
-
-theorem max_mem : ∀ (s : set α) (hs : s.nonempty), max s hs ∈ s :=
-h.wf.min_mem
-
-theorem not_max_lt : ∀ (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s), ¬ max s hs < x :=
-h.wf.not_lt_min
-
 theorem well_founded_gt_iff_has_max' {α : Type*} [has_lt α] : well_founded_gt α ↔
   ∀ s : set α, s.nonempty → ∃ m ∈ s, ∀ x ∈ s, ¬ m < x :=
 is_well_founded.is_well_founded_iff_has_min
@@ -154,9 +121,6 @@ variables [linear_order α] [well_founded_gt α]
 /-- If `>` is well-founded, then any nonempty set has a maximal element. -/
 theorem has_max : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, x ≤ a :=
 by { simp_rw ←not_lt, exact has_max' }
-
-theorem le_max (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s) : x ≤ max s hs :=
-by { rw ←not_lt, exact not_max_lt s hs hx }
 
 theorem well_founded_gt_iff_has_max {α : Type*} [linear_order α] : well_founded_gt α ↔
   ∀ s : set α, s.nonempty → ∃ m ∈ s, ∀ x ∈ s, x ≤ m :=

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -65,9 +65,11 @@ with respect to `r`. -/
 theorem has_min : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, ¬ r x a := h.wf.has_min
 
 /-- An arbitrary minimal element of a nonempty set in a well-founded order. -/
-noncomputable def min : Π s : set α, s.nonempty → α := h.wf.min
+noncomputable def min : Π s : set α, s.nonempty → α :=
+h.wf.min
 
-theorem min_mem : ∀ (s : set α) (hs : s.nonempty), min r s hs ∈ s := h.wf.min_mem
+theorem min_mem : ∀ (s : set α) (hs : s.nonempty), min r s hs ∈ s :=
+h.wf.min_mem
 
 theorem not_lt_min : ∀ (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s), ¬ r x (min r s hs) :=
 h.wf.not_lt_min
@@ -83,16 +85,18 @@ section has_lt
 variables [has_lt α] [h : well_founded_lt α]
 
 /-- If `<` is well-founded, then any nonempty set has a minimal element. -/
-theorem has_min : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, ¬ x < a := h.wf.has_min
+theorem has_min' : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, ¬ x < a := h.wf.has_min
 
 /-- A minimal element of a nonempty set in a well-founded order.
 
 If you're working with a nonempty linear order, consider defining a
 `conditionally_complete_linear_order_bot` instance via
 `well_founded.conditionally_complete_linear_order_with_bot` and using `Inf` instead. -/
-noncomputable def min : Π s : set α, s.nonempty → α := h.wf.min
+noncomputable def min : Π s : set α, s.nonempty → α :=
+h.wf.min
 
-theorem min_mem : ∀ (s : set α) (hs : s.nonempty), min s hs ∈ s := h.wf.min_mem
+theorem min_mem : ∀ (s : set α) (hs : s.nonempty), min s hs ∈ s :=
+h.wf.min_mem
 
 theorem not_lt_min : ∀ (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s), ¬ x < min s hs :=
 h.wf.not_lt_min
@@ -104,9 +108,13 @@ is_well_founded.is_well_founded_iff_has_min
 end has_lt
 
 section linear_order
+variables [linear_order α] [well_founded_lt α]
 
-theorem min_le [linear_order α] [well_founded_lt α] (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s) :
-  min s hs ≤ x :=
+/-- If `<` is well-founded, then any nonempty set has a minimal element. -/
+theorem has_min : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, a ≤ x :=
+by { simp_rw ←not_lt, exact has_min' }
+
+theorem min_le (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s) : min s hs ≤ x :=
 by { rw ←not_lt, exact not_lt_min s hs hx }
 
 theorem well_founded_lt_iff_has_min {α : Type*} [linear_order α] : well_founded_lt α ↔
@@ -121,12 +129,15 @@ section has_lt
 variables [has_lt α] [h : well_founded_gt α]
 
 /-- If `>` is well-founded, then any nonempty set has a maximal element. -/
-theorem has_max : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, ¬ a < x := h.wf.has_min
+theorem has_max' : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, ¬ a < x :=
+h.wf.has_min
 
 /-- A maximal element of a nonempty set in a well-founded order. -/
-noncomputable def max : Π s : set α, s.nonempty → α := h.wf.min
+noncomputable def max : Π s : set α, s.nonempty → α :=
+h.wf.min
 
-theorem max_mem : ∀ (s : set α) (hs : s.nonempty), max s hs ∈ s := h.wf.min_mem
+theorem max_mem : ∀ (s : set α) (hs : s.nonempty), max s hs ∈ s :=
+h.wf.min_mem
 
 theorem not_max_lt : ∀ (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s), ¬ max s hs < x :=
 h.wf.not_lt_min
@@ -138,9 +149,13 @@ is_well_founded.is_well_founded_iff_has_min
 end has_lt
 
 section linear_order
+variables [linear_order α] [well_founded_gt α]
 
-theorem le_max [linear_order α] [well_founded_gt α] (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s) :
-  x ≤ max s hs :=
+/-- If `>` is well-founded, then any nonempty set has a maximal element. -/
+theorem has_max : ∀ s : set α, s.nonempty → ∃ a ∈ s, ∀ x ∈ s, x ≤ a :=
+by { simp_rw ←not_lt, exact has_max' }
+
+theorem le_max (s : set α) (hs : s.nonempty) {x} (hx : x ∈ s) : x ≤ max s hs :=
 by { rw ←not_lt, exact not_max_lt s hs hx }
 
 theorem well_founded_gt_iff_has_max {α : Type*} [linear_order α] : well_founded_gt α ↔

--- a/src/set_theory/zfc/basic.lean
+++ b/src/set_theory/zfc/basic.lean
@@ -217,7 +217,6 @@ end⟩
 theorem mem_wf : @well_founded pSet (∈) := ⟨λ x, mem_wf_aux $ equiv.refl x⟩
 
 instance : has_well_founded pSet := ⟨_, mem_wf⟩
-instance : is_asymm pSet (∈) := mem_wf.is_asymm
 
 theorem mem_asymm {x y : pSet} : x ∈ y → y ∉ x := asymm
 theorem mem_irrefl (x : pSet) : x ∉ x := irrefl x
@@ -774,8 +773,6 @@ mem_wf.induction x h
 
 instance : has_well_founded Set := ⟨_, mem_wf⟩
 
-instance : is_asymm Set (∈) := mem_wf.is_asymm
-
 theorem mem_asymm {x y : Set} : x ∈ y → y ∉ x := asymm
 theorem mem_irrefl (x : Set) : x ∉ x := irrefl x
 
@@ -1009,7 +1006,6 @@ theorem mem_wf : @well_founded Class.{u} (∈) :=
 end⟩
 
 instance : has_well_founded Class := ⟨_, mem_wf⟩
-instance : is_asymm Class (∈) := mem_wf.is_asymm
 
 theorem mem_asymm {x y : Class} : x ∈ y → y ∉ x := asymm
 theorem mem_irrefl (x : Class) : x ∉ x := irrefl x


### PR DESCRIPTION
We add some boilerplate code for porting `well_founded.has_min` to the typeclasses `is_well_founded`, `well_founded_lt`, and `well_founded_gt`.

Besides the usual convenience from using instances, there's two advantages of doing this:
- the lemmas for `well_founded_gt` no longer have their names backwards (`min` instead of `max`)
- we're able to directly state `well_founded_lt.min_le` and `well_founded_gt.le_max` in linear orders

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [ ] depends on: #18750

Speaking of boilerplate, I'm not even sure we should keep `well_founded.min` and the like. In a proof, it's always better to use
```lean
obtain ⟨s, hs, hlt⟩ := well_founded.has_min s hns
```
and outside of it, I can't see much use for having a generic minimal element, unless you're already working in a linear order, in which case you can use `Inf` instead.

Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/well_founded.2Emin/near/347492784

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
