### PR TITLE
[Merged by Bors] - feat(data/matrix/reflection): add `mul_vec` and `vec_mul`

### DIFF
--- a/src/data/matrix/reflection.lean
+++ b/src/data/matrix/reflection.lean
@@ -132,7 +132,7 @@ example (a b c d : α) [has_mul α] [add_comm_monoid α] :
 def mulᵣ [has_mul α] [has_add α] [has_zero α]
   (A : matrix (fin l) (fin m) α) (B : matrix (fin m) (fin n) α) :
   matrix (fin l) (fin n) α :=
-of $ fin_vec.map (λ v₁, fin_vec.map (λ v₂, dot_productᵣ v₁ v₂) (transposeᵣ B)) A
+of $ fin_vec.map (λ v₁, fin_vec.map (λ v₂, dot_productᵣ v₁ v₂) Bᵀ) A
 
 /-- This can be used to prove
 ```lean
@@ -192,7 +192,7 @@ example [non_unital_non_assoc_semiring α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁
 /-- `matrix.vec_mul` with better defeq for `fin` -/
 def vec_mulᵣ [has_mul α] [has_add α] [has_zero α] (v : fin l → α) (A : matrix (fin l) (fin m) α):
   fin m → α :=
-fin_vec.map (λ a, dot_productᵣ v a) (transposeᵣ A)
+fin_vec.map (λ a, dot_productᵣ v a) Aᵀ
 
 /-- This can be used to prove
 ```lean


### PR DESCRIPTION
This follows the pattern already established by `mul`.

The motivation was an example on Zulip which wanted to compute the product of
```lean
def M := !![(2:ℂ), 0, 0; 0, 1, 0; 0, 0, 1]
def v := ![(0:ℂ), 0, 1]
```

As before, the meta code that makes this pleasant to use is absent, but I will add it along with the rest of the meta code in #15738.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
