### PR TITLE
[Merged by Bors] - refactor(number_theory/modular_forms/slash_actions): use the same notation everywhere

### DIFF
--- a/src/number_theory/modular_forms/basic.lean
+++ b/src/number_theory/modular_forms/basic.lean
@@ -35,14 +35,14 @@ open modular_form
 
 variables (F : Type*) (Γ : subgroup SL(2, ℤ)) (k : ℤ)
 
-local notation f `∣[`:73 k:0, A `]` :72 := slash_action.map ℂ k A f
+open_locale modular_form
 
 set_option old_structure_cmd true
 
 /--These are `slash_invariant_form`'s that are holomophic and bounded at infinity. -/
 structure modular_form extends slash_invariant_form Γ k :=
 (holo' : mdifferentiable 𝓘(ℂ) 𝓘(ℂ) (to_fun : ℍ → ℂ))
-(bdd_at_infty' : ∀ (A : SL(2, ℤ)), is_bounded_at_im_infty (to_fun ∣[k, A]))
+(bdd_at_infty' : ∀ (A : SL(2, ℤ)), is_bounded_at_im_infty (to_fun ∣[k] A))
 
 /-- The `slash_invariant_form` associated to a `modular_form`. -/
 add_decl_doc modular_form.to_slash_invariant_form
@@ -50,7 +50,7 @@ add_decl_doc modular_form.to_slash_invariant_form
 /--These are `slash_invariant_form`s that are holomophic and zero at infinity. -/
 structure cusp_form extends slash_invariant_form Γ k :=
 (holo' : mdifferentiable 𝓘(ℂ) 𝓘(ℂ) (to_fun : ℍ → ℂ))
-(zero_at_infty' : ∀ (A : SL(2, ℤ)), is_zero_at_im_infty (to_fun ∣[k, A]))
+(zero_at_infty' : ∀ (A : SL(2, ℤ)), is_zero_at_im_infty (to_fun ∣[k] A))
 
 /-- The `slash_invariant_form` associated to a `cusp_form`. -/
 add_decl_doc cusp_form.to_slash_invariant_form
@@ -60,14 +60,14 @@ add_decl_doc cusp_form.to_slash_invariant_form
 at infinity. -/
 class modular_form_class extends slash_invariant_form_class F Γ k :=
 (holo: ∀ f : F, mdifferentiable 𝓘(ℂ) 𝓘(ℂ) (f : ℍ → ℂ))
-(bdd_at_infty : ∀ (f : F) (A : SL(2, ℤ)), is_bounded_at_im_infty (f ∣[k, A]))
+(bdd_at_infty : ∀ (f : F) (A : SL(2, ℤ)), is_bounded_at_im_infty (f ∣[k] A))
 
 /--`cusp_form_class F Γ k` says that `F` is a type of bundled functions that extend
 `slash_invariant_forms_class` by requiring that the functions be holomorphic and zero
 at infinity. -/
 class cusp_form_class extends slash_invariant_form_class F Γ k :=
 (holo: ∀ f : F, mdifferentiable 𝓘(ℂ) 𝓘(ℂ) (f : ℍ → ℂ))
-(zero_at_infty : ∀ (f : F) (A : SL(2, ℤ)), is_zero_at_im_infty (f ∣[k, A]))
+(zero_at_infty : ∀ (f : F) (A : SL(2, ℤ)), is_zero_at_im_infty (f ∣[k] A))
 
 @[priority 100]
 instance modular_form_class.modular_form : modular_form_class (modular_form Γ k) Γ k :=

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -28,7 +28,7 @@ local notation `GL(` n `, ` R `)`⁺ := matrix.GL_pos (fin n) R
 local notation `SL(` n `, ` R `)` := matrix.special_linear_group (fin n) R
 
 /--A general version of the slash action of the space of modular forms.-/
-class slash_action (β G α γ : Type*) [group G] [has_zero α] [has_smul γ α] [has_add α] :=
+class slash_action (β G α γ : Type*) [group G] [add_monoid α] [has_smul γ α] :=
 (map : β → G → α → α)
 (zero_slash : ∀ (k : β) (g : G), map k g 0 = 0)
 (slash_one : ∀ (k : β) (a : α) , map k 1 a = a)
@@ -37,7 +37,7 @@ class slash_action (β G α γ : Type*) [group G] [has_zero α] [has_smul γ α]
 (add_action : ∀ (k : β) (g : G) (a b : α), map k g (a + b) = map k g a + map k g b)
 
 /--Slash_action induced by a monoid homomorphism.-/
-def monoid_hom_slash_action {β G H α γ : Type*} [group G] [has_zero α] [has_smul γ α] [has_add α]
+def monoid_hom_slash_action {β G H α γ : Type*} [group G] [add_monoid α] [has_smul γ α]
   [group H] [slash_action β G α γ] (h : H →* G) : slash_action β H α γ :=
 { map := λ k g, slash_action.map γ k (h g),
   zero_slash := λ k g, slash_action.zero_slash k (h g),

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -12,6 +12,13 @@ import linear_algebra.matrix.special_linear_group
 This file defines a class of slash actions, which are families of right actions of a given group
 parametrized by some Type. This is modeled on the slash action of `GL_pos (fin 2) ℝ` on the space
 of modular forms.
+
+## Notation
+
+In the `modular_form` locale, this provides
+
+* `f ∣[k;γ] A`: the `k`th `γ`-compatible slash action by `A` on `f`
+* `f ∣[k] A`: the `k`th `ℂ`-compatible slash action by `A` on `f`; a shorthand for `f ∣[k;ℂ] A`
 -/
 
 open complex upper_half_plane
@@ -36,6 +43,21 @@ class slash_action (β G α γ : Type*) [group G] [add_monoid α] [has_smul γ �
 (smul_action : ∀ (k : β) (g : G) (a : α) (z : γ), map k g (z • a) = z • (map k g a))
 (add_action : ∀ (k : β) (g : G) (a b : α), map k g (a + b) = map k g a + map k g b)
 
+localized "notation (name := modular_form.slash) f ` ∣[`:100 k `;` γ `] `:0 a :100 :=
+  slash_action.map γ k a f" in modular_form
+
+localized "notation (name := modular_form.slash_complex) f ` ∣[`:100 k `]`:0 a :100 :=
+  slash_action.map ℂ k a f" in modular_form
+
+@[simp] lemma slash_action.neg_slash (β G α γ : Type*) [group G] [add_group α] [has_smul γ α]
+  [slash_action β G α γ] (k : β) (g : G) (a : α) :
+  (-a) ∣[k;γ] g = - (a ∣[k;γ] g) :=
+eq_neg_of_add_eq_zero_left $ by rw [←slash_action.add_action, add_left_neg, slash_action.zero_slash]
+
+attribute [simp]
+  slash_action.zero_slash slash_action.slash_one
+  slash_action.smul_action slash_action.add_action
+
 /--Slash_action induced by a monoid homomorphism.-/
 def monoid_hom_slash_action {β G H α γ : Type*} [group G] [add_monoid α] [has_smul γ α]
   [group H] [slash_action β G α γ] (h : H →* G) : slash_action β H α γ :=
@@ -56,10 +78,12 @@ f (γ • x) * (((↑ₘ γ).det) : ℝ)^(k-1) * (upper_half_plane.denom γ x)^(
 
 variables {Γ : subgroup SL(2, ℤ)} {k: ℤ} (f : ℍ → ℂ)
 
-localized "notation (name := modular_form.slash) f ` ∣[`:100 k `]`:0 γ :100 :=
-  modular_form.slash k γ f" in modular_form
+section
 
-lemma slash_right_action (k : ℤ) (A B : GL(2, ℝ)⁺) (f : ℍ → ℂ) :
+-- temporary notation until the instance is built
+local notation f ` ∣[`:100 k `]`:0 γ :100 := modular_form.slash k γ f
+
+private lemma slash_right_action (k : ℤ) (A B : GL(2, ℝ)⁺) (f : ℍ → ℂ) :
   (f ∣[k] A) ∣[k] B = f ∣[k] (A * B) :=
 begin
   ext1,
@@ -78,7 +102,7 @@ begin
   simp_rw [this, ← mul_assoc, ←mul_zpow],
 end
 
-@[simp] lemma slash_add (k : ℤ) (A : GL(2, ℝ)⁺) (f g : ℍ → ℂ) :
+private lemma slash_add (k : ℤ) (A : GL(2, ℝ)⁺) (f g : ℍ → ℂ) :
   (f + g) ∣[k] A = (f ∣[k] A) + (g ∣[k] A) :=
 begin
   ext1,
@@ -86,12 +110,12 @@ begin
   ring,
 end
 
-@[simp] lemma slash_one (k : ℤ) (f : ℍ → ℂ) : (f ∣[k] 1) = f :=
+private lemma slash_one (k : ℤ) (f : ℍ → ℂ) : (f ∣[k] 1) = f :=
 funext $ by simp [slash]
 
 variables {α : Type*} [has_smul α ℂ] [is_scalar_tower α ℂ ℂ]
 
-@[simp] lemma smul_slash (k : ℤ) (A : GL(2, ℝ)⁺) (f : ℍ → ℂ) (c : α) :
+private lemma smul_slash (k : ℤ) (A : GL(2, ℝ)⁺) (f : ℍ → ℂ) (c : α) :
   (c • f) ∣[k] A = c • (f ∣[k] A) :=
 begin
   simp_rw [←smul_one_smul ℂ c f, ←smul_one_smul ℂ c (f ∣[k] A)],
@@ -102,10 +126,7 @@ begin
   ring,
 end
 
-@[simp] lemma neg_slash (k : ℤ) (A : GL(2, ℝ)⁺) (f : ℍ → ℂ) : (-f) ∣[k] A = - (f ∣[k] A) :=
-funext $ by simp [slash]
-
-@[simp] lemma zero_slash (k : ℤ) (A : GL(2, ℝ)⁺) : (0 : ℍ → ℂ) ∣[k] A = 0 :=
+private lemma zero_slash (k : ℤ) (A : GL(2, ℝ)⁺) : (0 : ℍ → ℂ) ∣[k] A = 0 :=
 funext $ λ _, by simp only [slash, pi.zero_apply, zero_mul]
 
 instance : slash_action ℤ GL(2, ℝ)⁺ (ℍ → ℂ) ℂ :=
@@ -116,31 +137,32 @@ instance : slash_action ℤ GL(2, ℝ)⁺ (ℍ → ℂ) ℂ :=
   smul_action := smul_slash,
   add_action := slash_add }
 
+end
+
+lemma slash_def (A : GL(2, ℝ)⁺) : f ∣[k] A = slash k A f := rfl
+
 instance subgroup_action (Γ : subgroup SL(2, ℤ)) : slash_action ℤ Γ (ℍ → ℂ) ℂ :=
 monoid_hom_slash_action (monoid_hom.comp (matrix.special_linear_group.to_GL_pos)
   (monoid_hom.comp (matrix.special_linear_group.map (int.cast_ring_hom ℝ)) (subgroup.subtype Γ)))
 
 @[simp] lemma subgroup_slash (Γ : subgroup SL(2, ℤ)) (γ : Γ):
-  (slash_action.map ℂ k γ f) = slash k (γ : GL(2,ℝ)⁺) f := rfl
+  (f ∣[k] γ) = f ∣[k] (γ : GL(2,ℝ)⁺) := rfl
 
 instance SL_action : slash_action ℤ SL(2, ℤ) (ℍ → ℂ) ℂ :=
 monoid_hom_slash_action (monoid_hom.comp (matrix.special_linear_group.to_GL_pos)
   (matrix.special_linear_group.map (int.cast_ring_hom ℝ)))
 
-@[simp] lemma SL_slash (γ : SL(2, ℤ)):
-  (slash_action.map ℂ k γ f) = slash k (γ : GL(2,ℝ)⁺) f := rfl
-
-local notation f `∣[`:73 k:0, A `]` :72 := slash_action.map ℂ k A f
+@[simp] lemma SL_slash (γ : SL(2, ℤ)): f ∣[k] γ = f ∣[k] (γ : GL(2,ℝ)⁺) := rfl
 
 /-- The constant function 1 is invariant under any element of `SL(2, ℤ)`. -/
-@[simp] lemma is_invariant_one (A : SL(2, ℤ)) : (1 : ℍ → ℂ) ∣[(0 : ℤ), A] = (1 : ℍ → ℂ) :=
+@[simp] lemma is_invariant_one (A : SL(2, ℤ)) : (1 : ℍ → ℂ) ∣[(0 : ℤ)] A = (1 : ℍ → ℂ) :=
 begin
   have : (((↑ₘ(A : GL(2,ℝ)⁺)).det) : ℝ) = 1,
   { simp only [coe_coe,
       matrix.special_linear_group.coe_GL_pos_coe_GL_coe_matrix,
       matrix.special_linear_group.det_coe], },
   funext,
-  rw [SL_slash, slash, zero_sub, this],
+  rw [SL_slash, slash_def, slash, zero_sub, this],
   simp,
 end
 
@@ -148,9 +170,9 @@ end
   if for every matrix `γ ∈ Γ` we have `f(γ • z)= (c*z+d)^k f(z)` where `γ= ![![a, b], ![c, d]]`,
   and it acts on `ℍ` via Möbius transformations. -/
 lemma slash_action_eq'_iff (k : ℤ) (Γ : subgroup SL(2, ℤ)) (f : ℍ → ℂ) (γ : Γ)  (z : ℍ) :
-  f ∣[k, γ] z = f z ↔ f (γ • z) = ((↑ₘ[ℤ]γ 1 0 : ℂ) * z + (↑ₘ[ℤ]γ 1 1 : ℂ))^k * f z :=
+  (f ∣[k] γ) z = f z ↔ f (γ • z) = ((↑ₘ[ℤ]γ 1 0 : ℂ) * z + (↑ₘ[ℤ]γ 1 1 : ℂ))^k * f z :=
 begin
-  simp only [subgroup_slash, modular_form.slash],
+  simp only [subgroup_slash, slash_def, modular_form.slash],
   convert inv_mul_eq_iff_eq_mul₀ _ using 2,
   { rw mul_comm,
     simp only [denom, coe_coe, matrix.special_linear_group.coe_GL_pos_coe_GL_coe_matrix, zpow_neg,
@@ -161,10 +183,10 @@ begin
 end
 
 lemma mul_slash (k1 k2 : ℤ) (A : GL(2, ℝ)⁺) (f g : ℍ → ℂ) :
-  (f * g) ∣[k1 + k2, A] = (((↑ₘ A).det) : ℝ) • (f ∣[k1, A]) * (g ∣[k2, A]) :=
+  (f * g) ∣[k1 + k2] A = (((↑ₘ A).det) : ℝ) • (f ∣[k1] A) * (g ∣[k2] A) :=
 begin
   ext1,
-  simp only [slash_action.map, slash, matrix.general_linear_group.coe_det_apply, subtype.val_eq_coe,
+  simp only [slash_def, slash, matrix.general_linear_group.coe_det_apply, subtype.val_eq_coe,
     pi.mul_apply, pi.smul_apply, algebra.smul_mul_assoc, real_smul],
   set d : ℂ := ↑((↑ₘ A).det : ℝ),
   have h1 : d ^ (k1 + k2 - 1) = d * d ^ (k1 - 1) * d ^ (k2 - 1),
@@ -182,13 +204,13 @@ begin
 end
 
 @[simp] lemma mul_slash_SL2 (k1 k2 : ℤ) (A : SL(2, ℤ)) (f g : ℍ → ℂ) :
-  (f * g) ∣[k1 + k2, A] = (f ∣[k1, A]) * (g ∣[k2, A]) :=
-calc (f * g) ∣[k1 + k2, (A : GL(2, ℝ)⁺)] = _ • (f ∣[k1, A]) * (g ∣[k2, A]) : mul_slash _ _ _ _ _
-... = (1:ℝ) • (f ∣[k1, A]) * (g ∣[k2, A]) : by simp [-matrix.special_linear_group.coe_matrix_coe]
-... = (f ∣[k1, A]) * (g ∣[k2, A]) : by simp
+  (f * g) ∣[k1 + k2] A = (f ∣[k1] A) * (g ∣[k2] A) :=
+calc (f * g) ∣[k1 + k2] (A : GL(2, ℝ)⁺) = _ • (f ∣[k1] A) * (g ∣[k2] A) : mul_slash _ _ _ _ _
+... = (1:ℝ) • (f ∣[k1] A) * (g ∣[k2] A) : by simp [-matrix.special_linear_group.coe_matrix_coe]
+... = (f ∣[k1] A) * (g ∣[k2] A) : by simp
 
 lemma mul_slash_subgroup (k1 k2 : ℤ) (Γ : subgroup SL(2, ℤ)) (A : Γ) (f g : ℍ → ℂ) :
-  (f * g) ∣[k1 + k2, A] = (f ∣[k1, A]) * (g ∣[k2, A]) :=
+  (f * g) ∣[k1 + k2] A = (f ∣[k1] A) * (g ∣[k2] A) :=
 mul_slash_SL2 k1 k2 A f g
 
 end modular_form

--- a/src/number_theory/modular_forms/slash_actions.lean
+++ b/src/number_theory/modular_forms/slash_actions.lean
@@ -46,13 +46,20 @@ class slash_action (β G α γ : Type*) [group G] [add_monoid α] [has_smul γ �
 localized "notation (name := modular_form.slash) f ` ∣[`:100 k `;` γ `] `:0 a :100 :=
   slash_action.map γ k a f" in modular_form
 
-localized "notation (name := modular_form.slash_complex) f ` ∣[`:100 k `]`:0 a :100 :=
+localized "notation (name := modular_form.slash_complex) f ` ∣[`:100 k `] `:0 a :100 :=
   slash_action.map ℂ k a f" in modular_form
 
-@[simp] lemma slash_action.neg_slash (β G α γ : Type*) [group G] [add_group α] [has_smul γ α]
+@[simp] lemma slash_action.neg_slash {β G α γ : Type*} [group G] [add_group α] [has_smul γ α]
   [slash_action β G α γ] (k : β) (g : G) (a : α) :
   (-a) ∣[k;γ] g = - (a ∣[k;γ] g) :=
 eq_neg_of_add_eq_zero_left $ by rw [←slash_action.add_action, add_left_neg, slash_action.zero_slash]
+
+@[simp] lemma slash_action.smul_slash_of_tower {R β G α : Type*} (γ : Type*) [group G] [add_group α]
+  [monoid γ] [mul_action γ α]
+  [has_smul R γ] [has_smul R α] [is_scalar_tower R γ α]
+  [slash_action β G α γ] (k : β) (g : G) (a : α) (r : R) :
+  (r • a) ∣[k;γ] g = r • (a ∣[k;γ] g) :=
+by rw [←smul_one_smul γ r a, slash_action.smul_action, smul_one_smul]
 
 attribute [simp]
   slash_action.zero_slash slash_action.slash_one

--- a/src/number_theory/modular_forms/slash_invariant_forms.lean
+++ b/src/number_theory/modular_forms/slash_invariant_forms.lean
@@ -15,7 +15,7 @@ that they form a module.
 
 open complex upper_half_plane
 
-open_locale upper_half_plane
+open_locale upper_half_plane modular_form
 
 noncomputable theory
 
@@ -36,17 +36,15 @@ open modular_form
 
 variables (F : Type*) (Γ : out_param $ subgroup SL(2, ℤ)) (k : out_param ℤ)
 
-localized "notation f `∣[`:73 k:0, A `]` :72 := slash_action.map ℂ k A f" in slash_invariant_forms
-
 /--Functions `ℍ → ℂ` that are invariant under the `slash_action`. -/
 structure slash_invariant_form :=
 (to_fun : ℍ → ℂ)
-(slash_action_eq' : ∀ γ : Γ, to_fun ∣[k, γ] = to_fun)
+(slash_action_eq' : ∀ γ : Γ, to_fun ∣[k] γ = to_fun)
 
 /--`slash_invariant_form_class F Γ k` asserts `F` is a type of bundled functions that are invariant
 under the `slash_action`. -/
 class slash_invariant_form_class extends fun_like F ℍ (λ _, ℂ) :=
-(slash_action_eq : ∀ (f : F) (γ : Γ), (f : ℍ → ℂ) ∣[k, γ] = f)
+(slash_action_eq : ∀ (f : F) (γ : Γ), (f : ℍ → ℂ) ∣[k] γ = f)
 
 attribute [nolint dangerous_instance] slash_invariant_form_class.to_fun_like
 
@@ -135,7 +133,7 @@ instance has_neg : has_neg (slash_invariant_form Γ k) :=
 ⟨ λ f,
   { to_fun := -f,
     slash_action_eq' := λ γ, by simpa [modular_form.subgroup_slash,
-      modular_form.neg_slash] using f.slash_action_eq' γ } ⟩
+      slash_action.neg_slash] using f.slash_action_eq' γ } ⟩
 
 @[simp] lemma coe_neg (f : slash_invariant_form Γ k) : ⇑(-f) = -f := rfl
 @[simp] lemma neg_apply (f : slash_invariant_form Γ k) (z : ℍ) : (-f) z = - (f z) := rfl


### PR DESCRIPTION
Previously we had both `f ∣[k] A` and `f ∣[k, A]` notation, this keeps only the former (on the assumption it more closely resembles the LaTeX). `f ∣[k;γ] A` is then added as notation for the more general `γ`-invariant case that the typeclass is designed around, even though that is never used.

This makes `slash_action.map` the canonical spelling of slash actions, as opposed to a mix of this spelling and `modular_form.slash`. 

Since `modular_form.slash` is no longer canonical, all the lemmas about it are made private as they are immediately subsumed by the typeclass lemmas.

Rather than defining the same local notation in each file, this now just opens the locale.

This also ungeneralizes `has_zero` + `has_add` to `add_monoid`, since the extra generality is not used, and we do not have it for the (suspiciously!) analogous `distrib_mul_action`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Thanks for the talk today @CBirkbeck!