### PR TITLE
[Merged by Bors] - chore(topology/continuous_function/algebra): simplify definition and proof

### DIFF
--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -743,22 +743,17 @@ end continuous_map
 instance continuous_map.subsingleton_subalgebra (α : Type*) [topological_space α]
   (R : Type*) [comm_semiring R] [topological_space R] [topological_semiring R]
   [subsingleton α] : subsingleton (subalgebra R C(α, R)) :=
-begin
-  fsplit,
-  intros s₁ s₂,
+⟨λ s₁ s₂, begin
   casesI is_empty_or_nonempty α,
-  { ext f,
-    have h : f = 0,
-    { ext x', exact is_empty_elim x', },
-    subst h,
-    simp only [subalgebra.zero_mem], },
+  { haveI : subsingleton C(α, R) := fun_like.coe_injective.subsingleton,
+    exact subsingleton.elim _ _ },
   { inhabit α,
     ext f,
     have h : f = algebra_map R C(α, R) (f default),
     { ext x', simp only [mul_one, algebra.id.smul_eq_mul, algebra_map_apply], congr, },
     rw h,
     simp only [subalgebra.algebra_map_mem], },
-end
+end⟩
 
 end algebra_structure
 

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -710,7 +710,7 @@ writing it this way avoids having to deal with casts inside the set.
 where the functions would be continuous functions vanishing at infinity.)
 -/
 def set.separates_points_strongly (s : set C(α, 𝕜)) : Prop :=
-∀ (v : α → 𝕜) (x y : α), ∃ f : s, (f x : 𝕜) = v x ∧ f y = v y
+∀ (v : α → 𝕜) (x y : α), ∃ f ∈ s, (f x : 𝕜) = v x ∧ f y = v y
 
 variables [field 𝕜] [topological_ring 𝕜]
 
@@ -727,25 +727,15 @@ lemma subalgebra.separates_points.strongly {s : subalgebra 𝕜 C(α, 𝕜)} (h 
 begin
   by_cases n : x = y,
   { subst n,
-    use ((v x) • 1 : C(α, 𝕜)),
-    { apply s.smul_mem,
-      apply s.one_mem, },
-    { simp [coe_fn_coe_base'] }, },
-  obtain ⟨f, ⟨f, ⟨m, rfl⟩⟩, w⟩ := h n,
-  replace w : f x - f y ≠ 0 := sub_ne_zero_of_ne w,
+    refine ⟨_, ((v x) • 1 : s).prop, mul_one _, mul_one _⟩ },
+  obtain ⟨_, ⟨f, hf, rfl⟩, hxy⟩ := h n,
+  replace hxy : f x - f y ≠ 0 := sub_ne_zero_of_ne hxy,
   let a := v x,
   let b := v y,
-  let f' := ((b - a) * (f x - f y)⁻¹) • (continuous_map.C (f x) - f) + continuous_map.C a,
-  refine ⟨⟨f', _⟩, _, _⟩,
-  { simp only [f', set_like.mem_coe, subalgebra.mem_to_submodule],
-    -- TODO should there be a tactic for this?
-    -- We could add an attribute `@[subobject_mem]`, and a tactic
-    -- ``def subobject_mem := `[solve_by_elim with subobject_mem { max_depth := 10 }]``
-    solve_by_elim
-      [subalgebra.add_mem, subalgebra.smul_mem, subalgebra.sub_mem, subalgebra.algebra_map_mem]
-      { max_depth := 6 }, },
-  { simp [f', coe_fn_coe_base'], },
-  { simp [f', coe_fn_coe_base', inv_mul_cancel_right₀ w], },
+  let f' : s := ((b - a) * (f x - f y)⁻¹) • (algebra_map _ _ (f x) - ⟨f, hf⟩) + algebra_map _ _ a,
+  refine ⟨f', f'.prop, _, _⟩,
+  { simp [f'], },
+  { simp [f', inv_mul_cancel_right₀ hxy], },
 end
 
 end continuous_map
@@ -756,18 +746,18 @@ instance continuous_map.subsingleton_subalgebra (α : Type*) [topological_space 
 begin
   fsplit,
   intros s₁ s₂,
-  by_cases n : nonempty α,
-  { obtain ⟨x⟩ := n,
+  casesI is_empty_or_nonempty α,
+  { ext f,
+    have h : f = 0,
+    { ext x', exact is_empty_elim x', },
+    subst h,
+    simp only [subalgebra.zero_mem], },
+  { inhabit α,
     ext f,
-    have h : f = algebra_map R C(α, R) (f x),
+    have h : f = algebra_map R C(α, R) (f default),
     { ext x', simp only [mul_one, algebra.id.smul_eq_mul, algebra_map_apply], congr, },
     rw h,
     simp only [subalgebra.algebra_map_mem], },
-  { ext f,
-    have h : f = 0,
-    { ext x', exact false.elim (n ⟨x'⟩), },
-    subst h,
-    simp only [subalgebra.zero_mem], },
 end
 
 end algebra_structure

--- a/src/topology/continuous_function/stone_weierstrass.lean
+++ b/src/topology/continuous_function/stone_weierstrass.lean
@@ -190,11 +190,8 @@ begin
   and finally using compactness to produce the desired function `h`
   as a maximum over finitely many `x` of a minimum over finitely many `y` of the `g x y`.
   -/
-  dsimp [set.separates_points_strongly] at sep,
-
-  let g : X → X → L := λ x y, (sep f x y).some,
-  have w₁ : ∀ x y, g x y x = f x := λ x y, (sep f x y).some_spec.1,
-  have w₂ : ∀ x y, g x y y = f y := λ x y, (sep f x y).some_spec.2,
+  dsimp only [set.separates_points_strongly] at sep,
+  choose g hg w₁ w₂ using sep f,
 
   -- For each `x y`, we define `U x y` to be `{z | f z - ε < g x y z}`,
   -- and observe this is a neighbourhood of `y`.
@@ -226,7 +223,7 @@ begin
   -- and `h x x = f x`.
   let h : Π x, L := λ x,
     ⟨(ys x).sup' (ys_nonempty x) (λ y, (g x y : C(X, ℝ))),
-      finset.sup'_mem _ sup_mem _ _ _ (λ y _, (g x y).2)⟩,
+      finset.sup'_mem _ sup_mem _ _ _ (λ y _, hg x y)⟩,
   have lt_h : ∀ x z, f z - ε < h x z,
   { intros x z,
     obtain ⟨y, ym, zm⟩ := set.exists_set_mem_of_union_eq_top _ _ (ys_w x) z,
@@ -234,7 +231,7 @@ begin
     simp only [coe_fn_coe_base', subtype.coe_mk, sup'_coe, finset.sup'_apply, finset.lt_sup'_iff],
     exact ⟨y, ym, zm⟩ },
   have h_eq : ∀ x, h x x = f x,
-  { intro x, simp only [coe_fn_coe_base'] at w₁, simp [coe_fn_coe_base', w₁], },
+  { intro x, simp [coe_fn_coe_base', w₁], },
 
   -- For each `x`, we define `W x` to be `{z | h x z < f z + ε}`,
   let W : Π x, set X := λ x, {z | h x z < f z + ε},


### PR DESCRIPTION
The definition isn't benefiting from the `coe_sort`, and the proof can save a lot of effort by staying within the subalgebra. This proof was proving annoying to port.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
