### PR TITLE
[Merged by Bors] - chore(category_theory/limits/preserves/finite): avoid instances with unbound universes

### DIFF
--- a/src/category_theory/limits/preserves/finite.lean
+++ b/src/category_theory/limits/preserves/finite.lean
@@ -56,6 +56,7 @@ noncomputable instance preserves_limits_of_shape_of_preserves_finite_limits (F :
 by apply preserves_limits_of_shape_of_equiv (fin_category.equiv_as_type J)
 
 -- This is a dangerous instance as it has unbound universe variables.
+/-- If we preserve limits of some arbitrary size, then we preserve all finite limits. -/
 noncomputable def preserves_limits_of_size.preserves_finite_limits (F : C ⥤ D)
   [preserves_limits_of_size.{w w₂} F] : preserves_finite_limits F :=
 ⟨λ J sJ fJ,
@@ -116,6 +117,7 @@ noncomputable instance preserves_colimits_of_shape_of_preserves_finite_colimits 
   preserves_colimits_of_shape J F :=
 by apply preserves_colimits_of_shape_of_equiv (fin_category.equiv_as_type J)
 
+/-- If we preserve colimits of some arbitrary size, then we preserve all finite colimits. -/
 -- This is a dangerous instance as it has unbound universe variables.
 noncomputable def preserves_colimits_of_size.preserves_finite_colimits (F : C ⥤ D)
   [preserves_colimits_of_size.{w w₂} F] : preserves_finite_colimits F :=

--- a/src/category_theory/limits/preserves/finite.lean
+++ b/src/category_theory/limits/preserves/finite.lean
@@ -55,8 +55,8 @@ noncomputable instance preserves_limits_of_shape_of_preserves_finite_limits (F :
   preserves_limits_of_shape J F :=
 by apply preserves_limits_of_shape_of_equiv (fin_category.equiv_as_type J)
 
-@[priority 100]
-noncomputable instance preserves_limits.preserves_finite_limits_of_size (F : C ⥤ D)
+-- This is a dangerous instance as it has unbound universe variables.
+noncomputable def preserves_limits_of_size.preserves_finite_limits (F : C ⥤ D)
   [preserves_limits_of_size.{w w₂} F] : preserves_finite_limits F :=
 ⟨λ J sJ fJ,
   begin
@@ -64,10 +64,17 @@ noncomputable instance preserves_limits.preserves_finite_limits_of_size (F : C �
     exact preserves_limits_of_shape_of_equiv (fin_category.equiv_as_type J) F,
   end⟩
 
+-- Added as a specialization of the dangerous instance above, for limits indexed in Type 0.
+@[priority 120]
+noncomputable instance preserves_limits_of_size.zero.preserves_finite_limits (F : C ⥤ D)
+    [preserves_limits_of_size.{0 0} F] : preserves_finite_limits F :=
+  preserves_limits_of_size.preserves_finite_limits F
+
+-- An alternative specialization of the dangerous instance for small limits.
 @[priority 120]
 noncomputable instance preserves_limits.preserves_finite_limits (F : C ⥤ D)
   [preserves_limits F] : preserves_finite_limits F :=
-preserves_limits.preserves_finite_limits_of_size F
+preserves_limits_of_size.preserves_finite_limits F
 
 /-- We can always derive `preserves_finite_limits C` by showing that we are preserving limits at an
 arbitrary universe. -/
@@ -109,14 +116,26 @@ noncomputable instance preserves_colimits_of_shape_of_preserves_finite_colimits 
   preserves_colimits_of_shape J F :=
 by apply preserves_colimits_of_shape_of_equiv (fin_category.equiv_as_type J)
 
-@[priority 100]
-noncomputable instance preserves_colimits.preserves_finite_colimits (F : C ⥤ D)
+-- This is a dangerous instance as it has unbound universe variables.
+noncomputable def preserves_colimits_of_size.preserves_finite_colimits (F : C ⥤ D)
   [preserves_colimits_of_size.{w w₂} F] : preserves_finite_colimits F :=
 ⟨λ J sJ fJ,
   begin
     haveI := preserves_smallest_colimits_of_preserves_colimits F,
     exact preserves_colimits_of_shape_of_equiv (fin_category.equiv_as_type J) F,
   end⟩
+
+-- Added as a specialization of the dangerous instance above, for colimits indexed in Type 0.
+@[priority 120]
+noncomputable instance preserves_colimits_of_size.zero.preserves_finite_colimits (F : C ⥤ D)
+    [preserves_colimits_of_size.{0 0} F] : preserves_finite_colimits F :=
+  preserves_colimits_of_size.preserves_finite_colimits F
+
+-- An alternative specialization of the dangerous instance for small colimits.
+@[priority 120]
+noncomputable instance preserves_colimits.preserves_finite_colimits (F : C ⥤ D)
+  [preserves_colimits F] : preserves_finite_colimits F :=
+preserves_colimits_of_size.preserves_finite_colimits F
 
 /-- We can always derive `preserves_finite_limits C` by showing that we are preserving limits at an
 arbitrary universe. -/

--- a/src/category_theory/preadditive/injective.lean
+++ b/src/category_theory/preadditive/injective.lean
@@ -290,7 +290,7 @@ lemma injective_of_map_injective (adj : F ⊣ G) [full G] [faithful G] (I : D)
   (hI : injective (G.obj I)) : injective I :=
 ⟨λ X Y f g, begin
   introI,
-  haveI := adj.right_adjoint_preserves_limits,
+  haveI : preserves_limits_of_size.{0 0} G := adj.right_adjoint_preserves_limits,
   rcases hI.factors (G.map f) (G.map g),
   use inv (adj.counit.app _) ≫ F.map w ≫ adj.counit.app _,
   refine faithful.map_injective G _,
@@ -304,7 +304,9 @@ def map_injective_presentation (adj : F ⊣ G) [F.preserves_monomorphisms] (X : 
 { J := G.obj I.J,
   injective := adj.map_injective _ I.injective,
   f := G.map I.f,
-  mono := by haveI := adj.right_adjoint_preserves_limits; apply_instance }
+  mono := by
+    haveI : preserves_limits_of_size.{0 0} G := adj.right_adjoint_preserves_limits;
+    apply_instance }
 
 end adjunction
 namespace equivalence

--- a/src/category_theory/preadditive/projective.lean
+++ b/src/category_theory/preadditive/projective.lean
@@ -203,7 +203,7 @@ lemma projective_of_map_projective (adj : F ⊣ G) [full F] [faithful F] (P : C)
   (hP : projective (F.obj P)) : projective P :=
 ⟨λ X Y f g, begin
   introI,
-  haveI := adj.left_adjoint_preserves_colimits,
+  haveI : preserves_colimits_of_size.{0 0} F := adj.left_adjoint_preserves_colimits,
   rcases @hP.1 (F.map f) (F.map g),
   use adj.unit.app _ ≫ G.map w ≫ (inv $ adj.unit.app _),
   refine faithful.map_injective F _,
@@ -217,7 +217,9 @@ def map_projective_presentation (adj : F ⊣ G) [G.preserves_epimorphisms] (X : 
 { P := F.obj Y.P,
   projective := adj.map_projective _ Y.projective,
   f := F.map Y.f,
-  epi := by haveI := adj.left_adjoint_preserves_colimits; apply_instance }
+  epi := by
+    haveI : preserves_colimits_of_size.{0 0} F := adj.left_adjoint_preserves_colimits;
+    apply_instance }
 
 end adjunction
 namespace equivalence


### PR DESCRIPTION
There were some instances with unbounded universe variables, which Lean 4 couldn't cope with (reasonably!).

This PR backports some changes made in https://github.com/leanprover-community/mathlib4/pull/3615 to remove these bad instances.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
