### PR TITLE
[Merged by Bors] - feat(data/set/pointwise/big_operators): image distributes across pointwise big operators

### DIFF
--- a/src/data/set/pointwise/big_operators.lean
+++ b/src/data/set/pointwise/big_operators.lean
@@ -152,6 +152,18 @@ lemma finset_prod_singleton {M ι : Type*} [comm_monoid M] (s : finset ι) (I : 
   ∏ (i : ι) in s, ({I i} : set M) = {∏ (i : ι) in s, I i} :=
 (map_prod (singleton_monoid_hom : M →* set M) _ _).symm
 
+/-- The n-ary version of `set.image_mul_prod`. -/
+@[to_additive "The n-ary version of `set.add_image_prod`. "]
+lemma set.image_finset_prod_pi (l : finset ι) (S : ι → set α) :
+  (λ f : ι → α, ∏ i in l, f i) '' (l : set ι).pi S = (∏ i in l, S i) :=
+by { ext, simp_rw [set.mem_finset_prod, set.mem_image, set.mem_pi, exists_prop, finset.mem_coe] }
+
+/-- A special case of `set.image_finset_prod_pi` for `finset.univ`. -/
+@[to_additive "A special case of `set.image_finset_sum_pi` for `finset.univ`. "]
+lemma set.image_fintype_prod_pi [fintype ι] (S : ι → set α) :
+  (λ f : ι → α, ∏ i, f i) '' set.univ.pi S = (∏ i, S i) :=
+by simpa only [finset.coe_univ] using set.image_finset_prod_pi finset.univ S
+
 end comm_monoid
 
 /-! TODO: define `decidable_mem_finset_prod` and `decidable_mem_finset_sum`. -/

--- a/src/data/set/pointwise/big_operators.lean
+++ b/src/data/set/pointwise/big_operators.lean
@@ -15,11 +15,36 @@ import data.set.pointwise.basic
 
 namespace set
 
-section big_operators
 open_locale big_operators pointwise
 open function
 
-variables {α : Type*} {ι : Type*} [comm_monoid α]
+variables {ι : Type*} {α : Type*} {β : Type*} {F : Type*}
+
+section monoid
+variables [monoid α] [monoid β] [monoid_hom_class F α β]
+
+@[to_additive]
+lemma set.image_list_prod (f : F) : ∀ (l : list (set α)),
+  (f : α → β) '' l.prod = (l.map (λ s, f '' s)).prod
+| [] := set.image_one.trans $ congr_arg singleton (map_one f)
+| (a :: as) := by rw [list.map_cons, list.prod_cons, list.prod_cons, set.image_mul,
+  set.image_list_prod]
+
+end monoid
+
+section comm_monoid
+variables [comm_monoid α] [comm_monoid β] [monoid_hom_class F α β]
+
+@[to_additive]
+lemma set.image_multiset_prod (f : F) : ∀ (m : multiset (set α)),
+  (f : α → β) '' m.prod = (m.map (λ s, f '' s)).prod :=
+quotient.ind $ by simpa only [multiset.quot_mk_to_coe, multiset.coe_prod, multiset.coe_map]
+                 using set.image_list_prod f
+
+@[to_additive]
+lemma set.image_finset_prod (f : F) (m : finset ι) (s : ι → set α) :
+  (f : α → β) '' (∏ i in m, s i) = (∏ i in m, f '' s i) :=
+(set.image_multiset_prod f _).trans $ congr_arg multiset.prod $ multiset.map_map _ _ _
 
 /-- The n-ary version of `set.mem_mul`. -/
 @[to_additive /-" The n-ary version of `set.mem_add`. "-/]
@@ -127,8 +152,8 @@ lemma finset_prod_singleton {M ι : Type*} [comm_monoid M] (s : finset ι) (I : 
   ∏ (i : ι) in s, ({I i} : set M) = {∏ (i : ι) in s, I i} :=
 (map_prod (singleton_monoid_hom : M →* set M) _ _).symm
 
-/-! TODO: define `decidable_mem_finset_prod` and `decidable_mem_finset_sum`. -/
+end comm_monoid
 
-end big_operators
+/-! TODO: define `decidable_mem_finset_prod` and `decidable_mem_finset_sum`. -/
 
 end set

--- a/src/data/set/pointwise/big_operators.lean
+++ b/src/data/set/pointwise/big_operators.lean
@@ -18,7 +18,7 @@ namespace set
 open_locale big_operators pointwise
 open function
 
-variables {ι : Type*} {α : Type*} {β : Type*} {F : Type*}
+variables {ι α β F : Type*}
 
 section monoid
 variables [monoid α] [monoid β] [monoid_hom_class F α β]
@@ -154,15 +154,15 @@ lemma finset_prod_singleton {M ι : Type*} [comm_monoid M] (s : finset ι) (I : 
 
 /-- The n-ary version of `set.image_mul_prod`. -/
 @[to_additive "The n-ary version of `set.add_image_prod`. "]
-lemma set.image_finset_prod_pi (l : finset ι) (S : ι → set α) :
+lemma image_finset_prod_pi (l : finset ι) (S : ι → set α) :
   (λ f : ι → α, ∏ i in l, f i) '' (l : set ι).pi S = (∏ i in l, S i) :=
-by { ext, simp_rw [set.mem_finset_prod, set.mem_image, set.mem_pi, exists_prop, finset.mem_coe] }
+by { ext, simp_rw [mem_finset_prod, mem_image, mem_pi, exists_prop, finset.mem_coe] }
 
 /-- A special case of `set.image_finset_prod_pi` for `finset.univ`. -/
 @[to_additive "A special case of `set.image_finset_sum_pi` for `finset.univ`. "]
-lemma set.image_fintype_prod_pi [fintype ι] (S : ι → set α) :
-  (λ f : ι → α, ∏ i, f i) '' set.univ.pi S = (∏ i, S i) :=
-by simpa only [finset.coe_univ] using set.image_finset_prod_pi finset.univ S
+lemma image_fintype_prod_pi [fintype ι] (S : ι → set α) :
+  (λ f : ι → α, ∏ i, f i) '' univ.pi S = (∏ i, S i) :=
+by simpa only [finset.coe_univ] using image_finset_prod_pi finset.univ S
 
 end comm_monoid
 

--- a/src/data/set/pointwise/big_operators.lean
+++ b/src/data/set/pointwise/big_operators.lean
@@ -24,11 +24,10 @@ section monoid
 variables [monoid α] [monoid β] [monoid_hom_class F α β]
 
 @[to_additive]
-lemma set.image_list_prod (f : F) : ∀ (l : list (set α)),
+lemma image_list_prod (f : F) : ∀ (l : list (set α)),
   (f : α → β) '' l.prod = (l.map (λ s, f '' s)).prod
-| [] := set.image_one.trans $ congr_arg singleton (map_one f)
-| (a :: as) := by rw [list.map_cons, list.prod_cons, list.prod_cons, set.image_mul,
-  set.image_list_prod]
+| [] := image_one.trans $ congr_arg singleton (map_one f)
+| (a :: as) := by rw [list.map_cons, list.prod_cons, list.prod_cons, image_mul, image_list_prod]
 
 end monoid
 
@@ -36,15 +35,15 @@ section comm_monoid
 variables [comm_monoid α] [comm_monoid β] [monoid_hom_class F α β]
 
 @[to_additive]
-lemma set.image_multiset_prod (f : F) : ∀ (m : multiset (set α)),
+lemma image_multiset_prod (f : F) : ∀ (m : multiset (set α)),
   (f : α → β) '' m.prod = (m.map (λ s, f '' s)).prod :=
 quotient.ind $ by simpa only [multiset.quot_mk_to_coe, multiset.coe_prod, multiset.coe_map]
-                 using set.image_list_prod f
+                 using image_list_prod f
 
 @[to_additive]
-lemma set.image_finset_prod (f : F) (m : finset ι) (s : ι → set α) :
+lemma image_finset_prod (f : F) (m : finset ι) (s : ι → set α) :
   (f : α → β) '' (∏ i in m, s i) = (∏ i in m, f '' s i) :=
-(set.image_multiset_prod f _).trans $ congr_arg multiset.prod $ multiset.map_map _ _ _
+(image_multiset_prod f _).trans $ congr_arg multiset.prod $ multiset.map_map _ _ _
 
 /-- The n-ary version of `set.mem_mul`. -/
 @[to_additive /-" The n-ary version of `set.mem_add`. "-/]


### PR DESCRIPTION
The main results here are:
* `set.image_finset_prod : f '' (∏ i in m, s i) = (∏ i in m, f '' s i)`, which says that the image under a monoid morphism commutes with the pointwise n-ary product of sets
* `set.image_finset_prod_pi : (λ f : ι → α, ∏ i in l, f i) '' (l : set ι).pi S = (∏ i in l, S i)`, which says that turning a family of sets into a set of families and taking the product over each family is the same as taking the pointwise product.

Both are n-ary versions of existing binary results.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
