### PR TITLE
[Merged by Bors] - feat(analysis/calculus/deriv): `polynomial.aeval` lemmas

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner, Sébastien Gouëzel
 -/
 import analysis.calculus.fderiv
-import data.polynomial.derivative
 import data.polynomial.algebra_map
+import data.polynomial.derivative
 import linear_algebra.affine_space.slope
 
 /-!

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -1867,7 +1867,8 @@ by simpa only [aeval_def, eval₂_eq_eval_map, derivative_map]
 protected lemma has_deriv_at (x : 𝕜) : has_deriv_at (λx, p.eval x) (p.derivative.eval x) x :=
 (p.has_strict_deriv_at x).has_deriv_at
 
-protected lemma has_deriv_at_aeval (x : 𝕜) : has_deriv_at (λx, aeval x q) (aeval x q.derivative) x :=
+protected lemma has_deriv_at_aeval (x : 𝕜) :
+  has_deriv_at (λx, aeval x q) (aeval x q.derivative) x :=
 (q.has_strict_deriv_at_aeval x).has_deriv_at
 
 protected theorem has_deriv_within_at (x : 𝕜) (s : set 𝕜) :

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -5,6 +5,7 @@ Authors: Gabriel Ebner, Sébastien Gouëzel
 -/
 import analysis.calculus.fderiv
 import data.polynomial.derivative
+import data.polynomial.algebra_map
 import linear_algebra.affine_space.slope
 
 /-!
@@ -1837,8 +1838,8 @@ end
 namespace polynomial
 /-! ### Derivative of a polynomial -/
 
-variables {x : 𝕜} {s : set 𝕜}
-variable (p : 𝕜[X])
+variables {R : Type*} [comm_semiring R] [algebra R 𝕜]
+variables (p : 𝕜[X]) (q : R[X]) {x : 𝕜} {s : set 𝕜}
 
 /-- The derivative (in the analysis sense) of a polynomial `p` is given by `p.derivative`. -/
 protected lemma has_strict_deriv_at (x : 𝕜) :
@@ -1857,28 +1858,55 @@ begin
       id.def], ring } }
 end
 
+protected lemma has_strict_deriv_at_aeval (x : 𝕜) :
+  has_strict_deriv_at (λx, aeval x q) (aeval x q.derivative) x :=
+by simpa only [aeval_def, eval₂_eq_eval_map, derivative_map]
+  using (q.map (algebra_map R 𝕜)).has_strict_deriv_at x
+
 /-- The derivative (in the analysis sense) of a polynomial `p` is given by `p.derivative`. -/
 protected lemma has_deriv_at (x : 𝕜) : has_deriv_at (λx, p.eval x) (p.derivative.eval x) x :=
 (p.has_strict_deriv_at x).has_deriv_at
+
+protected lemma has_deriv_at_aeval (x : 𝕜) : has_deriv_at (λx, aeval x q) (aeval x q.derivative) x :=
+(q.has_strict_deriv_at_aeval x).has_deriv_at
 
 protected theorem has_deriv_within_at (x : 𝕜) (s : set 𝕜) :
   has_deriv_within_at (λx, p.eval x) (p.derivative.eval x) s x :=
 (p.has_deriv_at x).has_deriv_within_at
 
-protected lemma differentiable_at : differentiable_at 𝕜 (λx, p.eval x) x :=
+protected theorem has_deriv_within_at_aeval (x : 𝕜) (s : set 𝕜) :
+  has_deriv_within_at (λx, aeval x q) (aeval x q.derivative.eval) s x :=
+(q.has_deriv_at_aeval x).has_deriv_within_at
+
+protected lemma differentiable_at (x : 𝕜) : differentiable_at 𝕜 (λx, p.eval x) x :=
 (p.has_deriv_at x).differentiable_at
+
+protected lemma differentiable_at_aeval (x : 𝕜) : differentiable_at 𝕜 (λx, aeval x q) x :=
+(q.has_deriv_at_aeval x).differentiable_at
 
 protected lemma differentiable_within_at : differentiable_within_at 𝕜 (λx, p.eval x) s x :=
 p.differentiable_at.differentiable_within_at
 
+protected lemma differentiable_within_at_aeval : differentiable_within_at 𝕜 (λx, aeval x q) s x :=
+q.differentiable_at_aeval.differentiable_within_at
+
 protected lemma differentiable : differentiable 𝕜 (λx, p.eval x) :=
 λx, p.differentiable_at
+
+protected lemma differentiable_aeval : differentiable 𝕜 (λx, aeval q x) :=
+λx, q.differentiable_at_aeval
 
 protected lemma differentiable_on : differentiable_on 𝕜 (λx, p.eval x) s :=
 p.differentiable.differentiable_on
 
+protected lemma differentiable_on_aeval : differentiable_on 𝕜 (λx, aeval x q) s :=
+q.differentiable_aeval.differentiable_on
+
 @[simp] protected lemma deriv : deriv (λx, p.eval x) x = p.derivative.eval x :=
 (p.has_deriv_at x).deriv
+
+@[simp] protected lemma deriv : deriv (λx, aeval x q) x = aeval x q.derivative :=
+(q.has_deriv_at_aeval x).deriv
 
 protected lemma deriv_within (hxs : unique_diff_within_at 𝕜 s x) :
   deriv_within (λx, p.eval x) s x = p.derivative.eval x :=
@@ -1887,21 +1915,41 @@ begin
   exact p.deriv
 end
 
+protected lemma deriv_within_aeval (hxs : unique_diff_within_at 𝕜 s x) :
+  deriv_within (λx, aeval x q) s x = aeval x q.derivative :=
+by simpa only [aeval_def, eval₂_eq_eval_map] using deriv_within (q.map (algebra_map R 𝕜)) x
+
 protected lemma has_fderiv_at (x : 𝕜) :
   has_fderiv_at (λx, p.eval x) (smul_right (1 : 𝕜 →L[𝕜] 𝕜) (p.derivative.eval x)) x :=
 p.has_deriv_at x
+
+protected lemma has_fderiv_at_aeval (x : 𝕜) :
+  has_fderiv_at (λx, aeval x q) (smul_right (1 : 𝕜 →L[𝕜] 𝕜) (aeval x q.derivative)) x :=
+q.has_deriv_at_aeval x
 
 protected lemma has_fderiv_within_at (x : 𝕜) :
   has_fderiv_within_at (λx, p.eval x) (smul_right (1 : 𝕜 →L[𝕜] 𝕜) (p.derivative.eval x)) s x :=
 (p.has_fderiv_at x).has_fderiv_within_at
 
+protected lemma has_fderiv_within_at_aeval (x : 𝕜) :
+  has_fderiv_within_at (λx, aeval x q) (smul_right (1 : 𝕜 →L[𝕜] 𝕜) (aeval x q.derivative)) s x :=
+(q.has_fderiv_at_aeval x).has_fderiv_within_at
+
 @[simp] protected lemma fderiv :
   fderiv 𝕜 (λx, p.eval x) x = smul_right (1 : 𝕜 →L[𝕜] 𝕜) (p.derivative.eval x) :=
 (p.has_fderiv_at x).fderiv
 
+@[simp] protected lemma fderiv_aeval :
+  fderiv 𝕜 (λx, aeval x q) x = smul_right (1 : 𝕜 →L[𝕜] 𝕜) (aeval x q.derivative) :=
+(q.has_fderiv_at_aeval x).fderiv
+
 protected lemma fderiv_within (hxs : unique_diff_within_at 𝕜 s x) :
   fderiv_within 𝕜 (λx, p.eval x) s x = smul_right (1 : 𝕜 →L[𝕜] 𝕜) (p.derivative.eval x) :=
 (p.has_fderiv_within_at x).fderiv_within hxs
+
+protected lemma fderiv_within_aeval (hxs : unique_diff_within_at 𝕜 s x) :
+  fderiv_within 𝕜 (λx, aeval x q) s x = smul_right (1 : 𝕜 →L[𝕜] 𝕜) (aeval x q.derivative) :=
+(q.has_fderiv_within_at_aeval x).fderiv_within hxs
 
 end polynomial
 

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -1875,13 +1875,13 @@ protected theorem has_deriv_within_at (x : 𝕜) (s : set 𝕜) :
 (p.has_deriv_at x).has_deriv_within_at
 
 protected theorem has_deriv_within_at_aeval (x : 𝕜) (s : set 𝕜) :
-  has_deriv_within_at (λx, aeval x q) (aeval x q.derivative.eval) s x :=
+  has_deriv_within_at (λx, aeval x q) (aeval x q.derivative) s x :=
 (q.has_deriv_at_aeval x).has_deriv_within_at
 
-protected lemma differentiable_at (x : 𝕜) : differentiable_at 𝕜 (λx, p.eval x) x :=
+protected lemma differentiable_at : differentiable_at 𝕜 (λx, p.eval x) x :=
 (p.has_deriv_at x).differentiable_at
 
-protected lemma differentiable_at_aeval (x : 𝕜) : differentiable_at 𝕜 (λx, aeval x q) x :=
+protected lemma differentiable_at_aeval : differentiable_at 𝕜 (λx, aeval x q) x :=
 (q.has_deriv_at_aeval x).differentiable_at
 
 protected lemma differentiable_within_at : differentiable_within_at 𝕜 (λx, p.eval x) s x :=
@@ -1893,7 +1893,7 @@ q.differentiable_at_aeval.differentiable_within_at
 protected lemma differentiable : differentiable 𝕜 (λx, p.eval x) :=
 λx, p.differentiable_at
 
-protected lemma differentiable_aeval : differentiable 𝕜 (λx, aeval q x) :=
+protected lemma differentiable_aeval : differentiable 𝕜 (λ x : 𝕜, aeval x q) :=
 λx, q.differentiable_at_aeval
 
 protected lemma differentiable_on : differentiable_on 𝕜 (λx, p.eval x) s :=
@@ -1905,7 +1905,7 @@ q.differentiable_aeval.differentiable_on
 @[simp] protected lemma deriv : deriv (λx, p.eval x) x = p.derivative.eval x :=
 (p.has_deriv_at x).deriv
 
-@[simp] protected lemma deriv : deriv (λx, aeval x q) x = aeval x q.derivative :=
+@[simp] protected lemma deriv_aeval : deriv (λx, aeval x q) x = aeval x q.derivative :=
 (q.has_deriv_at_aeval x).deriv
 
 protected lemma deriv_within (hxs : unique_diff_within_at 𝕜 s x) :
@@ -1917,7 +1917,8 @@ end
 
 protected lemma deriv_within_aeval (hxs : unique_diff_within_at 𝕜 s x) :
   deriv_within (λx, aeval x q) s x = aeval x q.derivative :=
-by simpa only [aeval_def, eval₂_eq_eval_map] using deriv_within (q.map (algebra_map R 𝕜)) x
+by simpa only [aeval_def, eval₂_eq_eval_map, derivative_map]
+  using (q.map (algebra_map R 𝕜)).deriv_within hxs
 
 protected lemma has_fderiv_at (x : 𝕜) :
   has_fderiv_at (λx, p.eval x) (smul_right (1 : 𝕜 →L[𝕜] 𝕜) (p.derivative.eval x)) x :=


### PR DESCRIPTION
This duplicates every lemma about differentiation of `polynomial.eval` for `polynomial.aeval` too.
Some of these turned out to be needed in #18896.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
