### PR TITLE
[Merged by Bors] - feat(number_theory/pell): add def and properties of fundamental solutions

### DIFF
--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -512,6 +512,15 @@ begin
     exact H _ (by linarith [hn]), }
 end
 
+/-- If `a` is a fundamental solution, then `(a^m).y < (a^n).y` if and only if `m < n`. -/
+lemma zpow_y_lt_iff_lt {a : solution₁ d} (h : is_fundamental a) {m n : ℤ} :
+  (a ^ m).y < (a ^ n).y ↔ m < n :=
+begin
+  refine ⟨λ H, _, λ H, h.y_strict_mono H⟩,
+  contrapose! H,
+  exact h.y_strict_mono.monotone H,
+end
+
 /-- The `n`th power of a fundamental solution is trivial if and only if `n = 0`. -/
 lemma pow_eq_one_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : a ^ n = 1 ↔ n = 0 :=
 begin

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -432,6 +432,14 @@ open solution₁
 lemma x_pos {a : solution₁ d} (h : is_fundamental a) : 0 < a.x :=
 zero_lt_one.trans h.1
 
+/-- If a fundamental solution exists, then `d` must be positive. -/
+lemma d_pos {a : solution₁ d} (h : is_fundamental a) : 0 < d :=
+begin
+  refine pos_of_mul_pos_left _ (sq_nonneg a.y),
+  rw [a.prop_y, sub_pos],
+  exact one_lt_pow h.1 two_ne_zero,
+end
+
 /-- If there is a fundamental solution, it is unique. -/
 lemma unique (h₀ : 0 < d) {a b : solution₁ d} (ha : is_fundamental a) (hb : is_fundamental b) :
   a = b :=

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -522,23 +522,23 @@ begin
 end
 
 /-- The `n`th power of a fundamental solution is trivial if and only if `n = 0`. -/
-lemma pow_eq_one_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : a ^ n = 1 ↔ n = 0 :=
+lemma zpow_eq_one_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : a ^ n = 1 ↔ n = 0 :=
 begin
   rw ← zpow_zero a,
   exact ⟨λ H, h.y_strict_mono.injective (congr_arg solution₁.y H), λ H, H ▸ rfl⟩,
 end
 
 /-- The `n`th power of a fundamental solution has positive `y` if and only if `n` is positive. -/
-lemma pow_y_pos_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : 0 < (a ^ n).y ↔ 0 < n :=
+lemma zpow_y_pos_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : 0 < (a ^ n).y ↔ 0 < n :=
 h.zpow_y_lt_iff_lt 0 n
 
 /-- The `n`th power of a fundamental solution has negative `y` if and only if `n` is negative. -/
-lemma pow_y_neg_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : (a ^ n).y < 0 ↔ n < 0 :=
+lemma zpow_y_neg_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : (a ^ n).y < 0 ↔ n < 0 :=
 h.zpow_y_lt_iff_lt n 0
 
 /-- A power of a fundamental solution is never equal to the negative of a power of this
 fundamental solution. -/
-lemma pow_ne_neg_pow {a : solution₁ d} (h : is_fundamental a) {n n' : ℤ} :
+lemma zpow_ne_neg_zpow {a : solution₁ d} (h : is_fundamental a) {n n' : ℤ} :
    a ^ n ≠ -a ^ n' :=
 begin
   intro hf,
@@ -688,12 +688,12 @@ begin
         ← zpow_neg_one, neg_mul, ← zpow_add, ← sub_eq_add_neg] at hn₁,
     cases hn₁,
     { rcases int.is_unit_iff.mp (is_unit_of_mul_eq_one _ _ $ sub_eq_zero.mp $
-                (ha₁.pow_eq_one_iff (n₂ * n₁ - 1)).mp hn₁) with rfl | rfl,
+                (ha₁.zpow_eq_one_iff (n₂ * n₁ - 1)).mp hn₁) with rfl | rfl,
       { rw zpow_one, },
       { rw [zpow_neg_one, y_inv, lt_neg, neg_zero] at Hy,
         exact false.elim (lt_irrefl _ $ ha₁.2.1.trans Hy), } },
     { rw [← zpow_zero a₁, eq_comm] at hn₁,
-      exact false.elim (ha₁.pow_ne_neg_pow hn₁), } },
+      exact false.elim (ha₁.zpow_ne_neg_zpow hn₁), } },
   { rw [x_neg, lt_neg] at Hx,
     have := (x_zpow_pos (zero_lt_one.trans ha₁.1) n₂).trans Hx,
     norm_num at this, }

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -552,43 +552,63 @@ begin
   exact h.x_le_x hax,
 end
 
-/-- If we multiply a positive solution with the inverse of a fundamental solution,
-the `x`-coordinate decreases and the `y`-coordinate remains nonnegative. -/
-lemma x_mul_inv_lt_x {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x)
-  (hay : 0 < a.y) :
-  0 < (a * a₁⁻¹).x ∧ (a * a₁⁻¹).x < a.x ∧ 0 ≤ (a * a₁⁻¹).y :=
+-- helper lemma for the next three results
+lemma x_mul_y_le_y_mul_x {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d}
+  (hax : 1 < a.x) (hay : 0 < a.y) :
+  a.x * a₁.y ≤ a.y * a₁.x :=
 begin
-  have hax' := zero_lt_one.trans hax,
-  have H₁ : a.x * a₁.y ≤ a.y * a₁.x,
-  { rw [← abs_of_pos hax', ← abs_of_pos hay,
-        ← abs_of_pos h.x_pos, ← abs_of_pos h.2.1, ← abs_mul, ← abs_mul, ← sq_le_sq,
-        mul_pow, mul_pow, a.prop_x, a₁.prop_x, ← sub_nonneg],
-    ring_nf,
-    rw [sub_nonneg, sq_le_sq, abs_of_pos hay, abs_of_pos h.2.1],
-    exact h.y_le_y hax hay, },
-  simp only [x_mul, x_inv, y_inv, mul_neg, add_neg_lt_iff_le_add',
-             lt_add_neg_iff_add_lt, zero_add, y_mul, le_neg_add_iff_add_le, add_zero],
-  refine ⟨_, _, H₁⟩,
-  { refine (mul_lt_mul_left hax').mp _,
-    rw [(by ring : a.x * (d * (a.y * a₁.y)) = (d * a.y) * (a.x * a₁.y))],
-    refine ((mul_le_mul_left $ mul_pos h.d_pos hay).mpr H₁).trans_lt _,
-    rw [← mul_assoc, mul_assoc d, ← sq, a.prop_y, ← sub_pos],
-    ring_nf,
-    exact zero_lt_one.trans h.1, },
-  { refine (mul_lt_mul_left h.2.1).mp _,
-    rw [(by ring : a₁.y * (a.x * a₁.x) = a.x * a₁.y * a₁.x)],
-    refine ((mul_le_mul_right $ zero_lt_one.trans h.1).mpr H₁).trans_lt _,
-    rw [mul_assoc, ← sq, a₁.prop_x, ← sub_neg],
-    ring_nf,
-    rw [sub_neg, ← abs_of_pos hay, ← abs_of_pos h.2.1, ← abs_of_pos hax', ← abs_mul, ← sq_lt_sq,
-        mul_pow, a.prop_x],
-    calc
-      a.y ^ 2 = 1 * a.y ^ 2                  : (one_mul _).symm
-          ... ≤ d * a.y ^ 2                  : (mul_le_mul_right $ sq_pos_of_pos hay).mpr h.d_pos
-          ... < d * a.y ^ 2 + 1              : lt_add_one _
-          ... = (1 + d * a.y ^ 2) * 1        : by rw [add_comm, mul_one]
-          ... ≤ (1 + d * a.y ^ 2) * a₁.y ^ 2
-                : (mul_le_mul_left (by {have := h.d_pos, positivity})).mpr (sq_pos_of_pos h.2.1), }
+  rw [← abs_of_pos $ zero_lt_one.trans hax, ← abs_of_pos hay, ← abs_of_pos h.x_pos,
+      ← abs_of_pos h.2.1, ← abs_mul, ← abs_mul, ← sq_le_sq, mul_pow, mul_pow, a.prop_x, a₁.prop_x,
+      ← sub_nonneg],
+  ring_nf,
+  rw [sub_nonneg, sq_le_sq, abs_of_pos hay, abs_of_pos h.2.1],
+  exact h.y_le_y hax hay,
+end
+
+/-- If we multiply a positive solution with the inverse of a fundamental solution,
+the `y`-coordinate remains nonnegative. -/
+lemma mul_inv_y_nonneg {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x)
+  (hay : 0 < a.y) :
+  0 ≤ (a * a₁⁻¹).y :=
+by simpa only [y_inv, mul_neg, y_mul, le_neg_add_iff_add_le, add_zero]
+     using h.x_mul_y_le_y_mul_x hax hay
+
+/-- If we multiply a positive solution with the inverse of a fundamental solution,
+the `x`-coordinate stays positive. -/
+lemma mul_inv_x_pos {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x)
+  (hay : 0 < a.y) :
+  0 < (a * a₁⁻¹).x :=
+begin
+  simp only [x_mul, x_inv, y_inv, mul_neg, lt_add_neg_iff_add_lt, zero_add],
+  refine (mul_lt_mul_left $ zero_lt_one.trans hax).mp _,
+  rw [(by ring : a.x * (d * (a.y * a₁.y)) = (d * a.y) * (a.x * a₁.y))],
+  refine ((mul_le_mul_left $ mul_pos h.d_pos hay).mpr $ x_mul_y_le_y_mul_x h hax hay).trans_lt _,
+  rw [← mul_assoc, mul_assoc d, ← sq, a.prop_y, ← sub_pos],
+  ring_nf,
+  exact zero_lt_one.trans h.1,
+end
+
+/-- If we multiply a positive solution with the inverse of a fundamental solution,
+the `x`-coordinate decreases. -/
+lemma mul_inv_x_lt_x {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x)
+  (hay : 0 < a.y) :
+  (a * a₁⁻¹).x < a.x :=
+begin
+  simp only [x_mul, x_inv, y_inv, mul_neg, add_neg_lt_iff_le_add'],
+  refine (mul_lt_mul_left h.2.1).mp _,
+  rw [(by ring : a₁.y * (a.x * a₁.x) = a.x * a₁.y * a₁.x)],
+  refine ((mul_le_mul_right $ zero_lt_one.trans h.1).mpr $ x_mul_y_le_y_mul_x h hax hay).trans_lt _,
+  rw [mul_assoc, ← sq, a₁.prop_x, ← sub_neg],
+  ring_nf,
+  rw [sub_neg, ← abs_of_pos hay, ← abs_of_pos h.2.1, ← abs_of_pos $ zero_lt_one.trans hax,
+      ← abs_mul, ← sq_lt_sq, mul_pow, a.prop_x],
+  calc
+    a.y ^ 2 = 1 * a.y ^ 2                  : (one_mul _).symm
+        ... ≤ d * a.y ^ 2                  : (mul_le_mul_right $ sq_pos_of_pos hay).mpr h.d_pos
+        ... < d * a.y ^ 2 + 1              : lt_add_one _
+        ... = (1 + d * a.y ^ 2) * 1        : by rw [add_comm, mul_one]
+        ... ≤ (1 + d * a.y ^ 2) * a₁.y ^ 2
+              : (mul_le_mul_left (by {have := h.d_pos, positivity})).mpr (sq_pos_of_pos h.2.1),
 end
 
 /-- Any nonnegative solution is a power with nonnegative exponent of a fundamental solution. -/
@@ -611,7 +631,9 @@ begin
     { exact hy.symm, } },
   { -- case 2: `a ≥ a₁`
     have hx₁ : 1 < a.x := by nlinarith [a.prop, h.d_pos],
-    obtain ⟨hxx₁, hxx₂, hyy⟩ := h.x_mul_inv_lt_x hx₁ hy,
+    have hxx₁ := h.mul_inv_x_pos hx₁ hy,
+    have hxx₂ := h.mul_inv_x_lt_x hx₁ hy,
+    have hyy := h.mul_inv_y_nonneg hx₁ hy,
     lift (a * a₁⁻¹).x to ℕ using hxx₁.le with x' hx',
     obtain ⟨n, hn⟩ := ih x' (by exact_mod_cast hxx₂.trans_eq hax'.symm) hxx₁ hyy hx',
     exact ⟨n + 1, by rw [pow_succ, ← hn, mul_comm a, ← mul_assoc, mul_inv_self, one_mul]⟩, },

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -485,8 +485,8 @@ begin
   rw hb' at hb ⊢,
   norm_cast at hb ⊢,
   refine nat.find_min' P ⟨hb, |b.y|, abs_pos.mpr $ y_ne_zero_of_one_lt_x hb'', _⟩,
-  convert b.prop using 1,
   rw [← hb', sq_abs],
+  exact b.prop,
 end
 
 /-- The `n`th power of a fundamental solution is trivial if and only if `n = 0`. -/

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -513,7 +513,7 @@ begin
 end
 
 /-- If `a` is a fundamental solution, then `(a^m).y < (a^n).y` if and only if `m < n`. -/
-lemma zpow_y_lt_iff_lt {a : solution₁ d} (h : is_fundamental a) {m n : ℤ} :
+lemma zpow_y_lt_iff_lt {a : solution₁ d} (h : is_fundamental a) (m n : ℤ) :
   (a ^ m).y < (a ^ n).y ↔ m < n :=
 begin
   refine ⟨λ H, _, λ H, h.y_strict_mono H⟩,
@@ -530,19 +530,11 @@ end
 
 /-- The `n`th power of a fundamental solution has positive `y` if and only if `n` is positive. -/
 lemma pow_y_pos_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : 0 < (a ^ n).y ↔ 0 < n :=
-begin
-  refine ⟨λ H, _, λ H, h.y_strict_mono H⟩,
-  contrapose! H,
-  exact h.y_strict_mono.monotone H,
-end
+h.zpow_y_lt_iff_lt 0 n
 
 /-- The `n`th power of a fundamental solution has negative `y` if and only if `n` is negative. -/
 lemma pow_y_neg_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : (a ^ n).y < 0 ↔ n < 0 :=
-begin
-  refine ⟨λ H, _, λ H, h.y_strict_mono H⟩,
-  contrapose! H,
-  exact h.y_strict_mono.monotone H,
-end
+h.zpow_y_lt_iff_lt n 0
 
 /-- A power of a fundamental solution is never equal to the negative of a power of this
 fundamental solution. -/

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -529,14 +529,6 @@ begin
   exact ⟨λ H, h.y_strict_mono.injective (congr_arg solution₁.y H), λ H, H ▸ rfl⟩,
 end
 
-/-- The `n`th power of a fundamental solution has positive `y` if and only if `n` is positive. -/
-lemma zpow_y_pos_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : 0 < (a ^ n).y ↔ 0 < n :=
-h.zpow_y_lt_iff_lt 0 n
-
-/-- The `n`th power of a fundamental solution has negative `y` if and only if `n` is negative. -/
-lemma zpow_y_neg_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : (a ^ n).y < 0 ↔ n < 0 :=
-h.zpow_y_lt_iff_lt n 0
-
 /-- A power of a fundamental solution is never equal to the negative of a power of this
 fundamental solution. -/
 lemma zpow_ne_neg_zpow {a : solution₁ d} (h : is_fundamental a) {n n' : ℤ} :

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -195,10 +195,9 @@ end
 /-- If a solution has `x > 1`, then `d` is not a square. -/
 lemma d_nonsquare_of_one_lt_x {a : solution₁ d} (ha : 1 < a.x) : ¬ is_square d :=
 begin
-  intro h,
-  obtain ⟨b, hb⟩ := h,
   have hp := a.prop,
-  simp_rw [hb, ← sq, ← mul_pow, sq_sub_sq, int.mul_eq_one_iff_eq_one_or_neg_one] at hp,
+  rintros ⟨b, rfl⟩,
+  simp_rw [← sq, ← mul_pow, sq_sub_sq, int.mul_eq_one_iff_eq_one_or_neg_one] at hp,
   rcases hp with ⟨hp₁, hp₂⟩ | ⟨hp₁, hp₂⟩; linarith [ha, hp₁, hp₂],
 end
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -468,8 +468,7 @@ begin
 end
 
 /-- The `n`th power of a fundamental solution is trivial if and only if `n = 0`. -/
-lemma pow_eq_one_iff (h₀ : 0 < d) {a : solution₁ d} (h : is_fundamental a) (n : ℤ) :
-  a ^ n = 1 ↔ n = 0 :=
+lemma pow_eq_one_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : a ^ n = 1 ↔ n = 0 :=
 begin
   refine ⟨λ H, _, λ H, by rw [H, zpow_zero]⟩,
   have H' : (a ^ n).y = 0 := by rw [H, y_one],
@@ -482,8 +481,7 @@ begin
 end
 
 /-- The `n`th power of a fundamental solution has positive `y` if and only if `n` is positive. -/
-lemma pow_y_pos_iff (h₀ : 0 < d) {a : solution₁ d} (h : is_fundamental a) (n : ℤ) :
-  0 < (a ^ n).y ↔ 0 < n :=
+lemma pow_y_pos_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : 0 < (a ^ n).y ↔ 0 < n :=
 begin
   refine ⟨λ H, _, y_zpow_pos h.x_pos h.2.1⟩,
   rcases lt_trichotomy 0 n with hn | rfl | hn,
@@ -495,16 +493,15 @@ begin
 end
 
 /-- The `n`th power of a fundamental solution has negative `y` if and only if `n` is negative. -/
-lemma pow_y_neg_iff (h₀ : 0 < d) {a : solution₁ d} (h : is_fundamental a) (n : ℤ) :
-  (a ^ n).y < 0 ↔ n < 0 :=
+lemma pow_y_neg_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : (a ^ n).y < 0 ↔ n < 0 :=
 begin
   rw [← neg_neg n, zpow_neg, y_inv, neg_lt, neg_zero, neg_lt, neg_zero],
-  exact h.pow_y_pos_iff h₀ (-n),
+  exact h.pow_y_pos_iff (-n),
 end
 
 /-- A power of a fundamental solution is never equal to the negative of a power of this
 fundamental solution. -/
-lemma pow_ne_neg_fundamental_pow (h₀ : 0 < d) {a : solution₁ d} (h : is_fundamental a) {n n' : ℤ} :
+lemma pow_ne_neg_fundamental_pow {a : solution₁ d} (h : is_fundamental a) {n n' : ℤ} :
    a ^ n ≠ -a ^ n' :=
 begin
   intro hf,
@@ -516,8 +513,7 @@ end
 
 /-- The `x`-coordinate of a fundamental solution is a lower bound for the `x`-coordinate
 of any positive solution. -/
-lemma le_x (h₀ : 0 < d) {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d}
-  (hax : 1 < a.x) (hay : 0 < a.y) :
+lemma le_x {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x) :
   a₁.x ≤ a.x :=
 h.2.2 hax
 
@@ -531,7 +527,7 @@ begin
   rw [← abs_of_pos hay, ← abs_of_pos h.2.1, ← sq_le_sq, ← mul_le_mul_left h₀, ← sub_nonpos,
       ← mul_sub, H, sub_nonpos, sq_le_sq, abs_of_pos (zero_lt_one.trans h.1),
       abs_of_pos (zero_lt_one.trans hax)],
-  exact h.le_x h₀ hax hay,
+  exact h.le_x hax,
 end
 
 /-- If we multiply a positive solution with the inverse of a fundamental solution,
@@ -642,12 +638,12 @@ begin
         ← zpow_neg_one, neg_mul, ← zpow_add, ← sub_eq_add_neg] at hn₁,
     cases hn₁,
     { rcases int.is_unit_iff.mp (is_unit_of_mul_eq_one _ _ $ sub_eq_zero.mp $
-                (ha₁.pow_eq_one_iff h₀ (n₂ * n₁ - 1)).mp hn₁) with rfl | rfl,
+                (ha₁.pow_eq_one_iff (n₂ * n₁ - 1)).mp hn₁) with rfl | rfl,
       { rw zpow_one, },
       { rw [zpow_neg_one, y_inv, lt_neg, neg_zero] at Hy,
         exact false.elim (lt_irrefl _ $ ha₁.2.1.trans Hy), } },
     { rw [← zpow_zero a₁, eq_comm] at hn₁,
-      exact false.elim (ha₁.pow_ne_neg_fundamental_pow h₀ hn₁), } },
+      exact false.elim (ha₁.pow_ne_neg_fundamental_pow hn₁), } },
   { rw [x_neg, lt_neg] at Hx,
     have := (x_zpow_pos (zero_lt_one.trans ha₁.1) n₂).trans Hx,
     norm_num at this, }

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -451,6 +451,10 @@ lemma x_pos {a : solution₁ d} (h : is_fundamental a) : 0 < a.x := zero_lt_one.
 /-- If a fundamental solution exists, then `d` must be positive. -/
 lemma d_pos {a : solution₁ d} (h : is_fundamental a) : 0 < d := d_pos_of_one_lt_x h.1
 
+/-- If a fundamental solution exists, then `d` must be a non-square. -/
+lemma d_nonsquare {a : solution₁ d} (h : is_fundamental a) : ¬ is_square d :=
+d_nonsquare_of_one_lt_x h.1
+
 /-- If there is a fundamental solution, it is unique. -/
 lemma unique {a b : solution₁ d} (ha : is_fundamental a) (hb : is_fundamental b) : a = b :=
 begin

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -693,7 +693,7 @@ begin
 end
 
 /-- A positive solution is a generator (up to sign) of the group of all solutions to the
-Pell equation `x^2 - d*y^2 = 1` if and only if it is a fundamental solution. -/
+Pell equation `x^2 - d*y^2 = 1` if and only if it is a fundamental solution.  -/
 theorem pos_generator_iff_fundamental (a : solution₁ d) :
   (1 < a.x ∧ 0 < a.y ∧ ∀ b : solution₁ d, ∃ n : ℤ, b = a ^ n ∨ b = -a ^ n) ↔ is_fundamental a :=
 begin

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -245,6 +245,17 @@ begin
     exact y_mul_pos hax hay (x_pow_pos hax _) ih, }
 end
 
+/-- If `(x, y)` is a solution with `x` and `y` positive, then all its powers with positive
+exponents have positive `y`. -/
+lemma y_zpow_pos {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y) {n : ℤ} (hn : 0 < n) :
+  0 < (a ^ n).y :=
+begin
+  rw [(int.to_nat_of_nonneg hn.le).symm, zpow_coe_nat],
+  replace hn : 0 < n.to_nat := int.lt_to_nat.mpr hn,
+  rw (nat.succ_pred_eq_of_pos hn).symm,
+  exact y_pow_succ_pos hax hay _,
+end
+
 /-- If `(x, y)` is a solution with `x` positive, then all its powers have positive `x`. -/
 lemma x_zpow_pos {a : solution₁ d} (hax : 0 < a.x) (n : ℤ) : 0 < (a ^ n).x :=
 begin

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -523,7 +523,7 @@ end
 
 /-- A power of a fundamental solution is never equal to the negative of a power of this
 fundamental solution. -/
-lemma pow_ne_neg_fundamental_pow {a : solution₁ d} (h : is_fundamental a) {n n' : ℤ} :
+lemma pow_ne_neg_pow {a : solution₁ d} (h : is_fundamental a) {n n' : ℤ} :
    a ^ n ≠ -a ^ n' :=
 begin
   intro hf,
@@ -541,7 +541,7 @@ h.2.2 hax
 
 /-- The `y`-coordinate of a fundamental solution is a lower bound for the `y`-coordinate
 of any positive solution. -/
-lemma le_y {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x)
+lemma y_le_y {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x)
   (hay : 0 < a.y) :
   a₁.y ≤ a.y :=
 begin
@@ -554,7 +554,7 @@ end
 
 /-- If we multiply a positive solution with the inverse of a fundamental solution,
 the `x`-coordinate decreases and the `y`-coordinate remains nonnegative. -/
-lemma mul_inv_lt_x {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x)
+lemma x_mul_inv_lt_x {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x)
   (hay : 0 < a.y) :
   0 < (a * a₁⁻¹).x ∧ (a * a₁⁻¹).x < a.x ∧ 0 ≤ (a * a₁⁻¹).y :=
 begin
@@ -565,7 +565,7 @@ begin
         mul_pow, mul_pow, a.prop_x, a₁.prop_x, ← sub_nonneg],
     ring_nf,
     rw [sub_nonneg, sq_le_sq, abs_of_pos hay, abs_of_pos h.2.1],
-    exact h.le_y hax hay, },
+    exact h.y_le_y hax hay, },
   simp only [x_mul, x_inv, y_inv, mul_neg, add_neg_lt_iff_le_add',
              lt_add_neg_iff_add_lt, zero_add, y_mul, le_neg_add_iff_add_le, add_zero],
   refine ⟨_, _, H₁⟩,
@@ -611,7 +611,7 @@ begin
     { exact hy.symm, } },
   { -- case 2: `a ≥ a₁`
     have hx₁ : 1 < a.x := by nlinarith [a.prop, h.d_pos],
-    obtain ⟨hxx₁, hxx₂, hyy⟩ := h.mul_inv_lt_x hx₁ hy,
+    obtain ⟨hxx₁, hxx₂, hyy⟩ := h.x_mul_inv_lt_x hx₁ hy,
     lift (a * a₁⁻¹).x to ℕ using hxx₁.le with x' hx',
     obtain ⟨n, hn⟩ := ih x' (by exact_mod_cast hxx₂.trans_eq hax'.symm) hxx₁ hyy hx',
     exact ⟨n + 1, by rw [pow_succ, ← hn, mul_comm a, ← mul_assoc, mul_inv_self, one_mul]⟩, },
@@ -656,7 +656,7 @@ begin
       { rw [zpow_neg_one, y_inv, lt_neg, neg_zero] at Hy,
         exact false.elim (lt_irrefl _ $ ha₁.2.1.trans Hy), } },
     { rw [← zpow_zero a₁, eq_comm] at hn₁,
-      exact false.elim (ha₁.pow_ne_neg_fundamental_pow hn₁), } },
+      exact false.elim (ha₁.pow_ne_neg_pow hn₁), } },
   { rw [x_neg, lt_neg] at Hx,
     have := (x_zpow_pos (zero_lt_one.trans ha₁.1) n₂).trans Hx,
     norm_num at this, }

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -441,12 +441,7 @@ lemma x_pos {a : solution₁ d} (h : is_fundamental a) : 0 < a.x :=
 zero_lt_one.trans h.1
 
 /-- If a fundamental solution exists, then `d` must be positive. -/
-lemma d_pos {a : solution₁ d} (h : is_fundamental a) : 0 < d :=
-begin
-  refine pos_of_mul_pos_left _ (sq_nonneg a.y),
-  rw [a.prop_y, sub_pos],
-  exact one_lt_pow h.1 two_ne_zero,
-end
+lemma d_pos {a : solution₁ d} (h : is_fundamental a) : 0 < d := d_pos_of_one_lt_x h.1
 
 /-- If there is a fundamental solution, it is unique. -/
 lemma unique {a b : solution₁ d} (ha : is_fundamental a) (hb : is_fundamental b) :

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -441,13 +441,13 @@ begin
 end
 
 /-- If there is a fundamental solution, it is unique. -/
-lemma unique (h₀ : 0 < d) {a b : solution₁ d} (ha : is_fundamental a) (hb : is_fundamental b) :
+lemma unique {a b : solution₁ d} (ha : is_fundamental a) (hb : is_fundamental b) :
   a = b :=
 begin
   have hx := le_antisymm (ha.2.2 hb.1) (hb.2.2 ha.1),
   refine solution₁.ext hx _,
   have : d * a.y ^ 2 = d * b.y ^ 2 := by rw [a.prop_y, b.prop_y, hx],
-  exact (sq_eq_sq ha.2.1.le hb.2.1.le).mp (int.eq_of_mul_eq_mul_left h₀.ne' this),
+  exact (sq_eq_sq ha.2.1.le hb.2.1.le).mp (int.eq_of_mul_eq_mul_left ha.d_pos.ne' this),
 end
 
 /-- If `d` is positive and not a square, then a fundamental solution exists. -/
@@ -527,12 +527,12 @@ h.2.2 hax
 
 /-- The `y`-coordinate of a fundamental solution is a lower bound for the `y`-coordinate
 of any positive solution. -/
-lemma le_y (h₀ : 0 < d) {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d}
-  (hax : 1 < a.x) (hay : 0 < a.y) :
+lemma le_y {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x)
+  (hay : 0 < a.y) :
   a₁.y ≤ a.y :=
 begin
   have H : d * (a₁.y ^ 2 - a.y ^ 2) = a₁.x ^ 2 - a.x ^ 2 := by { rw [a.prop_x, a₁.prop_x], ring },
-  rw [← abs_of_pos hay, ← abs_of_pos h.2.1, ← sq_le_sq, ← mul_le_mul_left h₀, ← sub_nonpos,
+  rw [← abs_of_pos hay, ← abs_of_pos h.2.1, ← sq_le_sq, ← mul_le_mul_left h.d_pos, ← sub_nonpos,
       ← mul_sub, H, sub_nonpos, sq_le_sq, abs_of_pos (zero_lt_one.trans h.1),
       abs_of_pos (zero_lt_one.trans hax)],
   exact h.le_x hax,
@@ -540,8 +540,8 @@ end
 
 /-- If we multiply a positive solution with the inverse of a fundamental solution,
 the `x`-coordinate decreases and the `y`-coordinate remains nonnegative. -/
-lemma mul_inv_lt_x (h₀ : 0 < d) {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d}
-  (hax : 1 < a.x) (hay : 0 < a.y) :
+lemma mul_inv_lt_x {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x)
+  (hay : 0 < a.y) :
   0 < (a * a₁⁻¹).x ∧ (a * a₁⁻¹).x < a.x ∧ 0 ≤ (a * a₁⁻¹).y :=
 begin
   have hax' := zero_lt_one.trans hax,
@@ -551,13 +551,13 @@ begin
         mul_pow, mul_pow, a.prop_x, a₁.prop_x, ← sub_nonneg],
     ring_nf,
     rw [sub_nonneg, sq_le_sq, abs_of_pos hay, abs_of_pos h.2.1],
-    exact h.le_y h₀ hax hay, },
+    exact h.le_y hax hay, },
   simp only [x_mul, x_inv, y_inv, mul_neg, add_neg_lt_iff_le_add',
              lt_add_neg_iff_add_lt, zero_add, y_mul, le_neg_add_iff_add_le, add_zero],
   refine ⟨_, _, H₁⟩,
   { refine (mul_lt_mul_left hax').mp _,
     rw [(by ring : a.x * (d * (a.y * a₁.y)) = (d * a.y) * (a.x * a₁.y))],
-    refine ((mul_le_mul_left $ mul_pos h₀ hay).mpr H₁).trans_lt _,
+    refine ((mul_le_mul_left $ mul_pos h.d_pos hay).mpr H₁).trans_lt _,
     rw [← mul_assoc, mul_assoc d, ← sq, a.prop_y, ← sub_pos],
     ring_nf,
     exact zero_lt_one.trans h.1, },
@@ -570,16 +570,16 @@ begin
         mul_pow, a.prop_x],
     calc
       a.y ^ 2 = 1 * a.y ^ 2                  : (one_mul _).symm
-          ... ≤ d * a.y ^ 2                  : (mul_le_mul_right $ sq_pos_of_pos hay).mpr h₀
+          ... ≤ d * a.y ^ 2                  : (mul_le_mul_right $ sq_pos_of_pos hay).mpr h.d_pos
           ... < d * a.y ^ 2 + 1              : lt_add_one _
           ... = (1 + d * a.y ^ 2) * 1        : by rw [add_comm, mul_one]
           ... ≤ (1 + d * a.y ^ 2) * a₁.y ^ 2
-                   : (mul_le_mul_left (by positivity)).mpr (sq_pos_of_pos h.2.1), }
+                : (mul_le_mul_left (by {have := h.d_pos, positivity})).mpr (sq_pos_of_pos h.2.1), }
 end
 
 /-- Any nonnegative solution is a power with nonnegative exponent of a fundamental solution. -/
-lemma pow_of_nonneg (h₀ : 0 < d) {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d}
-  (hax : 0 < a.x) (hay : 0 ≤ a.y) :
+lemma pow_of_nonneg {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 0 < a.x)
+  (hay : 0 ≤ a.y) :
   ∃ n : ℕ, a = a₁ ^ n :=
 begin
   lift a.x to ℕ using hax.le with ax hax',
@@ -596,19 +596,19 @@ begin
       norm_num at this, },
     { exact hy.symm, } },
   { -- case 2: `a ≥ a₁`
-    have hx₁ : 1 < a.x := by nlinarith [a.prop],
-    obtain ⟨hxx₁, hxx₂, hyy⟩ := h.mul_inv_lt_x h₀ hx₁ hy,
+    have hx₁ : 1 < a.x := by nlinarith [a.prop, h.d_pos],
+    obtain ⟨hxx₁, hxx₂, hyy⟩ := h.mul_inv_lt_x hx₁ hy,
     lift (a * a₁⁻¹).x to ℕ using hxx₁.le with x' hx',
     obtain ⟨n, hn⟩ := ih x' (by exact_mod_cast hxx₂.trans_eq hax'.symm) hxx₁ hyy hx',
     exact ⟨n + 1, by rw [pow_succ, ← hn, mul_comm a, ← mul_assoc, mul_inv_self, one_mul]⟩, },
 end
 
 /-- Every solution is, up to a sign, a power of a given fundamental solution. -/
-lemma zpow_or_neg_zpow (h₀ : 0 < d) {a₁ : solution₁ d} (h : is_fundamental a₁) (a : solution₁ d) :
+lemma zpow_or_neg_zpow {a₁ : solution₁ d} (h : is_fundamental a₁) (a : solution₁ d) :
   ∃ n : ℤ, a = a₁ ^ n ∨ a = -a₁ ^ n :=
 begin
-  obtain ⟨b, hbx, hby, hb⟩ := exists_pos_variant h₀ a,
-  obtain ⟨n, hn⟩ := h.pow_of_nonneg h₀ hbx hby,
+  obtain ⟨b, hbx, hby, hb⟩ := exists_pos_variant h.d_pos a,
+  obtain ⟨n, hn⟩ := h.pow_of_nonneg hbx hby,
   rcases hb with rfl | rfl | rfl | hb,
   { exact ⟨n, or.inl (by exact_mod_cast hn)⟩, },
   { exact ⟨-n, or.inl (by simp [hn])⟩, },
@@ -628,10 +628,10 @@ theorem exists_unique_pos_generator (h₀ : 0 < d) (hd : ¬ is_square d) :
   ∃! a₁ : solution₁ d, 1 < a₁.x ∧ 0 < a₁.y ∧ ∀ a : solution₁ d, ∃ n : ℤ, a = a₁ ^ n ∨ a = -a₁ ^ n :=
 begin
   obtain ⟨a₁, ha₁⟩ := is_fundamental.exists_of_not_is_square h₀ hd,
-  refine ⟨a₁, ⟨ha₁.1, ha₁.2.1, ha₁.zpow_or_neg_zpow h₀⟩, λ a (H : 1 < _ ∧ _), _⟩,
+  refine ⟨a₁, ⟨ha₁.1, ha₁.2.1, ha₁.zpow_or_neg_zpow⟩, λ a (H : 1 < _ ∧ _), _⟩,
   obtain ⟨Hx, Hy, H⟩ := H,
   obtain ⟨n₁, hn₁⟩ := H a₁,
-  obtain ⟨n₂, hn₂⟩ := ha₁.zpow_or_neg_zpow h₀ a,
+  obtain ⟨n₂, hn₂⟩ := ha₁.zpow_or_neg_zpow a,
   rcases hn₂ with rfl | rfl,
   { rw [← zpow_mul, eq_comm, @eq_comm _ a₁, ← mul_inv_eq_one, ← @mul_inv_eq_one _ _ _ a₁,
         ← zpow_neg_one, neg_mul, ← zpow_add, ← sub_eq_add_neg] at hn₁,
@@ -650,14 +650,14 @@ end
 
 /-- A positive solution is a generator (up to sign) of the group of all solutions to the
 Pell equation `x^2 + d*y^2 = 1` if and only if it is a fundamental solution. -/
-theorem pos_generator_iff_fundamental (h₀ : 0 < d) (hd : ¬ is_square d) (a : solution₁ d) :
+theorem pos_generator_iff_fundamental (hd : ¬ is_square d) (a : solution₁ d) :
   (1 < a.x ∧ 0 < a.y ∧ ∀ b : solution₁ d, ∃ n : ℤ, b = a ^ n ∨ b = -a ^ n) ↔ is_fundamental a :=
 begin
-  refine ⟨_, λ H, ⟨H.1, H.2.1, H.zpow_or_neg_zpow h₀⟩⟩,
+  refine ⟨_, λ H, ⟨H.1, H.2.1, H.zpow_or_neg_zpow⟩⟩,
   intro h,
   obtain ⟨a₁, ha₁⟩ := is_fundamental.exists_of_not_is_square h₀ hd,
   obtain ⟨b, hb₁, hb₂⟩ := exists_unique_pos_generator h₀ hd,
-  rwa [hb₂ a h, ← hb₂ a₁ ⟨ha₁.1, ha₁.2.1, ha₁.zpow_or_neg_zpow h₀⟩],
+  rwa [hb₂ a h, ← hb₂ a₁ ⟨ha₁.1, ha₁.2.1, ha₁.zpow_or_neg_zpow⟩],
 end
 
 end pell

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -251,9 +251,9 @@ exponents have positive `y`. -/
 lemma y_zpow_pos {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y) {n : ℤ} (hn : 0 < n) :
   0 < (a ^ n).y :=
 begin
-  rw [(int.to_nat_of_nonneg hn.le).symm, zpow_coe_nat],
-  replace hn : 0 < n.to_nat := int.lt_to_nat.mpr hn,
-  rw (nat.succ_pred_eq_of_pos hn).symm,
+  lift n to ℕ using hn.le,
+  norm_cast at hn ⊢,
+  rw ← nat.succ_pred_eq_of_pos hn,
   exact y_pow_succ_pos hax hay _,
 end
 
@@ -449,10 +449,10 @@ begin
   obtain ⟨a, ha₁, ha₂⟩ := exists_pos_of_not_is_square h₀ hd,
   -- convert to `x : ℕ` to be able to use `nat.find`
   have P : ∃ x' : ℕ, 1 < x' ∧ ∃ y' : ℤ, 0 < y' ∧ (x' : ℤ) ^ 2 - d * y' ^ 2 = 1,
-  { have hx' := (int.to_nat_of_nonneg $ zero_le_one.trans ha₁.le).symm,
-    rw hx' at ha₁,
+  { have hax := a.prop,
+    lift a.x to ℕ using (by positivity) with ax,
     norm_cast at ha₁,
-    exact ⟨a.x.to_nat, ha₁, a.y, ha₂, hx' ▸ a.prop⟩, },
+    exact ⟨ax, ha₁, a.y, ha₂, hax⟩, },
   classical, -- to avoid having to show that the predicate is decidable
   let x₁ := nat.find P,
   obtain ⟨hx, y₁, hy₀, hy₁⟩ := nat.find_spec P,

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -535,7 +535,7 @@ end
 
 /-- The `x`-coordinate of a fundamental solution is a lower bound for the `x`-coordinate
 of any positive solution. -/
-lemma le_x {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x) :
+lemma x_le_x {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 1 < a.x) :
   a₁.x ≤ a.x :=
 h.2.2 hax
 
@@ -549,7 +549,7 @@ begin
   rw [← abs_of_pos hay, ← abs_of_pos h.2.1, ← sq_le_sq, ← mul_le_mul_left h.d_pos, ← sub_nonpos,
       ← mul_sub, H, sub_nonpos, sq_le_sq, abs_of_pos (zero_lt_one.trans h.1),
       abs_of_pos (zero_lt_one.trans hax)],
-  exact h.le_x hax,
+  exact h.x_le_x hax,
 end
 
 /-- If we multiply a positive solution with the inverse of a fundamental solution,
@@ -592,7 +592,7 @@ begin
 end
 
 /-- Any nonnegative solution is a power with nonnegative exponent of a fundamental solution. -/
-lemma pow_of_nonneg {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 0 < a.x)
+lemma eq_pow_of_nonneg {a₁ : solution₁ d} (h : is_fundamental a₁) {a : solution₁ d} (hax : 0 < a.x)
   (hay : 0 ≤ a.y) :
   ∃ n : ℕ, a = a₁ ^ n :=
 begin
@@ -622,7 +622,7 @@ lemma zpow_or_neg_zpow {a₁ : solution₁ d} (h : is_fundamental a₁) (a : sol
   ∃ n : ℤ, a = a₁ ^ n ∨ a = -a₁ ^ n :=
 begin
   obtain ⟨b, hbx, hby, hb⟩ := exists_pos_variant h.d_pos a,
-  obtain ⟨n, hn⟩ := h.pow_of_nonneg hbx hby,
+  obtain ⟨n, hn⟩ := h.eq_pow_of_nonneg hbx hby,
   rcases hb with rfl | rfl | rfl | hb,
   { exact ⟨n, or.inl (by exact_mod_cast hn)⟩, },
   { exact ⟨-n, or.inl (by simp [hn])⟩, },

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -667,8 +667,7 @@ Pell equation `x^2 + d*y^2 = 1` if and only if it is a fundamental solution. -/
 theorem pos_generator_iff_fundamental (a : solution₁ d) :
   (1 < a.x ∧ 0 < a.y ∧ ∀ b : solution₁ d, ∃ n : ℤ, b = a ^ n ∨ b = -a ^ n) ↔ is_fundamental a :=
 begin
-  refine ⟨_, λ H, ⟨H.1, H.2.1, H.zpow_or_neg_zpow⟩⟩,
-  intro h,
+  refine ⟨λ h, _, λ H, ⟨H.1, H.2.1, H.zpow_or_neg_zpow⟩⟩,
   have h₀ := d_pos_of_one_lt_x h.1,
   have hd := d_nonsquare_of_one_lt_x h.1,
   obtain ⟨a₁, ha₁⟩ := is_fundamental.exists_of_not_is_square h₀ hd,

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -685,7 +685,7 @@ begin
 end
 
 /-- A positive solution is a generator (up to sign) of the group of all solutions to the
-Pell equation `x^2 + d*y^2 = 1` if and only if it is a fundamental solution. -/
+Pell equation `x^2 - d*y^2 = 1` if and only if it is a fundamental solution. -/
 theorem pos_generator_iff_fundamental (a : solution₁ d) :
   (1 < a.x ∧ 0 < a.y ∧ ∀ b : solution₁ d, ∃ n : ℤ, b = a ^ n ∨ b = -a ^ n) ↔ is_fundamental a :=
 begin

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -437,15 +437,13 @@ namespace is_fundamental
 open solution₁
 
 /-- A fundamental solution has positive `x`. -/
-lemma x_pos {a : solution₁ d} (h : is_fundamental a) : 0 < a.x :=
-zero_lt_one.trans h.1
+lemma x_pos {a : solution₁ d} (h : is_fundamental a) : 0 < a.x := zero_lt_one.trans h.1
 
 /-- If a fundamental solution exists, then `d` must be positive. -/
 lemma d_pos {a : solution₁ d} (h : is_fundamental a) : 0 < d := d_pos_of_one_lt_x h.1
 
 /-- If there is a fundamental solution, it is unique. -/
-lemma unique {a b : solution₁ d} (ha : is_fundamental a) (hb : is_fundamental b) :
-  a = b :=
+lemma unique {a b : solution₁ d} (ha : is_fundamental a) (hb : is_fundamental b) : a = b :=
 begin
   have hx := le_antisymm (ha.2.2 hb.1) (hb.2.2 ha.1),
   refine solution₁.ext hx _,
@@ -658,6 +656,7 @@ theorem pos_generator_iff_fundamental (hd : ¬ is_square d) (a : solution₁ d) 
 begin
   refine ⟨_, λ H, ⟨H.1, H.2.1, H.zpow_or_neg_zpow⟩⟩,
   intro h,
+  have h₀ := d_pos_of_one_lt_x h.1,
   obtain ⟨a₁, ha₁⟩ := is_fundamental.exists_of_not_is_square h₀ hd,
   obtain ⟨b, hb₁, hb₂⟩ := exists_unique_pos_generator h₀ hd,
   rwa [hb₂ a h, ← hb₂ a₁ ⟨ha₁.1, ha₁.2.1, ha₁.zpow_or_neg_zpow⟩],

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -192,6 +192,16 @@ begin
   exact one_lt_pow ha two_ne_zero,
 end
 
+/-- If a solution has `x > 1`, then `d` is not a square. -/
+lemma d_nonsquare_of_one_lt_x {a : solution₁ d} (ha : 1 < a.x) : ¬ is_square d :=
+begin
+  intro h,
+  obtain ⟨b, hb⟩ := h,
+  have hp := a.prop,
+  simp_rw [hb, ← sq, ← mul_pow, sq_sub_sq, int.mul_eq_one_iff_eq_one_or_neg_one] at hp,
+  rcases hp with ⟨hp₁, hp₂⟩ | ⟨hp₁, hp₂⟩; linarith [ha, hp₁, hp₂],
+end
+
 /-- A solution with `x = 1` is trivial. -/
 lemma eq_one_of_x_eq_one (h₀ : d ≠ 0) {a : solution₁ d} (ha : a.x = 1) : a = 1 :=
 begin

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -574,34 +574,25 @@ lemma pow_of_nonneg (h₀ : 0 < d) {a₁ : solution₁ d} (h : is_fundamental a�
   (hax : 0 < a.x) (hay : 0 ≤ a.y) :
   ∃ n : ℕ, a = a₁ ^ n :=
 begin
-  have help : ∀ (x : ℕ) (a : solution₁ d), a.x = x → 0 ≤ a.y → ∃ n : ℕ, a = a₁ ^ n,
-  { clear hay hax a, -- to avoid confusion
-    intro x,
-    induction x using nat.strong_induction_on with x ih,
-    intros a hax hay,
-    have hx₀ : 0 ≤ a.x,
-    { rw hax, exact nat.cast_nonneg x, },
-    cases hay.eq_or_lt with hy hy,
-    { -- case 1: `a = 1`
-      refine ⟨0, _⟩,
-      simp only [pow_zero],
-      ext; simp only [x_one, y_one],
-      { have prop := a.prop,
-        rw [← hy, sq (0 : ℤ), zero_mul, mul_zero, sub_zero, sq_eq_one_iff] at prop,
-        refine prop.resolve_right (λ hf, _),
-        have := hx₀.trans_eq hf,
-        norm_num at this, },
-      { exact hy.symm, } },
-    { -- case 2: `a ≥ a₁`
-      have hx₁ : 1 < a.x := by nlinarith [a.prop],
-      obtain ⟨hxx₁, hxx₂, hyy⟩ := h.mul_inv_lt_x h₀ hx₁ hy,
-      have hX := int.to_nat_of_nonneg hxx₁.le,
-      have hX' : (a * a₁⁻¹).x.to_nat < x,
-      { exact_mod_cast (hX.trans_lt hxx₂).trans_eq hax, },
-      obtain ⟨n, hn⟩ := ih (a * a₁⁻¹).x.to_nat hX' (a * a₁⁻¹) hX.symm hyy,
-      refine ⟨n + 1, _⟩,
-      rw [pow_succ, ← hn, mul_comm a, ← mul_assoc, mul_inv_self, one_mul], } },
-  exact help a.x.to_nat a (int.to_nat_of_nonneg hax.le).symm hay,
+  lift a.x to ℕ using hax.le with ax hax',
+  induction ax using nat.strong_induction_on with x ih generalizing a,
+  cases hay.eq_or_lt with hy hy,
+  { -- case 1: `a = 1`
+    refine ⟨0, _⟩,
+    simp only [pow_zero],
+    ext; simp only [x_one, y_one],
+    { have prop := a.prop,
+      rw [← hy, sq (0 : ℤ), zero_mul, mul_zero, sub_zero, sq_eq_one_iff] at prop,
+      refine prop.resolve_right (λ hf, _),
+      have := (hax.trans_eq hax').le.trans_eq hf,
+      norm_num at this, },
+    { exact hy.symm, } },
+  { -- case 2: `a ≥ a₁`
+    have hx₁ : 1 < a.x := by nlinarith [a.prop],
+    obtain ⟨hxx₁, hxx₂, hyy⟩ := h.mul_inv_lt_x h₀ hx₁ hy,
+    lift (a * a₁⁻¹).x to ℕ using hxx₁.le with x' hx',
+    obtain ⟨n, hn⟩ := ih x' (by exact_mod_cast hxx₂.trans_eq hax'.symm) hxx₁ hyy hx',
+    exact ⟨n + 1, by rw [pow_succ, ← hn, mul_comm a, ← mul_assoc, mul_inv_self, one_mul]⟩, },
 end
 
 /-- Every solution is, up to a sign, a power of a given fundamental solution. -/

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -693,7 +693,7 @@ begin
 end
 
 /-- A positive solution is a generator (up to sign) of the group of all solutions to the
-Pell equation `x^2 - d*y^2 = 1` if and only if it is a fundamental solution.  -/
+Pell equation `x^2 - d*y^2 = 1` if and only if it is a fundamental solution. -/
 theorem pos_generator_iff_fundamental (a : solution₁ d) :
   (1 < a.x ∧ 0 < a.y ∧ ∀ b : solution₁ d, ∃ n : ℤ, b = a ^ n ∨ b = -a ^ n) ↔ is_fundamental a :=
 begin

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -32,7 +32,8 @@ See `pell.exists_of_not_is_square` and `pell.exists_nontrivial_of_not_is_square`
 
 We then define the *fundamental solution* to be the solution
 with smallest $x$ among all solutions satisfying $x > 1$ and $y > 0$.
-We show that every solution is a power of the fundamental solution up to a (common) sign,
+We show that every solution is a power (in the sense of the group structure mentioned above)
+of the fundamental solution up to a (common) sign,
 see `pell.fundamental.eq_zpow_or_neg_zpow`, and that a (positive) solution has this property
 if and only if it is fundamental, see `pell.pos_generator_iff_fundamental`.
 
@@ -287,7 +288,7 @@ end
 /-- If `(x, y)` is a solution with `x` and `y` positive, then the `y` component of any power
 has the same sign as the exponent. -/
 lemma sign_y_zpow_eq_sign_of_x_pos_of_y_pos {a : solution₁ d} (hax : 0 < a.x) (hay : 0 < a.y)
-   (n : ℤ) :
+  (n : ℤ) :
   (a ^ n).y.sign = n.sign :=
 begin
   rcases n with (_ | _) | _,

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -457,7 +457,7 @@ lemma d_nonsquare {a : solution₁ d} (h : is_fundamental a) : ¬ is_square d :=
 d_nonsquare_of_one_lt_x h.1
 
 /-- If there is a fundamental solution, it is unique. -/
-lemma unique {a b : solution₁ d} (ha : is_fundamental a) (hb : is_fundamental b) : a = b :=
+lemma subsingleton {a b : solution₁ d} (ha : is_fundamental a) (hb : is_fundamental b) : a = b :=
 begin
   have hx := le_antisymm (ha.2.2 hb.1) (hb.2.2 ha.1),
   refine solution₁.ext hx _,

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -33,7 +33,7 @@ See `pell.exists_of_not_is_square` and `pell.exists_nontrivial_of_not_is_square`
 We then define the *fundamental solution* to be the solution
 with smallest $x$ among all solutions satisfying $x > 1$ and $y > 0$.
 We show that every solution is a power of the fundamental solution up to a (common) sign,
-see `pell.fundamental.zpow_or_neg_zpow`, and that a (positive) solution has this property
+see `pell.fundamental.eq_zpow_or_neg_zpow`, and that a (positive) solution has this property
 if and only if it is fundamental, see `pell.pos_generator_iff_fundamental`.
 
 ## References
@@ -618,7 +618,7 @@ begin
 end
 
 /-- Every solution is, up to a sign, a power of a given fundamental solution. -/
-lemma zpow_or_neg_zpow {a₁ : solution₁ d} (h : is_fundamental a₁) (a : solution₁ d) :
+lemma eq_zpow_or_neg_zpow {a₁ : solution₁ d} (h : is_fundamental a₁) (a : solution₁ d) :
   ∃ n : ℤ, a = a₁ ^ n ∨ a = -a₁ ^ n :=
 begin
   obtain ⟨b, hbx, hby, hb⟩ := exists_pos_variant h.d_pos a,
@@ -642,10 +642,10 @@ theorem exists_unique_pos_generator (h₀ : 0 < d) (hd : ¬ is_square d) :
   ∃! a₁ : solution₁ d, 1 < a₁.x ∧ 0 < a₁.y ∧ ∀ a : solution₁ d, ∃ n : ℤ, a = a₁ ^ n ∨ a = -a₁ ^ n :=
 begin
   obtain ⟨a₁, ha₁⟩ := is_fundamental.exists_of_not_is_square h₀ hd,
-  refine ⟨a₁, ⟨ha₁.1, ha₁.2.1, ha₁.zpow_or_neg_zpow⟩, λ a (H : 1 < _ ∧ _), _⟩,
+  refine ⟨a₁, ⟨ha₁.1, ha₁.2.1, ha₁.eq_zpow_or_neg_zpow⟩, λ a (H : 1 < _ ∧ _), _⟩,
   obtain ⟨Hx, Hy, H⟩ := H,
   obtain ⟨n₁, hn₁⟩ := H a₁,
-  obtain ⟨n₂, hn₂⟩ := ha₁.zpow_or_neg_zpow a,
+  obtain ⟨n₂, hn₂⟩ := ha₁.eq_zpow_or_neg_zpow a,
   rcases hn₂ with rfl | rfl,
   { rw [← zpow_mul, eq_comm, @eq_comm _ a₁, ← mul_inv_eq_one, ← @mul_inv_eq_one _ _ _ a₁,
         ← zpow_neg_one, neg_mul, ← zpow_add, ← sub_eq_add_neg] at hn₁,
@@ -667,12 +667,12 @@ Pell equation `x^2 + d*y^2 = 1` if and only if it is a fundamental solution. -/
 theorem pos_generator_iff_fundamental (a : solution₁ d) :
   (1 < a.x ∧ 0 < a.y ∧ ∀ b : solution₁ d, ∃ n : ℤ, b = a ^ n ∨ b = -a ^ n) ↔ is_fundamental a :=
 begin
-  refine ⟨λ h, _, λ H, ⟨H.1, H.2.1, H.zpow_or_neg_zpow⟩⟩,
+  refine ⟨λ h, _, λ H, ⟨H.1, H.2.1, H.eq_zpow_or_neg_zpow⟩⟩,
   have h₀ := d_pos_of_one_lt_x h.1,
   have hd := d_nonsquare_of_one_lt_x h.1,
   obtain ⟨a₁, ha₁⟩ := is_fundamental.exists_of_not_is_square h₀ hd,
   obtain ⟨b, hb₁, hb₂⟩ := exists_unique_pos_generator h₀ hd,
-  rwa [hb₂ a h, ← hb₂ a₁ ⟨ha₁.1, ha₁.2.1, ha₁.zpow_or_neg_zpow⟩],
+  rwa [hb₂ a h, ← hb₂ a₁ ⟨ha₁.1, ha₁.2.1, ha₁.eq_zpow_or_neg_zpow⟩],
 end
 
 end pell

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -522,7 +522,7 @@ end
 /-- The `n`th power of a fundamental solution has positive `y` if and only if `n` is positive. -/
 lemma pow_y_pos_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : 0 < (a ^ n).y ↔ 0 < n :=
 begin
-  refine ⟨λ H, _, y_zpow_pos h.x_pos h.2.1⟩,
+  refine ⟨λ H, _, λ H, h.y_strict_mono H⟩,
   contrapose! H,
   exact h.y_strict_mono.monotone H,
 end
@@ -530,8 +530,9 @@ end
 /-- The `n`th power of a fundamental solution has negative `y` if and only if `n` is negative. -/
 lemma pow_y_neg_iff {a : solution₁ d} (h : is_fundamental a) (n : ℤ) : (a ^ n).y < 0 ↔ n < 0 :=
 begin
-  rw [← neg_neg n, zpow_neg, y_inv, neg_lt, neg_zero, neg_lt, neg_zero],
-  exact h.pow_y_pos_iff (-n),
+  refine ⟨λ H, _, λ H, h.y_strict_mono H⟩,
+  contrapose! H,
+  exact h.y_strict_mono.monotone H,
 end
 
 /-- A power of a fundamental solution is never equal to the negative of a power of this

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -664,12 +664,13 @@ end
 
 /-- A positive solution is a generator (up to sign) of the group of all solutions to the
 Pell equation `x^2 + d*y^2 = 1` if and only if it is a fundamental solution. -/
-theorem pos_generator_iff_fundamental (hd : ¬ is_square d) (a : solution₁ d) :
+theorem pos_generator_iff_fundamental (a : solution₁ d) :
   (1 < a.x ∧ 0 < a.y ∧ ∀ b : solution₁ d, ∃ n : ℤ, b = a ^ n ∨ b = -a ^ n) ↔ is_fundamental a :=
 begin
   refine ⟨_, λ H, ⟨H.1, H.2.1, H.zpow_or_neg_zpow⟩⟩,
   intro h,
   have h₀ := d_pos_of_one_lt_x h.1,
+  have hd := d_nonsquare_of_one_lt_x h.1,
   obtain ⟨a₁, ha₁⟩ := is_fundamental.exists_of_not_is_square h₀ hd,
   obtain ⟨b, hb₁, hb₂⟩ := exists_unique_pos_generator h₀ hd,
   rwa [hb₂ a h, ← hb₂ a₁ ⟨ha₁.1, ha₁.2.1, ha₁.zpow_or_neg_zpow⟩],

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -30,9 +30,11 @@ $x^2 - d y^2 = 1$ has a nontrivial (i.e., with $y \ne 0$) solution in integers.
 
 See `pell.exists_of_not_is_square` and `pell.exists_nontrivial_of_not_is_square`.
 
-The next step (TODO) will be to define the *fundamental solution* as the solution
-with smallest $x$ among all solutions satisfying $x > 1$ and $y > 0$ and to show
-that every solution is a power of the fundamental solution up to a (common) sign.
+We then define the *fundamental solution* to be the solution
+with smallest $x$ among all solutions satisfying $x > 1$ and $y > 0$.
+We show that every solution is a power of the fundamental solution up to a (common) sign,
+see `pell.fundamental.zpow_or_neg_zpow`, and that a (positive) solution has this property
+if and only if it is fundamental, see `pell.pos_generator_iff_fundamental`.
 
 ## References
 
@@ -45,8 +47,7 @@ Pell's equation
 
 ## TODO
 
-* Provide the structure theory of the solution set to Pell's equation
-  and furthermore also for `x ^ 2 - d * y ^ 2 = -1` and further generalizations.
+* Extend to `x ^ 2 - d * y ^ 2 = -1` and further generalizations.
 * Connect solutions to the continued fraction expansion of `√d`.
 -/
 

--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -184,6 +184,14 @@ begin
   exact lt_irrefl _ (((one_lt_sq_iff $ zero_le_one.trans ha.le).mpr ha).trans_eq prop),
 end
 
+/-- If a solution has `x > 1`, then `d` is positive. -/
+lemma d_pos_of_one_lt_x {a : solution₁ d} (ha : 1 < a.x) : 0 < d :=
+begin
+  refine pos_of_mul_pos_left _ (sq_nonneg a.y),
+  rw [a.prop_y, sub_pos],
+  exact one_lt_pow ha two_ne_zero,
+end
+
 /-- A solution with `x = 1` is trivial. -/
 lemma eq_one_of_x_eq_one (h₀ : d ≠ 0) {a : solution₁ d} (ha : a.x = 1) : a = 1 :=
 begin


### PR DESCRIPTION
This is the next step in developing the theory of Pell's equation.

We define what a *fundamental solution* is, show that it exists and is unique and that it is characterized by the property that it (is positive and) generates the group of solutions up to sign.

See [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Proving.20Pell's.20equation.20is.20solvable/near/343270338).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
