### PR TITLE
refactor(algebra/star/basic): weaken the meaning of `star_ordered_ring`

### DIFF
--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -666,17 +666,13 @@ With `z ≤ w` iff `w - z` is real and nonnegative, `ℂ` is a star ordered ring
 (That is, a star ring in which the nonnegative elements are those of the form `star z * z`.)
 -/
 protected def star_ordered_ring : star_ordered_ring ℂ :=
-{ nonneg_iff := λ r, by
-  { refine ⟨λ hr, ⟨real.sqrt r.re, _⟩, λ h, _⟩,
-    { have h₁ : 0 ≤ r.re := by { rw [le_def] at hr, exact hr.1 },
-      have h₂ : r.im = 0 := by { rw [le_def] at hr, exact hr.2.symm },
-      ext,
-      { simp only [of_real_im, star_def, of_real_re, sub_zero, conj_re, mul_re, mul_zero,
-                   ←real.sqrt_mul h₁ r.re, real.sqrt_mul_self h₁] },
-      { simp only [h₂, add_zero, of_real_im, star_def, zero_mul, conj_im,
-                   mul_im, mul_zero, neg_zero] } },
-    { obtain ⟨s, rfl⟩ := h,
-      simp only [←norm_sq_eq_conj_mul_self, norm_sq_nonneg, zero_le_real, star_def] } },
+{ star_mul_self_nonneg := λ z,
+    (zero_le_real.mpr $ norm_sq_nonneg z).trans_eq norm_sq_eq_conj_mul_self,
+  conjugate_nonneg := λ c z hc, begin
+    rw mul_right_comm,
+    apply mul_nonneg _ hc,
+    exact (zero_le_real.mpr $ norm_sq_nonneg z).trans_eq norm_sq_eq_conj_mul_self,
+  end,
   ..complex.strict_ordered_comm_ring }
 
 localized "attribute [instance] complex.star_ordered_ring" in complex_order

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -339,11 +339,10 @@ begin
   { norm_cast, exact le_of_lt (nat.lt_succ_sqrt' a), },
 end
 
+-- TODO: move to an earlier file since this doesn't mention `sqrt`
 instance : star_ordered_ring ℝ :=
-{ nonneg_iff := λ r, by
-  { refine ⟨λ hr, ⟨sqrt r, show r = sqrt r * sqrt r, by rw [←sqrt_mul hr, sqrt_mul_self hr]⟩, _⟩,
-    rintros ⟨s, rfl⟩,
-    exact mul_self_nonneg s },
+{ star_mul_self_nonneg := (star_ordered_ring_of_comm ℝ).star_mul_self_nonneg,
+  conjugate_nonneg := (star_ordered_ring_of_comm ℝ).conjugate_nonneg,
   ..real.ordered_add_comm_group }
 
 end real


### PR DESCRIPTION
This lets any commutative linearly ordered ring be considered a star ring with a trivial star operation.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Star.20ordered.20ring/near/350376619).
This probably isn't actually a good idea, but demonstrates we don't currently use most of the strength of the current definition.