### PR TITLE
[Merged by Bors] - chore(linear_algebra/free_module/rank): golf a slow proof

### DIFF
--- a/src/linear_algebra/free_module/rank.lean
+++ b/src/linear_algebra/free_module/rank.lean
@@ -94,13 +94,9 @@ open module.free
 @[simp] lemma rank_tensor_product : module.rank R (M ⊗[R] N) = lift.{w v} (module.rank R M) *
   lift.{v w} (module.rank R N) :=
 begin
-  let ιM := choose_basis_index R M,
-  let ιN := choose_basis_index R N,
-
-  have h₁ := linear_equiv.lift_rank_eq (tensor_product.congr (repr R M) (repr R N)),
-  let b : basis (ιM × ιN) R (_ →₀ R) := finsupp.basis_single_one,
-  rw [linear_equiv.rank_eq (finsupp_tensor_finsupp' R ιM ιN), ← b.mk_eq_rank, mk_prod] at h₁,
-  rw [lift_inj.1 h₁, rank_eq_card_choose_basis_index R M, rank_eq_card_choose_basis_index R N],
+  obtain ⟨⟨_, bM⟩⟩ := module.free.exists_basis R M,
+  obtain ⟨⟨_, bN⟩⟩ := module.free.exists_basis R N,
+  rw [← bM.mk_eq_rank'', ← bN.mk_eq_rank'', ← (bM.tensor_product bN).mk_eq_rank'', cardinal.mk_prod]
 end
 
 /-- If `M` and `N` lie in the same universe, the rank of `M ⊗[R] N` is


### PR DESCRIPTION
We already do all the work for this when constructing the basis elsewhere.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
