### PR TITLE
[Merged by Bors] - feat(linear_algebra/matrix/nonsingular_inverse): interchange of matrix reindexing and inversion

### DIFF
--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -634,7 +634,7 @@ variables [decidable_eq m] [decidable_eq n]
 variables [comm_ring α]
 
 lemma inv_submatrix_equiv_self (e : n ≃ m) (A : matrix m m α):
-(A.submatrix e e)⁻¹ =  (A⁻¹).submatrix e e :=
+  (A.submatrix e e)⁻¹ = (A⁻¹).submatrix e e :=
 begin
   rw [matrix.inv_def, matrix.inv_def,
       det_submatrix_equiv_self,

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -624,16 +624,10 @@ by rw [det_one_add_mul_comm, det_unique, pi.add_apply, pi.add_apply, matrix.one_
 
 end det
 
-end matrix
+variables [fintype m]
+variables [decidable_eq m]
 
-namespace matrix
-
-variables {α : Type*} {m n : Type*}
-variables [fintype m] [fintype n]
-variables [decidable_eq m] [decidable_eq n]
-variables [comm_ring α]
-
-lemma inv_submatrix_equiv_self (e : n ≃ m) (A : matrix m m α) :
+@[simp] lemma inv_submatrix_equiv_self (e : n ≃ m) (A : matrix m m α) :
   (A.submatrix e e)⁻¹ = (A⁻¹).submatrix e e :=
 begin
   rw [matrix.inv_def, matrix.inv_def,
@@ -645,10 +639,6 @@ end
 
 lemma inv_reindex (e : n ≃ m) (A : matrix n n α) :
   (reindex e e A)⁻¹ = reindex e e (A⁻¹) :=
-begin
-  rw reindex_apply,
-  rw reindex_apply,
-  apply inv_submatrix_equiv_self,
-end
+  by simp only [inv_submatrix_equiv_self, reindex_apply]
 
 end matrix

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -627,9 +627,6 @@ end det
 end matrix
 
 namespace matrix
-open matrix
-open_locale matrix
-open equiv equiv.perm finset
 
 variables {α : Type*} {m n : Type*}
 variables [fintype m] [fintype n]

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -630,8 +630,8 @@ namespace matrix
 
 variables {α : Type*} {m n : Type*}
 variables [fintype m] [fintype n]
-variables  [decidable_eq m] [decidable_eq n]
-variables [field α]
+variables [decidable_eq m] [decidable_eq n]
+variables [comm_ring α]
 
 lemma inv_submatrix_equiv_self (e : n ≃ m) (A : matrix m m α):
 (A.submatrix e e)⁻¹ =  (A⁻¹).submatrix e e :=

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Tim Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tim Baanen, Lu-Ming Zhang
 -/
+import data.matrix.basic
 import linear_algebra.matrix.adjugate
 
 /-!
@@ -622,5 +623,35 @@ by rw [det_one_add_mul_comm, det_unique, pi.add_apply, pi.add_apply, matrix.one_
        matrix.row_mul_col_apply]
 
 end det
+
+end matrix
+
+namespace matrix
+open matrix
+open_locale matrix
+open equiv equiv.perm finset
+
+variables {α : Type*} {m n : Type*}
+variables [fintype m] [fintype n]
+variables  [decidable_eq m] [decidable_eq n]
+variables [field α]
+
+lemma inv_submatrix_equiv_self (e : n ≃ m) (A : matrix m m α) [invertible A]:
+(A.submatrix e e)⁻¹ =  (A⁻¹).submatrix e e :=
+begin
+  rw [matrix.inv_def, matrix.inv_def,
+      det_submatrix_equiv_self,
+      adjugate_submatrix_equiv_self,
+      submatrix_smul],
+  simp only [pi.smul_apply],
+end
+
+lemma inv_reindex (e : n ≃ m) (A : matrix n n α) [invertible A]:
+  (reindex e e A)⁻¹ = reindex e e (A⁻¹) :=
+begin
+  rw reindex_apply,
+  rw reindex_apply,
+  apply inv_submatrix_equiv_self,
+end
 
 end matrix

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -639,6 +639,6 @@ end
 
 lemma inv_reindex (e : n ≃ m) (A : matrix n n α) :
   (reindex e e A)⁻¹ = reindex e e (A⁻¹) :=
-  by simp only [inv_submatrix_equiv_self, reindex_apply]
+  inv_submatrix_equiv_self _ _
 
 end matrix

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -547,7 +547,11 @@ end
 by rw [← (A⁻¹).transpose_transpose, vec_mul_transpose, transpose_nonsing_inv, ← det_transpose,
     Aᵀ.det_smul_inv_mul_vec_eq_cramer _ (is_unit_det_transpose A h)]
 
-/-! ### Inverses of permutated matrices. -/
+/-! ### Inverses of permutated matrices
+
+Note that the simp-normal form of `matrix.reindex` is `matrix.submatrix`, so we prove most of these
+results about only the latter.
+-/
 
 section submatrix
 variables [fintype m]
@@ -577,8 +581,9 @@ begin
   convert (rfl : ⅟(A.submatrix e₁ e₂) = _),
 end
 
-/-- Together `matrix.diagonal_invertible` and `matrix.invertible_of_diagonal_invertible` form an
-equivalence, although both sides of the equiv are subsingleton anyway. -/
+/-- Together `matrix.submatrix_equiv_invertible` and
+`matrix.invertible_of_submatrix_equiv_invertible` form an equivalence, although both sides of the
+equiv are subsingleton anyway. -/
 @[simps]
 def submatrix_equiv_invertible_equiv_invertible (A : matrix m m α) (e₁ e₂ : n ≃ m) :
   invertible (A.submatrix e₁ e₂) ≃ invertible A :=

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -633,7 +633,7 @@ variables [fintype m] [fintype n]
 variables  [decidable_eq m] [decidable_eq n]
 variables [field α]
 
-lemma inv_submatrix_equiv_self (e : n ≃ m) (A : matrix m m α) [invertible A]:
+lemma inv_submatrix_equiv_self (e : n ≃ m) (A : matrix m m α):
 (A.submatrix e e)⁻¹ =  (A⁻¹).submatrix e e :=
 begin
   rw [matrix.inv_def, matrix.inv_def,
@@ -643,7 +643,7 @@ begin
   simp only [pi.smul_apply],
 end
 
-lemma inv_reindex (e : n ≃ m) (A : matrix n n α) [invertible A]:
+lemma inv_reindex (e : n ≃ m) (A : matrix n n α) :
   (reindex e e A)⁻¹ = reindex e e (A⁻¹) :=
 begin
   rw reindex_apply,

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -633,7 +633,7 @@ variables [fintype m] [fintype n]
 variables [decidable_eq m] [decidable_eq n]
 variables [comm_ring α]
 
-lemma inv_submatrix_equiv_self (e : n ≃ m) (A : matrix m m α):
+lemma inv_submatrix_equiv_self (e : n ≃ m) (A : matrix m m α) :
   (A.submatrix e e)⁻¹ = (A⁻¹).submatrix e e :=
 begin
   rw [matrix.inv_def, matrix.inv_def,


### PR DESCRIPTION
This follows the strategy taken in #13827, which gives us all of:

* `is_unit (A.submatrix e₁ e₂) ↔ is_unit A`
* `(A.submatrix e₁ e₂)⁻¹ = (A⁻¹).submatrix e₂ e₁`
* `⅟(A.submatrix e₁ e₂) = (⅟A).submatrix e₂ e₁`
* `invertible (A.submatrix e₁ e₂) ≃ invertible A`

Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Old description:

> This PR adds two lemmas:
> 
> - @[simp] lemma inv_submatrix_equiv_self
> - lemma inv_reindex
matrix inversion and matrix reindexing using the same re-index for rows and columns are interchangeable operations
>
> It is very important that the reindex must be the same for the rows and columns.

