### PR TITLE
[Merged by Bors] - chore(linear_algebra/dimension): remove outdated comment

### DIFF
--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -64,10 +64,6 @@ For vector spaces (i.e. modules over a field), we have
 
 ## Implementation notes
 
-There is a naming discrepancy: most of the theorem names refer to `rank`,
-even though the definition is of `module.rank`.
-This reflects that `module.rank` was originally called `rank`, and only defined for vector spaces.
-
 Many theorems in this file are not universe-generic when they relate dimensions
 in different universes. They should be as general as they can be without
 inserting `lift`s. The types `V`, `V'`, ... all live in different universes,


### PR DESCRIPTION
This used to be about `vector_space.dim`, but was caught up in the rename that fixed the naming inconsistency and is now nonsense.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
