### PR TITLE
[Merged by Bors] - feat(topology/sets/compacts): add `positive_compacts.map`

### DIFF
--- a/src/topology/sets/compacts.lean
+++ b/src/topology/sets/compacts.lean
@@ -111,11 +111,11 @@ lemma map_comp (f : β → γ) (g : α → β) (hf : continuous f) (hg : continu
 @[simp] lemma equiv_refl : compacts.equiv (homeomorph.refl α) = equiv.refl _ :=
 equiv.ext map_id
 
-lemma equiv_trans (f : α ≃ₜ β) (g : β ≃ₜ γ) :
+@[simp] lemma equiv_trans (f : α ≃ₜ β) (g : β ≃ₜ γ) :
   compacts.equiv (f.trans g) = (compacts.equiv f).trans (compacts.equiv g) :=
 equiv.ext $ map_comp _ _ _ _
 
-lemma equiv_symm (f : α ≃ₜ β) : compacts.equiv f.symm = (compacts.equiv f).symm :=
+@[simp] lemma equiv_symm (f : α ≃ₜ β) : compacts.equiv f.symm = (compacts.equiv f).symm :=
 rfl
 
 /-- The image of a compact set under a homeomorphism can also be expressed as a preimage. -/

--- a/src/topology/sets/compacts.lean
+++ b/src/topology/sets/compacts.lean
@@ -93,7 +93,7 @@ end
 protected def map (f : α → β) (hf : continuous f) (K : compacts α) : compacts β :=
 ⟨f '' K.1, K.2.image hf⟩
 
-@[simp] lemma coe_map {f : α → β} (hf : continuous f) (s : compacts α) :
+@[simp, norm_cast] lemma coe_map {f : α → β} (hf : continuous f) (s : compacts α) :
   (s.map f hf : set β) = f '' s := rfl
 
 @[simp] lemma map_id (K : compacts α) : K.map id continuous_id = K := compacts.ext $ set.image_id _
@@ -247,7 +247,7 @@ protected def map (f : α → β) (hf : continuous f) (hf' : is_open_map f) (K :
     (K.interior_nonempty'.image _).mono (hf'.image_interior_subset K.to_compacts),
   ..K.map f hf }
 
-@[simp] lemma coe_map {f : α → β} (hf : continuous f) (hf' : is_open_map f)
+@[simp, norm_cast] lemma coe_map {f : α → β} (hf : continuous f) (hf' : is_open_map f)
   (s : positive_compacts α) :
   (s.map f hf hf' : set β) = f '' s := rfl
 
@@ -357,8 +357,8 @@ instance : inhabited (compact_opens α) := ⟨⊥⟩
   compact_opens β :=
 ⟨s.to_compacts.map f hf, hf' _ s.is_open⟩
 
-@[simp] lemma coe_map {f : α → β} (hf : continuous f) (hf' : is_open_map f) (s : compact_opens α) :
-  (s.map f hf hf' : set β) = f '' s := rfl
+@[simp, norm_cast] lemma coe_map {f : α → β} (hf : continuous f) (hf' : is_open_map f)
+  (s : compact_opens α) : (s.map f hf hf' : set β) = f '' s := rfl
 
 @[simp] lemma map_id (K : compact_opens α) : K.map id continuous_id is_open_map.id = K :=
 compact_opens.ext $ set.image_id _


### PR DESCRIPTION
Also adds some missing functorial lemmas about `map`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


I expect to be able to use this in a future PR to golf `basis.parallelepiped`, though I think having basic functorial definitions is worthwhile in general.
