### PR TITLE
[Merged by Bors] - chore(data/set/intervals/monotone): fix names

### DIFF
--- a/src/data/set/intervals/monotone.lean
+++ b/src/data/set/intervals/monotone.lean
@@ -182,7 +182,7 @@ begin
   { exact ih (strict_mono_on.mono hφ (λ x hx, le_trans hx (le_succ _))) _ h }
 end
 
-lemma strict_mono_on.Iic_le_id [pred_order α] [is_pred_archimedean α] [order_top α]
+lemma strict_mono_on.Ici_le_id [pred_order α] [is_pred_archimedean α] [order_top α]
   {n : α} {φ : α → α} (hφ : strict_mono_on φ (set.Ici n)) :
   ∀ m, n ≤ m → φ m ≤ m :=
 @strict_mono_on.Iic_id_le αᵒᵈ _ _ _ _ _ _ (λ i hi j hj hij, hφ hj hi hij)
@@ -221,12 +221,12 @@ lemma strict_anti_on_Iic_of_succ_lt [succ_order α] [is_succ_archimedean α]
   strict_anti_on ψ (set.Iic n) :=
 λ i hi j hj hij, @strict_mono_on_Iic_of_lt_succ α βᵒᵈ _ _ ψ _ _ n hψ i hi j hj hij
 
-lemma strict_mono_on_Iic_of_pred_lt [pred_order α] [is_pred_archimedean α]
+lemma strict_mono_on_Ici_of_pred_lt [pred_order α] [is_pred_archimedean α]
   {n : α} (hψ : ∀ m, n < m → ψ (pred m) < ψ m) :
   strict_mono_on ψ (set.Ici n) :=
 λ i hi j hj hij, @strict_mono_on_Iic_of_lt_succ αᵒᵈ βᵒᵈ _ _ ψ _ _ n hψ j hj i hi hij
 
-lemma strict_anti_on_Iic_of_lt_pred [pred_order α] [is_pred_archimedean α]
+lemma strict_anti_on_Ici_of_lt_pred [pred_order α] [is_pred_archimedean α]
   {n : α} (hψ : ∀ m, n < m → ψ m < ψ (pred m)) :
   strict_anti_on ψ (set.Ici n) :=
 λ i hi j hj hij, @strict_anti_on_Iic_of_succ_lt αᵒᵈ βᵒᵈ _ _ ψ _ _ n hψ j hj i hi hij


### PR DESCRIPTION
Some lemmas used `Iic` instead of `Ici` in the names, probably because of a copy+paste error.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)