### PR TITLE
[Merged by Bors] - fix(topology/continuous_function/algebra): let `continuous_map.module'` use a `semiring` instead of ` ring`

### DIFF
--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -790,7 +790,7 @@ instance has_smul' {α : Type*} [topological_space α]
 ⟨λ f g, ⟨λ x, (f x) • (g x), (continuous.smul f.2 g.2)⟩⟩
 
 instance module' {α : Type*} [topological_space α]
-  (R : Type*) [ring R] [topological_space R] [topological_ring R]
+  (R : Type*) [semiring R] [topological_space R] [topological_semiring R]
   (M : Type*) [topological_space M] [add_comm_monoid M] [has_continuous_add M]
   [module R M] [has_continuous_smul R M] :
   module C(α, R) C(α, M) :=


### PR DESCRIPTION
This fixes an issue where Lean couldn't recognize via TC inference that, for a topological semiring `R`, that `C(R, R)` is an `R`-module, despite the fact that it knows it is an `R`-algebra through `continuous_map.algebra`. All that is necessary is to weaken the type class assumptions.

---

Note: this file currently has an open mathlib4 PR, so speedy merging is appreciated. I will comment on that PR to incorporate this change (and update the SHA) accordingly.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
