### PR TITLE
[Merged by Bors] - feat(data/real/ennreal): interactions between infi/supr and to_nnreal/to_real

### DIFF
--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1860,14 +1860,12 @@ begin
     simp_rw [← coe_infi, to_nnreal_coe] },
 end
 
-lemma to_nnreal_Inf (s : set ℝ≥0∞) (hf : ∀ r ∈ s, r ≠ ∞) :
+lemma to_nnreal_Inf (s : set ℝ≥0∞) (hs : ∀ r ∈ s, r ≠ ∞) :
   (Inf s).to_nnreal = Inf (ennreal.to_nnreal '' s) :=
 begin
-  lift s to set ℝ≥0 using hf,
-  obtain rfl | hs := s.eq_empty_or_nonempty,
-  { simp_rw [set.image_empty, Inf_empty, nnreal.Inf_empty, top_to_nnreal] },
-  { have := with_top.coe_Inf' hs,
-    simp_rw [←with_top.coe_Inf' hs, set.image_image, to_nnreal_coe, set.image_id'] }
+  let f : s → ℝ≥0∞ := coe,
+  have hf : ∀ i, f i ≠ ∞ := λ⟨r, rs⟩, hs r rs,
+  simpa [←Inf_range, subtype.range_coe, ←Inf_image'] using (to_nnreal_infi hf),
 end
 
 lemma to_nnreal_supr (hf : ∀ i, f i ≠ ∞) : (supr f).to_nnreal = ⨆ i, (f i).to_nnreal :=
@@ -1878,27 +1876,15 @@ begin
   { simp_rw [← coe_supr h, to_nnreal_coe] },
   { simp_rw [nnreal.supr_of_not_bdd_above h],
     convert top_to_nnreal,
-    rw supr_eq_top,
-    intros b hb,
-    lift b to ℝ≥0 using hb.ne,
-    simp_rw [not_bdd_above_iff, mem_range, exists_prop, exists_exists_eq_and, ←coe_lt_coe] at h,
-    exact h b }
+    exact (with_top.supr_coe_eq_top f).mpr h }
 end
 
-lemma to_nnreal_Sup (s : set ℝ≥0∞) (hf : ∀ r ∈ s, r ≠ ∞) :
+lemma to_nnreal_Sup (s : set ℝ≥0∞) (hs : ∀ r ∈ s, r ≠ ∞) :
   (Sup s).to_nnreal = Sup (ennreal.to_nnreal '' s) :=
 begin
-  lift s to set ℝ≥0 using hf,
-  simp_rw [image_image, to_nnreal_coe, set.image_id'],
-  by_cases h : bdd_above s,
-  { simp_rw [← with_top.coe_Sup' h, to_nnreal_coe] },
-  { simp_rw [nnreal.Sup_of_not_bdd_above h],
-    convert top_to_nnreal,
-    simp_rw [Sup_eq_top, set.mem_image, exists_prop, exists_exists_and_eq_and],
-    intros b hb,
-    lift b to ℝ≥0 using hb.ne,
-    simp_rw [not_bdd_above_iff, ←coe_lt_coe, exists_prop] at h,
-    exact h b }
+  let f : s → ℝ≥0∞ := coe,
+  have hf : ∀ i, f i ≠ ∞ := λ⟨r, rs⟩, hs r rs,
+  simpa [←Sup_range, subtype.range_coe, ←Sup_image'] using (to_nnreal_supr hf),
 end
 
 lemma to_real_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_real = ⨅ i, (f i).to_real :=

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1870,6 +1870,37 @@ begin
     simp_rw [←with_top.coe_Inf' hs, set.image_image, to_nnreal_coe, set.image_id'] }
 end
 
+lemma to_nnreal_supr (hf : ∀ i, f i ≠ ∞) : (supr f).to_nnreal = ⨆ i, (f i).to_nnreal :=
+begin
+  lift f to ι → ℝ≥0 using hf,
+  simp_rw to_nnreal_coe,
+  by_cases h : bdd_above (range f),
+  { simp_rw [← coe_supr h, to_nnreal_coe] },
+  { simp_rw [nnreal.supr_of_not_bdd_above h],
+    convert top_to_nnreal,
+    rw supr_eq_top,
+    intros b hb,
+    lift b to ℝ≥0 using hb.ne,
+    simp_rw [not_bdd_above_iff, mem_range, exists_prop, exists_exists_eq_and, ←coe_lt_coe] at h,
+    exact h b }
+end
+
+lemma to_nnreal_Sup (s : set ℝ≥0∞) (hf : ∀ r ∈ s, r ≠ ∞) :
+  (Sup s).to_nnreal = Sup (ennreal.to_nnreal '' s) :=
+begin
+  lift s to set ℝ≥0 using hf,
+  simp_rw [image_image, to_nnreal_coe, set.image_id'],
+  by_cases h : bdd_above s,
+  { simp_rw [← with_top.coe_Sup' h, to_nnreal_coe] },
+  { simp_rw [nnreal.Sup_of_not_bdd_above h],
+    convert top_to_nnreal,
+    simp_rw [Sup_eq_top, set.mem_image, exists_prop, exists_exists_and_eq_and],
+    intros b hb,
+    lift b to ℝ≥0 using hb.ne,
+    simp_rw [not_bdd_above_iff, ←coe_lt_coe, exists_prop] at h,
+    exact h b }
+end
+
 lemma to_real_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_real = ⨅ i, (f i).to_real :=
 by simp only [ennreal.to_real, to_nnreal_infi hf, nnreal.coe_infi]
 

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1863,9 +1863,8 @@ end
 lemma to_nnreal_Inf (s : set ℝ≥0∞) (hs : ∀ r ∈ s, r ≠ ∞) :
   (Inf s).to_nnreal = Inf (ennreal.to_nnreal '' s) :=
 begin
-  let f : s → ℝ≥0∞ := coe,
-  have hf : ∀ i, f i ≠ ∞ := λ⟨r, rs⟩, hs r rs,
-  simpa [←Inf_range, subtype.range_coe, ←Inf_image'] using (to_nnreal_infi hf),
+  have hf : ∀ i, (coe : s → ℝ≥0∞) i ≠ ∞ := λ⟨r, rs⟩, hs r rs,
+  simpa [←Inf_range, subtype.range_coe, ←Inf_image'] using (to_nnreal_infi hf)
 end
 
 lemma to_nnreal_supr (hf : ∀ i, f i ≠ ∞) : (supr f).to_nnreal = ⨆ i, (f i).to_nnreal :=
@@ -1882,9 +1881,8 @@ end
 lemma to_nnreal_Sup (s : set ℝ≥0∞) (hs : ∀ r ∈ s, r ≠ ∞) :
   (Sup s).to_nnreal = Sup (ennreal.to_nnreal '' s) :=
 begin
-  let f : s → ℝ≥0∞ := coe,
-  have hf : ∀ i, f i ≠ ∞ := λ⟨r, rs⟩, hs r rs,
-  simpa [←Sup_range, subtype.range_coe, ←Sup_image'] using (to_nnreal_supr hf),
+  have hf : ∀ i, (coe : s → ℝ≥0∞) i ≠ ∞ := λ⟨r, rs⟩, hs r rs,
+  simpa [←Sup_range, subtype.range_coe, ←Sup_image'] using (to_nnreal_supr hf)
 end
 
 lemma to_real_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_real = ⨅ i, (f i).to_real :=

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1872,10 +1872,8 @@ begin
   lift f to ι → ℝ≥0 using hf,
   simp_rw to_nnreal_coe,
   by_cases h : bdd_above (range f),
-  { simp_rw [← coe_supr h, to_nnreal_coe] },
-  { simp_rw [nnreal.supr_of_not_bdd_above h],
-    convert top_to_nnreal,
-    exact (with_top.supr_coe_eq_top f).mpr h }
+  { rw [← coe_supr h, to_nnreal_coe] },
+  { rw [nnreal.supr_of_not_bdd_above h, (with_top.supr_coe_eq_top f).mpr h, top_to_nnreal] }
 end
 
 lemma to_nnreal_Sup (s : set ℝ≥0∞) (hs : ∀ r ∈ s, r ≠ ∞) :

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1908,6 +1908,13 @@ lemma to_real_Inf (s : set ℝ≥0∞) (hf : ∀ r ∈ s, r ≠ ∞) :
   (Inf s).to_real = Inf (ennreal.to_real '' s) :=
 by simp only [ennreal.to_real, to_nnreal_Inf s hf, nnreal.coe_Inf, set.image_image]
 
+lemma to_real_supr (hf : ∀ i, f i ≠ ∞) : (supr f).to_real = ⨆ i, (f i).to_real :=
+by simp only [ennreal.to_real, to_nnreal_supr hf, nnreal.coe_supr]
+
+lemma to_real_Sup (s : set ℝ≥0∞) (hf : ∀ r ∈ s, r ≠ ∞) :
+  (Sup s).to_real = Sup (ennreal.to_real '' s) :=
+by simp only [ennreal.to_real, to_nnreal_Sup s hf, nnreal.coe_Sup, set.image_image]
+
 lemma infi_add : infi f + a = ⨅i, f i + a :=
 le_antisymm
   (le_infi $ assume i, add_le_add (infi_le _ _) $ le_rfl)

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1845,16 +1845,30 @@ end real
 section infi
 variables {ι : Sort*} {f g : ι → ℝ≥0∞}
 
-lemma to_nnreal_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_nnreal = ⨅i, (f i).to_nnreal :=
+lemma to_nnreal_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_nnreal = ⨅ i, (f i).to_nnreal :=
 begin
   casesI is_empty_or_nonempty ι,
   { rw [infi_of_empty, top_to_nnreal, nnreal.infi_empty] },
   { lift f to ι → ℝ≥0 using hf,
-    norm_cast }
+    simp_rw [← with_top.coe_infi, to_nnreal_coe] },
 end
 
-lemma to_real_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_real = ⨅i, (f i).to_real :=
+lemma to_nnreal_Inf (s : set ℝ≥0∞) (hf : ∀ r ∈ s, r ≠ ∞) :
+  (Inf s).to_nnreal = Inf (ennreal.to_nnreal '' s) :=
+begin
+  lift s to set ℝ≥0 using hf,
+  obtain rfl | hs := s.eq_empty_or_nonempty,
+  { simp_rw [set.image_empty, Inf_empty, nnreal.Inf_empty, top_to_nnreal] },
+  { have := with_top.coe_Inf' hs,
+    simp_rw [←with_top.coe_Inf' hs, set.image_image, to_nnreal_coe, set.image_id'] }
+end
+
+lemma to_real_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_real = ⨅ i, (f i).to_real :=
 by simp only [ennreal.to_real, to_nnreal_infi hf, nnreal.coe_infi]
+
+lemma to_real_Inf (s : set ℝ≥0∞) (hf : ∀ r ∈ s, r ≠ ∞) :
+  (Inf s).to_real = Inf (ennreal.to_real '' s) :=
+by simp only [ennreal.to_real, to_nnreal_Inf s hf, nnreal.coe_Inf, set.image_image]
 
 lemma infi_add : infi f + a = ⨅i, f i + a :=
 le_antisymm

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1864,7 +1864,7 @@ lemma to_nnreal_Inf (s : set ℝ≥0∞) (hs : ∀ r ∈ s, r ≠ ∞) :
   (Inf s).to_nnreal = Inf (ennreal.to_nnreal '' s) :=
 begin
   have hf : ∀ i, (coe : s → ℝ≥0∞) i ≠ ∞ := λ⟨r, rs⟩, hs r rs,
-  simpa [←Inf_range, subtype.range_coe, ←Inf_image'] using (to_nnreal_infi hf)
+  simpa [←Inf_range, ←Inf_image'] using to_nnreal_infi hf
 end
 
 lemma to_nnreal_supr (hf : ∀ i, f i ≠ ∞) : (supr f).to_nnreal = ⨆ i, (f i).to_nnreal :=
@@ -1882,7 +1882,7 @@ lemma to_nnreal_Sup (s : set ℝ≥0∞) (hs : ∀ r ∈ s, r ≠ ∞) :
   (Sup s).to_nnreal = Sup (ennreal.to_nnreal '' s) :=
 begin
   have hf : ∀ i, (coe : s → ℝ≥0∞) i ≠ ∞ := λ⟨r, rs⟩, hs r rs,
-  simpa [←Sup_range, subtype.range_coe, ←Sup_image'] using (to_nnreal_supr hf)
+  simpa [←Sup_range, ←Sup_image'] using to_nnreal_supr hf
 end
 
 lemma to_real_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_real = ⨅ i, (f i).to_real :=

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1863,8 +1863,8 @@ end
 lemma to_nnreal_Inf (s : set ℝ≥0∞) (hs : ∀ r ∈ s, r ≠ ∞) :
   (Inf s).to_nnreal = Inf (ennreal.to_nnreal '' s) :=
 begin
-  have hf : ∀ i, (coe : s → ℝ≥0∞) i ≠ ∞ := λ⟨r, rs⟩, hs r rs,
-  simpa [←Inf_range, ←Inf_image'] using to_nnreal_infi hf
+  have hf : ∀ i, (coe : s → ℝ≥0∞) i ≠ ∞ := λ ⟨r, rs⟩, hs r rs,
+  simpa only [←Inf_range, ←Inf_image', subtype.range_coe_subtype] using to_nnreal_infi hf
 end
 
 lemma to_nnreal_supr (hf : ∀ i, f i ≠ ∞) : (supr f).to_nnreal = ⨆ i, (f i).to_nnreal :=
@@ -1880,7 +1880,7 @@ lemma to_nnreal_Sup (s : set ℝ≥0∞) (hs : ∀ r ∈ s, r ≠ ∞) :
   (Sup s).to_nnreal = Sup (ennreal.to_nnreal '' s) :=
 begin
   have hf : ∀ i, (coe : s → ℝ≥0∞) i ≠ ∞ := λ⟨r, rs⟩, hs r rs,
-  simpa [←Sup_range, ←Sup_image'] using to_nnreal_supr hf
+  simpa only [←Sup_range, ←Sup_image', subtype.range_coe_subtype] using to_nnreal_supr hf
 end
 
 lemma to_real_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_real = ⨅ i, (f i).to_real :=

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -657,6 +657,13 @@ section complete_lattice
 lemma coe_Sup {s : set ℝ≥0} : bdd_above s → (↑(Sup s) : ℝ≥0∞) = (⨆a∈s, ↑a) := with_top.coe_Sup
 lemma coe_Inf {s : set ℝ≥0} : s.nonempty → (↑(Inf s) : ℝ≥0∞) = (⨅a∈s, ↑a) := with_top.coe_Inf
 
+lemma coe_supr {ι : Sort*} {f : ι → ℝ≥0} (hf : bdd_above (range f)) :
+  (↑(supr f) : ℝ≥0∞) = ⨆a, ↑(f a) :=
+with_top.coe_supr _ hf
+@[norm_cast]
+lemma coe_infi {ι : Sort*} [nonempty ι] (f : ι → ℝ≥0) : (↑(infi f) : ℝ≥0∞) = (⨅ a, ↑(f a)) :=
+with_top.coe_infi f
+
 lemma coe_mem_upper_bounds {s : set ℝ≥0} :
   ↑r ∈ upper_bounds ((coe : ℝ≥0 → ℝ≥0∞) '' s) ↔ r ∈ upper_bounds s :=
 by simp [upper_bounds, ball_image_iff, -mem_image, *] {contextual := tt}
@@ -1850,7 +1857,7 @@ begin
   casesI is_empty_or_nonempty ι,
   { rw [infi_of_empty, top_to_nnreal, nnreal.infi_empty] },
   { lift f to ι → ℝ≥0 using hf,
-    simp_rw [← with_top.coe_infi, to_nnreal_coe] },
+    simp_rw [← coe_infi, to_nnreal_coe] },
 end
 
 lemma to_nnreal_Inf (s : set ℝ≥0∞) (hf : ∀ r ∈ s, r ≠ ∞) :

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1845,6 +1845,17 @@ end real
 section infi
 variables {ι : Sort*} {f g : ι → ℝ≥0∞}
 
+lemma to_nnreal_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_nnreal = ⨅i, (f i).to_nnreal :=
+begin
+  casesI is_empty_or_nonempty ι,
+  { rw [infi_of_empty, top_to_nnreal, nnreal.infi_empty] },
+  { lift f to ι → ℝ≥0 using hf,
+    norm_cast }
+end
+
+lemma to_real_infi (hf : ∀ i, f i ≠ ∞) : (infi f).to_real = ⨅i, (f i).to_real :=
+by simp only [ennreal.to_real, to_nnreal_infi hf, nnreal.coe_infi]
+
 lemma infi_add : infi f + a = ⨅i, f i + a :=
 le_antisymm
   (le_infi $ assume i, add_le_add (infi_le _ _) $ le_rfl)

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -425,6 +425,14 @@ open emetric
 /-- The minimal distance of a point to a set -/
 def inf_dist (x : α) (s : set α) : ℝ := ennreal.to_real (inf_edist x s)
 
+theorem inf_dist_eq_infi : inf_dist x s = ⨅ y : s, dist x y :=
+begin
+  rw [inf_dist, inf_edist, infi_subtype', ennreal.to_real_infi],
+  { simp only [dist_edist],
+    refl },
+  { exact λ _, edist_ne_top _ _ }
+end
+
 /-- the minimal distance is always nonnegative -/
 lemma inf_dist_nonneg : 0 ≤ inf_dist x s := by simp [inf_dist]
 


### PR DESCRIPTION
Add lemmas relating `ennreal.to_real` and `ennreal.to_nnreal` to the indexed infimum.

Note that a slightly different set of lemmas and proofs were added in leanprover-community/mathlib4#3457.
Please make sure to switch to these versions when forward-porting, and add `#align`s to the existing lemmas.

This also adds `inf_dist_eq_infi`, which is from the same mathlib4 PR.

---
Backport from mathlib4, as requested in https://github.com/leanprover-community/mathlib4/pull/3457#discussion_r1185950888

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
