### PR TITLE
[Merged by Bors] - chore(zmod/basic): remove unneeded import

### DIFF
--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -6,8 +6,8 @@ Authors: Chris Hughes
 
 import algebra.char_p.basic
 import data.nat.parity
-import algebra.group.conj_finite
 import tactic.fin_cases
+import data.fintype.units
 
 /-!
 # Integers mod `n`


### PR DESCRIPTION
This file was importing a weird dependency; I am now minimising this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


Will this sort of change be easy to forward-port? If not, I guess this can wait.