### PR TITLE
[Merged by Bors] - chore(mv_polynomial/funext): backport golfed proof

### DIFF
--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -901,6 +901,22 @@ begin
   congr' with a, simp
 end
 
+@[simp]
+theorem eval₂_id (p : mv_polynomial σ R) (g : σ → R) : eval₂ (ring_hom.id _) g p = eval g p :=
+  rfl
+
+theorem eval_eval₂ {τ : Type*} (f : R →+* mv_polynomial τ S₁) (g : σ → mv_polynomial τ S₁)
+  (p : mv_polynomial σ R) (x : τ → S₁) :
+  eval x (eval₂ f g p) = eval₂ ((eval x).comp f) (λ s, eval x (g s)) p :=
+begin
+  apply induction_on p,
+  { simp, },
+  { intros p q hp hq,
+    simp [hp, hq] },
+  { intros p n hp,
+    simp [hp] }
+end
+
 end eval
 
 section map

--- a/src/data/mv_polynomial/funext.lean
+++ b/src/data/mv_polynomial/funext.lean
@@ -6,6 +6,7 @@ Authors: Johan Commelin
 import data.polynomial.ring_division
 import data.mv_polynomial.rename
 import ring_theory.polynomial.basic
+import data.mv_polynomial.polynomial
 
 /-!
 ## Function extensionality for multivariate polynomials
@@ -27,41 +28,17 @@ variables {R : Type*} [comm_ring R] [is_domain R] [infinite R]
 private lemma funext_fin {n : ℕ} {p : mv_polynomial (fin n) R}
   (h : ∀ x : fin n → R, eval x p = 0) : p = 0 :=
 begin
-  unfreezingI { induction n with n ih generalizing R },
-  { let e := (mv_polynomial.is_empty_ring_equiv R (fin 0)),
-    apply e.injective,
-    rw ring_equiv.map_zero,
-    convert h fin_zero_elim,
-    suffices : (eval₂_hom (ring_hom.id _) (is_empty.elim' fin.is_empty)) p =
-      (eval fin_zero_elim : mv_polynomial (fin 0) R →+* R) p,
-    { rw [← this],
-      simp only [coe_eval₂_hom, is_empty_ring_equiv_apply,
-        ring_equiv.trans_apply, aeval_eq_eval₂_hom],
-      congr },
-    exact eval₂_hom_congr rfl (subsingleton.elim _ _) rfl },
-  { let e := (fin_succ_equiv R n).to_ring_equiv,
-    apply e.injective,
-    simp only [ring_equiv.map_zero],
-    apply polynomial.funext,
-    intro q,
+  induction n with n ih,
+  { apply (mv_polynomial.is_empty_ring_equiv R (fin 0)).injective,
+    rw [ring_equiv.map_zero],
+    convert h _, },
+  { apply (fin_succ_equiv R n).injective,
+    simp only [alg_equiv.map_zero],
+    refine polynomial.funext (λ q, _),
     rw [polynomial.eval_zero],
-    apply ih, swap, { apply_instance },
-    intro x,
-    dsimp [e],
-    rw [fin_succ_equiv_apply],
-    calc _ = eval _ p : _
-       ... = 0 : h _,
-    { intro i, exact fin.cases (eval x q) x i },
-    apply induction_on p,
-    { intro r,
-      simp only [eval_C, polynomial.eval_C, ring_hom.coe_comp, eval₂_hom_C], },
-    { intros, simp only [*, ring_hom.map_add, polynomial.eval_add] },
-    { intros φ i hφ, simp only [*, eval_X, polynomial.eval_mul, ring_hom.map_mul, eval₂_hom_X'],
-      congr' 1,
-      by_cases hi : i = 0,
-      { subst hi, simp only [polynomial.eval_X, fin.cases_zero] },
-      { rw [← fin.succ_pred i hi], simp only [eval_X, polynomial.eval_C, fin.cases_succ] } },
-    { apply_instance, }, },
+    apply ih (λ x, _),
+    calc _ = _ : eval_polynomial_eval_fin_succ_equiv p _ _
+       ... = 0 : h _, }
 end
 
 /-- Two multivariate polynomials over an infinite integral domain are equal

--- a/src/data/mv_polynomial/polynomial.lean
+++ b/src/data/mv_polynomial/polynomial.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import data.mv_polynomial.equiv
+import data.polynomial.eval
+
+/-!
+# Some lemmas relating polynomials and multivariable polynomials.
+-/
+
+namespace mv_polynomial
+
+variables {R S : Type*} [comm_semiring R] [comm_semiring S] {σ : Type*}
+
+theorem polynomial_eval_eval₂
+    (f : R →+* polynomial S) (g : σ → polynomial S) (p : mv_polynomial σ R) (x : S) :
+    polynomial.eval x (mv_polynomial.eval₂ f g p) =
+      mv_polynomial.eval₂ ((polynomial.eval_ring_hom x).comp f) (λ s, polynomial.eval x (g s)) p :=
+begin
+  apply mv_polynomial.induction_on p,
+  { simp },
+  { intros p q hp hq,
+    simp [hp, hq], },
+  { intros p n hp,
+    simp [hp], },
+end
+
+theorem eval_polynomial_eval_fin_succ_equiv {n : ℕ}
+  (f : mv_polynomial (fin (n + 1)) R) (q : mv_polynomial (fin n) R) (x : fin n → R) :
+  (eval x) (polynomial.eval q (fin_succ_equiv R n f)) =
+    eval (show fin (n+1) → R, from @fin.cases _ (λ _, R) (eval x q) x) f :=
+begin
+  simp only [fin_succ_equiv_apply, coe_eval₂_hom, eval_eval₂, polynomial_eval_eval₂],
+  have : (eval x).comp ((polynomial.eval_ring_hom q).comp (polynomial.C.comp C)) = ring_hom.id _,
+  { ext, simp, },
+  simp only [this, eval₂_id],
+  congr,
+  funext i,
+  refine fin.cases (by simp) (by simp) i,
+end
+
+end mv_polynomial


### PR DESCRIPTION
This proof was timing out in https://github.com/leanprover-community/mathlib4/pull/3225, so I completely rewrote it using smaller lemmas. This is the backport.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
