### PR TITLE
[Merged by Bors] - feat(algebra/order/to_interval_mod): symmetric variants of lemmas

### DIFF
--- a/src/algebra/order/to_interval_mod.lean
+++ b/src/algebra/order/to_interval_mod.lean
@@ -293,7 +293,8 @@ by rw [←sub_neg_eq_add, to_Ioc_div_sub_eq_to_Ioc_div_add, sub_eq_add_neg]
 lemma to_Ico_div_neg (a b : α) : to_Ico_div hp a (-b) = -(to_Ioc_div hp (-a) b + 1) :=
 begin
   suffices : to_Ico_div hp a (-b) = -(to_Ioc_div hp (-(a + p)) b),
-  { rwa [neg_add, ←sub_eq_add_neg, to_Ioc_div_sub_eq_to_Ioc_div_add', to_Ioc_div_add_right] at this },
+  { rwa [neg_add, ←sub_eq_add_neg, to_Ioc_div_sub_eq_to_Ioc_div_add',
+      to_Ioc_div_add_right] at this },
   rw [← neg_eq_iff_eq_neg, eq_comm],
   apply to_Ioc_div_eq_of_sub_zsmul_mem_Ioc,
   obtain ⟨hc, ho⟩ := sub_to_Ico_div_zsmul_mem_Ico hp a (-b),

--- a/src/algebra/order/to_interval_mod.lean
+++ b/src/algebra/order/to_interval_mod.lean
@@ -181,10 +181,26 @@ by { rw [to_Ioc_mod_eq_iff hp, set.right_mem_Ioc], exact ⟨lt_add_of_pos_right 
 to_Ico_div_eq_of_sub_zsmul_mem_Ico hp $
   by simpa only [add_smul, add_sub_add_right_eq_sub] using sub_to_Ico_div_zsmul_mem_Ico hp a b
 
+@[simp] lemma to_Ico_div_add_zsmul' (a b: α) (m : ℤ) :
+  to_Ico_div hp (a + m • p) b = to_Ico_div hp a b - m :=
+begin
+  refine to_Ico_div_eq_of_sub_zsmul_mem_Ico _ _,
+  rw [sub_smul, ←sub_add, add_right_comm],
+  simpa using sub_to_Ico_div_zsmul_mem_Ico hp a b,
+end
+
 @[simp] lemma to_Ioc_div_add_zsmul (a b : α) (m : ℤ) :
   to_Ioc_div hp a (b + m • p) = to_Ioc_div hp a b + m :=
 to_Ioc_div_eq_of_sub_zsmul_mem_Ioc hp $
   by simpa only [add_smul, add_sub_add_right_eq_sub] using sub_to_Ioc_div_zsmul_mem_Ioc hp a b
+
+@[simp] lemma to_Ioc_div_add_zsmul' (a b : α) (m : ℤ) :
+  to_Ioc_div hp (a + m • p) b = to_Ioc_div hp a b - m :=
+begin
+  refine to_Ioc_div_eq_of_sub_zsmul_mem_Ioc _ _,
+  rw [sub_smul, ←sub_add, add_right_comm],
+  simpa using sub_to_Ioc_div_zsmul_mem_Ioc hp a b,
+end
 
 @[simp] lemma to_Ico_div_zsmul_add (a b : α) (m : ℤ) :
   to_Ico_div hp a (m • p + b) = m + to_Ico_div hp a b :=
@@ -260,25 +276,49 @@ by rw [←neg_neg b, to_Ico_div_neg, neg_neg, neg_neg, neg_add', neg_neg, add_su
   to_Ico_mod hp a (b + m • p) = to_Ico_mod hp a b :=
 by { rw [to_Ico_mod, to_Ico_div_add_zsmul, to_Ico_mod, add_smul], abel }
 
+@[simp] lemma to_Ico_mod_add_zsmul' (a b : α) (m : ℤ) :
+  to_Ico_mod hp (a + m • p) b = to_Ico_mod hp a b + m • p :=
+by simp only [to_Ico_mod, to_Ico_div_add_zsmul', sub_smul, sub_add]
+
 @[simp] lemma to_Ioc_mod_add_zsmul (a b : α) (m : ℤ) :
   to_Ioc_mod hp a (b + m • p) = to_Ioc_mod hp a b :=
 by { rw [to_Ioc_mod, to_Ioc_div_add_zsmul, to_Ioc_mod, add_smul], abel }
+
+@[simp] lemma to_Ioc_mod_add_zsmul' (a b : α) (m : ℤ) :
+  to_Ioc_mod hp (a + m • p) b = to_Ioc_mod hp a b + m • p :=
+by simp only [to_Ioc_mod, to_Ioc_div_add_zsmul', sub_smul, sub_add]
 
 @[simp] lemma to_Ico_mod_zsmul_add (a b : α) (m : ℤ) :
   to_Ico_mod hp a (m • p + b) = to_Ico_mod hp a b :=
 by rw [add_comm, to_Ico_mod_add_zsmul]
 
+@[simp] lemma to_Ico_mod_zsmul_add' (a b : α) (m : ℤ) :
+  to_Ico_mod hp (m • p + a) b = m • p + to_Ico_mod hp a b :=
+by rw [add_comm, to_Ico_mod_add_zsmul', add_comm]
+
 @[simp] lemma to_Ioc_mod_zsmul_add (a b : α) (m : ℤ) :
   to_Ioc_mod hp a (m • p + b) = to_Ioc_mod hp a b :=
 by rw [add_comm, to_Ioc_mod_add_zsmul]
+
+@[simp] lemma to_Ioc_mod_zsmul_add' (a b : α) (m : ℤ) :
+  to_Ioc_mod hp (m • p + a) b = m • p + to_Ioc_mod hp a b :=
+by rw [add_comm, to_Ioc_mod_add_zsmul', add_comm]
 
 @[simp] lemma to_Ico_mod_sub_zsmul (a b : α) (m : ℤ) :
   to_Ico_mod hp a (b - m • p) = to_Ico_mod hp a b :=
 by rw [sub_eq_add_neg, ←neg_smul, to_Ico_mod_add_zsmul]
 
+@[simp] lemma to_Ico_mod_sub_zsmul' (a b : α) (m : ℤ) :
+  to_Ico_mod hp (a - m • p) b = to_Ico_mod hp a b - m • p :=
+by simp_rw [sub_eq_add_neg, ←neg_smul, to_Ico_mod_add_zsmul']
+
 @[simp] lemma to_Ioc_mod_sub_zsmul (a b : α) (m : ℤ) :
   to_Ioc_mod hp a (b - m • p) = to_Ioc_mod hp a b :=
 by rw [sub_eq_add_neg, ←neg_smul, to_Ioc_mod_add_zsmul]
+
+@[simp] lemma to_Ioc_mod_sub_zsmul' (a b : α) (m : ℤ) :
+  to_Ioc_mod hp (a - m • p) b = to_Ioc_mod hp a b - m • p :=
+by simp_rw [sub_eq_add_neg, ←neg_smul, to_Ioc_mod_add_zsmul']
 
 @[simp] lemma to_Ico_mod_add_right (a b : α) : to_Ico_mod hp a (b + p) = to_Ico_mod hp a b :=
 by simpa only [one_zsmul] using to_Ico_mod_add_zsmul hp a b 1

--- a/src/algebra/order/to_interval_mod.lean
+++ b/src/algebra/order/to_interval_mod.lean
@@ -206,9 +206,13 @@ end
   to_Ico_div hp a (m • p + b) = m + to_Ico_div hp a b :=
 by rw [add_comm, to_Ico_div_add_zsmul, add_comm]
 
+/-! Note we omit `to_Ico_div_zsmul_add'` as `-m + to_Ico_div hp a b` is not very convenient. -/
+
 @[simp] lemma to_Ioc_div_zsmul_add (a b : α) (m : ℤ) :
   to_Ioc_div hp a (m • p + b) = m + to_Ioc_div hp a b :=
 by rw [add_comm, to_Ioc_div_add_zsmul, add_comm]
+
+/-! Note we omit `to_Ioc_div_zsmul_add'` as `-m + to_Ioc_div hp a b` is not very convenient. -/
 
 @[simp] lemma to_Ico_div_sub_zsmul (a b : α) (m : ℤ) :
   to_Ico_div hp a (b - m • p) = to_Ico_div hp a b - m :=

--- a/src/algebra/order/to_interval_mod.lean
+++ b/src/algebra/order/to_interval_mod.lean
@@ -207,7 +207,7 @@ end
 by rw [add_comm, to_Ico_div_add_zsmul, add_comm]
 
 @[simp] lemma to_Ioc_div_zsmul_add (a b : α) (m : ℤ) :
-  to_Ioc_div hp a (m • p + b) = to_Ioc_div hp a b + m :=
+  to_Ioc_div hp a (m • p + b) = m + to_Ioc_div hp a b :=
 by rw [add_comm, to_Ioc_div_add_zsmul, add_comm]
 
 @[simp] lemma to_Ico_div_sub_zsmul (a b : α) (m : ℤ) :

--- a/src/algebra/order/to_interval_mod.lean
+++ b/src/algebra/order/to_interval_mod.lean
@@ -214,52 +214,78 @@ by rw [add_comm, to_Ioc_div_add_zsmul, add_comm]
   to_Ico_div hp a (b - m • p) = to_Ico_div hp a b - m :=
 by rw [sub_eq_add_neg, ←neg_smul, to_Ico_div_add_zsmul, sub_eq_add_neg]
 
+@[simp] lemma to_Ico_div_sub_zsmul' (a b : α) (m : ℤ) :
+  to_Ico_div hp (a - m • p) b = to_Ico_div hp a b + m :=
+by rw [sub_eq_add_neg, ←neg_smul, to_Ico_div_add_zsmul', sub_neg_eq_add]
+
 @[simp] lemma to_Ioc_div_sub_zsmul (a b : α) (m : ℤ) :
   to_Ioc_div hp a (b - m • p) = to_Ioc_div hp a b - m :=
 by rw [sub_eq_add_neg, ←neg_smul, to_Ioc_div_add_zsmul, sub_eq_add_neg]
 
+@[simp] lemma to_Ioc_div_sub_zsmul' (a b : α) (m : ℤ) :
+  to_Ioc_div hp (a - m • p) b = to_Ioc_div hp a b + m :=
+by rw [sub_eq_add_neg, ←neg_smul, to_Ioc_div_add_zsmul', sub_neg_eq_add]
+
 @[simp] lemma to_Ico_div_add_right (a b : α) : to_Ico_div hp a (b + p) = to_Ico_div hp a b + 1 :=
 by simpa only [one_zsmul] using to_Ico_div_add_zsmul hp a b 1
+
+@[simp] lemma to_Ico_div_add_right' (a b : α) : to_Ico_div hp (a + p) b = to_Ico_div hp a b - 1 :=
+by simpa only [one_zsmul] using to_Ico_div_add_zsmul' hp a b 1
 
 @[simp] lemma to_Ioc_div_add_right (a b : α) : to_Ioc_div hp a (b + p) = to_Ioc_div hp a b + 1 :=
 by simpa only [one_zsmul] using to_Ioc_div_add_zsmul hp a b 1
 
+@[simp] lemma to_Ioc_div_add_right' (a b : α) : to_Ioc_div hp (a + p) b = to_Ioc_div hp a b - 1 :=
+by simpa only [one_zsmul] using to_Ioc_div_add_zsmul' hp a b 1
+
 @[simp] lemma to_Ico_div_add_left (a b : α) : to_Ico_div hp a (p + b) = to_Ico_div hp a b + 1 :=
 by rw [add_comm, to_Ico_div_add_right]
+
+@[simp] lemma to_Ico_div_add_left' (a b : α) : to_Ico_div hp (p + a) b = to_Ico_div hp a b - 1 :=
+by rw [add_comm, to_Ico_div_add_right']
 
 @[simp] lemma to_Ioc_div_add_left (a b : α) : to_Ioc_div hp a (p + b) = to_Ioc_div hp a b + 1 :=
 by rw [add_comm, to_Ioc_div_add_right]
 
+@[simp] lemma to_Ioc_div_add_left' (a b : α) : to_Ioc_div hp (p + a) b = to_Ioc_div hp a b - 1 :=
+by rw [add_comm, to_Ioc_div_add_right']
+
 @[simp] lemma to_Ico_div_sub (a b : α) : to_Ico_div hp a (b - p) = to_Ico_div hp a b - 1 :=
 by simpa only [one_zsmul] using to_Ico_div_sub_zsmul hp a b 1
+
+@[simp] lemma to_Ico_div_sub' (a b : α) : to_Ico_div hp (a - p) b = to_Ico_div hp a b + 1 :=
+by simpa only [one_zsmul] using to_Ico_div_sub_zsmul' hp a b 1
 
 @[simp] lemma to_Ioc_div_sub (a b : α) : to_Ioc_div hp a (b - p) = to_Ioc_div hp a b - 1 :=
 by simpa only [one_zsmul] using to_Ioc_div_sub_zsmul hp a b 1
 
-lemma to_Ico_div_sub' (a b c : α) : to_Ico_div hp a (b - c) = to_Ico_div hp (a + c) b :=
+@[simp] lemma to_Ioc_div_sub' (a b : α) : to_Ioc_div hp (a - p) b = to_Ioc_div hp a b + 1 :=
+by simpa only [one_zsmul] using to_Ioc_div_sub_zsmul' hp a b 1
+
+lemma to_Ico_div_sub_eq (a b c : α) : to_Ico_div hp a (b - c) = to_Ico_div hp (a + c) b :=
 begin
   apply to_Ico_div_eq_of_sub_zsmul_mem_Ico,
   rw [←sub_right_comm, set.sub_mem_Ico_iff_left, add_right_comm],
   exact sub_to_Ico_div_zsmul_mem_Ico hp (a + c) b,
 end
 
-lemma to_Ioc_div_sub' (a b c : α) : to_Ioc_div hp a (b - c) = to_Ioc_div hp (a + c) b :=
+lemma to_Ioc_div_sub_eq (a b c : α) : to_Ioc_div hp a (b - c) = to_Ioc_div hp (a + c) b :=
 begin
   apply to_Ioc_div_eq_of_sub_zsmul_mem_Ioc,
   rw [←sub_right_comm, set.sub_mem_Ioc_iff_left, add_right_comm],
   exact sub_to_Ioc_div_zsmul_mem_Ioc hp (a + c) b,
 end
 
-lemma to_Ico_div_add_right' (a b c : α) : to_Ico_div hp a (b + c) = to_Ico_div hp (a - c) b :=
-by rw [←sub_neg_eq_add, to_Ico_div_sub', sub_eq_add_neg]
+lemma to_Ico_div_add_right_eq (a b c : α) : to_Ico_div hp a (b + c) = to_Ico_div hp (a - c) b :=
+by rw [←sub_neg_eq_add, to_Ico_div_sub_eq, sub_eq_add_neg]
 
-lemma to_Ioc_div_add_right' (a b c : α) : to_Ioc_div hp a (b + c) = to_Ioc_div hp (a - c) b :=
-by rw [←sub_neg_eq_add, to_Ioc_div_sub', sub_eq_add_neg]
+lemma to_Ioc_div_add_right_eq (a b c : α) : to_Ioc_div hp a (b + c) = to_Ioc_div hp (a - c) b :=
+by rw [←sub_neg_eq_add, to_Ioc_div_sub_eq, sub_eq_add_neg]
 
 lemma to_Ico_div_neg (a b : α) : to_Ico_div hp a (-b) = -(to_Ioc_div hp (-a) b + 1) :=
 begin
   suffices : to_Ico_div hp a (-b) = -(to_Ioc_div hp (-(a + p)) b),
-  { rwa [neg_add, ←sub_eq_add_neg, ←to_Ioc_div_add_right', to_Ioc_div_add_right] at this },
+  { rwa [neg_add, ←sub_eq_add_neg, ←to_Ioc_div_add_right_eq, to_Ioc_div_add_right] at this },
   rw [← neg_eq_iff_eq_neg, eq_comm],
   apply to_Ioc_div_eq_of_sub_zsmul_mem_Ioc,
   obtain ⟨hc, ho⟩ := sub_to_Ico_div_zsmul_mem_Ico hp a (-b),
@@ -269,8 +295,14 @@ begin
   rw [neg_add, neg_add_cancel_right],
 end
 
+lemma to_Ico_div_neg' (a b : α) : to_Ico_div hp (-a) b = -(to_Ioc_div hp a (-b) + 1) :=
+by simpa only [neg_neg] using to_Ico_div_neg hp (-a) (-b)
+
 lemma to_Ioc_div_neg (a b : α) : to_Ioc_div hp a (-b) = -(to_Ico_div hp (-a) b + 1) :=
 by rw [←neg_neg b, to_Ico_div_neg, neg_neg, neg_neg, neg_add', neg_neg, add_sub_cancel]
+
+lemma to_Ioc_div_neg' (a b : α) : to_Ioc_div hp (-a) b = -(to_Ico_div hp a (-b) + 1) :=
+by simpa only [neg_neg] using to_Ioc_div_neg hp (-a) (-b)
 
 @[simp] lemma to_Ico_mod_add_zsmul (a b : α) (m : ℤ) :
   to_Ico_mod hp a (b + m • p) = to_Ico_mod hp a b :=
@@ -357,18 +389,18 @@ by simpa only [one_zsmul] using to_Ioc_mod_sub_zsmul hp a b 1
 by simpa only [one_zsmul] using to_Ioc_mod_sub_zsmul' hp a b 1
 
 lemma to_Ico_mod_sub_eq_sub (a b c : α) : to_Ico_mod hp a (b - c) = to_Ico_mod hp (a + c) b - c :=
-by simp_rw [to_Ico_mod, to_Ico_div_sub', sub_right_comm]
+by simp_rw [to_Ico_mod, to_Ico_div_sub_eq, sub_right_comm]
 
 lemma to_Ioc_mod_sub_eq_sub (a b c : α) : to_Ioc_mod hp a (b - c) = to_Ioc_mod hp (a + c) b - c :=
-by simp_rw [to_Ioc_mod, to_Ioc_div_sub', sub_right_comm]
+by simp_rw [to_Ioc_mod, to_Ioc_div_sub_eq, sub_right_comm]
 
 lemma to_Ico_mod_add_right_eq_add (a b c : α) :
   to_Ico_mod hp a (b + c) = to_Ico_mod hp (a - c) b + c :=
-by simp_rw [to_Ico_mod, to_Ico_div_add_right', sub_add_eq_add_sub]
+by simp_rw [to_Ico_mod, to_Ico_div_add_right_eq, sub_add_eq_add_sub]
 
 lemma to_Ioc_mod_add_right_eq_add (a b c : α) :
   to_Ioc_mod hp a (b + c) = to_Ioc_mod hp (a - c) b + c :=
-by simp_rw [to_Ioc_mod, to_Ioc_div_add_right', sub_add_eq_add_sub]
+by simp_rw [to_Ioc_mod, to_Ioc_div_add_right_eq, sub_add_eq_add_sub]
 
 lemma to_Ico_mod_neg (a b : α) : to_Ico_mod hp a (-b) = p - to_Ioc_mod hp (-a) b :=
 by { simp_rw [to_Ico_mod, to_Ioc_mod, to_Ico_div_neg, neg_smul, add_smul], abel }

--- a/src/algebra/order/to_interval_mod.lean
+++ b/src/algebra/order/to_interval_mod.lean
@@ -266,30 +266,34 @@ by simpa only [one_zsmul] using to_Ioc_div_sub_zsmul hp a b 1
 @[simp] lemma to_Ioc_div_sub' (a b : α) : to_Ioc_div hp (a - p) b = to_Ioc_div hp a b + 1 :=
 by simpa only [one_zsmul] using to_Ioc_div_sub_zsmul' hp a b 1
 
-lemma to_Ico_div_sub_eq (a b c : α) : to_Ico_div hp a (b - c) = to_Ico_div hp (a + c) b :=
+lemma to_Ico_div_sub_eq_to_Ico_div_add (a b c : α) :
+  to_Ico_div hp a (b - c) = to_Ico_div hp (a + c) b :=
 begin
   apply to_Ico_div_eq_of_sub_zsmul_mem_Ico,
   rw [←sub_right_comm, set.sub_mem_Ico_iff_left, add_right_comm],
   exact sub_to_Ico_div_zsmul_mem_Ico hp (a + c) b,
 end
 
-lemma to_Ioc_div_sub_eq (a b c : α) : to_Ioc_div hp a (b - c) = to_Ioc_div hp (a + c) b :=
+lemma to_Ioc_div_sub_eq_to_Ioc_div_add (a b c : α) :
+  to_Ioc_div hp a (b - c) = to_Ioc_div hp (a + c) b :=
 begin
   apply to_Ioc_div_eq_of_sub_zsmul_mem_Ioc,
   rw [←sub_right_comm, set.sub_mem_Ioc_iff_left, add_right_comm],
   exact sub_to_Ioc_div_zsmul_mem_Ioc hp (a + c) b,
 end
 
-lemma to_Ico_div_add_right_eq (a b c : α) : to_Ico_div hp a (b + c) = to_Ico_div hp (a - c) b :=
-by rw [←sub_neg_eq_add, to_Ico_div_sub_eq, sub_eq_add_neg]
+lemma to_Ico_div_sub_eq_to_Ico_div_add' (a b c : α) :
+  to_Ico_div hp (a - c) b = to_Ico_div hp a (b + c) :=
+by rw [←sub_neg_eq_add, to_Ico_div_sub_eq_to_Ico_div_add, sub_eq_add_neg]
 
-lemma to_Ioc_div_add_right_eq (a b c : α) : to_Ioc_div hp a (b + c) = to_Ioc_div hp (a - c) b :=
-by rw [←sub_neg_eq_add, to_Ioc_div_sub_eq, sub_eq_add_neg]
+lemma to_Ioc_div_sub_eq_to_Ioc_div_add' (a b c : α) :
+  to_Ioc_div hp (a - c) b = to_Ioc_div hp a (b + c) :=
+by rw [←sub_neg_eq_add, to_Ioc_div_sub_eq_to_Ioc_div_add, sub_eq_add_neg]
 
 lemma to_Ico_div_neg (a b : α) : to_Ico_div hp a (-b) = -(to_Ioc_div hp (-a) b + 1) :=
 begin
   suffices : to_Ico_div hp a (-b) = -(to_Ioc_div hp (-(a + p)) b),
-  { rwa [neg_add, ←sub_eq_add_neg, ←to_Ioc_div_add_right_eq, to_Ioc_div_add_right] at this },
+  { rwa [neg_add, ←sub_eq_add_neg, to_Ioc_div_sub_eq_to_Ioc_div_add', to_Ioc_div_add_right] at this },
   rw [← neg_eq_iff_eq_neg, eq_comm],
   apply to_Ioc_div_eq_of_sub_zsmul_mem_Ioc,
   obtain ⟨hc, ho⟩ := sub_to_Ico_div_zsmul_mem_Ico hp a (-b),
@@ -393,18 +397,18 @@ by simpa only [one_zsmul] using to_Ioc_mod_sub_zsmul hp a b 1
 by simpa only [one_zsmul] using to_Ioc_mod_sub_zsmul' hp a b 1
 
 lemma to_Ico_mod_sub_eq_sub (a b c : α) : to_Ico_mod hp a (b - c) = to_Ico_mod hp (a + c) b - c :=
-by simp_rw [to_Ico_mod, to_Ico_div_sub_eq, sub_right_comm]
+by simp_rw [to_Ico_mod, to_Ico_div_sub_eq_to_Ico_div_add, sub_right_comm]
 
 lemma to_Ioc_mod_sub_eq_sub (a b c : α) : to_Ioc_mod hp a (b - c) = to_Ioc_mod hp (a + c) b - c :=
-by simp_rw [to_Ioc_mod, to_Ioc_div_sub_eq, sub_right_comm]
+by simp_rw [to_Ioc_mod, to_Ioc_div_sub_eq_to_Ioc_div_add, sub_right_comm]
 
 lemma to_Ico_mod_add_right_eq_add (a b c : α) :
   to_Ico_mod hp a (b + c) = to_Ico_mod hp (a - c) b + c :=
-by simp_rw [to_Ico_mod, to_Ico_div_add_right_eq, sub_add_eq_add_sub]
+by simp_rw [to_Ico_mod, to_Ico_div_sub_eq_to_Ico_div_add', sub_add_eq_add_sub]
 
 lemma to_Ioc_mod_add_right_eq_add (a b c : α) :
   to_Ioc_mod hp a (b + c) = to_Ioc_mod hp (a - c) b + c :=
-by simp_rw [to_Ioc_mod, to_Ioc_div_add_right_eq, sub_add_eq_add_sub]
+by simp_rw [to_Ioc_mod, to_Ioc_div_sub_eq_to_Ioc_div_add', sub_add_eq_add_sub]
 
 lemma to_Ico_mod_neg (a b : α) : to_Ico_mod hp a (-b) = p - to_Ioc_mod hp (-a) b :=
 by { simp_rw [to_Ico_mod, to_Ioc_mod, to_Ico_div_neg, neg_smul, add_smul], abel }

--- a/src/algebra/order/to_interval_mod.lean
+++ b/src/algebra/order/to_interval_mod.lean
@@ -405,14 +405,14 @@ by simp_rw [to_Ioc_mod, to_Ioc_div_add_right_eq, sub_add_eq_add_sub]
 lemma to_Ico_mod_neg (a b : α) : to_Ico_mod hp a (-b) = p - to_Ioc_mod hp (-a) b :=
 by { simp_rw [to_Ico_mod, to_Ioc_mod, to_Ico_div_neg, neg_smul, add_smul], abel }
 
+lemma to_Ico_mod_neg' (a b : α) : to_Ico_mod hp (-a) b = p - to_Ioc_mod hp a (-b) :=
+by simpa only [neg_neg] using to_Ico_mod_neg hp (-a) (-b)
+
 lemma to_Ioc_mod_neg (a b : α) : to_Ioc_mod hp a (-b) = p - to_Ico_mod hp (-a) b :=
 by { simp_rw [to_Ioc_mod, to_Ico_mod, to_Ioc_div_neg, neg_smul, add_smul], abel }
 
-lemma to_Ico_mod_neg' (a b : α) : to_Ico_mod hp (-a) b = p - to_Ioc_mod hp a (-b) :=
-by rw [to_Ioc_mod_neg, sub_sub_cancel]
-
 lemma to_Ioc_mod_neg' (a b : α) : to_Ioc_mod hp (-a) b = p - to_Ico_mod hp a (-b) :=
-by rw [to_Ico_mod_neg, sub_sub_cancel]
+by simpa only [neg_neg] using to_Ioc_mod_neg hp (-a) (-b)
 
 lemma to_Ico_mod_eq_to_Ico_mod : to_Ico_mod hp a b = to_Ico_mod hp a c ↔ ∃ n : ℤ, c - b = n • p :=
 begin

--- a/src/algebra/order/to_interval_mod.lean
+++ b/src/algebra/order/to_interval_mod.lean
@@ -323,31 +323,51 @@ by simp_rw [sub_eq_add_neg, ←neg_smul, to_Ioc_mod_add_zsmul']
 @[simp] lemma to_Ico_mod_add_right (a b : α) : to_Ico_mod hp a (b + p) = to_Ico_mod hp a b :=
 by simpa only [one_zsmul] using to_Ico_mod_add_zsmul hp a b 1
 
+@[simp] lemma to_Ico_mod_add_right' (a b : α) : to_Ico_mod hp (a + p) b = to_Ico_mod hp a b + p :=
+by simpa only [one_zsmul] using to_Ico_mod_add_zsmul' hp a b 1
+
 @[simp] lemma to_Ioc_mod_add_right (a b : α) : to_Ioc_mod hp a (b + p) = to_Ioc_mod hp a b :=
 by simpa only [one_zsmul] using to_Ioc_mod_add_zsmul hp a b 1
+
+@[simp] lemma to_Ioc_mod_add_right' (a b : α) : to_Ioc_mod hp (a + p) b = to_Ioc_mod hp a b + p :=
+by simpa only [one_zsmul] using to_Ioc_mod_add_zsmul' hp a b 1
 
 @[simp] lemma to_Ico_mod_add_left (a b : α) : to_Ico_mod hp a (p + b) = to_Ico_mod hp a b :=
 by rw [add_comm, to_Ico_mod_add_right]
 
+@[simp] lemma to_Ico_mod_add_left' (a b : α) : to_Ico_mod hp (p + a) b = p + to_Ico_mod hp a b :=
+by rw [add_comm, to_Ico_mod_add_right', add_comm]
+
 @[simp] lemma to_Ioc_mod_add_left (a b : α) : to_Ioc_mod hp a (p + b) = to_Ioc_mod hp a b :=
 by rw [add_comm, to_Ioc_mod_add_right]
+
+@[simp] lemma to_Ioc_mod_add_left' (a b : α) : to_Ioc_mod hp (p + a) b = p + to_Ioc_mod hp a b :=
+by rw [add_comm, to_Ioc_mod_add_right', add_comm]
 
 @[simp] lemma to_Ico_mod_sub (a b : α) : to_Ico_mod hp a (b - p) = to_Ico_mod hp a b :=
 by simpa only [one_zsmul] using to_Ico_mod_sub_zsmul hp a b 1
 
+@[simp] lemma to_Ico_mod_sub' (a b : α) : to_Ico_mod hp (a - p) b = to_Ico_mod hp a b - p :=
+by simpa only [one_zsmul] using to_Ico_mod_sub_zsmul' hp a b 1
+
 @[simp] lemma to_Ioc_mod_sub (a b : α) : to_Ioc_mod hp a (b - p) = to_Ioc_mod hp a b :=
 by simpa only [one_zsmul] using to_Ioc_mod_sub_zsmul hp a b 1
 
-lemma to_Ico_mod_sub' (a b c : α) : to_Ico_mod hp a (b - c) = to_Ico_mod hp (a + c) b - c :=
+@[simp] lemma to_Ioc_mod_sub' (a b : α) : to_Ioc_mod hp (a - p) b = to_Ioc_mod hp a b - p :=
+by simpa only [one_zsmul] using to_Ioc_mod_sub_zsmul' hp a b 1
+
+lemma to_Ico_mod_sub_eq_sub (a b c : α) : to_Ico_mod hp a (b - c) = to_Ico_mod hp (a + c) b - c :=
 by simp_rw [to_Ico_mod, to_Ico_div_sub', sub_right_comm]
 
-lemma to_Ioc_mod_sub' (a b c : α) : to_Ioc_mod hp a (b - c) = to_Ioc_mod hp (a + c) b - c :=
+lemma to_Ioc_mod_sub_eq_sub (a b c : α) : to_Ioc_mod hp a (b - c) = to_Ioc_mod hp (a + c) b - c :=
 by simp_rw [to_Ioc_mod, to_Ioc_div_sub', sub_right_comm]
 
-lemma to_Ico_mod_add_right' (a b c : α) : to_Ico_mod hp a (b + c) = to_Ico_mod hp (a - c) b + c :=
+lemma to_Ico_mod_add_right_eq_add (a b c : α) :
+  to_Ico_mod hp a (b + c) = to_Ico_mod hp (a - c) b + c :=
 by simp_rw [to_Ico_mod, to_Ico_div_add_right', sub_add_eq_add_sub]
 
-lemma to_Ioc_mod_add_right' (a b c : α) : to_Ioc_mod hp a (b + c) = to_Ioc_mod hp (a - c) b + c :=
+lemma to_Ioc_mod_add_right_eq_add (a b c : α) :
+  to_Ioc_mod hp a (b + c) = to_Ioc_mod hp (a - c) b + c :=
 by simp_rw [to_Ioc_mod, to_Ioc_div_add_right', sub_add_eq_add_sub]
 
 lemma to_Ico_mod_neg (a b : α) : to_Ico_mod hp a (-b) = p - to_Ioc_mod hp (-a) b :=
@@ -355,6 +375,12 @@ by { simp_rw [to_Ico_mod, to_Ioc_mod, to_Ico_div_neg, neg_smul, add_smul], abel 
 
 lemma to_Ioc_mod_neg (a b : α) : to_Ioc_mod hp a (-b) = p - to_Ico_mod hp (-a) b :=
 by { simp_rw [to_Ioc_mod, to_Ico_mod, to_Ioc_div_neg, neg_smul, add_smul], abel }
+
+lemma to_Ico_mod_neg' (a b : α) : to_Ico_mod hp (-a) b = p - to_Ioc_mod hp a (-b) :=
+by rw [to_Ioc_mod_neg, sub_sub_cancel]
+
+lemma to_Ioc_mod_neg' (a b : α) : to_Ioc_mod hp (-a) b = p - to_Ico_mod hp a (-b) :=
+by rw [to_Ico_mod_neg, sub_sub_cancel]
 
 lemma to_Ico_mod_eq_to_Ico_mod : to_Ico_mod hp a b = to_Ico_mod hp a c ↔ ∃ n : ℤ, c - b = n • p :=
 begin


### PR DESCRIPTION
These lemmas are about expressions in the second instead of third arguments of the `I{co,oc}_{mod,div}` functions.

Some existing lemmas clashed with these new lemmas; they have been renamed as follows:
* `to_Ico_div_sub'` → `to_Ico_div_sub_eq_to_Ico_div_add`
* `to_Ioc_div_sub'` → `to_Ioc_div_sub_eq_to_Ioc_div_add`
* `to_Ico_div_add_right'` → `to_Ico_div_sub_eq_to_Ico_div_add'` (and reversed)
* `to_Ioc_div_add_right'` → `to_Ioc_div_sub_eq_to_Ioc_div_add'` (and reversed)
* `to_Ico_mod_sub'` → `to_Ico_mod_sub_eq_sub`
* `to_Ioc_mod_sub'` → `to_Ioc_mod_sub_eq_sub`
* `to_Ico_mod_add_right'` → `to_Ico_mod_add_right_eq_add`
* `to_Ioc_mod_add_right'` → `to_Ioc_mod_add_right_eq_add`

The statement of `to_Ioc_div_zsmul_add` is commuted to be consistent with the lemmas around it; presumably it was a copy-and-paste error.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
