### PR TITLE
[Merged by Bors] - feat(category_theory/site/limits): generalise universes

### DIFF
--- a/src/category_theory/limits/presheaf.lean
+++ b/src/category_theory/limits/presheaf.lean
@@ -157,7 +157,7 @@ Show `extend_along_yoneda` is left adjoint to `restricted_yoneda`.
 
 The construction of [MM92], Chapter I, Section 5, Theorem 2.
 -/
-def yoneda_adjunction : extend_along_yoneda A ⊣ restricted_yoneda A :=
+def yoeda_adjunction : extend_along_yoneda A ⊣ restricted_yoneda A :=
 adjunction.adjunction_of_equiv_left _ _
 
 /--

--- a/src/category_theory/limits/presheaf.lean
+++ b/src/category_theory/limits/presheaf.lean
@@ -157,7 +157,7 @@ Show `extend_along_yoneda` is left adjoint to `restricted_yoneda`.
 
 The construction of [MM92], Chapter I, Section 5, Theorem 2.
 -/
-def yoeda_adjunction : extend_along_yoneda A ⊣ restricted_yoneda A :=
+def yoneda_adjunction : extend_along_yoneda A ⊣ restricted_yoneda A :=
 adjunction.adjunction_of_equiv_left _ _
 
 /--

--- a/src/category_theory/sites/limits.lean
+++ b/src/category_theory/sites/limits.lean
@@ -34,7 +34,7 @@ open opposite
 section limits
 
 universes w v u z
-variables {C : Type (max v u)} [category.{v} C] {J : grothendieck_topology C}
+variables {C : Type u} [category.{v} C] {J : grothendieck_topology C}
 variables {D : Type w} [category.{max v u} D]
 variables {K : Type z} [small_category K]
 
@@ -166,7 +166,7 @@ end limits
 section colimits
 
 universes w v u
-variables {C : Type (max v u)} [category.{v} C] {J : grothendieck_topology C}
+variables {C : Type u} [category.{v} C] {J : grothendieck_topology C}
 variables {D : Type w} [category.{max v u} D]
 variables {K : Type (max v u)} [small_category K]
 -- Now we need a handful of instances to obtain sheafification...


### PR DESCRIPTION
The objects in category `C` in this file had type `Type max v u` but there's no reason they can't just have type `Type u`. There are no uses in this file of `u` as a universe by itself, so this does not make any results less general.

This makes porting the file easier. [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Universe.20issues.20with.20concrete.20categories/near/350340297)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
