### PR TITLE
[Merged by Bors] - chore(linear_algebra/matrix/dot_product): weaken typeclasses

### DIFF
--- a/src/linear_algebra/matrix/dot_product.lean
+++ b/src/linear_algebra/matrix/dot_product.lean
@@ -79,16 +79,16 @@ variables [fintype n]
 
 /-- Note that this applies to `ℂ` via `complex.strict_ordered_comm_ring`. -/
 @[simp] lemma dot_product_star_self_eq_zero
-  [strict_ordered_ring R] [star_ordered_ring R] [no_zero_divisors R] {v : n → R} :
+  [partial_order R] [non_unital_ring R] [star_ordered_ring R] [no_zero_divisors R] {v : n → R} :
   dot_product (star v) v = 0 ↔ v = 0 :=
-(finset.sum_eq_zero_iff_of_nonneg $ λ i _, @star_mul_self_nonneg _ _ _ _ (v i)).trans $
+(finset.sum_eq_zero_iff_of_nonneg $ λ i _, (@star_mul_self_nonneg _ _ _ _ (v i) : _)).trans $
   by simp [function.funext_iff, mul_eq_zero]
 
 /-- Note that this applies to `ℂ` via `complex.strict_ordered_comm_ring`. -/
 @[simp] lemma dot_product_self_star_eq_zero
-  [strict_ordered_ring R] [star_ordered_ring R] [no_zero_divisors R] {v : n → R} :
+  [partial_order R] [non_unital_ring R] [star_ordered_ring R] [no_zero_divisors R] {v : n → R} :
   dot_product v (star v) = 0 ↔ v = 0 :=
-(finset.sum_eq_zero_iff_of_nonneg $ λ i _, @star_mul_self_nonneg' _ _ _ _ (v i)).trans $
+(finset.sum_eq_zero_iff_of_nonneg $ λ i _, (@star_mul_self_nonneg' _ _ _ _ (v i) : _)).trans $
   by simp [function.funext_iff, mul_eq_zero]
 
 end self


### PR DESCRIPTION
This makes unification slightly harder on Lean, so `: _`s are added.

Fixes a stupid error in #18783 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
