### PR TITLE
[Merged by Bors] - chore(algebra/star/basic): generalize quaternion lemmas

### DIFF
--- a/src/algebra/quaternion.lean
+++ b/src/algebra/quaternion.lean
@@ -394,7 +394,8 @@ end
 lemma commute_self_conj : commute a a.conj :=
 a.commute_conj_self.symm
 
-lemma commute_conj_conj {a b : ℍ[R, c₁, c₂]} (h : commute a b) : commute a.conj b.conj := h.star
+lemma commute_conj_conj {a b : ℍ[R, c₁, c₂]} (h : commute a b) : commute a.conj b.conj :=
+h.star_star
 
 @[simp, norm_cast] lemma conj_coe : conj (x : ℍ[R, c₁, c₂]) = x := by ext; simp
 

--- a/src/algebra/quaternion.lean
+++ b/src/algebra/quaternion.lean
@@ -362,11 +362,17 @@ lemma conj_add : (a + b).conj = a.conj + b.conj := conj.map_add a b
 
 @[simp] lemma conj_mul : (a * b).conj = b.conj * a.conj := by ext; simp; ring_exp
 
-lemma conj_conj_mul : (a.conj * b).conj = b.conj * a :=
-by rw [conj_mul, conj_conj]
+instance : star_ring ℍ[R, c₁, c₂] :=
+{ star := conj,
+  star_involutive := conj_conj,
+  star_add := conj_add,
+  star_mul := conj_mul }
 
-lemma conj_mul_conj : (a * b.conj).conj = b * a.conj :=
-by rw [conj_mul, conj_conj]
+@[simp] lemma star_def (a : ℍ[R, c₁, c₂]) : star a = conj a := rfl
+
+lemma conj_conj_mul : (a.conj * b).conj = b.conj * a := star_star_mul _
+
+lemma conj_mul_conj : (a * b.conj).conj = b * a.conj := star_mul_star _
 
 lemma self_add_conj' : a + a.conj = ↑(2 * a.re) := by ext; simp [two_mul]
 
@@ -388,10 +394,7 @@ end
 lemma commute_self_conj : commute a a.conj :=
 a.commute_conj_self.symm
 
-lemma commute_conj_conj {a b : ℍ[R, c₁, c₂]} (h : commute a b) : commute a.conj b.conj :=
-calc a.conj * b.conj = (b * a).conj    : (conj_mul b a).symm
-                 ... = (a * b).conj    : by rw h.eq
-                 ... = b.conj * a.conj : conj_mul a b
+lemma commute_conj_conj {a b : ℍ[R, c₁, c₂]} (h : commute a b) : commute a.conj b.conj := h.star
 
 @[simp, norm_cast] lemma conj_coe : conj (x : ℍ[R, c₁, c₂]) = x := by ext; simp
 
@@ -441,13 +444,6 @@ lemma conj_neg : (-a).conj = -a.conj := (conj : ℍ[R, c₁, c₂] ≃ₗ[R] _).
 
 lemma conj_sub : (a - b).conj = a.conj - b.conj := (conj : ℍ[R, c₁, c₂] ≃ₗ[R] _).map_sub a b
 
-instance : star_ring ℍ[R, c₁, c₂] :=
-{ star := conj,
-  star_involutive := conj_conj,
-  star_add := conj_add,
-  star_mul := conj_mul }
-
-@[simp] lemma star_def (a : ℍ[R, c₁, c₂]) : star a = conj a := rfl
 
 @[simp] lemma conj_pow (n : ℕ) : (a ^ n).conj = a.conj ^ n := star_pow _ _
 

--- a/src/algebra/quaternion.lean
+++ b/src/algebra/quaternion.lean
@@ -370,9 +370,9 @@ instance : star_ring ℍ[R, c₁, c₂] :=
 
 @[simp] lemma star_def (a : ℍ[R, c₁, c₂]) : star a = conj a := rfl
 
-lemma conj_conj_mul : (a.conj * b).conj = b.conj * a := star_star_mul _
+lemma conj_conj_mul : (a.conj * b).conj = b.conj * a := star_star_mul _ _
 
-lemma conj_mul_conj : (a * b.conj).conj = b * a.conj := star_mul_star _
+lemma conj_mul_conj : (a * b.conj).conj = b * a.conj := star_mul_star _ _
 
 lemma self_add_conj' : a + a.conj = ↑(2 * a.re) := by ext; simp [two_mul]
 
@@ -402,9 +402,9 @@ h.star_star
 @[simp] lemma conj_im : conj a.im = - a.im := im_conj _
 
 @[simp, norm_cast] lemma conj_nat_cast (n : ℕ) : conj (n : ℍ[R, c₁, c₂]) = n :=
-by rw [←coe_nat_cast, conj_coe]
+@star_nat_cast ℍ[R, c₁, c₂] _ _ n
 @[simp, norm_cast] lemma conj_int_cast (z : ℤ) : conj (z : ℍ[R, c₁, c₂]) = z :=
-by rw [←coe_int_cast, conj_coe]
+@star_int_cast ℍ[R, c₁, c₂] _ _ z
 
 @[simp] lemma conj_smul [monoid S] [distrib_mul_action S R] (s : S) (a : ℍ[R, c₁, c₂]) :
   conj (s • a) = s • conj a :=

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -126,23 +126,23 @@ class star_semigroup (R : Type u) [semigroup R] extends has_involutive_star R :=
 export star_semigroup (star_mul)
 attribute [simp] star_mul
 
-lemma star_star_mul [semigroup R] [star_semigroup R] (x y : R) : star (star x * y) = star y * x :=
-by rw [star_mul, star_star]
+section star_semigroup
+variables [semigroup R] [star_semigroup R]
 
-lemma star_mul_star [semigroup R] [star_semigroup R] (x y : R) : star (x * star y) = y * star x :=
-by rw [star_mul, star_star]
+lemma star_star_mul (x y : R) : star (star x * y) = star y * x := by rw [star_mul, star_star]
 
-lemma commute.star_star [semigroup R] [star_semigroup R] {x y : R} (h : commute x y) :
-  commute (star x) (star y) :=
+lemma star_mul_star (x y : R) : star (x * star y) = y * star x := by rw [star_mul, star_star]
+
+lemma commute.star_star {x y : R} (h : commute x y) : commute (star x) (star y) :=
 (star_mul _ _).symm.trans $ (congr_arg star h.symm).trans $ star_mul _ _
 
-@[simp] lemma commute_star_star [semigroup R] [star_semigroup R] {x y : R} :
-  commute (star x) (star y) ↔ commute x y :=
+@[simp] lemma commute_star_star {x y : R} : commute (star x) (star y) ↔ commute x y :=
 ⟨λ h, by simpa only [star_star] using h.star_star, commute.star_star⟩
 
-lemma commute_star_comm [semigroup R] [star_semigroup R] {x y : R} :
-  commute (star x) y ↔ commute x (star y) :=
+lemma commute_star_comm {x y : R} : commute (star x) y ↔ commute x (star y) :=
 by rw [←commute_star_star, star_star]
+
+end star_semigroup
 
 /-- In a commutative ring, make `simp` prefer leaving the order unchanged. -/
 @[simp] lemma star_mul' [comm_semigroup R] [star_semigroup R] (x y : R) :

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -94,6 +94,9 @@ star_involutive _
 lemma star_injective [has_involutive_star R] : function.injective (star : R → R) :=
 star_involutive.injective
 
+@[simp] lemma star_inj [has_involutive_star R] {x y : R} : star x = star y ↔ x = y :=
+star_injective.eq_iff
+
 /-- `star` as an equivalence when it is involutive. -/
 protected def equiv.star [has_involutive_star R] : equiv.perm R :=
 star_involutive.to_perm _
@@ -135,7 +138,7 @@ lemma star_mul_star (x y : R) : star (x * star y) = y * star x := by rw [star_mu
 
 @[simp] lemma semiconj_by_star_star_star {x y z : R} :
   semiconj_by (star x) (star z) (star y) ↔ semiconj_by x y z :=
-by simp_rw [semiconj_by, ←star_mul, star_injective.eq_iff, eq_comm]
+by simp_rw [semiconj_by, ←star_mul, star_inj, eq_comm]
 
 alias semiconj_by_star_star_star ↔ _ semiconj_by.star_star_star
 

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -126,6 +126,24 @@ class star_semigroup (R : Type u) [semigroup R] extends has_involutive_star R :=
 export star_semigroup (star_mul)
 attribute [simp] star_mul
 
+lemma star_star_mul [semigroup R] [star_semigroup R] (x y : R) : star (star x * y) = star y * x :=
+by rw [star_mul, star_star]
+
+lemma star_mul_star [semigroup R] [star_semigroup R] (x y : R) : star (x * star y) = y * star x :=
+by rw [star_mul, star_star]
+
+lemma commute.star_star [semigroup R] [star_semigroup R] {x y : R} (h : commute x y) :
+  commute (star x) (star y) :=
+(star_mul _ _).symm.trans $ (congr_arg star h.symm).trans $ star_mul _ _
+
+@[simp] lemma commute_star_star [semigroup R] [star_semigroup R] {x y : R} :
+  commute (star x) (star y) ↔ commute x y :=
+⟨λ h, by simpa only [star_star] using h.star_star, commute.star_star⟩
+
+lemma commute_star_comm [semigroup R] [star_semigroup R] {x y : R} :
+  commute (star x) y ↔ commute x (star y) :=
+by rw [←commute_star_star, star_star]
+
 /-- In a commutative ring, make `simp` prefer leaving the order unchanged. -/
 @[simp] lemma star_mul' [comm_semigroup R] [star_semigroup R] (x y : R) :
   star (x * y) = star x * star y :=

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -133,11 +133,16 @@ lemma star_star_mul (x y : R) : star (star x * y) = star y * x := by rw [star_mu
 
 lemma star_mul_star (x y : R) : star (x * star y) = y * star x := by rw [star_mul, star_star]
 
-lemma commute.star_star {x y : R} (h : commute x y) : commute (star x) (star y) :=
-(star_mul _ _).symm.trans $ (congr_arg star h.symm).trans $ star_mul _ _
+@[simp] lemma semiconj_by_star_star_star {x y z : R} :
+  semiconj_by (star x) (star z) (star y) ↔ semiconj_by x y z :=
+by simp_rw [semiconj_by, ←star_mul, star_injective.eq_iff, eq_comm]
+
+alias semiconj_by_star_star_star ↔ _ semiconj_by.star_star_star
 
 @[simp] lemma commute_star_star {x y : R} : commute (star x) (star y) ↔ commute x y :=
-⟨λ h, by simpa only [star_star] using h.star_star, commute.star_star⟩
+semiconj_by_star_star_star
+
+alias commute_star_star ↔ _ commute.star_star
 
 lemma commute_star_comm {x y : R} : commute (star x) y ↔ commute x (star y) :=
 by rw [←commute_star_star, star_star]


### PR DESCRIPTION
We already had most of these lemmas specialized to quaternions; this generalizes them to any star ring.

We should consider replacing `quaternion.conj` with `star` in future.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
