### PR TITLE
[Merged by Bors] - chore(ring_theory/ideal/quotient): add missing smul compatibility instances

### DIFF
--- a/src/ring_theory/congruence.lean
+++ b/src/ring_theory/congruence.lean
@@ -247,6 +247,23 @@ function.surjective.comm_ring _ quotient.surjective_quotient_mk'
   rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
   (λ _, rfl) (λ _, rfl)
 
+instance is_scalar_tower_right [has_add R] [mul_one_class R] [has_smul α R] [is_scalar_tower α R R]
+  (c : ring_con R) :
+  is_scalar_tower α c.quotient c.quotient :=
+{ smul_assoc := λ a, quotient.ind₂' $ by exact λ m₁ m₂,
+    congr_arg quotient.mk' $ smul_mul_assoc _ _ _ }
+
+instance smul_comm_class [has_add R] [mul_one_class R] [has_smul α R]
+  [is_scalar_tower α R R] [smul_comm_class α R R] (c : ring_con R) :
+  smul_comm_class α c.quotient c.quotient :=
+{ smul_comm := λ a, quotient.ind₂' $ by exact λ m₁ m₂,
+    congr_arg quotient.mk' $ (mul_smul_comm _ _ _).symm }
+
+instance smul_comm_class' [has_add R] [mul_one_class R] [has_smul α R]
+  [is_scalar_tower α R R] [smul_comm_class R α R] (c : ring_con R) :
+  smul_comm_class c.quotient α c.quotient :=
+by haveI := smul_comm_class.symm R α R; exact smul_comm_class.symm _ _ _
+
 instance [monoid α] [non_assoc_semiring R] [distrib_mul_action α R] [is_scalar_tower α R R]
   (c : ring_con R) :
   distrib_mul_action α c.quotient :=

--- a/src/ring_theory/ideal/quotient.lean
+++ b/src/ring_theory/ideal/quotient.lean
@@ -72,6 +72,8 @@ instance comm_ring (I : ideal R) : comm_ring (R ⧸ I) :=
 { ..submodule.quotient.add_comm_group I,  -- to help with unification
   ..(quotient.ring_con I)^.quotient.comm_ring }
 
+-- this instance is harder to find than the one via `algebra α (R ⧸ I)`, so use a lower priority
+@[priority 100]
 instance is_scalar_tower_right {α} [has_smul α R] [is_scalar_tower α R R] :
   is_scalar_tower α (R ⧸ I) (R ⧸ I) :=
 (quotient.ring_con I)^.is_scalar_tower_right

--- a/src/ring_theory/ideal/quotient.lean
+++ b/src/ring_theory/ideal/quotient.lean
@@ -72,6 +72,18 @@ instance comm_ring (I : ideal R) : comm_ring (R ⧸ I) :=
 { ..submodule.quotient.add_comm_group I,  -- to help with unification
   ..(quotient.ring_con I)^.quotient.comm_ring }
 
+instance is_scalar_tower_right {α} [has_smul α R] [is_scalar_tower α R R] :
+  is_scalar_tower α (R ⧸ I) (R ⧸ I) :=
+(quotient.ring_con I)^.is_scalar_tower_right
+
+instance smul_comm_class {α} [has_smul α R] [is_scalar_tower α R R] [smul_comm_class α R R] :
+  smul_comm_class α (R ⧸ I) (R ⧸ I) :=
+(quotient.ring_con I)^.smul_comm_class
+
+instance smul_comm_class' {α} [has_smul α R] [is_scalar_tower α R R] [smul_comm_class R α R] :
+  smul_comm_class (R ⧸ I) α (R ⧸ I) :=
+(quotient.ring_con I)^.smul_comm_class'
+
 /-- The ring homomorphism from a ring `R` to a quotient ring `R/I`. -/
 def mk (I : ideal R) : R →+* (R ⧸ I) :=
 ⟨λ a, submodule.quotient.mk a, rfl, λ _ _, rfl, rfl, λ _ _, rfl⟩


### PR DESCRIPTION
The low priority is needed to avoid a timeout in what will be `ring_theory/kaehler.lean`.

These instances are more general cases of the instances implied by `algebra α c.quotient` and `algebra α (R ⧸ I)`, which work for cases like `α = units R`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
