### PR TITLE
[Merged by Bors] - feat(analysis/calculus/cont_diff_def): no continuity is needed for has_ftaylor_series_up_to if n = ∞

### DIFF
--- a/src/analysis/calculus/cont_diff_def.lean
+++ b/src/analysis/calculus/cont_diff_def.lean
@@ -248,6 +248,16 @@ begin
       apply (H m).cont m le_rfl } }
 end
 
+/-- In the case that `n = ∞` we don't need the continuity assumption in
+`has_ftaylor_series_up_to_on`. -/
+lemma has_ftaylor_series_up_to_on_top_iff' : has_ftaylor_series_up_to_on ∞ f p s ↔
+  (∀ x ∈ s, (p x 0).uncurry0 = f x) ∧
+  (∀ (m : ℕ), ∀ x ∈ s, has_fderiv_within_at (λ y, p y m) (p x m.succ).curry_left s x) :=
+-- Everything except for the continuity is trivial:
+⟨λ h, ⟨h.1, λ m, h.2 m (with_top.coe_lt_top m)⟩, λ h, ⟨h.1, λ m _, h.2 m, λ m _ x hx,
+  -- The continuity follows from the existence of a derivative:
+  (h.2 m x hx).continuous_within_at⟩⟩
+
 /-- If a function has a Taylor series at order at least `1`, then the term of order `1` of this
 series is a derivative of `f`. -/
 lemma has_ftaylor_series_up_to_on.has_fderiv_within_at
@@ -1233,6 +1243,18 @@ lemma has_ftaylor_series_up_to_zero_iff :
   has_ftaylor_series_up_to 0 f p ↔ continuous f ∧ (∀ x, (p x 0).uncurry0 = f x) :=
 by simp [has_ftaylor_series_up_to_on_univ_iff.symm, continuous_iff_continuous_on_univ,
          has_ftaylor_series_up_to_on_zero_iff]
+
+lemma has_ftaylor_series_up_to_top_iff : has_ftaylor_series_up_to ∞ f p ↔
+  ∀ (n : ℕ), has_ftaylor_series_up_to n f p :=
+by simp only [← has_ftaylor_series_up_to_on_univ_iff, has_ftaylor_series_up_to_on_top_iff]
+
+/-- In the case that `n = ∞` we don't need the continuity assumption in
+`has_ftaylor_series_up_to`. -/
+lemma has_ftaylor_series_up_to_top_iff' : has_ftaylor_series_up_to ∞ f p ↔
+  (∀ x, (p x 0).uncurry0 = f x) ∧
+  (∀ (m : ℕ) x, has_fderiv_at (λ y, p y m) (p x m.succ).curry_left x) :=
+by simp only [← has_ftaylor_series_up_to_on_univ_iff, has_ftaylor_series_up_to_on_top_iff',
+  mem_univ, forall_true_left, has_fderiv_within_at_univ]
 
 /-- If a function has a Taylor series at order at least `1`, then the term of order `1` of this
 series is a derivative of `f`. -/


### PR DESCRIPTION
We also add `has_ftaylor_series_up_to_iff_top` in order that the notation is consistent between `has_ftaylor_series_up_to` and `has_ftaylor_series_up_to_on`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
