### PR TITLE
[Merged by Bors] - feat(data/matrix/rank): rank of a matrix is the rank of its column space

### DIFF
--- a/src/data/matrix/rank.lean
+++ b/src/data/matrix/rank.lean
@@ -114,7 +114,7 @@ lemma rank_le_height [strong_rank_condition R] {m n : ℕ} (A : matrix (fin m) (
 A.rank_le_card_height.trans $ (fintype.card_fin m).le
 
 /-- The rank of a matrix is the rank of the space spanned by its columns. -/
-lemma rank_eq_finrank_span_cols [strong_rank_condition R] (A : matrix m n R) :
+lemma rank_eq_finrank_span_cols (A : matrix m n R) :
   A.rank = finrank R (submodule.span R (set.range Aᵀ)) :=
 by rw [rank, matrix.range_to_lin']
 

--- a/src/data/matrix/rank.lean
+++ b/src/data/matrix/rank.lean
@@ -19,7 +19,7 @@ This definition does not depend on the choice of basis, see `matrix.rank_eq_finr
 
 ## TODO
 
-* Show that `matrix.rank` is equal to the row-rank and column-rank
+* Show that `matrix.rank` is equal to the row-rank, and that `rank Aᵀ = rank A`.
 
 -/
 
@@ -112,5 +112,10 @@ omit m_fin
 lemma rank_le_height [strong_rank_condition R] {m n : ℕ} (A : matrix (fin m) (fin n) R) :
   A.rank ≤ m :=
 A.rank_le_card_height.trans $ (fintype.card_fin m).le
+
+/-- The rank of a matrix is the rank of the space spanned by its columns. -/
+lemma rank_eq_finrank_span_cols [strong_rank_condition R] (A : matrix m n R) :
+  A.rank = finrank R (submodule.span R (set.range Aᵀ)) :=
+by rw [rank, matrix.range_to_lin']
 
 end matrix


### PR DESCRIPTION
This is a TODO comment in this file left from #10826. Proving the link to the row space is harder, and only easy to prove for `is_R_or_C`; so I've left it for another time.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
