### PR TITLE
[Merged by Bors] - chore(analysis/inner_product_space/symmetric): change lemma name

### DIFF
--- a/src/analysis/inner_product_space/symmetric.lean
+++ b/src/analysis/inner_product_space/symmetric.lean
@@ -178,7 +178,7 @@ end
 
 /-- A symmetric linear map `T` is zero if and only if `⟪T x, x⟫_ℝ = 0` for all `x`.
 See `inner_map_self_eq_zero` for the complex version without the symmetric assumption. -/
-lemma is_symmetric.inner_map_eq_zero {T : E →ₗ[𝕜] E} (hT : T.is_symmetric) :
+lemma is_symmetric.inner_map_self_eq_zero {T : E →ₗ[𝕜] E} (hT : T.is_symmetric) :
   (∀ x, ⟪T x, x⟫ = 0) ↔ T = 0 :=
 begin
   simp_rw [linear_map.ext_iff, zero_apply],


### PR DESCRIPTION
changed name from [`linear_map.is_symmetric.inner_map_eq_zero`](https://leanprover-community.github.io/mathlib_docs/analysis/inner_product_space/symmetric.html#linear_map.is_symmetric.inner_map_eq_zero) to `linear_map.is_symmetric.inner_map_self_eq_zero` to match [`inner_map_self_eq_zero`](https://leanprover-community.github.io/mathlib_docs/analysis/inner_product_space/basic.html#inner_map_self_eq_zero)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
