### PR TITLE
[Merged by Bors] - chore(algebra/order/to_interval_mod): Reorder arguments

### DIFF
--- a/src/algebra/order/to_interval_mod.lean
+++ b/src/algebra/order/to_interval_mod.lean
@@ -21,12 +21,12 @@ interval.
 
 ## Main definitions
 
-* `to_Ico_div a hb x` (where `hb : 0 < b`): The unique integer such that this multiple of `b`,
-  subtracted from `x`, is in `Ico a (a + b)`.
-* `to_Ico_mod a hb x` (where `hb : 0 < b`): Reduce `x` to the interval `Ico a (a + b)`.
-* `to_Ioc_div a hb x` (where `hb : 0 < b`): The unique integer such that this multiple of `b`,
-  subtracted from `x`, is in `Ioc a (a + b)`.
-* `to_Ioc_mod a hb x` (where `hb : 0 < b`): Reduce `x` to the interval `Ioc a (a + b)`.
+* `to_Ico_div hp a b` (where `hp : 0 < p`): The unique integer such that this multiple of `p`,
+  subtracted from `b`, is in `Ico a (a + p)`.
+* `to_Ico_mod hp a b` (where `hp : 0 < p`): Reduce `b` to the interval `Ico a (a + p)`.
+* `to_Ioc_div hp a b` (where `hp : 0 < p`): The unique integer such that this multiple of `p`,
+  subtracted from `b`, is in `Ioc a (a + p)`.
+* `to_Ioc_mod hp a b` (where `hp : 0 < p`): Reduce `b` to the interval `Ioc a (a + p)`.
 
 -/
 
@@ -34,410 +34,288 @@ noncomputable theory
 
 section linear_ordered_add_comm_group
 
-variables {α : Type*} [linear_ordered_add_comm_group α] [hα : archimedean α]
+variables {α : Type*} [linear_ordered_add_comm_group α] [hα : archimedean α] {p : α} (hp : 0 < p)
+  {a b c : α} {n : ℤ}
 include hα
 
 /--
-The unique integer such that this multiple of `b`, subtracted from `x`, is in `Ico a (a + b)`. -/
-def to_Ico_div (a : α) {b : α} (hb : 0 < b) (x : α) : ℤ :=
-(exists_unique_sub_zsmul_mem_Ico hb x a).some
+The unique integer such that this multiple of `p`, subtracted from `b`, is in `Ico a (a + p)`. -/
+def to_Ico_div (a b : α) : ℤ := (exists_unique_sub_zsmul_mem_Ico hp b a).some
 
-lemma sub_to_Ico_div_zsmul_mem_Ico (a : α) {b : α} (hb : 0 < b) (x : α) :
-  x - to_Ico_div a hb x • b ∈ set.Ico a (a + b) :=
-(exists_unique_sub_zsmul_mem_Ico hb x a).some_spec.1
+lemma sub_to_Ico_div_zsmul_mem_Ico (a b : α) : b - to_Ico_div hp a b • p ∈ set.Ico a (a + p) :=
+(exists_unique_sub_zsmul_mem_Ico hp b a).some_spec.1
 
-lemma eq_to_Ico_div_of_sub_zsmul_mem_Ico {a b x : α} (hb : 0 < b) {y : ℤ}
-  (hy : x - y • b ∈ set.Ico a (a + b)) : y = to_Ico_div a hb x :=
-(exists_unique_sub_zsmul_mem_Ico hb x a).some_spec.2 y hy
+lemma to_Ico_div_eq_of_sub_zsmul_mem_Ico (h : b - n • p ∈ set.Ico a (a + p)) :
+  to_Ico_div hp a b = n :=
+((exists_unique_sub_zsmul_mem_Ico hp b a).some_spec.2 _ h).symm
 
 /--
-The unique integer such that this multiple of `b`, subtracted from `x`, is in `Ioc a (a + b)`. -/
-def to_Ioc_div (a : α) {b : α} (hb : 0 < b) (x : α) : ℤ :=
-(exists_unique_sub_zsmul_mem_Ioc hb x a).some
+The unique integer such that this multiple of `p`, subtracted from `b`, is in `Ioc a (a + p)`. -/
+def to_Ioc_div (a b : α) : ℤ := (exists_unique_sub_zsmul_mem_Ioc hp b a).some
 
-lemma sub_to_Ioc_div_zsmul_mem_Ioc (a : α) {b : α} (hb : 0 < b) (x : α) :
-  x - to_Ioc_div a hb x • b ∈ set.Ioc a (a + b) :=
-(exists_unique_sub_zsmul_mem_Ioc hb x a).some_spec.1
+lemma sub_to_Ioc_div_zsmul_mem_Ioc (a b : α) : b - to_Ioc_div hp a b • p ∈ set.Ioc a (a + p) :=
+(exists_unique_sub_zsmul_mem_Ioc hp b a).some_spec.1
 
-lemma eq_to_Ioc_div_of_sub_zsmul_mem_Ioc {a b x : α} (hb : 0 < b) {y : ℤ}
-  (hy : x - y • b ∈ set.Ioc a (a + b)) : y = to_Ioc_div a hb x :=
-(exists_unique_sub_zsmul_mem_Ioc hb x a).some_spec.2 y hy
+lemma to_Ioc_div_eq_of_sub_zsmul_mem_Ioc (h : b - n • p ∈ set.Ioc a (a + p)) :
+  to_Ioc_div hp a b = n :=
+((exists_unique_sub_zsmul_mem_Ioc hp b a).some_spec.2 _ h).symm
 
-/-- Reduce `x` to the interval `Ico a (a + b)`. -/
-def to_Ico_mod (a : α) {b : α} (hb : 0 < b) (x : α) : α := x - to_Ico_div a hb x • b
+/-- Reduce `b` to the interval `Ico a (a + p)`. -/
+def to_Ico_mod (a b : α) : α := b - to_Ico_div hp a b • p
 
-/-- Reduce `x` to the interval `Ioc a (a + b)`. -/
-def to_Ioc_mod (a : α) {b : α} (hb : 0 < b) (x : α) : α := x - to_Ioc_div a hb x • b
+/-- Reduce `b` to the interval `Ioc a (a + p)`. -/
+def to_Ioc_mod (a b : α) : α := b - to_Ioc_div hp a b • p
 
-lemma to_Ico_mod_mem_Ico (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a hb x ∈ set.Ico a (a + b) :=
-sub_to_Ico_div_zsmul_mem_Ico a hb x
+lemma to_Ico_mod_mem_Ico (a b : α) : to_Ico_mod hp a b ∈ set.Ico a (a + p) :=
+sub_to_Ico_div_zsmul_mem_Ico hp a b
 
-lemma to_Ico_mod_mem_Ico' {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod 0 hb x ∈ set.Ico 0 b :=
-by { convert to_Ico_mod_mem_Ico 0 hb x, exact (zero_add b).symm, }
+lemma to_Ico_mod_mem_Ico' (b : α) : to_Ico_mod hp 0 b ∈ set.Ico 0 p :=
+by { convert to_Ico_mod_mem_Ico hp 0 b, exact (zero_add p).symm, }
 
-lemma to_Ioc_mod_mem_Ioc (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a hb x ∈ set.Ioc a (a + b) :=
-sub_to_Ioc_div_zsmul_mem_Ioc a hb x
+lemma to_Ioc_mod_mem_Ioc (a b : α) : to_Ioc_mod hp a b ∈ set.Ioc a (a + p) :=
+sub_to_Ioc_div_zsmul_mem_Ioc hp a b
 
-lemma left_le_to_Ico_mod (a : α) {b : α} (hb : 0 < b) (x : α) : a ≤ to_Ico_mod a hb x :=
-(set.mem_Ico.1 (to_Ico_mod_mem_Ico a hb x)).1
+lemma left_le_to_Ico_mod (a b : α) : a ≤ to_Ico_mod hp a b :=
+(set.mem_Ico.1 (to_Ico_mod_mem_Ico hp a b)).1
 
-lemma left_lt_to_Ioc_mod (a : α) {b : α} (hb : 0 < b) (x : α) : a < to_Ioc_mod a hb x :=
-(set.mem_Ioc.1 (to_Ioc_mod_mem_Ioc a hb x)).1
+lemma left_lt_to_Ioc_mod (a b : α) : a < to_Ioc_mod hp a b :=
+(set.mem_Ioc.1 (to_Ioc_mod_mem_Ioc hp a b)).1
 
-lemma to_Ico_mod_lt_right (a : α) {b : α} (hb : 0 < b) (x : α) : to_Ico_mod a hb x < a + b :=
-(set.mem_Ico.1 (to_Ico_mod_mem_Ico a hb x)).2
+lemma to_Ico_mod_lt_right (a b : α) : to_Ico_mod hp a b < a + p :=
+(set.mem_Ico.1 (to_Ico_mod_mem_Ico hp a b)).2
 
-lemma to_Ioc_mod_le_right (a : α) {b : α} (hb : 0 < b) (x : α) : to_Ioc_mod a hb x ≤ a + b :=
-(set.mem_Ioc.1 (to_Ioc_mod_mem_Ioc a hb x)).2
+lemma to_Ioc_mod_le_right (a b : α) : to_Ioc_mod hp a b ≤ a + p :=
+(set.mem_Ioc.1 (to_Ioc_mod_mem_Ioc hp a b)).2
 
-@[simp] lemma self_sub_to_Ico_div_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) :
-  x - to_Ico_div a hb x • b = to_Ico_mod a hb x :=
+@[simp] lemma self_sub_to_Ico_div_zsmul (a b : α) : b - to_Ico_div hp a b • p = to_Ico_mod hp a b :=
 rfl
 
-@[simp] lemma self_sub_to_Ioc_div_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) :
-  x - to_Ioc_div a hb x • b = to_Ioc_mod a hb x :=
+@[simp] lemma self_sub_to_Ioc_div_zsmul (a b : α) : b - to_Ioc_div hp a b • p = to_Ioc_mod hp a b :=
 rfl
 
-@[simp] lemma to_Ico_div_zsmul_sub_self (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_div a hb x • b - x = -to_Ico_mod a hb x :=
+@[simp] lemma to_Ico_div_zsmul_sub_self (a b : α) :
+  to_Ico_div hp a b • p - b = -to_Ico_mod hp a b :=
 by rw [to_Ico_mod, neg_sub]
 
-@[simp] lemma to_Ioc_div_zsmul_sub_self (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_div a hb x • b - x = -to_Ioc_mod a hb x :=
+@[simp] lemma to_Ioc_div_zsmul_sub_self (a b : α) :
+  to_Ioc_div hp a b • p - b = -to_Ioc_mod hp a b :=
 by rw [to_Ioc_mod, neg_sub]
 
-@[simp] lemma to_Ico_mod_sub_self (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a hb x - x = -to_Ico_div a hb x • b :=
+@[simp] lemma to_Ico_mod_sub_self (a b : α) : to_Ico_mod hp a b - b = -to_Ico_div hp a b • p :=
 by rw [to_Ico_mod, sub_sub_cancel_left, neg_smul]
 
-@[simp] lemma to_Ioc_mod_sub_self (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a hb x - x = -to_Ioc_div a hb x • b :=
+@[simp] lemma to_Ioc_mod_sub_self (a b : α) : to_Ioc_mod hp a b - b = -to_Ioc_div hp a b • p :=
 by rw [to_Ioc_mod, sub_sub_cancel_left, neg_smul]
 
-@[simp] lemma self_sub_to_Ico_mod (a : α) {b : α} (hb : 0 < b) (x : α) :
-  x - to_Ico_mod a hb x = to_Ico_div a hb x • b :=
+@[simp] lemma self_sub_to_Ico_mod (a b : α) : b - to_Ico_mod hp a b = to_Ico_div hp a b • p :=
 by rw [to_Ico_mod, sub_sub_cancel]
 
-@[simp] lemma self_sub_to_Ioc_mod (a : α) {b : α} (hb : 0 < b) (x : α) :
-  x - to_Ioc_mod a hb x = to_Ioc_div a hb x • b :=
+@[simp] lemma self_sub_to_Ioc_mod (a b : α) : b - to_Ioc_mod hp a b = to_Ioc_div hp a b • p :=
 by rw [to_Ioc_mod, sub_sub_cancel]
 
-@[simp] lemma to_Ico_mod_add_to_Ico_div_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a hb x + to_Ico_div a hb x • b = x :=
+@[simp] lemma to_Ico_mod_add_to_Ico_div_zsmul (a b : α) :
+  to_Ico_mod hp a b + to_Ico_div hp a b • p = b :=
 by rw [to_Ico_mod, sub_add_cancel]
 
-@[simp] lemma to_Ioc_mod_add_to_Ioc_div_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a hb x + to_Ioc_div a hb x • b = x :=
+@[simp] lemma to_Ioc_mod_add_to_Ioc_div_zsmul (a b : α) :
+  to_Ioc_mod hp a b + to_Ioc_div hp a b • p = b :=
 by rw [to_Ioc_mod, sub_add_cancel]
 
-@[simp] lemma to_Ico_div_zsmul_sub_to_Ico_mod (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_div a hb x • b + to_Ico_mod a hb x = x :=
+@[simp] lemma to_Ico_div_zsmul_sub_to_Ico_mod (a b : α) :
+  to_Ico_div hp a b • p + to_Ico_mod hp a b = b :=
 by rw [add_comm, to_Ico_mod_add_to_Ico_div_zsmul]
 
-@[simp] lemma to_Ioc_div_zsmul_sub_to_Ioc_mod (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_div a hb x • b + to_Ioc_mod a hb x = x :=
+@[simp] lemma to_Ioc_div_zsmul_sub_to_Ioc_mod (a b : α) :
+  to_Ioc_div hp a b • p + to_Ioc_mod hp a b = b :=
 by rw [add_comm, to_Ioc_mod_add_to_Ioc_div_zsmul]
 
-lemma to_Ico_mod_eq_iff {a b x y : α} (hb : 0 < b) :
-  to_Ico_mod a hb x = y ↔ y ∈ set.Ico a (a + b) ∧ ∃ z : ℤ, x = y + z • b :=
+lemma to_Ico_mod_eq_iff : to_Ico_mod hp a b = c ↔ c ∈ set.Ico a (a + p) ∧ ∃ z : ℤ, b = c + z • p :=
 begin
-  refine ⟨λ h, ⟨h ▸ to_Ico_mod_mem_Ico a hb x,
-                to_Ico_div a hb x,
-                h ▸ (to_Ico_mod_add_to_Ico_div_zsmul _ _ _).symm⟩,
-          λ h, _⟩,
-  rcases h with ⟨hy, z, hz⟩,
-  rw ←sub_eq_iff_eq_add at hz,
-  subst hz,
-  rw eq_to_Ico_div_of_sub_zsmul_mem_Ico hb hy,
-  refl
+  refine ⟨λ h, ⟨h ▸ to_Ico_mod_mem_Ico hp a b, to_Ico_div hp a b,
+                h ▸ (to_Ico_mod_add_to_Ico_div_zsmul _ _ _).symm⟩, _⟩,
+  simp_rw ←@sub_eq_iff_eq_add,
+  rintro ⟨hc, n, rfl⟩,
+  rw [←to_Ico_div_eq_of_sub_zsmul_mem_Ico hp hc, to_Ico_mod],
 end
 
-lemma to_Ioc_mod_eq_iff {a b x y : α} (hb : 0 < b) :
-  to_Ioc_mod a hb x = y ↔ y ∈ set.Ioc a (a + b) ∧ ∃ z : ℤ, x = y + z • b :=
+lemma to_Ioc_mod_eq_iff : to_Ioc_mod hp a b = c ↔ c ∈ set.Ioc a (a + p) ∧ ∃ z : ℤ, b = c + z • p :=
 begin
-  refine ⟨λ h, ⟨h ▸ to_Ioc_mod_mem_Ioc a hb x,
-                to_Ioc_div a hb x,
-                h ▸ (to_Ioc_mod_add_to_Ioc_div_zsmul _ hb _).symm⟩,
-          λ h, _⟩,
-  rcases h with ⟨hy, z, hz⟩,
-  rw ←sub_eq_iff_eq_add at hz,
-  subst hz,
-  rw eq_to_Ioc_div_of_sub_zsmul_mem_Ioc hb hy,
-  refl
+  refine ⟨λ h, ⟨h ▸ to_Ioc_mod_mem_Ioc hp a b, to_Ioc_div hp a b,
+                h ▸ (to_Ioc_mod_add_to_Ioc_div_zsmul hp _ _).symm⟩, _⟩,
+  simp_rw ←@sub_eq_iff_eq_add,
+  rintro ⟨hc, n, rfl⟩,
+  rw [←to_Ioc_div_eq_of_sub_zsmul_mem_Ioc hp hc, to_Ioc_mod],
 end
 
-@[simp] lemma to_Ico_div_apply_left (a : α) {b : α} (hb : 0 < b) : to_Ico_div a hb a = 0 :=
-begin
-  refine (eq_to_Ico_div_of_sub_zsmul_mem_Ico hb _).symm,
-  simp [hb]
-end
+@[simp] lemma to_Ico_div_apply_left (a : α) : to_Ico_div hp a a = 0 :=
+to_Ico_div_eq_of_sub_zsmul_mem_Ico hp $ by simp [hp]
 
-@[simp] lemma to_Ioc_div_apply_left (a : α) {b : α} (hb : 0 < b) : to_Ioc_div a hb a = -1 :=
-begin
-  refine (eq_to_Ioc_div_of_sub_zsmul_mem_Ioc hb _).symm,
-  simp [hb],
-end
+@[simp] lemma to_Ioc_div_apply_left (a : α) : to_Ioc_div hp a a = -1 :=
+to_Ioc_div_eq_of_sub_zsmul_mem_Ioc hp $ by simp [hp]
 
-@[simp] lemma to_Ico_mod_apply_left (a : α) {b : α} (hb : 0 < b) : to_Ico_mod a hb a = a :=
-begin
-  rw [to_Ico_mod_eq_iff hb, set.left_mem_Ico],
-  refine ⟨lt_add_of_pos_right _ hb, 0, _⟩,
-  simp
-end
+@[simp] lemma to_Ico_mod_apply_left (a : α) : to_Ico_mod hp a a = a :=
+by { rw [to_Ico_mod_eq_iff hp, set.left_mem_Ico], exact ⟨lt_add_of_pos_right _ hp, 0, by simp⟩ }
 
-@[simp] lemma to_Ioc_mod_apply_left (a : α) {b : α} (hb : 0 < b) : to_Ioc_mod a hb a = a + b :=
-begin
-  rw [to_Ioc_mod_eq_iff hb, set.right_mem_Ioc],
-  refine ⟨lt_add_of_pos_right _ hb, -1, _⟩,
-  simp
-end
+@[simp] lemma to_Ioc_mod_apply_left (a : α) : to_Ioc_mod hp a a = a + p :=
+by { rw [to_Ioc_mod_eq_iff hp, set.right_mem_Ioc], exact ⟨lt_add_of_pos_right _ hp, -1, by simp⟩ }
 
-lemma to_Ico_div_apply_right (a : α) {b : α} (hb : 0 < b) :
-  to_Ico_div a hb (a + b) = 1 :=
-begin
-  refine (eq_to_Ico_div_of_sub_zsmul_mem_Ico hb _).symm,
-  simp [hb]
-end
+lemma to_Ico_div_apply_right (a : α) : to_Ico_div hp a (a + p) = 1 :=
+to_Ico_div_eq_of_sub_zsmul_mem_Ico hp $ by simp [hp]
 
-lemma to_Ioc_div_apply_right (a : α) {b : α} (hb : 0 < b) :
-  to_Ioc_div a hb (a + b) = 0 :=
-begin
-  refine (eq_to_Ioc_div_of_sub_zsmul_mem_Ioc hb _).symm,
-  simp [hb]
-end
+lemma to_Ioc_div_apply_right (a : α) : to_Ioc_div hp a (a + p) = 0 :=
+to_Ioc_div_eq_of_sub_zsmul_mem_Ioc hp $ by simp [hp]
 
-lemma to_Ico_mod_apply_right (a : α) {b : α} (hb : 0 < b) : to_Ico_mod a hb (a + b) = a :=
-begin
-  rw [to_Ico_mod_eq_iff hb, set.left_mem_Ico],
-  refine ⟨lt_add_of_pos_right _ hb, 1, _⟩,
-  simp
-end
+lemma to_Ico_mod_apply_right (a : α) : to_Ico_mod hp a (a + p) = a :=
+by { rw [to_Ico_mod_eq_iff hp, set.left_mem_Ico], exact ⟨lt_add_of_pos_right _ hp, 1, by simp⟩ }
 
-lemma to_Ioc_mod_apply_right (a : α) {b : α} (hb : 0 < b) :
-  to_Ioc_mod a hb (a + b) = a + b :=
-begin
-  rw [to_Ioc_mod_eq_iff hb, set.right_mem_Ioc],
-  refine ⟨lt_add_of_pos_right _ hb, 0, _⟩,
-  simp
-end
+lemma to_Ioc_mod_apply_right (a : α) : to_Ioc_mod hp a (a + p) = a + p :=
+by { rw [to_Ioc_mod_eq_iff hp, set.right_mem_Ioc], exact ⟨lt_add_of_pos_right _ hp, 0, by simp⟩ }
 
-@[simp] lemma to_Ico_div_add_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ico_div a hb (x + m • b) = to_Ico_div a hb x + m :=
-begin
-  refine (eq_to_Ico_div_of_sub_zsmul_mem_Ico hb _).symm,
-  convert sub_to_Ico_div_zsmul_mem_Ico a hb x using 1,
-  simp [add_smul],
-end
+@[simp] lemma to_Ico_div_add_zsmul (a b : α) (m : ℤ) :
+  to_Ico_div hp a (b + m • p) = to_Ico_div hp a b + m :=
+to_Ico_div_eq_of_sub_zsmul_mem_Ico hp $
+  by simpa only [add_smul, add_sub_add_right_eq_sub] using sub_to_Ico_div_zsmul_mem_Ico hp a b
 
-@[simp] lemma to_Ioc_div_add_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ioc_div a hb (x + m • b) = to_Ioc_div a hb x + m :=
-begin
-  refine (eq_to_Ioc_div_of_sub_zsmul_mem_Ioc hb _).symm,
-  convert sub_to_Ioc_div_zsmul_mem_Ioc a hb x using 1,
-  simp [add_smul]
-end
+@[simp] lemma to_Ioc_div_add_zsmul (a b : α) (m : ℤ) :
+  to_Ioc_div hp a (b + m • p) = to_Ioc_div hp a b + m :=
+to_Ioc_div_eq_of_sub_zsmul_mem_Ioc hp $
+  by simpa only [add_smul, add_sub_add_right_eq_sub] using sub_to_Ioc_div_zsmul_mem_Ioc hp a b
 
-@[simp] lemma to_Ico_div_zsmul_add (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ico_div a hb (m • b + x) = m + to_Ico_div a hb x :=
+@[simp] lemma to_Ico_div_zsmul_add (a b : α) (m : ℤ) :
+  to_Ico_div hp a (m • p + b) = m + to_Ico_div hp a b :=
 by rw [add_comm, to_Ico_div_add_zsmul, add_comm]
 
-@[simp] lemma to_Ioc_div_zsmul_add (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ioc_div a hb (m • b + x) = to_Ioc_div a hb x + m :=
+@[simp] lemma to_Ioc_div_zsmul_add (a b : α) (m : ℤ) :
+  to_Ioc_div hp a (m • p + b) = to_Ioc_div hp a b + m :=
 by rw [add_comm, to_Ioc_div_add_zsmul, add_comm]
 
-@[simp] lemma to_Ico_div_sub_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ico_div a hb (x - m • b) = to_Ico_div a hb x - m :=
+@[simp] lemma to_Ico_div_sub_zsmul (a b : α) (m : ℤ) :
+  to_Ico_div hp a (b - m • p) = to_Ico_div hp a b - m :=
 by rw [sub_eq_add_neg, ←neg_smul, to_Ico_div_add_zsmul, sub_eq_add_neg]
 
-@[simp] lemma to_Ioc_div_sub_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ioc_div a hb (x - m • b) = to_Ioc_div a hb x - m :=
+@[simp] lemma to_Ioc_div_sub_zsmul (a b : α) (m : ℤ) :
+  to_Ioc_div hp a (b - m • p) = to_Ioc_div hp a b - m :=
 by rw [sub_eq_add_neg, ←neg_smul, to_Ioc_div_add_zsmul, sub_eq_add_neg]
 
-@[simp] lemma to_Ico_div_add_right (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_div a hb (x + b) = to_Ico_div a hb x + 1 :=
-begin
-  convert to_Ico_div_add_zsmul a hb x 1,
-  exact (one_zsmul _).symm
-end
+@[simp] lemma to_Ico_div_add_right (a b : α) : to_Ico_div hp a (b + p) = to_Ico_div hp a b + 1 :=
+by simpa only [one_zsmul] using to_Ico_div_add_zsmul hp a b 1
 
-@[simp] lemma to_Ioc_div_add_right (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_div a hb (x + b) = to_Ioc_div a hb x + 1 :=
-begin
-  convert to_Ioc_div_add_zsmul a hb x 1,
-  exact (one_zsmul _).symm
-end
+@[simp] lemma to_Ioc_div_add_right (a b : α) : to_Ioc_div hp a (b + p) = to_Ioc_div hp a b + 1 :=
+by simpa only [one_zsmul] using to_Ioc_div_add_zsmul hp a b 1
 
-@[simp] lemma to_Ico_div_add_left (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_div a hb (b + x) = to_Ico_div a hb x + 1 :=
+@[simp] lemma to_Ico_div_add_left (a b : α) : to_Ico_div hp a (p + b) = to_Ico_div hp a b + 1 :=
 by rw [add_comm, to_Ico_div_add_right]
 
-@[simp] lemma to_Ioc_div_add_left (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_div a hb (b + x) = to_Ioc_div a hb x + 1 :=
+@[simp] lemma to_Ioc_div_add_left (a b : α) : to_Ioc_div hp a (p + b) = to_Ioc_div hp a b + 1 :=
 by rw [add_comm, to_Ioc_div_add_right]
 
-@[simp] lemma to_Ico_div_sub (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_div a hb (x - b) = to_Ico_div a hb x - 1 :=
-begin
-  convert to_Ico_div_sub_zsmul a hb x 1,
-  exact (one_zsmul _).symm
-end
+@[simp] lemma to_Ico_div_sub (a b : α) : to_Ico_div hp a (b - p) = to_Ico_div hp a b - 1 :=
+by simpa only [one_zsmul] using to_Ico_div_sub_zsmul hp a b 1
 
-@[simp] lemma to_Ioc_div_sub (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_div a hb (x - b) = to_Ioc_div a hb x - 1 :=
-begin
-  convert to_Ioc_div_sub_zsmul a hb x 1,
-  exact (one_zsmul _).symm
-end
+@[simp] lemma to_Ioc_div_sub (a b : α) : to_Ioc_div hp a (b - p) = to_Ioc_div hp a b - 1 :=
+by simpa only [one_zsmul] using to_Ioc_div_sub_zsmul hp a b 1
 
-lemma to_Ico_div_sub' (a : α) {b : α} (hb : 0 < b) (x y : α) :
-  to_Ico_div a hb (x - y) = to_Ico_div (a + y) hb x :=
+lemma to_Ico_div_sub' (a b c : α) : to_Ico_div hp a (b - c) = to_Ico_div hp (a + c) b :=
 begin
-  rw eq_comm,
-  apply eq_to_Ico_div_of_sub_zsmul_mem_Ico,
+  apply to_Ico_div_eq_of_sub_zsmul_mem_Ico,
   rw [←sub_right_comm, set.sub_mem_Ico_iff_left, add_right_comm],
-  exact sub_to_Ico_div_zsmul_mem_Ico (a + y) hb x,
+  exact sub_to_Ico_div_zsmul_mem_Ico hp (a + c) b,
 end
 
-lemma to_Ioc_div_sub' (a : α) {b : α} (hb : 0 < b) (x y : α) :
-  to_Ioc_div a hb (x - y) = to_Ioc_div (a + y) hb x :=
+lemma to_Ioc_div_sub' (a b c : α) : to_Ioc_div hp a (b - c) = to_Ioc_div hp (a + c) b :=
 begin
-  rw eq_comm,
-  apply eq_to_Ioc_div_of_sub_zsmul_mem_Ioc,
+  apply to_Ioc_div_eq_of_sub_zsmul_mem_Ioc,
   rw [←sub_right_comm, set.sub_mem_Ioc_iff_left, add_right_comm],
-  exact sub_to_Ioc_div_zsmul_mem_Ioc (a + y) hb x,
+  exact sub_to_Ioc_div_zsmul_mem_Ioc hp (a + c) b,
 end
 
-lemma to_Ico_div_add_right' (a : α) {b : α} (hb : 0 < b) (x y : α) :
-  to_Ico_div a hb (x + y) = to_Ico_div (a - y) hb x :=
+lemma to_Ico_div_add_right' (a b c : α) : to_Ico_div hp a (b + c) = to_Ico_div hp (a - c) b :=
 by rw [←sub_neg_eq_add, to_Ico_div_sub', sub_eq_add_neg]
 
-lemma to_Ioc_div_add_right' (a : α) {b : α} (hb : 0 < b) (x y : α) :
-  to_Ioc_div a hb (x + y) = to_Ioc_div (a - y) hb x :=
+lemma to_Ioc_div_add_right' (a b c : α) : to_Ioc_div hp a (b + c) = to_Ioc_div hp (a - c) b :=
 by rw [←sub_neg_eq_add, to_Ioc_div_sub', sub_eq_add_neg]
 
-lemma to_Ico_div_neg (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_div a hb (-x) = -(to_Ioc_div (-a) hb x + 1) :=
+lemma to_Ico_div_neg (a b : α) : to_Ico_div hp a (-b) = -(to_Ioc_div hp (-a) b + 1) :=
 begin
-  suffices : to_Ico_div a hb (-x) = -(to_Ioc_div (-(a + b)) hb x),
+  suffices : to_Ico_div hp a (-b) = -(to_Ioc_div hp (-(a + p)) b),
   { rwa [neg_add, ←sub_eq_add_neg, ←to_Ioc_div_add_right', to_Ioc_div_add_right] at this },
-  rw [← neg_eq_iff_eq_neg],
-  apply eq_to_Ioc_div_of_sub_zsmul_mem_Ioc,
-  obtain ⟨hc, ho⟩ := sub_to_Ico_div_zsmul_mem_Ico a hb (-x),
-  rw [←neg_lt_neg_iff, neg_sub' (-x), neg_neg, ←neg_smul] at ho,
-  rw [←neg_le_neg_iff, neg_sub' (-x), neg_neg, ←neg_smul] at hc,
+  rw [← neg_eq_iff_eq_neg, eq_comm],
+  apply to_Ioc_div_eq_of_sub_zsmul_mem_Ioc,
+  obtain ⟨hc, ho⟩ := sub_to_Ico_div_zsmul_mem_Ico hp a (-b),
+  rw [←neg_lt_neg_iff, neg_sub' (-b), neg_neg, ←neg_smul] at ho,
+  rw [←neg_le_neg_iff, neg_sub' (-b), neg_neg, ←neg_smul] at hc,
   refine ⟨ho, hc.trans_eq _⟩,
   rw [neg_add, neg_add_cancel_right],
 end
 
-lemma to_Ioc_div_neg (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_div a hb (-x) = -(to_Ico_div (-a) hb x + 1) :=
-by rw [←neg_neg x, to_Ico_div_neg, neg_neg, neg_neg, neg_add', neg_neg, add_sub_cancel]
+lemma to_Ioc_div_neg (a b : α) : to_Ioc_div hp a (-b) = -(to_Ico_div hp (-a) b + 1) :=
+by rw [←neg_neg b, to_Ico_div_neg, neg_neg, neg_neg, neg_add', neg_neg, add_sub_cancel]
 
-@[simp] lemma to_Ico_mod_add_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ico_mod a hb (x + m • b) = to_Ico_mod a hb x :=
-begin
-  rw [to_Ico_mod, to_Ico_div_add_zsmul, to_Ico_mod, add_smul],
-  abel
-end
+@[simp] lemma to_Ico_mod_add_zsmul (a b : α) (m : ℤ) :
+  to_Ico_mod hp a (b + m • p) = to_Ico_mod hp a b :=
+by { rw [to_Ico_mod, to_Ico_div_add_zsmul, to_Ico_mod, add_smul], abel }
 
-@[simp] lemma to_Ioc_mod_add_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ioc_mod a hb (x + m • b) = to_Ioc_mod a hb x :=
-begin
-  rw [to_Ioc_mod, to_Ioc_div_add_zsmul, to_Ioc_mod, add_smul],
-  abel
-end
+@[simp] lemma to_Ioc_mod_add_zsmul (a b : α) (m : ℤ) :
+  to_Ioc_mod hp a (b + m • p) = to_Ioc_mod hp a b :=
+by { rw [to_Ioc_mod, to_Ioc_div_add_zsmul, to_Ioc_mod, add_smul], abel }
 
-@[simp] lemma to_Ico_mod_zsmul_add (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ico_mod a hb (m • b + x) = to_Ico_mod a hb x :=
+@[simp] lemma to_Ico_mod_zsmul_add (a b : α) (m : ℤ) :
+  to_Ico_mod hp a (m • p + b) = to_Ico_mod hp a b :=
 by rw [add_comm, to_Ico_mod_add_zsmul]
 
-@[simp] lemma to_Ioc_mod_zsmul_add (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ioc_mod a hb (m • b + x) = to_Ioc_mod a hb x :=
+@[simp] lemma to_Ioc_mod_zsmul_add (a b : α) (m : ℤ) :
+  to_Ioc_mod hp a (m • p + b) = to_Ioc_mod hp a b :=
 by rw [add_comm, to_Ioc_mod_add_zsmul]
 
-@[simp] lemma to_Ico_mod_sub_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ico_mod a hb (x - m • b) = to_Ico_mod a hb x :=
+@[simp] lemma to_Ico_mod_sub_zsmul (a b : α) (m : ℤ) :
+  to_Ico_mod hp a (b - m • p) = to_Ico_mod hp a b :=
 by rw [sub_eq_add_neg, ←neg_smul, to_Ico_mod_add_zsmul]
 
-@[simp] lemma to_Ioc_mod_sub_zsmul (a : α) {b : α} (hb : 0 < b) (x : α) (m : ℤ) :
-  to_Ioc_mod a hb (x - m • b) = to_Ioc_mod a hb x :=
+@[simp] lemma to_Ioc_mod_sub_zsmul (a b : α) (m : ℤ) :
+  to_Ioc_mod hp a (b - m • p) = to_Ioc_mod hp a b :=
 by rw [sub_eq_add_neg, ←neg_smul, to_Ioc_mod_add_zsmul]
 
-@[simp] lemma to_Ico_mod_add_right (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a hb (x + b) = to_Ico_mod a hb x :=
-begin
-  convert to_Ico_mod_add_zsmul a hb x 1,
-  exact (one_zsmul _).symm
-end
+@[simp] lemma to_Ico_mod_add_right (a b : α) : to_Ico_mod hp a (b + p) = to_Ico_mod hp a b :=
+by simpa only [one_zsmul] using to_Ico_mod_add_zsmul hp a b 1
 
-@[simp] lemma to_Ioc_mod_add_right (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a hb (x + b) = to_Ioc_mod a hb x :=
-begin
-  convert to_Ioc_mod_add_zsmul a hb x 1,
-  exact (one_zsmul _).symm
-end
+@[simp] lemma to_Ioc_mod_add_right (a b : α) : to_Ioc_mod hp a (b + p) = to_Ioc_mod hp a b :=
+by simpa only [one_zsmul] using to_Ioc_mod_add_zsmul hp a b 1
 
-@[simp] lemma to_Ico_mod_add_left (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a hb (b + x) = to_Ico_mod a hb x :=
+@[simp] lemma to_Ico_mod_add_left (a b : α) : to_Ico_mod hp a (p + b) = to_Ico_mod hp a b :=
 by rw [add_comm, to_Ico_mod_add_right]
 
-@[simp] lemma to_Ioc_mod_add_left (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a hb (b + x) = to_Ioc_mod a hb x :=
+@[simp] lemma to_Ioc_mod_add_left (a b : α) : to_Ioc_mod hp a (p + b) = to_Ioc_mod hp a b :=
 by rw [add_comm, to_Ioc_mod_add_right]
 
-@[simp] lemma to_Ico_mod_sub (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a hb (x - b) = to_Ico_mod a hb x :=
-begin
-  convert to_Ico_mod_sub_zsmul a hb x 1,
-  exact (one_zsmul _).symm
-end
+@[simp] lemma to_Ico_mod_sub (a b : α) : to_Ico_mod hp a (b - p) = to_Ico_mod hp a b :=
+by simpa only [one_zsmul] using to_Ico_mod_sub_zsmul hp a b 1
 
-@[simp] lemma to_Ioc_mod_sub (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a hb (x - b) = to_Ioc_mod a hb x :=
-begin
-  convert to_Ioc_mod_sub_zsmul a hb x 1,
-  exact (one_zsmul _).symm
-end
+@[simp] lemma to_Ioc_mod_sub (a b : α) : to_Ioc_mod hp a (b - p) = to_Ioc_mod hp a b :=
+by simpa only [one_zsmul] using to_Ioc_mod_sub_zsmul hp a b 1
 
-lemma to_Ico_mod_sub' (a : α) {b : α} (hb : 0 < b) (x y : α) :
-  to_Ico_mod a hb (x - y) = to_Ico_mod (a + y) hb x - y :=
+lemma to_Ico_mod_sub' (a b c : α) : to_Ico_mod hp a (b - c) = to_Ico_mod hp (a + c) b - c :=
 by simp_rw [to_Ico_mod, to_Ico_div_sub', sub_right_comm]
 
-lemma to_Ioc_mod_sub' (a : α) {b : α} (hb : 0 < b) (x y : α) :
-  to_Ioc_mod a hb (x - y) = to_Ioc_mod (a + y) hb x - y :=
+lemma to_Ioc_mod_sub' (a b c : α) : to_Ioc_mod hp a (b - c) = to_Ioc_mod hp (a + c) b - c :=
 by simp_rw [to_Ioc_mod, to_Ioc_div_sub', sub_right_comm]
 
-lemma to_Ico_mod_add_right' (a : α) {b : α} (hb : 0 < b) (x y : α) :
-  to_Ico_mod a hb (x + y) = to_Ico_mod (a - y) hb x + y :=
+lemma to_Ico_mod_add_right' (a b c : α) : to_Ico_mod hp a (b + c) = to_Ico_mod hp (a - c) b + c :=
 by simp_rw [to_Ico_mod, to_Ico_div_add_right', sub_add_eq_add_sub]
 
-lemma to_Ioc_mod_add_right' (a : α) {b : α} (hb : 0 < b) (x y : α) :
-  to_Ioc_mod a hb (x + y) = to_Ioc_mod (a - y) hb x + y :=
+lemma to_Ioc_mod_add_right' (a b c : α) : to_Ioc_mod hp a (b + c) = to_Ioc_mod hp (a - c) b + c :=
 by simp_rw [to_Ioc_mod, to_Ioc_div_add_right', sub_add_eq_add_sub]
 
-lemma to_Ico_mod_neg (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a hb (-x) = b - to_Ioc_mod (-a) hb x :=
-begin
-  simp_rw [to_Ico_mod, to_Ioc_mod, to_Ico_div_neg, neg_smul, add_smul],
-  abel,
-end
+lemma to_Ico_mod_neg (a b : α) : to_Ico_mod hp a (-b) = p - to_Ioc_mod hp (-a) b :=
+by { simp_rw [to_Ico_mod, to_Ioc_mod, to_Ico_div_neg, neg_smul, add_smul], abel }
 
-lemma to_Ioc_mod_neg (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a hb (-x) = b - to_Ico_mod (-a) hb x :=
-begin
-  simp_rw [to_Ioc_mod, to_Ico_mod, to_Ioc_div_neg, neg_smul, add_smul],
-  abel,
-end
+lemma to_Ioc_mod_neg (a b : α) : to_Ioc_mod hp a (-b) = p - to_Ico_mod hp (-a) b :=
+by { simp_rw [to_Ioc_mod, to_Ico_mod, to_Ioc_div_neg, neg_smul, add_smul], abel }
 
-lemma to_Ico_mod_eq_to_Ico_mod (a : α) {b x y : α} (hb : 0 < b) :
-  to_Ico_mod a hb x = to_Ico_mod a hb y ↔ ∃ z : ℤ, y - x = z • b :=
+lemma to_Ico_mod_eq_to_Ico_mod : to_Ico_mod hp a b = to_Ico_mod hp a c ↔ ∃ n : ℤ, c - b = n • p :=
 begin
-  refine ⟨λ h, ⟨to_Ico_div a hb y - to_Ico_div a hb x, _⟩, λ h, _⟩,
-  { conv_lhs { rw [←to_Ico_mod_add_to_Ico_div_zsmul a hb x,
-                   ←to_Ico_mod_add_to_Ico_div_zsmul a hb y] },
+  refine ⟨λ h, ⟨to_Ico_div hp a c - to_Ico_div hp a b, _⟩, λ h, _⟩,
+  { conv_lhs { rw [←to_Ico_mod_add_to_Ico_div_zsmul hp a b,
+                   ←to_Ico_mod_add_to_Ico_div_zsmul hp a c] },
     rw [h, sub_smul],
     abel },
   { rcases h with ⟨z, hz⟩,
@@ -445,12 +323,11 @@ begin
     rw [hz, to_Ico_mod_zsmul_add] }
 end
 
-lemma to_Ioc_mod_eq_to_Ioc_mod (a : α) {b x y : α} (hb : 0 < b) :
-  to_Ioc_mod a hb x = to_Ioc_mod a hb y ↔ ∃ z : ℤ, y - x = z • b :=
+lemma to_Ioc_mod_eq_to_Ioc_mod : to_Ioc_mod hp a b = to_Ioc_mod hp a c ↔ ∃ n : ℤ, c - b = n • p :=
 begin
-  refine ⟨λ h, ⟨to_Ioc_div a hb y - to_Ioc_div a hb x, _⟩, λ h, _⟩,
-  { conv_lhs { rw [←to_Ioc_mod_add_to_Ioc_div_zsmul a hb x,
-                   ←to_Ioc_mod_add_to_Ioc_div_zsmul a hb y] },
+  refine ⟨λ h, ⟨to_Ioc_div hp a c - to_Ioc_div hp a b, _⟩, λ h, _⟩,
+  { conv_lhs { rw [←to_Ioc_mod_add_to_Ioc_div_zsmul hp a b,
+                   ←to_Ioc_mod_add_to_Ioc_div_zsmul hp a c] },
     rw [h, sub_smul],
     abel },
   { rcases h with ⟨z, hz⟩,
@@ -461,278 +338,250 @@ end
 /-! ### Links between the `Ico` and `Ioc` variants applied to the same element -/
 
 section Ico_Ioc
-
-variables (a : α) {b : α} (hb : 0 < b) (x : α)
+variables (a b)
 
 omit hα
-/-- `mem_Ioo_mod a b x` means that `x` lies in the open interval `(a, a + b)` modulo `b`.
-Equivalently (as shown below), `x` is not congruent to `a` modulo `b`, or `to_Ico_mod a hb` agrees
-with `to_Ioc_mod a hb` at `x`, or `to_Ico_div a hb` agrees with `to_Ioc_div a hb` at `x`. -/
-def mem_Ioo_mod (b x : α) : Prop := ∃ z : ℤ, x - z • b ∈ set.Ioo a (a + b)
+/-- `mem_Ioo_mod a p b` means that `b` lies in the open interval `(a, a + p)` modulo `p`.
+Equivalently (as shown below), `b` is not congruent to `a` modulo `p`, or `to_Ico_mod hp a` agrees
+with `to_Ioc_mod hp a` at `b`, or `to_Ico_div hp a` agrees with `to_Ioc_div hp a` at `b`. -/
+def mem_Ioo_mod (p b : α) : Prop := ∃ z : ℤ, b - z • p ∈ set.Ioo a (a + p)
 include hα
 
 lemma tfae_mem_Ioo_mod :
-  tfae [mem_Ioo_mod a b x,
-    to_Ico_mod a hb x = to_Ioc_mod a hb x,
-    to_Ico_mod a hb x + b ≠ to_Ioc_mod a hb x,
-    to_Ico_mod a hb x ≠ a] :=
+  tfae [mem_Ioo_mod a p b,
+    to_Ico_mod hp a b = to_Ioc_mod hp a b,
+    to_Ico_mod hp a b + p ≠ to_Ioc_mod hp a b,
+    to_Ico_mod hp a b ≠ a] :=
 begin
   tfae_have : 1 → 2,
   { exact λ ⟨i, hi⟩,
-      ((to_Ico_mod_eq_iff hb).2 ⟨set.Ioo_subset_Ico_self hi, i, (sub_add_cancel x _).symm⟩).trans
-      ((to_Ioc_mod_eq_iff hb).2 ⟨set.Ioo_subset_Ioc_self hi, i, (sub_add_cancel x _).symm⟩).symm },
+      ((to_Ico_mod_eq_iff hp).2 ⟨set.Ioo_subset_Ico_self hi, i, (sub_add_cancel b _).symm⟩).trans
+      ((to_Ioc_mod_eq_iff hp).2 ⟨set.Ioo_subset_Ioc_self hi, i, (sub_add_cancel b _).symm⟩).symm },
   tfae_have : 2 → 3,
-  { intro h, rw [h, ne, add_right_eq_self], exact hb.ne' },
+  { intro h, rw [h, ne, add_right_eq_self], exact hp.ne' },
   tfae_have : 3 → 4,
   { refine mt (λ h, _),
     rw [h, eq_comm, to_Ioc_mod_eq_iff, set.right_mem_Ioc],
-    refine ⟨lt_add_of_pos_right a hb, to_Ico_div a hb x - 1, _⟩,
+    refine ⟨lt_add_of_pos_right a hp, to_Ico_div hp a b - 1, _⟩,
     rw [sub_one_zsmul, add_add_add_comm, add_right_neg, add_zero],
-    conv_lhs { rw [← to_Ico_mod_add_to_Ico_div_zsmul a hb x, h] } },
+    conv_lhs { rw [← to_Ico_mod_add_to_Ico_div_zsmul hp a b, h] } },
   tfae_have : 4 → 1,
-  { have h' := to_Ico_mod_mem_Ico a hb x, exact λ h, ⟨_, h'.1.lt_of_ne' h, h'.2⟩ },
+  { have h' := to_Ico_mod_mem_Ico hp a b, exact λ h, ⟨_, h'.1.lt_of_ne' h, h'.2⟩ },
   tfae_finish,
 end
 
-variables {a x}
+variables {a b}
 
 lemma mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod :
-  mem_Ioo_mod a b x ↔ to_Ico_mod a hb x = to_Ioc_mod a hb x := (tfae_mem_Ioo_mod a hb x).out 0 1
+  mem_Ioo_mod a p b ↔ to_Ico_mod hp a b = to_Ioc_mod hp a b := (tfae_mem_Ioo_mod hp a b).out 0 1
 lemma mem_Ioo_mod_iff_to_Ico_mod_add_period_ne_to_Ioc_mod :
-  mem_Ioo_mod a b x ↔ to_Ico_mod a hb x + b ≠ to_Ioc_mod a hb x := (tfae_mem_Ioo_mod a hb x).out 0 2
+  mem_Ioo_mod a p b ↔ to_Ico_mod hp a b + p ≠ to_Ioc_mod hp a b := (tfae_mem_Ioo_mod hp a b).out 0 2
 lemma mem_Ioo_mod_iff_to_Ico_mod_ne_left :
-  mem_Ioo_mod a b x ↔ to_Ico_mod a hb x ≠ a := (tfae_mem_Ioo_mod a hb x).out 0 3
+  mem_Ioo_mod a p b ↔ to_Ico_mod hp a b ≠ a := (tfae_mem_Ioo_mod hp a b).out 0 3
 
 lemma not_mem_Ioo_mod_iff_to_Ico_mod_add_period_eq_to_Ioc_mod :
-  ¬mem_Ioo_mod a b x ↔ to_Ico_mod a hb x + b = to_Ioc_mod a hb x :=
-(mem_Ioo_mod_iff_to_Ico_mod_add_period_ne_to_Ioc_mod hb).not_left
+  ¬mem_Ioo_mod a p b ↔ to_Ico_mod hp a b + p = to_Ioc_mod hp a b :=
+(mem_Ioo_mod_iff_to_Ico_mod_add_period_ne_to_Ioc_mod hp).not_left
 
-lemma not_mem_Ioo_mod_iff_to_Ico_mod_eq_left : ¬mem_Ioo_mod a b x ↔ to_Ico_mod a hb x = a :=
-(mem_Ioo_mod_iff_to_Ico_mod_ne_left hb).not_left
+lemma not_mem_Ioo_mod_iff_to_Ico_mod_eq_left : ¬mem_Ioo_mod a p b ↔ to_Ico_mod hp a b = a :=
+(mem_Ioo_mod_iff_to_Ico_mod_ne_left hp).not_left
 
-lemma mem_Ioo_mod_iff_to_Ioc_mod_ne_right : mem_Ioo_mod a b x ↔ to_Ioc_mod a hb x ≠ a + b :=
+lemma mem_Ioo_mod_iff_to_Ioc_mod_ne_right : mem_Ioo_mod a p b ↔ to_Ioc_mod hp a b ≠ a + p :=
 begin
-  rw [mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod, to_Ico_mod_eq_iff hb],
-  obtain ⟨h₁, h₂⟩ := to_Ioc_mod_mem_Ioc a hb x,
+  rw [mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod, to_Ico_mod_eq_iff hp],
+  obtain ⟨h₁, h₂⟩ := to_Ioc_mod_mem_Ioc hp a b,
   exact ⟨λ h, h.1.2.ne, λ h, ⟨⟨h₁.le, h₂.lt_of_ne h⟩, _,
     (to_Ioc_mod_add_to_Ioc_div_zsmul _ _ _).symm⟩⟩,
 end
 
-lemma not_mem_Ioo_mod_iff_to_Ioc_eq_right : ¬mem_Ioo_mod a b x ↔ to_Ioc_mod a hb x = a + b :=
-(mem_Ioo_mod_iff_to_Ioc_mod_ne_right hb).not_left
+lemma not_mem_Ioo_mod_iff_to_Ioc_eq_right : ¬mem_Ioo_mod a p b ↔ to_Ioc_mod hp a b = a + p :=
+(mem_Ioo_mod_iff_to_Ioc_mod_ne_right hp).not_left
 
 lemma mem_Ioo_mod_iff_to_Ico_div_eq_to_Ioc_div :
-  mem_Ioo_mod a b x ↔ to_Ico_div a hb x = to_Ioc_div a hb x :=
-by rw [mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod hb,
-       to_Ico_mod, to_Ioc_mod, sub_right_inj, (zsmul_strict_mono_left hb).injective.eq_iff]
+  mem_Ioo_mod a p b ↔ to_Ico_div hp a b = to_Ioc_div hp a b :=
+by rw [mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod hp,
+       to_Ico_mod, to_Ioc_mod, sub_right_inj, (zsmul_strict_mono_left hp).injective.eq_iff]
 
 lemma mem_Ioo_mod_iff_to_Ico_div_ne_to_Ioc_div_add_one :
-  mem_Ioo_mod a b x ↔ to_Ico_div a hb x ≠ to_Ioc_div a hb x + 1 :=
-by rw [mem_Ioo_mod_iff_to_Ico_mod_add_period_ne_to_Ioc_mod hb, ne, ne, to_Ico_mod, to_Ioc_mod,
+  mem_Ioo_mod a p b ↔ to_Ico_div hp a b ≠ to_Ioc_div hp a b + 1 :=
+by rw [mem_Ioo_mod_iff_to_Ico_mod_add_period_ne_to_Ioc_mod hp, ne, ne, to_Ico_mod, to_Ioc_mod,
        ← eq_sub_iff_add_eq, sub_sub, sub_right_inj, ← add_one_zsmul,
-       (zsmul_strict_mono_left hb).injective.eq_iff]
+       (zsmul_strict_mono_left hp).injective.eq_iff]
 
 lemma not_mem_Ioo_mod_iff_to_Ico_div_eq_to_Ioc_div_add_one :
-  ¬mem_Ioo_mod a b x ↔ to_Ico_div a hb x = to_Ioc_div a hb x + 1 :=
-(mem_Ioo_mod_iff_to_Ico_div_ne_to_Ioc_div_add_one hb).not_left
+  ¬mem_Ioo_mod a p b ↔ to_Ico_div hp a b = to_Ioc_div hp a b + 1 :=
+(mem_Ioo_mod_iff_to_Ico_div_ne_to_Ioc_div_add_one hp).not_left
 
-include hb
+include hp
 
-lemma mem_Ioo_mod_iff_ne_add_zsmul : mem_Ioo_mod a b x ↔ ∀ z : ℤ, x ≠ a + z • b :=
+lemma mem_Ioo_mod_iff_ne_add_zsmul : mem_Ioo_mod a p b ↔ ∀ z : ℤ, b ≠ a + z • p :=
 begin
-  rw [mem_Ioo_mod_iff_to_Ico_mod_ne_left hb, ← not_iff_not],
+  rw [mem_Ioo_mod_iff_to_Ico_mod_ne_left hp, ← not_iff_not],
   push_neg, split; intro h,
   { rw ← h,
     exact ⟨_, (to_Ico_mod_add_to_Ico_div_zsmul _ _ _).symm⟩ },
   { rw [to_Ico_mod_eq_iff, set.left_mem_Ico],
-    exact ⟨lt_add_of_pos_right a hb, h⟩, },
+    exact ⟨lt_add_of_pos_right a hp, h⟩, },
 end
 
-lemma not_mem_Ioo_mod_iff_eq_add_zsmul : ¬mem_Ioo_mod a b x ↔ ∃ z : ℤ, x = a + z • b :=
-by simpa only [not_forall, not_ne_iff] using (mem_Ioo_mod_iff_ne_add_zsmul hb).not
+lemma not_mem_Ioo_mod_iff_eq_add_zsmul : ¬mem_Ioo_mod a p b ↔ ∃ z : ℤ, b = a + z • p :=
+by simpa only [not_forall, not_ne_iff] using (mem_Ioo_mod_iff_ne_add_zsmul hp).not
 
 lemma not_mem_Ioo_mod_iff_eq_mod_zmultiples :
-  ¬mem_Ioo_mod a b x ↔ (x : α ⧸ add_subgroup.zmultiples b) = a :=
-by simp_rw [not_mem_Ioo_mod_iff_eq_add_zsmul hb, quotient_add_group.eq_iff_sub_mem,
+  ¬mem_Ioo_mod a p b ↔ (b : α ⧸ add_subgroup.zmultiples p) = a :=
+by simp_rw [not_mem_Ioo_mod_iff_eq_add_zsmul hp, quotient_add_group.eq_iff_sub_mem,
     add_subgroup.mem_zmultiples_iff, eq_sub_iff_add_eq', eq_comm]
 
 lemma mem_Ioo_mod_iff_ne_mod_zmultiples :
-  mem_Ioo_mod a b x ↔ (x : α ⧸ add_subgroup.zmultiples b) ≠ a :=
-(not_mem_Ioo_mod_iff_eq_mod_zmultiples hb).not_right
+  mem_Ioo_mod a p b ↔ (b : α ⧸ add_subgroup.zmultiples p) ≠ a :=
+(not_mem_Ioo_mod_iff_eq_mod_zmultiples hp).not_right
 
 lemma Ico_eq_locus_Ioc_eq_Union_Ioo :
-  {x | to_Ico_mod a hb x = to_Ioc_mod a hb x} = ⋃ z : ℤ, set.Ioo (a + z • b) (a + b + z • b) :=
+  {b | to_Ico_mod hp a b = to_Ioc_mod hp a b} = ⋃ z : ℤ, set.Ioo (a + z • p) (a + p + z • p) :=
 begin
   ext1, simp_rw [set.mem_set_of, set.mem_Union, ← set.sub_mem_Ioo_iff_left],
-  exact (mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod hb).symm,
+  exact (mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod hp).symm,
 end
 
-lemma to_Ioc_div_wcovby_to_Ico_div (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_div a hb x ⩿ to_Ico_div a hb x :=
+lemma to_Ioc_div_wcovby_to_Ico_div (a b : α) : to_Ioc_div hp a b ⩿ to_Ico_div hp a b :=
 begin
-  suffices : to_Ioc_div a hb x = to_Ico_div a hb x ∨ to_Ioc_div a hb x + 1 = to_Ico_div a hb x,
+  suffices : to_Ioc_div hp a b = to_Ico_div hp a b ∨ to_Ioc_div hp a b + 1 = to_Ico_div hp a b,
   { rwa [wcovby_iff_eq_or_covby, ←order.succ_eq_iff_covby] },
   rw [eq_comm, ←mem_Ioo_mod_iff_to_Ico_div_eq_to_Ioc_div,
     eq_comm, ←not_mem_Ioo_mod_iff_to_Ico_div_eq_to_Ioc_div_add_one],
   exact em _,
 end
 
-lemma to_Ico_mod_le_to_Ioc_mod (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a hb x ≤ to_Ioc_mod a hb x :=
+lemma to_Ico_mod_le_to_Ioc_mod (a b : α) : to_Ico_mod hp a b ≤ to_Ioc_mod hp a b :=
 begin
   rw [to_Ico_mod, to_Ioc_mod, sub_le_sub_iff_left],
-  exact zsmul_mono_left hb.le (to_Ioc_div_wcovby_to_Ico_div _ _ _).le
+  exact zsmul_mono_left hp.le (to_Ioc_div_wcovby_to_Ico_div _ _ _).le
 end
 
-lemma to_Ioc_mod_le_to_Ico_mod_add (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a hb x ≤ to_Ico_mod a hb x + b :=
+lemma to_Ioc_mod_le_to_Ico_mod_add (a b : α) : to_Ioc_mod hp a b ≤ to_Ico_mod hp a b + p :=
 begin
   rw [to_Ico_mod, to_Ioc_mod, sub_add, sub_le_sub_iff_left, sub_le_iff_le_add, ←add_one_zsmul,
-    (zsmul_strict_mono_left hb).le_iff_le],
+    (zsmul_strict_mono_left hp).le_iff_le],
   apply (to_Ioc_div_wcovby_to_Ico_div _ _ _).le_succ,
 end
 
 end Ico_Ioc
 
-lemma to_Ico_mod_eq_self {a b x : α} (hb : 0 < b) : to_Ico_mod a hb x = x ↔ x ∈ set.Ico a (a + b) :=
-begin
-  rw [to_Ico_mod_eq_iff, and_iff_left],
-  refine ⟨0, _⟩,
-  simp
-end
+lemma to_Ico_mod_eq_self : to_Ico_mod hp a b = b ↔ b ∈ set.Ico a (a + p) :=
+by { rw [to_Ico_mod_eq_iff, and_iff_left], exact ⟨0, by simp⟩ }
 
-lemma to_Ioc_mod_eq_self {a b x : α} (hb : 0 < b) : to_Ioc_mod a hb x = x ↔ x ∈ set.Ioc a (a + b) :=
-begin
-  rw [to_Ioc_mod_eq_iff, and_iff_left],
-  refine ⟨0, _⟩,
-  simp
-end
+lemma to_Ioc_mod_eq_self : to_Ioc_mod hp a b = b ↔ b ∈ set.Ioc a (a + p) :=
+by { rw [to_Ioc_mod_eq_iff, and_iff_left], exact ⟨0, by simp⟩ }
 
-@[simp] lemma to_Ico_mod_to_Ico_mod (a₁ a₂ : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a₁ hb (to_Ico_mod a₂ hb x) = to_Ico_mod a₁ hb x :=
-begin
-  rw to_Ico_mod_eq_to_Ico_mod,
-  exact ⟨to_Ico_div a₂ hb x, self_sub_to_Ico_mod a₂ hb x⟩
-end
+@[simp] lemma to_Ico_mod_to_Ico_mod (a₁ a₂ b : α) :
+  to_Ico_mod hp a₁ (to_Ico_mod hp a₂ b) = to_Ico_mod hp a₁ b :=
+(to_Ico_mod_eq_to_Ico_mod _).2 ⟨to_Ico_div hp a₂ b, self_sub_to_Ico_mod hp a₂ b⟩
 
-@[simp] lemma to_Ico_mod_to_Ioc_mod (a₁ a₂ : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a₁ hb (to_Ioc_mod a₂ hb x) = to_Ico_mod a₁ hb x :=
-begin
-  rw to_Ico_mod_eq_to_Ico_mod,
-  exact ⟨to_Ioc_div a₂ hb x, self_sub_to_Ioc_mod a₂ hb x⟩
-end
+@[simp] lemma to_Ico_mod_to_Ioc_mod (a₁ a₂ b : α) :
+  to_Ico_mod hp a₁ (to_Ioc_mod hp a₂ b) = to_Ico_mod hp a₁ b :=
+(to_Ico_mod_eq_to_Ico_mod _).2 ⟨to_Ioc_div hp a₂ b, self_sub_to_Ioc_mod hp a₂ b⟩
 
-@[simp] lemma to_Ioc_mod_to_Ioc_mod (a₁ a₂ : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a₁ hb (to_Ioc_mod a₂ hb x) = to_Ioc_mod a₁ hb x :=
-begin
-  rw to_Ioc_mod_eq_to_Ioc_mod,
-  exact ⟨to_Ioc_div a₂ hb x, self_sub_to_Ioc_mod a₂ hb x⟩
-end
+@[simp] lemma to_Ioc_mod_to_Ioc_mod (a₁ a₂ b : α) :
+  to_Ioc_mod hp a₁ (to_Ioc_mod hp a₂ b) = to_Ioc_mod hp a₁ b :=
+(to_Ioc_mod_eq_to_Ioc_mod _).2 ⟨to_Ioc_div hp a₂ b, self_sub_to_Ioc_mod hp a₂ b⟩
 
-@[simp] lemma to_Ioc_mod_to_Ico_mod (a₁ a₂ : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a₁ hb (to_Ico_mod a₂ hb x) = to_Ioc_mod a₁ hb x :=
-begin
-  rw to_Ioc_mod_eq_to_Ioc_mod,
-  exact ⟨to_Ico_div a₂ hb x, self_sub_to_Ico_mod a₂ hb x⟩
-end
+@[simp] lemma to_Ioc_mod_to_Ico_mod (a₁ a₂ b : α) :
+  to_Ioc_mod hp a₁ (to_Ico_mod hp a₂ b) = to_Ioc_mod hp a₁ b :=
+(to_Ioc_mod_eq_to_Ioc_mod _).2 ⟨to_Ico_div hp a₂ b, self_sub_to_Ico_mod hp a₂ b⟩
 
-lemma to_Ico_mod_periodic (a : α) {b : α} (hb : 0 < b) : function.periodic (to_Ico_mod a hb) b :=
-to_Ico_mod_add_right a hb
+lemma to_Ico_mod_periodic (a : α) : function.periodic (to_Ico_mod hp a) p :=
+to_Ico_mod_add_right hp a
 
-lemma to_Ioc_mod_periodic (a : α) {b : α} (hb : 0 < b) : function.periodic (to_Ioc_mod a hb) b :=
-to_Ioc_mod_add_right a hb
+lemma to_Ioc_mod_periodic (a : α) : function.periodic (to_Ioc_mod hp a) p :=
+to_Ioc_mod_add_right hp a
 
 /-- `to_Ico_mod` as an equiv from the quotient. -/
 @[simps symm_apply]
-def quotient_add_group.equiv_Ico_mod (a : α) {b : α} (hb : 0 < b) :
-  (α ⧸ add_subgroup.zmultiples b) ≃ set.Ico a (a + b) :=
-{ to_fun := λ x, ⟨(to_Ico_mod_periodic a hb).lift x,
-    quotient_add_group.induction_on' x $ to_Ico_mod_mem_Ico a hb⟩,
+def quotient_add_group.equiv_Ico_mod (a : α) :
+  (α ⧸ add_subgroup.zmultiples p) ≃ set.Ico a (a + p) :=
+{ to_fun := λ b, ⟨(to_Ico_mod_periodic hp a).lift b,
+    quotient_add_group.induction_on' b $ to_Ico_mod_mem_Ico hp a⟩,
   inv_fun := coe,
-  right_inv := λ x, subtype.ext $ (to_Ico_mod_eq_self hb).mpr x.prop,
-  left_inv := λ x, begin
-    induction x using quotient_add_group.induction_on',
+  right_inv := λ b, subtype.ext $ (to_Ico_mod_eq_self hp).mpr b.prop,
+  left_inv := λ b, begin
+    induction b using quotient_add_group.induction_on',
     dsimp,
     rw [quotient_add_group.eq_iff_sub_mem, to_Ico_mod_sub_self],
     apply add_subgroup.zsmul_mem_zmultiples,
   end }
 
 @[simp]
-lemma quotient_add_group.equiv_Ico_mod_coe (a : α) {b : α} (hb : 0 < b) (x : α) :
-  quotient_add_group.equiv_Ico_mod a hb ↑x = ⟨to_Ico_mod a hb x, to_Ico_mod_mem_Ico a hb _⟩ :=
+lemma quotient_add_group.equiv_Ico_mod_coe (a b : α) :
+  quotient_add_group.equiv_Ico_mod hp a ↑b = ⟨to_Ico_mod hp a b, to_Ico_mod_mem_Ico hp a _⟩ :=
 rfl
 
 /-- `to_Ioc_mod` as an equiv  from the quotient. -/
 @[simps symm_apply]
-def quotient_add_group.equiv_Ioc_mod (a : α) {b : α} (hb : 0 < b) :
-  (α ⧸ add_subgroup.zmultiples b) ≃ set.Ioc a (a + b) :=
-{ to_fun := λ x, ⟨(to_Ioc_mod_periodic a hb).lift x,
-    quotient_add_group.induction_on' x $ to_Ioc_mod_mem_Ioc a hb⟩,
+def quotient_add_group.equiv_Ioc_mod (a : α) :
+  (α ⧸ add_subgroup.zmultiples p) ≃ set.Ioc a (a + p) :=
+{ to_fun := λ b, ⟨(to_Ioc_mod_periodic hp a).lift b,
+    quotient_add_group.induction_on' b $ to_Ioc_mod_mem_Ioc hp a⟩,
   inv_fun := coe,
-  right_inv := λ x, subtype.ext $ (to_Ioc_mod_eq_self hb).mpr x.prop,
-  left_inv := λ x, begin
-    induction x using quotient_add_group.induction_on',
+  right_inv := λ b, subtype.ext $ (to_Ioc_mod_eq_self hp).mpr b.prop,
+  left_inv := λ b, begin
+    induction b using quotient_add_group.induction_on',
     dsimp,
     rw [quotient_add_group.eq_iff_sub_mem, to_Ioc_mod_sub_self],
     apply add_subgroup.zsmul_mem_zmultiples,
   end }
 
 @[simp]
-lemma quotient_add_group.equiv_Ioc_mod_coe (a : α) {b : α} (hb : 0 < b) (x : α) :
-  quotient_add_group.equiv_Ioc_mod a hb ↑x = ⟨to_Ioc_mod a hb x, to_Ioc_mod_mem_Ioc a hb _⟩ :=
+lemma quotient_add_group.equiv_Ioc_mod_coe (a b : α) :
+  quotient_add_group.equiv_Ioc_mod hp a ↑b = ⟨to_Ioc_mod hp a b, to_Ioc_mod_mem_Ioc hp a _⟩ :=
 rfl
 
 end linear_ordered_add_comm_group
 
 section linear_ordered_field
 
-variables {α : Type*} [linear_ordered_field α] [floor_ring α]
+variables {α : Type*} [linear_ordered_field α] [floor_ring α] {p : α} (hp : 0 < p)
 
-lemma to_Ico_div_eq_floor (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_div a hb x = ⌊(x - a) / b⌋ :=
+lemma to_Ico_div_eq_floor (a b : α) : to_Ico_div hp a b = ⌊(b - a) / p⌋ :=
 begin
-  refine (eq_to_Ico_div_of_sub_zsmul_mem_Ico hb _).symm,
+  refine to_Ico_div_eq_of_sub_zsmul_mem_Ico hp _,
   rw [set.mem_Ico, zsmul_eq_mul, ←sub_nonneg, add_comm, sub_right_comm, ←sub_lt_iff_lt_add,
     sub_right_comm _ _ a],
-  exact ⟨int.sub_floor_div_mul_nonneg _ hb, int.sub_floor_div_mul_lt _ hb⟩,
+  exact ⟨int.sub_floor_div_mul_nonneg _ hp, int.sub_floor_div_mul_lt _ hp⟩,
 end
 
-lemma to_Ioc_div_eq_neg_floor (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_div a hb x = -⌊(a + b - x) / b⌋ :=
+lemma to_Ioc_div_eq_neg_floor (a b : α) : to_Ioc_div hp a b = -⌊(a + p - b) / p⌋ :=
 begin
-  refine (eq_to_Ioc_div_of_sub_zsmul_mem_Ioc hb _).symm,
+  refine to_Ioc_div_eq_of_sub_zsmul_mem_Ioc hp _,
   rw [set.mem_Ioc, zsmul_eq_mul, int.cast_neg, neg_mul, sub_neg_eq_add, ←sub_nonneg,
     sub_add_eq_sub_sub],
-  refine ⟨_, int.sub_floor_div_mul_nonneg _ hb⟩,
-  rw [←add_lt_add_iff_right b, add_assoc, add_comm x, ←sub_lt_iff_lt_add, add_comm (_ * _),
+  refine ⟨_, int.sub_floor_div_mul_nonneg _ hp⟩,
+  rw [←add_lt_add_iff_right p, add_assoc, add_comm b, ←sub_lt_iff_lt_add, add_comm (_ * _),
       ←sub_lt_iff_lt_add],
-  exact int.sub_floor_div_mul_lt _ hb
+  exact int.sub_floor_div_mul_lt _ hp
 end
 
-lemma to_Ico_div_zero_one (x : α) : to_Ico_div (0 : α) zero_lt_one x = ⌊x⌋ :=
+lemma to_Ico_div_zero_one (b : α) : to_Ico_div (zero_lt_one' α) 0 b = ⌊b⌋ :=
 by simp [to_Ico_div_eq_floor]
 
-lemma to_Ico_mod_eq_add_fract_mul (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod a hb x = a + int.fract ((x - a) / b) * b :=
+lemma to_Ico_mod_eq_add_fract_mul (a b : α) : to_Ico_mod hp a b = a + int.fract ((b - a) / p) * p :=
 begin
   rw [to_Ico_mod, to_Ico_div_eq_floor, int.fract],
-  field_simp [hb.ne.symm],
+  field_simp [hp.ne.symm],
   ring
 end
 
-lemma to_Ico_mod_eq_fract_mul {b : α} (hb : 0 < b) (x : α) :
-  to_Ico_mod 0 hb x = int.fract (x / b) * b :=
+lemma to_Ico_mod_eq_fract_mul (b : α) : to_Ico_mod hp 0 b = int.fract (b / p) * p :=
 by simp [to_Ico_mod_eq_add_fract_mul]
 
-lemma to_Ioc_mod_eq_sub_fract_mul (a : α) {b : α} (hb : 0 < b) (x : α) :
-  to_Ioc_mod a hb x = a + b - int.fract ((a + b - x) / b) * b :=
+lemma to_Ioc_mod_eq_sub_fract_mul (a b : α) :
+  to_Ioc_mod hp a b = a + p - int.fract ((a + p - b) / p) * p :=
 begin
   rw [to_Ioc_mod, to_Ioc_div_eq_neg_floor, int.fract],
-  field_simp [hb.ne.symm],
+  field_simp [hp.ne.symm],
   ring
 end
 
-lemma to_Ico_mod_zero_one (x : α) : to_Ico_mod (0 : α) zero_lt_one x = int.fract x :=
+lemma to_Ico_mod_zero_one (b : α) : to_Ico_mod (zero_lt_one' α) 0 b = int.fract b :=
 by simp [to_Ico_mod_eq_add_fract_mul]
 
 end linear_ordered_field
@@ -744,39 +593,39 @@ open set int
 
 section linear_ordered_add_comm_group
 
-variables {α : Type*} [linear_ordered_add_comm_group α] [archimedean α] (a : α) {b : α} (hb : 0 < b)
-include hb
+variables {α : Type*} [linear_ordered_add_comm_group α] [archimedean α] {p : α} (hp : 0 < p) (a : α)
+include hp
 
-lemma Union_Ioc_add_zsmul : (⋃ (n : ℤ), Ioc (a + n • b) (a + (n + 1) • b)) = univ :=
+lemma Union_Ioc_add_zsmul : (⋃ (n : ℤ), Ioc (a + n • p) (a + (n + 1) • p)) = univ :=
 begin
-  refine eq_univ_iff_forall.mpr (λ x, mem_Union.mpr _),
-  rcases sub_to_Ioc_div_zsmul_mem_Ioc a hb x with ⟨hl, hr⟩,
-  refine ⟨to_Ioc_div a hb x, ⟨lt_sub_iff_add_lt.mp hl, _⟩⟩,
+  refine eq_univ_iff_forall.mpr (λ b, mem_Union.mpr _),
+  rcases sub_to_Ioc_div_zsmul_mem_Ioc hp a b with ⟨hl, hr⟩,
+  refine ⟨to_Ioc_div hp a b, ⟨lt_sub_iff_add_lt.mp hl, _⟩⟩,
   rw [add_smul, one_smul, ←add_assoc],
   convert sub_le_iff_le_add.mp hr using 1, abel,
 end
 
-lemma Union_Ico_add_zsmul : (⋃ (n : ℤ), Ico (a + n • b) (a + (n + 1) • b)) = univ :=
+lemma Union_Ico_add_zsmul : (⋃ (n : ℤ), Ico (a + n • p) (a + (n + 1) • p)) = univ :=
 begin
-  refine eq_univ_iff_forall.mpr (λ x, mem_Union.mpr _),
-  rcases sub_to_Ico_div_zsmul_mem_Ico a hb x with ⟨hl, hr⟩,
-  refine ⟨to_Ico_div a hb x, ⟨le_sub_iff_add_le.mp hl, _⟩⟩,
+  refine eq_univ_iff_forall.mpr (λ b, mem_Union.mpr _),
+  rcases sub_to_Ico_div_zsmul_mem_Ico hp a b with ⟨hl, hr⟩,
+  refine ⟨to_Ico_div hp a b, ⟨le_sub_iff_add_le.mp hl, _⟩⟩,
   rw [add_smul, one_smul, ←add_assoc],
   convert sub_lt_iff_lt_add.mp hr using 1, abel,
 end
 
-lemma Union_Icc_add_zsmul : (⋃ (n : ℤ), Icc (a + n • b) (a + (n + 1) • b)) = univ :=
-by simpa only [Union_Ioc_add_zsmul a hb, univ_subset_iff] using
-  Union_mono (λ n : ℤ, (Ioc_subset_Icc_self : Ioc (a + n • b) (a + (n + 1) • b) ⊆ Icc _ _))
+lemma Union_Icc_add_zsmul : (⋃ (n : ℤ), Icc (a + n • p) (a + (n + 1) • p)) = univ :=
+by simpa only [Union_Ioc_add_zsmul hp a, univ_subset_iff] using
+  Union_mono (λ n : ℤ, (Ioc_subset_Icc_self : Ioc (a + n • p) (a + (n + 1) • p) ⊆ Icc _ _))
 
-lemma Union_Ioc_zsmul : (⋃ (n : ℤ), Ioc (n • b) ((n + 1) • b)) = univ :=
-by simpa only [zero_add] using Union_Ioc_add_zsmul 0 hb
+lemma Union_Ioc_zsmul : (⋃ (n : ℤ), Ioc (n • p) ((n + 1) • p)) = univ :=
+by simpa only [zero_add] using Union_Ioc_add_zsmul hp 0
 
-lemma Union_Ico_zsmul : (⋃ (n : ℤ), Ico (n • b) ((n + 1) • b)) = univ :=
-by simpa only [zero_add] using Union_Ico_add_zsmul 0 hb
+lemma Union_Ico_zsmul : (⋃ (n : ℤ), Ico (n • p) ((n + 1) • p)) = univ :=
+by simpa only [zero_add] using Union_Ico_add_zsmul hp 0
 
-lemma Union_Icc_zsmul : (⋃ (n : ℤ), Icc (n • b) ((n + 1) • b)) = univ :=
-by simpa only [zero_add] using Union_Icc_add_zsmul 0 hb
+lemma Union_Icc_zsmul : (⋃ (n : ℤ), Icc (n • p) ((n + 1) • p)) = univ :=
+by simpa only [zero_add] using Union_Icc_add_zsmul hp 0
 
 end linear_ordered_add_comm_group
 
@@ -786,15 +635,15 @@ variables {α : Type*} [linear_ordered_ring α] [archimedean α] (a : α)
 
 lemma Union_Ioc_add_int_cast : (⋃ (n : ℤ), Ioc (a + n) (a + n + 1)) = set.univ :=
 by simpa only [zsmul_one, int.cast_add, int.cast_one, ←add_assoc]
-  using Union_Ioc_add_zsmul a zero_lt_one
+  using Union_Ioc_add_zsmul zero_lt_one a
 
 lemma Union_Ico_add_int_cast : (⋃ (n : ℤ), Ico (a + n) (a + n + 1)) = set.univ :=
 by simpa only [zsmul_one, int.cast_add, int.cast_one, ←add_assoc]
-  using Union_Ico_add_zsmul a zero_lt_one
+  using Union_Ico_add_zsmul zero_lt_one a
 
 lemma Union_Icc_add_int_cast : (⋃ (n : ℤ), Icc (a + n) (a + n + 1)) = set.univ :=
 by simpa only [zsmul_one, int.cast_add, int.cast_one, ←add_assoc]
-  using Union_Icc_add_zsmul a (zero_lt_one' α)
+  using Union_Icc_add_zsmul zero_lt_one a
 
 variables (α)
 

--- a/src/algebra/order/to_interval_mod.lean
+++ b/src/algebra/order/to_interval_mod.lean
@@ -341,14 +341,14 @@ section Ico_Ioc
 variables (a b)
 
 omit hα
-/-- `mem_Ioo_mod a p b` means that `b` lies in the open interval `(a, a + p)` modulo `p`.
+/-- `mem_Ioo_mod p a b` means that `b` lies in the open interval `(a, a + p)` modulo `p`.
 Equivalently (as shown below), `b` is not congruent to `a` modulo `p`, or `to_Ico_mod hp a` agrees
 with `to_Ioc_mod hp a` at `b`, or `to_Ico_div hp a` agrees with `to_Ioc_div hp a` at `b`. -/
-def mem_Ioo_mod (p b : α) : Prop := ∃ z : ℤ, b - z • p ∈ set.Ioo a (a + p)
+def mem_Ioo_mod (p a b : α) : Prop := ∃ z : ℤ, b - z • p ∈ set.Ioo a (a + p)
 include hα
 
 lemma tfae_mem_Ioo_mod :
-  tfae [mem_Ioo_mod a p b,
+  tfae [mem_Ioo_mod p a b,
     to_Ico_mod hp a b = to_Ioc_mod hp a b,
     to_Ico_mod hp a b + p ≠ to_Ioc_mod hp a b,
     to_Ico_mod hp a b ≠ a] :=
@@ -373,20 +373,20 @@ end
 variables {a b}
 
 lemma mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod :
-  mem_Ioo_mod a p b ↔ to_Ico_mod hp a b = to_Ioc_mod hp a b := (tfae_mem_Ioo_mod hp a b).out 0 1
+  mem_Ioo_mod p a b ↔ to_Ico_mod hp a b = to_Ioc_mod hp a b := (tfae_mem_Ioo_mod hp a b).out 0 1
 lemma mem_Ioo_mod_iff_to_Ico_mod_add_period_ne_to_Ioc_mod :
-  mem_Ioo_mod a p b ↔ to_Ico_mod hp a b + p ≠ to_Ioc_mod hp a b := (tfae_mem_Ioo_mod hp a b).out 0 2
+  mem_Ioo_mod p a b ↔ to_Ico_mod hp a b + p ≠ to_Ioc_mod hp a b := (tfae_mem_Ioo_mod hp a b).out 0 2
 lemma mem_Ioo_mod_iff_to_Ico_mod_ne_left :
-  mem_Ioo_mod a p b ↔ to_Ico_mod hp a b ≠ a := (tfae_mem_Ioo_mod hp a b).out 0 3
+  mem_Ioo_mod p a b ↔ to_Ico_mod hp a b ≠ a := (tfae_mem_Ioo_mod hp a b).out 0 3
 
 lemma not_mem_Ioo_mod_iff_to_Ico_mod_add_period_eq_to_Ioc_mod :
-  ¬mem_Ioo_mod a p b ↔ to_Ico_mod hp a b + p = to_Ioc_mod hp a b :=
+  ¬mem_Ioo_mod p a b ↔ to_Ico_mod hp a b + p = to_Ioc_mod hp a b :=
 (mem_Ioo_mod_iff_to_Ico_mod_add_period_ne_to_Ioc_mod hp).not_left
 
-lemma not_mem_Ioo_mod_iff_to_Ico_mod_eq_left : ¬mem_Ioo_mod a p b ↔ to_Ico_mod hp a b = a :=
+lemma not_mem_Ioo_mod_iff_to_Ico_mod_eq_left : ¬mem_Ioo_mod p a b ↔ to_Ico_mod hp a b = a :=
 (mem_Ioo_mod_iff_to_Ico_mod_ne_left hp).not_left
 
-lemma mem_Ioo_mod_iff_to_Ioc_mod_ne_right : mem_Ioo_mod a p b ↔ to_Ioc_mod hp a b ≠ a + p :=
+lemma mem_Ioo_mod_iff_to_Ioc_mod_ne_right : mem_Ioo_mod p a b ↔ to_Ioc_mod hp a b ≠ a + p :=
 begin
   rw [mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod, to_Ico_mod_eq_iff hp],
   obtain ⟨h₁, h₂⟩ := to_Ioc_mod_mem_Ioc hp a b,
@@ -394,27 +394,27 @@ begin
     (to_Ioc_mod_add_to_Ioc_div_zsmul _ _ _).symm⟩⟩,
 end
 
-lemma not_mem_Ioo_mod_iff_to_Ioc_eq_right : ¬mem_Ioo_mod a p b ↔ to_Ioc_mod hp a b = a + p :=
+lemma not_mem_Ioo_mod_iff_to_Ioc_eq_right : ¬mem_Ioo_mod p a b ↔ to_Ioc_mod hp a b = a + p :=
 (mem_Ioo_mod_iff_to_Ioc_mod_ne_right hp).not_left
 
 lemma mem_Ioo_mod_iff_to_Ico_div_eq_to_Ioc_div :
-  mem_Ioo_mod a p b ↔ to_Ico_div hp a b = to_Ioc_div hp a b :=
+  mem_Ioo_mod p a b ↔ to_Ico_div hp a b = to_Ioc_div hp a b :=
 by rw [mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod hp,
        to_Ico_mod, to_Ioc_mod, sub_right_inj, (zsmul_strict_mono_left hp).injective.eq_iff]
 
 lemma mem_Ioo_mod_iff_to_Ico_div_ne_to_Ioc_div_add_one :
-  mem_Ioo_mod a p b ↔ to_Ico_div hp a b ≠ to_Ioc_div hp a b + 1 :=
+  mem_Ioo_mod p a b ↔ to_Ico_div hp a b ≠ to_Ioc_div hp a b + 1 :=
 by rw [mem_Ioo_mod_iff_to_Ico_mod_add_period_ne_to_Ioc_mod hp, ne, ne, to_Ico_mod, to_Ioc_mod,
        ← eq_sub_iff_add_eq, sub_sub, sub_right_inj, ← add_one_zsmul,
        (zsmul_strict_mono_left hp).injective.eq_iff]
 
 lemma not_mem_Ioo_mod_iff_to_Ico_div_eq_to_Ioc_div_add_one :
-  ¬mem_Ioo_mod a p b ↔ to_Ico_div hp a b = to_Ioc_div hp a b + 1 :=
+  ¬mem_Ioo_mod p a b ↔ to_Ico_div hp a b = to_Ioc_div hp a b + 1 :=
 (mem_Ioo_mod_iff_to_Ico_div_ne_to_Ioc_div_add_one hp).not_left
 
 include hp
 
-lemma mem_Ioo_mod_iff_ne_add_zsmul : mem_Ioo_mod a p b ↔ ∀ z : ℤ, b ≠ a + z • p :=
+lemma mem_Ioo_mod_iff_ne_add_zsmul : mem_Ioo_mod p a b ↔ ∀ z : ℤ, b ≠ a + z • p :=
 begin
   rw [mem_Ioo_mod_iff_to_Ico_mod_ne_left hp, ← not_iff_not],
   push_neg, split; intro h,
@@ -424,16 +424,16 @@ begin
     exact ⟨lt_add_of_pos_right a hp, h⟩, },
 end
 
-lemma not_mem_Ioo_mod_iff_eq_add_zsmul : ¬mem_Ioo_mod a p b ↔ ∃ z : ℤ, b = a + z • p :=
+lemma not_mem_Ioo_mod_iff_eq_add_zsmul : ¬mem_Ioo_mod p a b ↔ ∃ z : ℤ, b = a + z • p :=
 by simpa only [not_forall, not_ne_iff] using (mem_Ioo_mod_iff_ne_add_zsmul hp).not
 
 lemma not_mem_Ioo_mod_iff_eq_mod_zmultiples :
-  ¬mem_Ioo_mod a p b ↔ (b : α ⧸ add_subgroup.zmultiples p) = a :=
+  ¬mem_Ioo_mod p a b ↔ (b : α ⧸ add_subgroup.zmultiples p) = a :=
 by simp_rw [not_mem_Ioo_mod_iff_eq_add_zsmul hp, quotient_add_group.eq_iff_sub_mem,
     add_subgroup.mem_zmultiples_iff, eq_sub_iff_add_eq', eq_comm]
 
 lemma mem_Ioo_mod_iff_ne_mod_zmultiples :
-  mem_Ioo_mod a p b ↔ (b : α ⧸ add_subgroup.zmultiples p) ≠ a :=
+  mem_Ioo_mod p a b ↔ (b : α ⧸ add_subgroup.zmultiples p) ≠ a :=
 (not_mem_Ioo_mod_iff_eq_mod_zmultiples hp).not_right
 
 lemma Ico_eq_locus_Ioc_eq_Union_Ioo :

--- a/src/analysis/special_functions/complex/arg.lean
+++ b/src/analysis/special_functions/complex/arg.lean
@@ -389,17 +389,17 @@ begin
 end
 
 lemma arg_mul_cos_add_sin_mul_I_eq_to_Ioc_mod {r : ℝ} (hr : 0 < r) (θ : ℝ) :
-  arg (r * (cos θ + sin θ * I)) = to_Ioc_mod (-π) real.two_pi_pos θ :=
+  arg (r * (cos θ + sin θ * I)) = to_Ioc_mod real.two_pi_pos (-π) θ :=
 begin
-  have hi : to_Ioc_mod (-π) real.two_pi_pos θ ∈ Ioc (-π) π,
-  { convert to_Ioc_mod_mem_Ioc _ real.two_pi_pos _,
+  have hi : to_Ioc_mod real.two_pi_pos (-π) θ ∈ Ioc (-π) π,
+  { convert to_Ioc_mod_mem_Ioc _ _ _,
     ring },
   convert arg_mul_cos_add_sin_mul_I hr hi using 3,
   simp [to_Ioc_mod, cos_sub_int_mul_two_pi, sin_sub_int_mul_two_pi]
 end
 
 lemma arg_cos_add_sin_mul_I_eq_to_Ioc_mod (θ : ℝ) :
-  arg (cos θ + sin θ * I) = to_Ioc_mod (-π) real.two_pi_pos θ :=
+  arg (cos θ + sin θ * I) = to_Ioc_mod real.two_pi_pos (-π) θ :=
 by rw [←one_mul (_ + _), ←of_real_one, arg_mul_cos_add_sin_mul_I_eq_to_Ioc_mod zero_lt_one]
 
 lemma arg_mul_cos_add_sin_mul_I_sub {r : ℝ} (hr : 0 < r) (θ : ℝ) :

--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -404,26 +404,25 @@ begin
   exact abs_cos_eq_of_two_nsmul_eq h
 end
 
-@[simp] lemma coe_to_Ico_mod (θ ψ : ℝ) : ↑(to_Ico_mod ψ two_pi_pos θ) = (θ : angle) :=
+@[simp] lemma coe_to_Ico_mod (θ ψ : ℝ) : ↑(to_Ico_mod two_pi_pos ψ θ) = (θ : angle) :=
 begin
   rw angle_eq_iff_two_pi_dvd_sub,
-  refine ⟨-to_Ico_div ψ two_pi_pos θ, _⟩,
+  refine ⟨-to_Ico_div two_pi_pos ψ θ, _⟩,
   rw [to_Ico_mod_sub_self, zsmul_eq_mul, mul_comm]
 end
 
-@[simp] lemma coe_to_Ioc_mod (θ ψ : ℝ) : ↑(to_Ioc_mod ψ two_pi_pos θ) = (θ : angle) :=
+@[simp] lemma coe_to_Ioc_mod (θ ψ : ℝ) : ↑(to_Ioc_mod two_pi_pos ψ θ) = (θ : angle) :=
 begin
   rw angle_eq_iff_two_pi_dvd_sub,
-  refine ⟨-to_Ioc_div ψ two_pi_pos θ, _⟩,
+  refine ⟨-to_Ioc_div two_pi_pos ψ θ, _⟩,
   rw [to_Ioc_mod_sub_self, zsmul_eq_mul, mul_comm]
 end
 
 /-- Convert a `real.angle` to a real number in the interval `Ioc (-π) π`. -/
 def to_real (θ : angle) : ℝ :=
-(to_Ioc_mod_periodic (-π) two_pi_pos).lift θ
+(to_Ioc_mod_periodic two_pi_pos (-π)).lift θ
 
-lemma to_real_coe (θ : ℝ) : (θ : angle).to_real = to_Ioc_mod (-π) two_pi_pos θ :=
-rfl
+lemma to_real_coe (θ : ℝ) : (θ : angle).to_real = to_Ioc_mod two_pi_pos (-π) θ := rfl
 
 lemma to_real_coe_eq_self_iff {θ : ℝ} : (θ : angle).to_real = θ ↔ -π < θ ∧ θ ≤ π :=
 begin
@@ -455,13 +454,13 @@ end
 lemma neg_pi_lt_to_real (θ : angle) : -π < θ.to_real :=
 begin
   induction θ using real.angle.induction_on,
-  exact left_lt_to_Ioc_mod _ two_pi_pos _
+  exact left_lt_to_Ioc_mod _ _ _
 end
 
 lemma to_real_le_pi (θ : angle) : θ.to_real ≤ π :=
 begin
   induction θ using real.angle.induction_on,
-  convert to_Ioc_mod_le_right _ two_pi_pos _,
+  convert to_Ioc_mod_le_right two_pi_pos _ _,
   ring
 end
 
@@ -471,7 +470,7 @@ abs_le.2 ⟨(neg_pi_lt_to_real _).le, to_real_le_pi _⟩
 lemma to_real_mem_Ioc (θ : angle) : θ.to_real ∈ set.Ioc (-π) π :=
 ⟨neg_pi_lt_to_real _, to_real_le_pi _⟩
 
-@[simp] lemma to_Ioc_mod_to_real (θ : angle): to_Ioc_mod (-π) two_pi_pos θ.to_real = θ.to_real :=
+@[simp] lemma to_Ioc_mod_to_real (θ : angle): to_Ioc_mod two_pi_pos (-π) θ.to_real = θ.to_real :=
 begin
   induction θ using real.angle.induction_on,
   rw to_real_coe,

--- a/src/topology/instances/add_circle.lean
+++ b/src/topology/instances/add_circle.lean
@@ -57,17 +57,17 @@ variables {𝕜 B : Type*}
 section continuity
 
 variables [linear_ordered_add_comm_group 𝕜] [archimedean 𝕜]
-  [topological_space 𝕜] [order_topology 𝕜] (a : 𝕜) {p : 𝕜} (hp : 0 < p) (x : 𝕜)
+  [topological_space 𝕜] [order_topology 𝕜] {p : 𝕜} (hp : 0 < p) (a x : 𝕜)
 
-lemma continuous_right_to_Ico_mod : continuous_within_at (to_Ico_mod a hp) (Ici x) x :=
+lemma continuous_right_to_Ico_mod : continuous_within_at (to_Ico_mod hp a) (Ici x) x :=
 begin
   intros s h,
   rw [filter.mem_map, mem_nhds_within_iff_exists_mem_nhds_inter],
   haveI : nontrivial 𝕜 := ⟨⟨0, p, hp.ne⟩⟩,
   simp_rw mem_nhds_iff_exists_Ioo_subset at h ⊢,
   obtain ⟨l, u, hxI, hIs⟩ := h,
-  let d := to_Ico_div a hp x • p,
-  have hd := to_Ico_mod_mem_Ico a hp x,
+  let d := to_Ico_div hp a x • p,
+  have hd := to_Ico_mod_mem_Ico hp a x,
   simp_rw [subset_def, mem_inter_iff],
   refine ⟨_, ⟨l + d, min (a + p) u + d, _, λ x, id⟩, λ y, _⟩;
     simp_rw [← sub_mem_Ioo_iff_left, mem_Ioo, lt_min_iff],
@@ -77,28 +77,28 @@ begin
     exacts [⟨h.1, h.2.2⟩, ⟨hd.1.trans (sub_le_sub_right h' _), h.2.1⟩] },
 end
 
-lemma continuous_left_to_Ioc_mod : continuous_within_at (to_Ioc_mod a hp) (Iic x) x :=
+lemma continuous_left_to_Ioc_mod : continuous_within_at (to_Ioc_mod hp a) (Iic x) x :=
 begin
   rw (funext (λ y, eq.trans (by rw neg_neg) $ to_Ioc_mod_neg _ _ _) :
-    to_Ioc_mod a hp = (λ x, p - x) ∘ to_Ico_mod (-a) hp ∘ has_neg.neg),
+    to_Ioc_mod hp a = (λ x, p - x) ∘ to_Ico_mod hp (-a) ∘ has_neg.neg),
   exact ((continuous_sub_left _).continuous_at.comp_continuous_within_at $
     (continuous_right_to_Ico_mod _ _ _).comp continuous_neg.continuous_within_at $ λ y, neg_le_neg),
 end
 
 variables {x} (hx : (x : 𝕜 ⧸ zmultiples p) ≠ a)
 
-lemma to_Ico_mod_eventually_eq_to_Ioc_mod : to_Ico_mod a hp =ᶠ[𝓝 x] to_Ioc_mod a hp :=
+lemma to_Ico_mod_eventually_eq_to_Ioc_mod : to_Ico_mod hp a =ᶠ[𝓝 x] to_Ioc_mod hp a :=
 is_open.mem_nhds (by {rw Ico_eq_locus_Ioc_eq_Union_Ioo, exact is_open_Union (λ i, is_open_Ioo)}) $
   (mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod hp).1 ((mem_Ioo_mod_iff_ne_mod_zmultiples hp).2 hx)
 
-lemma continuous_at_to_Ico_mod : continuous_at (to_Ico_mod a hp) x :=
-let h := to_Ico_mod_eventually_eq_to_Ioc_mod a hp hx in continuous_at_iff_continuous_left_right.2 $
-  ⟨(continuous_left_to_Ioc_mod a hp x).congr_of_eventually_eq
-    (h.filter_mono nhds_within_le_nhds) h.eq_of_nhds, continuous_right_to_Ico_mod a hp x⟩
+lemma continuous_at_to_Ico_mod : continuous_at (to_Ico_mod hp a) x :=
+let h := to_Ico_mod_eventually_eq_to_Ioc_mod hp a hx in continuous_at_iff_continuous_left_right.2 $
+  ⟨(continuous_left_to_Ioc_mod hp a x).congr_of_eventually_eq
+    (h.filter_mono nhds_within_le_nhds) h.eq_of_nhds, continuous_right_to_Ico_mod hp a x⟩
 
-lemma continuous_at_to_Ioc_mod : continuous_at (to_Ioc_mod a hp) x :=
-let h := to_Ico_mod_eventually_eq_to_Ioc_mod a hp hx in continuous_at_iff_continuous_left_right.2 $
-  ⟨continuous_left_to_Ioc_mod a hp x, (continuous_right_to_Ico_mod a hp x).congr_of_eventually_eq
+lemma continuous_at_to_Ioc_mod : continuous_at (to_Ioc_mod hp a) x :=
+let h := to_Ico_mod_eventually_eq_to_Ioc_mod hp a hx in continuous_at_iff_continuous_left_right.2 $
+  ⟨continuous_left_to_Ioc_mod hp a x, (continuous_right_to_Ico_mod hp a x).congr_of_eventually_eq
     (h.symm.filter_mono nhds_within_le_nhds) h.symm.eq_of_nhds⟩
 
 end continuity
@@ -157,11 +157,11 @@ variables (a : 𝕜) [archimedean 𝕜]
 
 /-- The equivalence between `add_circle p` and the half-open interval `[a, a + p)`, whose inverse
 is the natural quotient map. -/
-def equiv_Ico : add_circle p ≃ Ico a (a + p) := quotient_add_group.equiv_Ico_mod a hp.out
+def equiv_Ico : add_circle p ≃ Ico a (a + p) := quotient_add_group.equiv_Ico_mod hp.out a
 
 /-- The equivalence between `add_circle p` and the half-open interval `(a, a + p]`, whose inverse
 is the natural quotient map. -/
-def equiv_Ioc : add_circle p ≃ Ioc a (a + p) := quotient_add_group.equiv_Ioc_mod a hp.out
+def equiv_Ioc : add_circle p ≃ Ioc a (a + p) := quotient_add_group.equiv_Ioc_mod hp.out a
 
 /-- Given a function on `𝕜`, return the unique function on `add_circle p` agreeing with `f` on
 `[a, a + p)`. -/
@@ -218,14 +218,14 @@ lemma continuous_at_equiv_Ico : continuous_at (equiv_Ico p a) x :=
 begin
   induction x using quotient_add_group.induction_on',
   rw [continuous_at, filter.tendsto, quotient_add_group.nhds_eq, filter.map_map],
-  apply continuous_at.cod_restrict, exact continuous_at_to_Ico_mod a hp.out hx,
+  exact (continuous_at_to_Ico_mod hp.out a hx).cod_restrict _,
 end
 
 lemma continuous_at_equiv_Ioc : continuous_at (equiv_Ioc p a) x :=
 begin
   induction x using quotient_add_group.induction_on',
   rw [continuous_at, filter.tendsto, quotient_add_group.nhds_eq, filter.map_map],
-  apply continuous_at.cod_restrict, exact continuous_at_to_Ioc_mod a hp.out hx,
+  exact (continuous_at_to_Ioc_mod hp.out a hx).cod_restrict _,
 end
 
 end continuity
@@ -492,10 +492,10 @@ def equiv_Icc_quot : 𝕋 ≃ quot (endpoint_ident p a) :=
     apply congr_arg subtype.val ((equiv_Ico p a).right_inv ⟨x, hx.1, hx.2.lt_of_ne h⟩) } }
 
 lemma equiv_Icc_quot_comp_mk_eq_to_Ico_mod : equiv_Icc_quot p a ∘ quotient.mk' =
-  λ x, quot.mk _ ⟨to_Ico_mod a hp.out x, Ico_subset_Icc_self $ to_Ico_mod_mem_Ico a _ x⟩ := rfl
+  λ x, quot.mk _ ⟨to_Ico_mod hp.out a x, Ico_subset_Icc_self $ to_Ico_mod_mem_Ico _ _ x⟩ := rfl
 
 lemma equiv_Icc_quot_comp_mk_eq_to_Ioc_mod : equiv_Icc_quot p a ∘ quotient.mk' =
-  λ x, quot.mk _ ⟨to_Ioc_mod a hp.out x, Ioc_subset_Icc_self $ to_Ioc_mod_mem_Ioc a _ x⟩ :=
+  λ x, quot.mk _ ⟨to_Ioc_mod hp.out a x, Ioc_subset_Icc_self $ to_Ioc_mod_mem_Ioc _ _ x⟩ :=
 begin
   rw equiv_Icc_quot_comp_mk_eq_to_Ico_mod, funext,
   by_cases mem_Ioo_mod a p x,

--- a/src/topology/instances/add_circle.lean
+++ b/src/topology/instances/add_circle.lean
@@ -498,7 +498,7 @@ lemma equiv_Icc_quot_comp_mk_eq_to_Ioc_mod : equiv_Icc_quot p a ∘ quotient.mk'
   λ x, quot.mk _ ⟨to_Ioc_mod hp.out a x, Ioc_subset_Icc_self $ to_Ioc_mod_mem_Ioc _ _ x⟩ :=
 begin
   rw equiv_Icc_quot_comp_mk_eq_to_Ico_mod, funext,
-  by_cases mem_Ioo_mod a p x,
+  by_cases mem_Ioo_mod p a x,
   { simp_rw (mem_Ioo_mod_iff_to_Ico_mod_eq_to_Ioc_mod hp.out).1 h },
   { simp_rw [not_imp_comm.1 (mem_Ioo_mod_iff_to_Ico_mod_ne_left hp.out).2 h,
              not_imp_comm.1 (mem_Ioo_mod_iff_to_Ioc_mod_ne_right hp.out).2 h],


### PR DESCRIPTION
The current argument order to `to_Ixx_mod` is a bit poor: In `to_Ico a hb x`, `a` and `x` play a similar role while `b` is completely separate. This PR changes this to `to_Ico hp a b`, where the translation is as follows:
* `mem_Ioo_mod a p b` → `mem_Ioo_mod p a b` (this is more consistent with `int.modeq p a b`)
* `to_Ico_div a hp b` → `to_Ico_div hp a b`
* `to_Ioc_div a hp b` → `to_Ioc_div hp a b`
* `to_Ico_mod a hp b` → `to_Ico_mod hp a b`
* `to_Ioc_mod a hp b` → `to_Ioc_mod hp a b`

While it might be tempting to order`to_Ico_div hp a b` as `to_Ico_div b a hp` to match the order of the morally equivalent `(b - a) / p + a`, we opt for the simpler convention of being consistent with `mem_Ioo_mod`, as in downstream files we also find it convenient to have `b` as the last argument.

Generally speaking, the variables have been renamed to

* `a` → `a` (the left end)
* `b` → `p` (the period)
* `x` → `b` (the interval length)
* `y` → `c` (additional argument similar to the left end and interval length)
* `z` → `n` (the euclidean dividend)

Proofs are golfed slightly. The only lemma statements that changed are `to_Ico_div_eq_of_sub_zsmul_mem_Ico`/`to_Ioc_div_eq_of_sub_zsmul_mem_Ioc` that now state `to_Ico_div hp a b = n` rather than `n = to_Ico_div hp a b` (they were always used in this new direction).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
