### PR TITLE
chore(analysis/convex/combination): remove unneeded universe parametricity

### DIFF
--- a/src/analysis/convex/combination.lean
+++ b/src/analysis/convex/combination.lean
@@ -288,10 +288,11 @@ begin
     exact affine_combination_mem_convex_hull hw₀ hw₁, },
 end
 
-/-- Convex hull of `s` is equal to the set of all centers of masses of `finset`s `t`, `z '' t ⊆ s`.
-This version allows finsets in any type in any universe. -/
+/--
+Convex hull of `s` is equal to the set of all centers of masses of `finset`s `t`, `z '' t ⊆ s`.
+-/
 lemma convex_hull_eq (s : set E) :
-  convex_hull R s = {x : E | ∃ (ι : Type u') (t : finset ι) (w : ι → R) (z : ι → E)
+  convex_hull R s = {x : E | ∃ (ι : Type) (t : finset ι) (w : ι → R) (z : ι → E)
     (hw₀ : ∀ i ∈ t, 0 ≤ w i) (hw₁ : ∑ i in t, w i = 1) (hz : ∀ i ∈ t, z i ∈ s),
     t.center_mass w z = x} :=
 begin


### PR DESCRIPTION
This free universe variable causes problems in mathlib4, where we're having to specify it explicitly in several places.
I'm guessing it serves no purpose (perhaps CI or @YaelDillies will tell me otherwise?), so this PR just attempts removing it.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
