### PR TITLE
[Merged by Bors] - refactor(linear_algebra/matrix/rank): remove `decidable_eq` arguments

### DIFF
--- a/src/data/matrix/rank.lean
+++ b/src/data/matrix/rank.lean
@@ -30,22 +30,23 @@ namespace matrix
 open finite_dimensional
 
 variables {m n o R : Type*} [m_fin : fintype m] [fintype n] [fintype o]
-variables [decidable_eq n] [decidable_eq o] [comm_ring R]
+variables [comm_ring R]
 
 /-- The rank of a matrix is the rank of its image. -/
-noncomputable def rank (A : matrix m n R) : ℕ := finrank R A.to_lin'.range
+noncomputable def rank (A : matrix m n R) : ℕ := finrank R A.mul_vec_lin.range
 
-@[simp] lemma rank_one [strong_rank_condition R] : rank (1 : matrix n n R) = fintype.card n :=
-by rw [rank, to_lin'_one, linear_map.range_id, finrank_top, finrank_pi]
+@[simp] lemma rank_one [strong_rank_condition R] [decidable_eq n] :
+  rank (1 : matrix n n R) = fintype.card n :=
+by rw [rank, mul_vec_lin_one, linear_map.range_id, finrank_top, finrank_pi]
 
 @[simp] lemma rank_zero [nontrivial R] : rank (0 : matrix m n R) = 0 :=
-by rw [rank, linear_equiv.map_zero, linear_map.range_zero, finrank_bot]
+by rw [rank, mul_vec_lin_zero, linear_map.range_zero, finrank_bot]
 
 lemma rank_le_card_width [strong_rank_condition R] (A : matrix m n R) : A.rank ≤ fintype.card n :=
 begin
   haveI : module.finite R (n → R) := module.finite.pi,
   haveI : module.free R (n → R) := module.free.pi _ _,
-  exact A.to_lin'.finrank_range_le.trans_eq (finrank_pi _)
+  exact A.mul_vec_lin.finrank_range_le.trans_eq (finrank_pi _)
 end
 
 lemma rank_le_width [strong_rank_condition R] {m n : ℕ} (A : matrix (fin m) (fin n) R) :
@@ -55,12 +56,12 @@ A.rank_le_card_width.trans $ (fintype.card_fin n).le
 lemma rank_mul_le [strong_rank_condition R] (A : matrix m n R) (B : matrix n o R) :
   (A ⬝ B).rank ≤ A.rank :=
 begin
-  rw [rank, rank, to_lin'_mul],
+  rw [rank, rank, mul_vec_lin_mul],
   exact cardinal.to_nat_le_of_le_of_lt_aleph_0
     (rank_lt_aleph_0 _ _) (linear_map.rank_comp_le_left _ _),
 end
 
-lemma rank_unit [strong_rank_condition R] (A : (matrix n n R)ˣ) :
+lemma rank_unit [strong_rank_condition R] [decidable_eq n] (A : (matrix n n R)ˣ) :
   (A : matrix n n R).rank = fintype.card n :=
 begin
   refine le_antisymm (rank_le_card_width A) _,
@@ -68,13 +69,13 @@ begin
   rwa [← mul_eq_mul, ← units.coe_mul, mul_inv_self, units.coe_one, rank_one] at this,
 end
 
-lemma rank_of_is_unit [strong_rank_condition R] (A : matrix n n R) (h : is_unit A) :
+lemma rank_of_is_unit [strong_rank_condition R] [decidable_eq n] (A : matrix n n R) (h : is_unit A) :
   A.rank = fintype.card n :=
 by { obtain ⟨A, rfl⟩ := h, exact rank_unit A }
 
 include m_fin
 
-lemma rank_eq_finrank_range_to_lin
+lemma rank_eq_finrank_range_to_lin [decidable_eq n]
   {M₁ M₂ : Type*} [add_comm_group M₁] [add_comm_group M₂]
   [module R M₁] [module R M₂] (A : matrix m n R) (v₁ : basis m R M₁) (v₂ : basis n R M₂) :
   A.rank = finrank R (to_lin v₂ v₁ A).range :=
@@ -89,7 +90,7 @@ begin
   apply linear_map.pi_ext', rintro i, apply linear_map.ext_ring,
   have aux₁ := to_lin_self (pi.basis_fun R n) (pi.basis_fun R m) A i,
   have aux₂ := basis.equiv_apply (pi.basis_fun R n) i v₂,
-  rw [to_lin_eq_to_lin'] at aux₁,
+  rw [to_lin_eq_to_lin', to_lin'_apply'] at aux₁,
   rw [pi.basis_fun_apply, linear_map.coe_std_basis] at aux₁ aux₂,
   simp only [linear_map.comp_apply, e₁, e₂, linear_equiv.coe_coe, equiv.refl_apply, aux₁, aux₂,
     linear_map.coe_single, to_lin_self, linear_equiv.map_sum, linear_equiv.map_smul,
@@ -113,6 +114,6 @@ A.rank_le_card_height.trans $ (fintype.card_fin m).le
 /-- The rank of a matrix is the rank of the space spanned by its columns. -/
 lemma rank_eq_finrank_span_cols (A : matrix m n R) :
   A.rank = finrank R (submodule.span R (set.range Aᵀ)) :=
-by rw [rank, matrix.range_to_lin']
+by rw [rank, matrix.range_mul_vec_lin]
 
 end matrix

--- a/src/data/matrix/rank.lean
+++ b/src/data/matrix/rank.lean
@@ -69,7 +69,8 @@ begin
   rwa [← mul_eq_mul, ← units.coe_mul, mul_inv_self, units.coe_one, rank_one] at this,
 end
 
-lemma rank_of_is_unit [strong_rank_condition R] [decidable_eq n] (A : matrix n n R) (h : is_unit A) :
+lemma rank_of_is_unit [strong_rank_condition R] [decidable_eq n] (A : matrix n n R)
+  (h : is_unit A) :
   A.rank = fintype.card n :=
 by { obtain ⟨A, rfl⟩ := h, exact rank_unit A }
 

--- a/src/linear_algebra/matrix/to_lin.lean
+++ b/src/linear_algebra/matrix/to_lin.lean
@@ -166,20 +166,53 @@ variables {R : Type*} [comm_semiring R]
 variables {l m n : Type*}
 
 /-- `matrix.mul_vec M` is a linear map. -/
-@[simps] def matrix.mul_vec_lin [fintype n] (M : matrix m n R) : (n → R) →ₗ[R] (m → R) :=
+def matrix.mul_vec_lin [fintype n] (M : matrix m n R) : (n → R) →ₗ[R] (m → R) :=
 { to_fun := M.mul_vec,
   map_add' := λ v w, funext (λ i, dot_product_add _ _ _),
   map_smul' := λ c v, funext (λ i, dot_product_smul _ _ _) }
 
-variables [fintype n] [decidable_eq n]
+@[simp] lemma matrix.mul_vec_lin_apply [fintype n] (M : matrix m n R) (v : n → R) :
+  M.mul_vec_lin v = M.mul_vec v := rfl
 
-lemma matrix.mul_vec_std_basis (M : matrix m n R) (i j) :
+@[simp] lemma matrix.mul_vec_lin_zero [fintype n] : matrix.mul_vec_lin (0 : matrix m n R) = 0 :=
+linear_map.ext zero_mul_vec
+
+@[simp] lemma matrix.mul_vec_lin_add [fintype n] (M N : matrix m n R) :
+  (M + N).mul_vec_lin = M.mul_vec_lin + N.mul_vec_lin :=
+linear_map.ext $ λ _, add_mul_vec _ _ _
+
+variables [fintype n]
+
+@[simp] lemma matrix.mul_vec_lin_one [decidable_eq n] :
+  matrix.mul_vec_lin (1 : matrix n n R) = id :=
+by { ext, simp [linear_map.one_apply, std_basis_apply] }
+
+@[simp] lemma matrix.mul_vec_lin_mul [fintype m] (M : matrix l m R)
+  (N : matrix m n R) :
+  matrix.mul_vec_lin (M ⬝ N) = (matrix.mul_vec_lin M).comp (matrix.mul_vec_lin N) :=
+linear_map.ext $ λ x, (mul_vec_mul_vec _ _ _).symm
+
+lemma matrix.ker_mul_vec_lin_eq_bot_iff {M : matrix n n R} :
+  M.mul_vec_lin.ker = ⊥ ↔ ∀ v, M.mul_vec v = 0 → v = 0 :=
+by simp only [submodule.eq_bot_iff, linear_map.mem_ker, matrix.mul_vec_lin_apply]
+
+lemma matrix.mul_vec_std_basis [decidable_eq n] (M : matrix m n R) (i j) :
   M.mul_vec (std_basis R (λ _, R) j 1) i = M i j :=
 (congr_fun (matrix.mul_vec_single _ _ (1 : R)) i).trans $ mul_one _
 
-@[simp] lemma matrix.mul_vec_std_basis_apply (M : matrix m n R) (j) :
+@[simp] lemma matrix.mul_vec_std_basis_apply [decidable_eq n] (M : matrix m n R) (j) :
   M.mul_vec (std_basis R (λ _, R) j 1) = Mᵀ j :=
 funext $ λ i, matrix.mul_vec_std_basis M i j
+
+lemma matrix.range_mul_vec_lin (M : matrix m n R) : M.mul_vec_lin.range = span R (range Mᵀ) :=
+begin
+  letI := classical.dec_eq n,
+  simp_rw [range_eq_map, ←supr_range_std_basis, submodule.map_supr, range_eq_map,
+    ←ideal.span_singleton_one, ideal.span, submodule.map_span, image_image, image_singleton,
+    matrix.mul_vec_lin_apply, M.mul_vec_std_basis_apply, supr_span, range_eq_Union]
+end
+
+variables [decidable_eq n]
 
 /-- Linear maps `(n → R) →ₗ[R] (m → R)` are linearly equivalent to `matrix m n R`. -/
 def linear_map.to_matrix' : ((n → R) →ₗ[R] (m → R)) ≃ₗ[R] matrix m n R :=
@@ -197,9 +230,13 @@ def linear_map.to_matrix' : ((n → R) →ₗ[R] (m → R)) ≃ₗ[R] matrix m n
   map_smul' := λ c f, by { ext i j, simp only [pi.smul_apply, linear_map.smul_apply,
                                                ring_hom.id_apply, of_apply] } }
 
-/-- A `matrix m n R` is linearly equivalent to a linear map `(n → R) →ₗ[R] (m → R)`. -/
+/-- A `matrix m n R` is linearly equivalent to a linear map `(n → R) →ₗ[R] (m → R)`.
+
+Note that the forward-direction does not require `decidable_eq` and is `matrix.vec_mul_lin`. -/
 def matrix.to_lin' : matrix m n R ≃ₗ[R] ((n → R) →ₗ[R] (m → R)) :=
 linear_map.to_matrix'.symm
+
+lemma matrix.to_lin'_apply' (M : matrix m n R) : matrix.to_lin' M = M.mul_vec_lin := rfl
 
 @[simp] lemma linear_map.to_matrix'_symm :
   (linear_map.to_matrix'.symm : matrix m n R ≃ₗ[R] _) = matrix.to_lin' :=
@@ -232,8 +269,7 @@ end
   matrix.to_lin' M v = M.mul_vec v := rfl
 
 @[simp] lemma matrix.to_lin'_one :
-  matrix.to_lin' (1 : matrix n n R) = id :=
-by { ext, simp [linear_map.one_apply, std_basis_apply] }
+  matrix.to_lin' (1 : matrix n n R) = id := matrix.mul_vec_lin_one
 
 @[simp] lemma linear_map.to_matrix'_id :
   (linear_map.to_matrix' (linear_map.id : (n → R) →ₗ[R] (n → R))) = 1 :=
@@ -241,7 +277,7 @@ by { ext, rw [matrix.one_apply, linear_map.to_matrix'_apply, id_apply] }
 
 @[simp] lemma matrix.to_lin'_mul [fintype m] [decidable_eq m] (M : matrix l m R)
   (N : matrix m n R) : matrix.to_lin' (M ⬝ N) = (matrix.to_lin' M).comp (matrix.to_lin' N) :=
-linear_map.ext $ λ x, (mul_vec_mul_vec _ _ _).symm
+matrix.mul_vec_lin_mul _ _
 
 /-- Shortcut lemma for `matrix.to_lin'_mul` and `linear_map.comp_apply` -/
 lemma matrix.to_lin'_mul_apply [fintype m] [decidable_eq m] (M : matrix l m R)
@@ -266,12 +302,10 @@ by simp [module.algebra_map_End_eq_smul_id]
 
 lemma matrix.ker_to_lin'_eq_bot_iff {M : matrix n n R} :
   M.to_lin'.ker = ⊥ ↔ ∀ v, M.mul_vec v = 0 → v = 0 :=
-by simp only [submodule.eq_bot_iff, linear_map.mem_ker, matrix.to_lin'_apply]
+matrix.ker_mul_vec_lin_eq_bot_iff
 
 lemma matrix.range_to_lin' (M : matrix m n R) : M.to_lin'.range = span R (range Mᵀ) :=
-by simp_rw [range_eq_map, ←supr_range_std_basis, submodule.map_supr, range_eq_map,
-  ←ideal.span_singleton_one, ideal.span, submodule.map_span, image_image, image_singleton,
-  matrix.to_lin'_apply, M.mul_vec_std_basis_apply, supr_span, range_eq_Union]
+matrix.range_mul_vec_lin _
 
 /-- If `M` and `M'` are each other's inverse matrices, they provide an equivalence between `m → A`
 and `n → A` corresponding to `M.mul_vec` and `M'.mul_vec`. -/


### PR DESCRIPTION
`matrix.to_lin' M` is just `matrix.vec_mul_lin M` with an unused decidability argument.

We're a bit close to the tide to risk attempting to do a global replacement, so this just:

* Refactors some lemmas about `matrix.to_lin'` to be first proven about `matrix.vec_mul_lin`
* Changes `matrix.rank` to be defined in terms of the latter.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

~~This will have a boring conflict with #18784 that I'll resolve once bors is done with that PR~~ Done