### PR TITLE
[Merged by Bors] - chore(probability/kernel/basic): make the function argument of kernel.deterministic explicit

### DIFF
--- a/src/probability/kernel/basic.lean
+++ b/src/probability/kernel/basic.lean
@@ -28,7 +28,7 @@ Classes of kernels:
 * `is_s_finite_kernel κ`: a kernel is called s-finite if it is a countable sum of finite kernels.
 
 Particular kernels:
-* `deterministic {f : α → β} (hf : measurable f)`: kernel `a ↦ measure.dirac (f a)`.
+* `deterministic (f : α → β) (hf : measurable f)`: kernel `a ↦ measure.dirac (f a)`.
 * `const α (μβ : measure β)`: constant kernel `a ↦ μβ`.
 * `kernel.restrict κ (hs : measurable_set s)`: kernel for which the image of `a : α` is
   `(κ a).restrict s`.
@@ -317,7 +317,7 @@ section deterministic
 
 /-- Kernel which to `a` associates the dirac measure at `f a`. This is a Markov kernel. -/
 noncomputable
-def deterministic {f : α → β} (hf : measurable f) :
+def deterministic (f : α → β) (hf : measurable f) :
   kernel α β :=
 { val := λ a, measure.dirac (f a),
   property :=
@@ -328,11 +328,11 @@ def deterministic {f : α → β} (hf : measurable f) :
     end, }
 
 lemma deterministic_apply {f : α → β} (hf : measurable f) (a : α) :
-  deterministic hf a = measure.dirac (f a) := rfl
+  deterministic f hf a = measure.dirac (f a) := rfl
 
 lemma deterministic_apply' {f : α → β} (hf : measurable f) (a : α) {s : set β}
   (hs : measurable_set s) :
-  deterministic hf a s = s.indicator (λ _, 1) (f a) :=
+  deterministic f hf a s = s.indicator (λ _, 1) (f a) :=
 begin
   rw [deterministic],
   change measure.dirac (f a) s = s.indicator 1 (f a),
@@ -340,7 +340,7 @@ begin
 end
 
 instance is_markov_kernel_deterministic {f : α → β} (hf : measurable f) :
-  is_markov_kernel (deterministic hf) :=
+  is_markov_kernel (deterministic f hf) :=
 ⟨λ a, by { rw deterministic_apply hf, apply_instance, }⟩
 
 end deterministic

--- a/src/probability/kernel/composition.lean
+++ b/src/probability/kernel/composition.lean
@@ -661,7 +661,7 @@ begin
 end
 
 lemma deterministic_comp_eq_map (hf : measurable f) (κ : kernel α β) [is_s_finite_kernel κ] :
-  (deterministic hf ∘ₖ κ) = map κ f hf :=
+  (deterministic f hf ∘ₖ κ) = map κ f hf :=
 begin
   ext a s hs : 2,
   simp_rw [map_apply' _ _ _ hs, comp_apply _ _ _ hs, deterministic_apply' hf _ hs,
@@ -669,7 +669,7 @@ begin
 end
 
 lemma comp_deterministic_eq_comap (κ : kernel α β) [is_s_finite_kernel κ] (hg : measurable g) :
-  (κ ∘ₖ deterministic hg) = comap κ g hg :=
+  (κ ∘ₖ deterministic g hg) = comap κ g hg :=
 begin
   ext a s hs : 2,
   simp_rw [comap_apply' _ _ _ s, comp_apply _ _ _ hs, deterministic_apply hg a,


### PR DESCRIPTION
If that argument is implicit, the infoview often shows only `deterministic _`, which does not allow to see which function is used. Making it explicit fixes that problem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
