### PR TITLE
chore(data/fintype/card): instance `well_founded_of_trans_of_irrefl`

### DIFF
--- a/src/data/dfinsupp/well_founded.lean
+++ b/src/data/dfinsupp/well_founded.lean
@@ -171,9 +171,9 @@ begin
   obtain h | ⟨⟨x⟩⟩ := is_empty_or_nonempty (Π i, α i),
   { convert empty_wf, ext1 x, exact (h.1 x).elim },
   letI : Π i, has_zero (α i) := λ i, ⟨(hs i).min ⊤ ⟨x i, trivial⟩⟩,
-  haveI := is_trans.swap r, haveI := is_irrefl.swap r, haveI := fintype.of_finite ι,
+  haveI := is_strict_order.swap r, haveI := fintype.of_finite ι,
   refine inv_image.wf equiv_fun_on_fintype.symm (lex.well_founded' (λ i a, _) hs _),
-  exacts [(hs i).not_lt_min ⊤ _ trivial, finite.well_founded_of_trans_of_irrefl r.swap],
+  exacts [(hs i).not_lt_min ⊤ _ trivial, (finite.is_well_founded_of_strict_order r.swap).wf],
 end
 
 instance pi.lex.well_founded_lt [linear_order ι] [finite ι] [Π i, has_lt (α i)]

--- a/src/data/fin/tuple/bubble_sort_induction.lean
+++ b/src/data/fin/tuple/bubble_sort_induction.lean
@@ -40,7 +40,7 @@ lemma bubble_sort_induction' {n : ℕ} {α : Type*} [linear_order α] {f : fin n
 begin
   letI := @preorder.lift _ (lex (fin n → α)) _ (λ σ : equiv.perm (fin n), to_lex (f ∘ σ)),
   refine @well_founded.induction_bot' _ _ _
-    (@finite.preorder.well_founded_lt (equiv.perm (fin n)) _ _)
+    (@finite.is_well_founded_of_strict_order (equiv.perm (fin n)) _ (<) _).wf
     (equiv.refl _) (sort f) P (λ σ, f ∘ σ) (λ σ hσ hfσ, _) hf,
   obtain ⟨i, j, hij₁, hij₂⟩ := antitone_pair_of_not_sorted' hσ,
   exact ⟨σ * equiv.swap i j, pi.lex_desc hij₁ hij₂, h σ i j hij₁ hij₂ hfσ⟩,

--- a/src/data/fin/tuple/bubble_sort_induction.lean
+++ b/src/data/fin/tuple/bubble_sort_induction.lean
@@ -40,7 +40,7 @@ lemma bubble_sort_induction' {n : ℕ} {α : Type*} [linear_order α] {f : fin n
 begin
   letI := @preorder.lift _ (lex (fin n → α)) _ (λ σ : equiv.perm (fin n), to_lex (f ∘ σ)),
   refine @well_founded.induction_bot' _ _ _
-    (@finite.is_well_founded_of_strict_order (equiv.perm (fin n)) _ (<) _).wf
+    (@finite.is_well_founded_of_strict_order _ _ (<) _).wf
     (equiv.refl _) (sort f) P (λ σ, f ∘ σ) (λ σ hσ hfσ, _) hf,
   obtain ⟨i, j, hij₁, hij₂⟩ := antitone_pair_of_not_sorted' hσ,
   exact ⟨σ * equiv.swap i j, pi.lex_desc hij₁ hij₂, h σ i j hij₁ hij₂ hfσ⟩,

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -759,7 +759,7 @@ lemma finset.exists_minimal {α : Type*} [preorder α] (s : finset α) (h : s.no
   ∃ m ∈ s, ∀ x ∈ s, ¬ (x < m) :=
 begin
   obtain ⟨c, hcs : c ∈ s⟩ := h,
-  have : is_well_founded _ (@has_lt.lt {x // x ∈ s} _) := by apply_instance,
+  have : well_founded_lt {x // x ∈ s} := by apply_instance,
   obtain ⟨⟨m, hms : m ∈ s⟩, -, H⟩ := this.wf.has_min set.univ ⟨⟨c, hcs⟩, trivial⟩,
   exact ⟨m, hms, λ x hx hxm, H ⟨x, hx⟩ trivial hxm⟩,
 end

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -716,27 +716,19 @@ end
 namespace finite
 variables [finite α]
 
-lemma well_founded_of_trans_of_irrefl (r : α → α → Prop) [is_trans α r] [is_irrefl α r] :
-  well_founded r :=
-by classical; casesI nonempty_fintype α; exact
+instance is_well_founded_of_strict_order (r : α → α → Prop) [is_strict_order α r] :
+  is_well_founded α r :=
+⟨by classical; casesI nonempty_fintype α; exact
 have ∀ x y, r x y → (univ.filter (λ z, r z x)).card < (univ.filter (λ z, r z y)).card,
   from λ x y hxy, finset.card_lt_card $
     by simp only [finset.lt_iff_ssubset.symm, lt_iff_le_not_le,
       finset.le_iff_subset, finset.subset_iff, mem_filter, true_and, mem_univ, hxy];
     exact ⟨λ z hzx, trans hzx hxy, not_forall_of_exists_not ⟨x, not_imp.2 ⟨hxy, irrefl x⟩⟩⟩,
-subrelation.wf this (measure_wf _)
+subrelation.wf this (measure_wf _)⟩
 
-lemma preorder.well_founded_lt [preorder α] : well_founded ((<) : α → α → Prop) :=
-well_founded_of_trans_of_irrefl _
+@[priority 10] instance linear_order.is_well_order_lt [linear_order α] : is_well_order α (<) := { }
 
-lemma preorder.well_founded_gt [preorder α] : well_founded ((>) : α → α → Prop) :=
-well_founded_of_trans_of_irrefl _
-
-@[priority 10] instance linear_order.is_well_order_lt [linear_order α] : is_well_order α (<) :=
-{ wf := preorder.well_founded_lt }
-
-@[priority 10] instance linear_order.is_well_order_gt [linear_order α] : is_well_order α (>) :=
-{ wf := preorder.well_founded_gt }
+@[priority 10] instance linear_order.is_well_order_gt [linear_order α] : is_well_order α (>) := { }
 
 end finite
 
@@ -767,8 +759,8 @@ lemma finset.exists_minimal {α : Type*} [preorder α] (s : finset α) (h : s.no
   ∃ m ∈ s, ∀ x ∈ s, ¬ (x < m) :=
 begin
   obtain ⟨c, hcs : c ∈ s⟩ := h,
-  have : well_founded (@has_lt.lt {x // x ∈ s} _) := finite.well_founded_of_trans_of_irrefl _,
-  obtain ⟨⟨m, hms : m ∈ s⟩, -, H⟩ := this.has_min set.univ ⟨⟨c, hcs⟩, trivial⟩,
+  have : is_well_founded _ (@has_lt.lt {x // x ∈ s} _) := by apply_instance,
+  obtain ⟨⟨m, hms : m ∈ s⟩, -, H⟩ := this.wf.has_min set.univ ⟨⟨c, hcs⟩, trivial⟩,
   exact ⟨m, hms, λ x hx hxm, H ⟨x, hx⟩ trivial hxm⟩,
 end
 

--- a/src/topology/noetherian_space.lean
+++ b/src/topology/noetherian_space.lean
@@ -174,7 +174,7 @@ end
 
 @[priority 100]
 instance finite.to_noetherian_space [finite α] : noetherian_space α :=
-⟨finite.well_founded_of_trans_of_irrefl _⟩
+⟨is_well_founded.wf⟩
 
 lemma noetherian_space.exists_finset_irreducible [noetherian_space α] (s : closeds α) :
   ∃ S : finset (closeds α), (∀ k : S, is_irreducible (k : set α)) ∧ s = S.sup id :=


### PR DESCRIPTION
This PR does the following:
- turn `well_founded_of_trans_of_irrefl` into an instance, rename to `is_well_founded_of_strict_order`
- use `is_strict_order α r` instead of the equivalent `is_trans α r` + `is_irrefl α r`
- remove `preorder.well_founded_(lt/gt)`, as their instance forms can now be inferred automatically
- golf + fix elsewhere

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
