### PR TITLE
[Merged by Bors] - chore(data/complex/module): split out orientation to a separate file

### DIFF
--- a/src/analysis/inner_product_space/two_dim.lean
+++ b/src/analysis/inner_product_space/two_dim.lean
@@ -5,6 +5,7 @@ Authors: Heather Macbeth
 -/
 import analysis.inner_product_space.dual
 import analysis.inner_product_space.orientation
+import data.complex.orientation
 import tactic.linear_combination
 
 /-!

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Alexander Bentkamp, Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp, Sébastien Gouëzel, Eric Wieser
 -/
-import linear_algebra.orientation
 import algebra.order.smul
 import data.complex.basic
 import data.fin.vec_notation
@@ -166,9 +165,6 @@ by simp [← finrank_eq_rank, finrank_real_complex, bit0]
 /-- `fact` version of the dimension of `ℂ` over `ℝ`, locally useful in the definition of the
 circle. -/
 lemma finrank_real_complex_fact : fact (finrank ℝ ℂ = 2) := ⟨finrank_real_complex⟩
-
-/-- The standard orientation on `ℂ`. -/
-protected noncomputable def orientation : orientation ℝ ℂ (fin 2) := complex.basis_one_I.orientation
 
 end complex
 

--- a/src/data/complex/orientation.lean
+++ b/src/data/complex/orientation.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2021 Heather Macbeth. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Heather Macbeth
+-/
+import data.complex.module
+import linear_algebra.orientation
+
+/-!
+# The standard orientation on `ℂ`.
+
+This had previously been in `linear_algebra.orientation`,
+but keeping it separate results in a significant import reduction.
+-/
+
+namespace complex
+
+/-- The standard orientation on `ℂ`. -/
+protected noncomputable def orientation : orientation ℝ ℂ (fin 2) := complex.basis_one_I.orientation
+
+end complex


### PR DESCRIPTION
This removes the imports

- linear_algebra.matrix.determinant
- linear_algebra.matrix.mv_polynomial
- linear_algebra.matrix.adjugate
- linear_algebra.matrix.nonsingular_inverse
- linear_algebra.matrix.basis
- linear_algebra.determinant
- linear_algebra.orientation

from `data.complex.module`, which aren't otherwise needed here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
