### PR TITLE
[Merged by Bors] - chore(algebra/group_with_zero/units/basic): Deduplicate instance

### DIFF
--- a/src/algebra/group_with_zero/units/basic.lean
+++ b/src/algebra/group_with_zero/units/basic.lean
@@ -207,14 +207,6 @@ instance group_with_zero.no_zero_divisors : no_zero_divisors G₀ :=
     end,
   .. (‹_› : group_with_zero G₀) }
 
-@[priority 10] -- see Note [lower instance priority]
-instance group_with_zero.cancel_monoid_with_zero : cancel_monoid_with_zero G₀ :=
-{ mul_left_cancel_of_ne_zero := λ x y z hx h,
-    by rw [← inv_mul_cancel_left₀ hx y, h, inv_mul_cancel_left₀ hx z],
-  mul_right_cancel_of_ne_zero := λ x y z hy h,
-    by rw [← mul_inv_cancel_right₀ hy x, h, mul_inv_cancel_right₀ hy z],
-  .. (‹_› : group_with_zero G₀) }
-
 -- Can't be put next to the other `mk0` lemmas because it depends on the
 -- `no_zero_divisors` instance, which depends on `mk0`.
 @[simp] lemma units.mk0_mul (x y : G₀) (hxy) :
@@ -247,8 +239,8 @@ section comm_group_with_zero -- comm
 variables [comm_group_with_zero G₀] {a b c d : G₀}
 
 @[priority 10] -- see Note [lower instance priority]
-instance comm_group_with_zero.cancel_comm_monoid_with_zero : cancel_comm_monoid_with_zero G₀ :=
-{ ..group_with_zero.cancel_monoid_with_zero, ..comm_group_with_zero.to_comm_monoid_with_zero G₀ }
+instance comm_group_with_zero.to_cancel_comm_monoid_with_zero : cancel_comm_monoid_with_zero G₀ :=
+{ ..group_with_zero.to_cancel_monoid_with_zero, ..comm_group_with_zero.to_comm_monoid_with_zero G₀ }
 
 @[priority 100] -- See note [lower instance priority]
 instance comm_group_with_zero.to_division_comm_monoid : division_comm_monoid G₀ :=


### PR DESCRIPTION
`group_with_zero.cancel_monoid_with_zero` was a duplicate of `group_with_zero.to_cancel_monoid_with_zero`.
`comm_group_with_zero.cancel_comm_monoid_with_zero` is renamed to include the usual `to_` prefix.

This should have been done in #18698.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
