### PR TITLE
[Merged by Bors] - chore(ring_theory/polynomial/quotient): remove spurious restrict_scalars

### DIFF
--- a/src/ring_theory/polynomial/quotient.lean
+++ b/src/ring_theory/polynomial/quotient.lean
@@ -22,7 +22,7 @@ variables {R : Type*} [comm_ring R]
 isomorphism of $R$-algebras $R[X] / \langle X - x \rangle \cong R$. -/
 noncomputable def quotient_span_X_sub_C_alg_equiv (x : R) :
   (R[X] ⧸ ideal.span ({X - C x} : set R[X])) ≃ₐ[R] R :=
-(alg_equiv.restrict_scalars R $ ideal.quotient_equiv_alg_of_eq R
+(ideal.quotient_equiv_alg_of_eq R
   (by exact ker_eval_ring_hom x : ring_hom.ker (aeval x).to_ring_hom = _)).symm.trans $
   ideal.quotient_ker_alg_equiv_of_right_inverse $ λ _, eval_C
 


### PR DESCRIPTION
Verifying that the `restrict_scalars` here is spurious. This proof is timing out badly in mathlib4.

If someone would like to merge this, please do so, but please then handle updating the SHA in mathlib4 as well. :-)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
