### PR TITLE
feat(field_theory/normal): characterizations of a normal intermedate field

### DIFF
--- a/src/field_theory/normal.lean
+++ b/src/field_theory/normal.lean
@@ -438,3 +438,62 @@ end
 end normal_closure
 
 end normal_closure
+
+section tfae
+
+namespace intermediate_field
+
+/-- Equivalent characterizations for an intermediate field in a normal extension to be normal. -/
+theorem normal_tfae [hK : normal F K] (E : intermediate_field F K) :
+  [ normal F E,
+    ∀ σ : K ≃ₐ[F] K, E.map ↑σ = E,
+    ∀ σ : K ≃ₐ[F] K, E.map ↑σ ≤ E ].tfae :=
+begin
+  tfae_have : 1 → 2,
+  { introsI _ σ,
+    ext x,
+    rw [← set_like.mem_coe, coe_map],
+    split,
+    { rintro ⟨y, hy, rfl⟩,
+      rw [alg_equiv.coe_alg_hom, ← show _ = σ y, from σ.restrict_normal_commutes E ⟨y, hy⟩],
+      apply set_like.coe_mem },
+    { intro hx,
+      refine ⟨σ.symm x, _, σ.apply_symm_apply _⟩,
+      rw [← show _ = σ.symm x, from σ.symm.restrict_normal_commutes E ⟨x, hx⟩, set_like.mem_coe],
+      apply set_like.coe_mem } },
+  tfae_have : 2 → 3,
+  { intros h σ,
+    exact (h σ).symm ▸ le_refl E },
+  tfae_have : 3 → 1,
+  { intro h,
+    split,
+    { intro x,
+      exact is_algebraic_iff.2 (hK.is_algebraic _) },
+    intro x,
+    rw minpoly_eq,
+    refine splits_of_splits (hK.splits x) _,
+    intros y hy,
+    have hx := hK.is_integral (x : K),
+    let σ := (adjoin_root.lift_hom _ _ (aeval_eq_zero_of_mem_root_set hy)).comp
+      (adjoin_root_equiv_adjoin F hx).symm.to_alg_hom,
+    apply set_like.le_def.1
+      (h (alg_equiv.of_bijective _ ((σ.lift_normal K).normal_bijective _ _ _))),
+    rw [← set_like.mem_coe, coe_map],
+    use x,
+    rw set_like.mem_coe,
+    refine ⟨set_like.coe_mem _, _⟩,
+    show σ.lift_normal K (algebra_map _ K (adjoin_simple.gen F (x : K))) = _,
+    rw alg_hom.lift_normal_commutes,
+    show adjoin_root.lift_hom _ _ _ ((adjoin_root_equiv_adjoin F hx).symm _) = _,
+    rw [← adjoin_root_equiv_adjoin_apply_root F hx,
+      alg_equiv.symm_apply_apply, adjoin_root.lift_hom_root] },
+  tfae_finish
+end
+
+lemma normal_iff_forall_map_eq [normal F K] {E : intermediate_field F K} :
+  normal F E ↔ ∀ σ : K ≃ₐ[F] K, E.map ↑σ = E :=
+E.normal_tfae.out 0 1
+
+end intermediate_field
+
+end tfae


### PR DESCRIPTION
Add equivalent characterizations for an intermediate field in a normal field extension to be normal over the base field.

---

In particular, this can be used to show that normal extensions correspond to normal subgroups in the Galois correspondence.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
