### PR TITLE
[Merged by Bors] - refactor(algebra/quaternion): remove `quaternion.conj`

### DIFF
--- a/src/analysis/normed_space/quaternion_exponential.lean
+++ b/src/analysis/normed_space/quaternion_exponential.lean
@@ -27,8 +27,6 @@ open_locale quaternion nat
 
 namespace quaternion
 
-lemma conj_exp (q : ℍ[ℝ]) : conj (exp ℝ q) = exp ℝ (conj q) := star_exp q
-
 @[simp, norm_cast] lemma exp_coe (r : ℝ) : exp ℝ (r : ℍ[ℝ]) = ↑(exp ℝ r) :=
 (map_exp ℝ (algebra_map ℝ ℍ[ℝ]) (continuous_algebra_map _ _) _).symm
 
@@ -119,7 +117,7 @@ calc norm_sq (exp ℝ q)
       congr' 1,
       obtain hv | hv := eq_or_ne (‖q.im‖) 0,
       { simp [hv] },
-      rw [norm_sq_add, norm_sq_smul, conj_smul, coe_mul_eq_smul, smul_re, smul_re, conj_re, im_re,
+      rw [norm_sq_add, norm_sq_smul, star_smul, coe_mul_eq_smul, smul_re, smul_re, star_re, im_re,
         smul_zero, smul_zero, mul_zero, add_zero, div_pow, norm_sq_coe, norm_sq_eq_norm_sq, ←sq,
         div_mul_cancel _ (pow_ne_zero _ hv)],
     end

--- a/src/analysis/quaternion.lean
+++ b/src/analysis/quaternion.lean
@@ -35,11 +35,11 @@ open_locale real_inner_product_space
 
 namespace quaternion
 
-instance : has_inner ℝ ℍ := ⟨λ a b, (a * b.conj).re⟩
+instance : has_inner ℝ ℍ := ⟨λ a b, (a * star b).re⟩
 
 lemma inner_self (a : ℍ) : ⟪a, a⟫ = norm_sq a := rfl
 
-lemma inner_def (a b : ℍ) : ⟪a, b⟫ = (a * b.conj).re := rfl
+lemma inner_def (a b : ℍ) : ⟪a, b⟫ = (a * star b).re := rfl
 
 noncomputable instance : normed_add_comm_group ℍ :=
 @inner_product_space.of_core.to_normed_add_comm_group ℝ ℍ _ _ _
@@ -65,11 +65,11 @@ by rw [norm_eq_sqrt_real_inner, inner_self, norm_sq_coe, real.sqrt_sq_eq_abs, re
 @[simp, norm_cast] lemma nnnorm_coe (a : ℝ) : ‖(a : ℍ)‖₊ = ‖a‖₊ :=
 subtype.ext $ norm_coe a
 
-@[simp] lemma norm_conj (a : ℍ) : ‖conj a‖ = ‖a‖ :=
-by simp_rw [norm_eq_sqrt_real_inner, inner_self, norm_sq_conj]
+@[simp] lemma norm_star (a : ℍ) : ‖star a‖ = ‖a‖ :=
+by simp_rw [norm_eq_sqrt_real_inner, inner_self, norm_sq_star]
 
-@[simp] lemma nnnorm_conj (a : ℍ) : ‖conj a‖₊ = ‖a‖₊ :=
-subtype.ext $ norm_conj a
+@[simp] lemma nnnorm_star (a : ℍ) : ‖star a‖₊ = ‖a‖₊ :=
+subtype.ext $ norm_star a
 
 noncomputable instance : normed_division_ring ℍ :=
 { dist_eq := λ _ _, rfl,
@@ -81,7 +81,7 @@ instance : normed_algebra ℝ ℍ :=
   to_algebra := (quaternion.algebra : algebra ℝ ℍ) }
 
 instance : cstar_ring ℍ :=
-{ norm_star_mul_self := λ x, (norm_mul _ _).trans $ congr_arg (* ‖x‖) (norm_conj x) }
+{ norm_star_mul_self := λ x, (norm_mul _ _).trans $ congr_arg (* ‖x‖) (norm_star x) }
 
 instance : has_coe ℂ ℍ := ⟨λ z, ⟨z.re, z.im, 0, 0⟩⟩
 
@@ -127,9 +127,6 @@ noncomputable def linear_isometry_equiv_tuple : ℍ ≃ₗᵢ[ℝ] euclidean_spa
   norm_map' := norm_pi_Lp_equiv_symm_equiv_tuple,
   ..(quaternion_algebra.linear_equiv_tuple (-1 : ℝ) (-1 : ℝ)).trans
       (pi_Lp.linear_equiv 2 ℝ (λ _ : fin 4, ℝ)).symm }
-
-@[continuity] lemma continuous_conj : continuous (conj : ℍ → ℍ) :=
-continuous_star
 
 @[continuity] lemma continuous_coe : continuous (coe : ℝ → ℍ) :=
 continuous_algebra_map ℝ ℍ

--- a/src/linear_algebra/clifford_algebra/equivs.lean
+++ b/src/linear_algebra/clifford_algebra/equivs.lean
@@ -273,20 +273,20 @@ clifford_algebra.lift_ι_apply _ _ v
 
 /-- The "clifford conjugate" maps to the quaternion conjugate. -/
 lemma to_quaternion_star (c : clifford_algebra (Q c₁ c₂)) :
-  to_quaternion (star c) = quaternion_algebra.conj (to_quaternion c) :=
+  to_quaternion (star c) = star (to_quaternion c) :=
 begin
   simp only [clifford_algebra.star_def'],
   induction c using clifford_algebra.induction,
   case h_grade0 : r
   { simp only [reverse.commutes, alg_hom.commutes, quaternion_algebra.coe_algebra_map,
-      quaternion_algebra.conj_coe], },
+      quaternion_algebra.star_coe], },
   case h_grade1 : x
   { rw [reverse_ι, involute_ι, to_quaternion_ι, alg_hom.map_neg, to_quaternion_ι,
-      quaternion_algebra.neg_mk, conj_mk, neg_zero], },
+      quaternion_algebra.neg_mk, star_mk, neg_zero], },
   case h_mul : x₁ x₂ hx₁ hx₂
-  { simp only [reverse.map_mul, alg_hom.map_mul, hx₁, hx₂, quaternion_algebra.conj_mul] },
+  { simp only [reverse.map_mul, alg_hom.map_mul, hx₁, hx₂, star_mul] },
   case h_add : x₁ x₂ hx₁ hx₂
-  { simp only [reverse.map_add, alg_hom.map_add, hx₁, hx₂, quaternion_algebra.conj_add] },
+  { simp only [reverse.map_add, alg_hom.map_add, hx₁, hx₂, star_add] },
 end
 
 /-- Map a quaternion into the clifford algebra. -/

--- a/src/linear_algebra/clifford_algebra/equivs.lean
+++ b/src/linear_algebra/clifford_algebra/equivs.lean
@@ -48,7 +48,7 @@ We show additionally that this equivalence sends `quaternion_algebra.conj` to th
 and vice-versa:
 
 * `clifford_algebra_quaternion.to_quaternion_star`
-* `clifford_algebra_quaternion.of_quaternion_conj`
+* `clifford_algebra_quaternion.of_quaternion_star`
 
 ## Dual numbers
 
@@ -339,8 +339,8 @@ alg_equiv.of_alg_hom to_quaternion of_quaternion
   of_quaternion_comp_to_quaternion
 
 /-- The quaternion conjugate maps to the "clifford conjugate" (aka `star`). -/
-@[simp] lemma of_quaternion_conj (q : ℍ[R,c₁,c₂]) :
-  of_quaternion (q.conj) = star (of_quaternion q) :=
+@[simp] lemma of_quaternion_star (q : ℍ[R,c₁,c₂]) :
+  of_quaternion (star q) = star (of_quaternion q) :=
 clifford_algebra_quaternion.equiv.injective $
   by rw [equiv_apply, equiv_apply, to_quaternion_star, to_quaternion_of_quaternion,
     to_quaternion_of_quaternion]


### PR DESCRIPTION
Instead we use `star` directly. We keep only the lemmas that refer to quaternion-specific operators, as the rest are already covered by the star API.

In practice, this is mostly the lemmas about the real and imaginary parts of quaternions.

The `commute_self_conj` lemma has been replaced by a `is_star_normal` instance.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #18802

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
