### PR TITLE
[Merged by Bors] - feat(topology/metric_space/basic): decomposition of a "sphere" hypercube

### DIFF
--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1577,12 +1577,13 @@ theorem closed_ball_prod_same (x : α) (y : β) (r : ℝ) :
   closed_ball x r ×ˢ closed_ball y r = closed_ball (x, y) r :=
 ext $ λ z, by simp [prod.dist_eq]
 
-theorem sphere_prod (x : α) (y : β) (r : ℝ) :
-  sphere (x, y) r = sphere x r ×ˢ closed_ball y r ∪ closed_ball x r ×ˢ sphere y r :=
+theorem sphere_prod (x : α × β) (r : ℝ) :
+  sphere x r = sphere x.1 r ×ˢ closed_ball x.2 r ∪ closed_ball x.1 r ×ˢ sphere x.2 r :=
 begin
   obtain hr | rfl | hr := lt_trichotomy r 0,
   { simp [hr], },
-  { simp_rw [←closed_ball_eq_sphere_of_nonpos le_rfl, union_self, closed_ball_prod_same] },
+  { cases x,
+    simp_rw [←closed_ball_eq_sphere_of_nonpos le_rfl, union_self, closed_ball_prod_same] },
   { ext ⟨x', y'⟩,
     simp_rw [set.mem_union, set.mem_prod, metric.mem_closed_ball, metric.mem_sphere,
       prod.dist_eq, max_eq_iff],

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1837,7 +1837,7 @@ lemma dist_pi_lt_iff {f g : Πb, π b} {r : ℝ} (hr : 0 < r) :
   dist f g < r ↔ ∀b, dist (f b) (g b) < r :=
 begin
   lift r to ℝ≥0 using hr.le,
-  simp [dist_pi_def, finset.sup_lt_iff (show ⊥ < r, from hr)],
+  exact nndist_pi_lt_iff hr,
 end
 
 lemma dist_pi_le_iff {f g : Πb, π b} {r : ℝ} (hr : 0 ≤ r) :

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -462,14 +462,12 @@ show dist x x ≤ ε, by rw dist_self; assumption
 @[simp] lemma closed_ball_eq_empty : closed_ball x ε = ∅ ↔ ε < 0 :=
 by rw [← not_nonempty_iff_eq_empty, nonempty_closed_ball, not_le]
 
-/-- A ball of radius zero is the sphere of radius zero -/
-theorem closed_ball_zero_eq_sphere_zero : closed_ball x 0 = sphere x 0 :=
-set.ext $ λ _, iff.symm $ le_antisymm_iff.trans $ and_iff_left dist_nonneg
-
-@[simp] theorem closed_ball_eq_sphere_of_nonneg (hε : ε ≤ 0) : closed_ball x ε = sphere x ε :=
+/-- Closed balls and spheres coincide only when the radius is non-positive -/
+@[simp] theorem closed_ball_eq_sphere_of_nonpos (hε : ε ≤ 0) : closed_ball x ε = sphere x ε :=
 begin
   obtain rfl | hr := hε.eq_or_lt,
-  { exact closed_ball_zero_eq_sphere_zero },
+  { ext,
+    exact iff.symm (le_antisymm_iff.trans $ and_iff_left dist_nonneg) },
   { rw [closed_ball_eq_empty.mpr hr, sphere_eq_empty_of_neg hr] }
 end
 
@@ -1912,7 +1910,7 @@ lemma sphere_pi (x : Πb, π b) {r : ℝ} (h : 0 < r ∨ nonempty β) :
 begin
   obtain hr | rfl | hr := lt_trichotomy r 0,
   { simp [hr], },
-  { rw [closed_ball_zero_eq_sphere_zero, eq_comm, set.inter_eq_right_iff_subset],
+  { rw [closed_ball_eq_sphere_of_nonpos le_rfl, eq_comm, set.inter_eq_right_iff_subset],
     letI := h.resolve_left (lt_irrefl _),
     inhabit β,
     refine subset_Union_of_subset default _,

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1577,6 +1577,19 @@ theorem closed_ball_prod_same (x : α) (y : β) (r : ℝ) :
   closed_ball x r ×ˢ closed_ball y r = closed_ball (x, y) r :=
 ext $ λ z, by simp [prod.dist_eq]
 
+theorem sphere_prod (x : α) (y : β) (r : ℝ) :
+  sphere (x, y) r = sphere x r ×ˢ closed_ball y r ∪ closed_ball x r ×ˢ sphere y r :=
+begin
+  obtain hr | rfl | hr := lt_trichotomy r 0,
+  { simp [hr], },
+  { simp_rw [←closed_ball_eq_sphere_of_nonpos le_rfl, union_self, closed_ball_prod_same] },
+  { ext ⟨x', y'⟩,
+    simp_rw [set.mem_union, set.mem_prod, metric.mem_closed_ball, metric.mem_sphere,
+      prod.dist_eq, max_eq_iff],
+    refine or_congr (and_congr_right _) ((and_comm _ _).trans (and_congr_left _)),
+    all_goals { rintro rfl, refl } },
+end
+
 end prod
 
 theorem uniform_continuous_dist : uniform_continuous (λp:α×α, dist p.1 p.2) :=

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -463,14 +463,14 @@ show dist x x ≤ ε, by rw dist_self; assumption
 by rw [← not_nonempty_iff_eq_empty, nonempty_closed_ball, not_le]
 
 /-- A ball of radius zero is the sphere of radius zero -/
-@[simp] theorem closed_ball_zero_eq_sphere_zero : closed_ball x 0 = sphere x 0 :=
+theorem closed_ball_zero_eq_sphere_zero : closed_ball x 0 = sphere x 0 :=
 set.ext $ λ _, iff.symm $ le_antisymm_iff.trans $ and_iff_left dist_nonneg
 
 @[simp] theorem closed_ball_eq_sphere_of_nonneg (hε : ε ≤ 0) : closed_ball x ε = sphere x ε :=
 begin
   obtain rfl | hr := hε.eq_or_lt,
-  { simp },
-  { simp [hr] }
+  { exact closed_ball_zero_eq_sphere_zero },
+  { rw [closed_ball_eq_empty.mpr hr, sphere_eq_empty_of_neg hr] }
 end
 
 theorem ball_subset_closed_ball : ball x ε ⊆ closed_ball x ε :=

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -439,6 +439,12 @@ theorem mem_sphere' : y ∈ sphere x ε ↔ dist x y = ε := by rw [dist_comm, m
 theorem ne_of_mem_sphere (h : y ∈ sphere x ε) (hε : ε ≠ 0) : y ≠ x :=
 by { contrapose! hε, symmetry, simpa [hε] using h  }
 
+theorem pos_of_mem_sphere (hy : y ∈ sphere x ε) : 0 ≤ ε :=
+dist_nonneg.trans_eq hy
+
+@[simp] theorem sphere_eq_empty_of_neg (hε : ε < 0) : sphere x ε = ∅ :=
+set.eq_empty_iff_forall_not_mem.mpr $ λ y hy, (pos_of_mem_sphere hy).not_lt hε
+
 theorem sphere_eq_empty_of_subsingleton [subsingleton α] (hε : ε ≠ 0) :
   sphere x ε = ∅ :=
 set.eq_empty_iff_forall_not_mem.mpr $ λ y hy, ne_of_mem_sphere hy hε (subsingleton.elim _ _)
@@ -455,6 +461,17 @@ show dist x x ≤ ε, by rw dist_self; assumption
 
 @[simp] lemma closed_ball_eq_empty : closed_ball x ε = ∅ ↔ ε < 0 :=
 by rw [← not_nonempty_iff_eq_empty, nonempty_closed_ball, not_le]
+
+/-- A ball of radius zero is the sphere of radius zero -/
+@[simp] theorem closed_ball_zero_eq_sphere_zero : closed_ball x 0 = sphere x 0 :=
+set.ext $ λ _, iff.symm $ le_antisymm_iff.trans $ and_iff_left dist_nonneg
+
+@[simp] theorem closed_ball_eq_sphere_of_nonneg (hε : ε ≤ 0) : closed_ball x ε = sphere x ε :=
+begin
+  obtain rfl | hr := hε.eq_or_lt,
+  { simp },
+  { simp [hr] }
+end
 
 theorem ball_subset_closed_ball : ball x ε ⊆ closed_ball x ε :=
 assume y (hy : _ < _), le_of_lt hy
@@ -1802,6 +1819,20 @@ lemma nndist_pi_le_iff {f g : Πb, π b} {r : ℝ≥0} :
   nndist f g ≤ r ↔ ∀b, nndist (f b) (g b) ≤ r :=
 by simp [nndist_pi_def]
 
+lemma nndist_pi_lt_iff {f g : Πb, π b} {r : ℝ≥0} (hr : 0 < r) :
+  nndist f g < r ↔ ∀b, nndist (f b) (g b) < r :=
+by simp [nndist_pi_def, finset.sup_lt_iff (show ⊥ < r, from hr)]
+
+lemma nndist_pi_eq_iff {f g : Πb, π b} {r : ℝ≥0} (hr : 0 < r) :
+  nndist f g = r ↔ (∃ i, nndist (f i) (g i) = r) ∧ ∀ b, nndist (f b) (g b) ≤ r :=
+begin
+  rw [eq_iff_le_not_lt, nndist_pi_lt_iff hr, nndist_pi_le_iff, not_forall, and_comm],
+  simp_rw [not_lt, and.congr_left_iff, le_antisymm_iff],
+  intro h,
+  refine exists_congr (λ b, _),
+  apply (and_iff_right $ h _).symm,
+end
+
 lemma dist_pi_lt_iff {f g : Πb, π b} {r : ℝ} (hr : 0 < r) :
   dist f g < r ↔ ∀b, dist (f b) (g b) < r :=
 begin
@@ -1814,6 +1845,13 @@ lemma dist_pi_le_iff {f g : Πb, π b} {r : ℝ} (hr : 0 ≤ r) :
 begin
   lift r to ℝ≥0 using hr,
   exact nndist_pi_le_iff
+end
+
+lemma dist_pi_eq_iff {f g : Πb, π b} {r : ℝ} (hr : 0 < r) :
+  dist f g = r ↔ (∃ i, dist (f i) (g i) = r) ∧ ∀ b, dist (f b) (g b) ≤ r :=
+begin
+  lift r to ℝ≥0 using hr.le,
+  simp_rw [←coe_nndist, nnreal.coe_eq, nndist_pi_eq_iff hr, nnreal.coe_le_coe],
 end
 
 lemma dist_pi_le_iff' [nonempty β] {f g : Π b, π b} {r : ℝ} :
@@ -1866,6 +1904,25 @@ for a version assuming `0 ≤ r` instead of `nonempty β`. -/
 lemma closed_ball_pi' [nonempty β] (x : Π b, π b) (r : ℝ) :
   closed_ball x r = set.pi univ (λ b, closed_ball (x b) r) :=
 (le_or_lt 0 r).elim (closed_ball_pi x) $ λ hr, by simp [closed_ball_eq_empty.2 hr]
+
+/-- A sphere in a product space is a union of spheres on each component restricted to the closed
+ball. -/
+lemma sphere_pi (x : Πb, π b) {r : ℝ} (h : 0 < r ∨ nonempty β) :
+  sphere x r = (⋃ i : β, function.eval i ⁻¹' sphere (x i) r) ∩ closed_ball x r :=
+begin
+  obtain hr | rfl | hr := lt_trichotomy r 0,
+  { simp [hr], },
+  { rw [closed_ball_zero_eq_sphere_zero, eq_comm, set.inter_eq_right_iff_subset],
+    letI := h.resolve_left (lt_irrefl _),
+    inhabit β,
+    refine subset_Union_of_subset default _,
+    intros x hx,
+    replace hx := hx.le,
+    rw [dist_pi_le_iff le_rfl] at hx,
+    exact le_antisymm (hx default) dist_nonneg },
+  { ext,
+    simp [dist_pi_eq_iff hr,  dist_pi_le_iff hr.le] },
+end
 
 @[simp] lemma fin.nndist_insert_nth_insert_nth {n : ℕ} {α : fin (n + 1) → Type*}
   [Π i, pseudo_metric_space (α i)] (i : fin (n + 1)) (x y : α i) (f g : Π j, α (i.succ_above j)) :

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -464,10 +464,7 @@ by rw [← not_nonempty_iff_eq_empty, nonempty_closed_ball, not_le]
 
 /-- Closed balls and spheres coincide only when the radius is non-positive -/
 @[simp] theorem closed_ball_eq_sphere_of_nonpos (hε : ε ≤ 0) : closed_ball x ε = sphere x ε :=
-begin
-  ext x,
-  exact (hε.trans dist_nonneg).le_iff_eq
-end
+set.ext $ λ _, (hε.trans dist_nonneg).le_iff_eq
 
 theorem ball_subset_closed_ball : ball x ε ⊆ closed_ball x ε :=
 assume y (hy : _ < _), le_of_lt hy

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -462,8 +462,8 @@ show dist x x ≤ ε, by rw dist_self; assumption
 @[simp] lemma closed_ball_eq_empty : closed_ball x ε = ∅ ↔ ε < 0 :=
 by rw [← not_nonempty_iff_eq_empty, nonempty_closed_ball, not_le]
 
-/-- Closed balls and spheres coincide only when the radius is non-positive -/
-@[simp] theorem closed_ball_eq_sphere_of_nonpos (hε : ε ≤ 0) : closed_ball x ε = sphere x ε :=
+/-- Closed balls and spheres coincide when the radius is non-positive -/
+theorem closed_ball_eq_sphere_of_nonpos (hε : ε ≤ 0) : closed_ball x ε = sphere x ε :=
 set.ext $ λ _, (hε.trans dist_nonneg).le_iff_eq
 
 theorem ball_subset_closed_ball : ball x ε ⊆ closed_ball x ε :=

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -443,7 +443,7 @@ theorem nonneg_of_mem_sphere (hy : y ∈ sphere x ε) : 0 ≤ ε :=
 dist_nonneg.trans_eq hy
 
 @[simp] theorem sphere_eq_empty_of_neg (hε : ε < 0) : sphere x ε = ∅ :=
-set.eq_empty_iff_forall_not_mem.mpr $ λ y hy, (pos_of_mem_sphere hy).not_lt hε
+set.eq_empty_iff_forall_not_mem.mpr $ λ y hy, (nonneg_of_mem_sphere hy).not_lt hε
 
 theorem sphere_eq_empty_of_subsingleton [subsingleton α] (hε : ε ≠ 0) :
   sphere x ε = ∅ :=

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -439,7 +439,7 @@ theorem mem_sphere' : y ∈ sphere x ε ↔ dist x y = ε := by rw [dist_comm, m
 theorem ne_of_mem_sphere (h : y ∈ sphere x ε) (hε : ε ≠ 0) : y ≠ x :=
 by { contrapose! hε, symmetry, simpa [hε] using h  }
 
-theorem pos_of_mem_sphere (hy : y ∈ sphere x ε) : 0 ≤ ε :=
+theorem nonneg_of_mem_sphere (hy : y ∈ sphere x ε) : 0 ≤ ε :=
 dist_nonneg.trans_eq hy
 
 @[simp] theorem sphere_eq_empty_of_neg (hε : ε < 0) : sphere x ε = ∅ :=
@@ -465,10 +465,8 @@ by rw [← not_nonempty_iff_eq_empty, nonempty_closed_ball, not_le]
 /-- Closed balls and spheres coincide only when the radius is non-positive -/
 @[simp] theorem closed_ball_eq_sphere_of_nonpos (hε : ε ≤ 0) : closed_ball x ε = sphere x ε :=
 begin
-  obtain rfl | hr := hε.eq_or_lt,
-  { ext,
-    exact iff.symm (le_antisymm_iff.trans $ and_iff_left dist_nonneg) },
-  { rw [closed_ball_eq_empty.mpr hr, sphere_eq_empty_of_neg hr] }
+  ext x,
+  exact (hε.trans dist_nonneg).le_iff_eq
 end
 
 theorem ball_subset_closed_ball : ball x ε ⊆ closed_ball x ε :=
@@ -1832,10 +1830,10 @@ lemma nndist_pi_le_iff {f g : Πb, π b} {r : ℝ≥0} :
 by simp [nndist_pi_def]
 
 lemma nndist_pi_lt_iff {f g : Πb, π b} {r : ℝ≥0} (hr : 0 < r) :
-  nndist f g < r ↔ ∀b, nndist (f b) (g b) < r :=
+  nndist f g < r ↔ ∀ b, nndist (f b) (g b) < r :=
 by simp [nndist_pi_def, finset.sup_lt_iff (show ⊥ < r, from hr)]
 
-lemma nndist_pi_eq_iff {f g : Πb, π b} {r : ℝ≥0} (hr : 0 < r) :
+lemma nndist_pi_eq_iff {f g : Π b, π b} {r : ℝ≥0} (hr : 0 < r) :
   nndist f g = r ↔ (∃ i, nndist (f i) (g i) = r) ∧ ∀ b, nndist (f b) (g b) ≤ r :=
 begin
   rw [eq_iff_le_not_lt, nndist_pi_lt_iff hr, nndist_pi_le_iff, not_forall, and_comm],


### PR DESCRIPTION
The main result here is `sphere x r = (⋃ i : β, function.eval i ⁻¹' sphere (x i) r) ∩ closed_ball x r`, which attempts to express that you can form the surface of a cube by taking the union of the faces in each axis.

The `prod` result, `sphere (x, y) r = sphere x r ×ˢ closed_ball y r ∪ closed_ball x r ×ˢ sphere y r`, is a little easier to follow.

I can imagine these being useful if we wanted to prove that the surface area of a "sphere" in `fin 3 -> R` was `24*r*r`!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
