### PR TITLE
[Merged by Bors] - chore(representation_theory/group_cohomology): use `fin.cast_succ` instead of coe

### DIFF
--- a/src/algebra/big_operators/fin.lean
+++ b/src/algebra/big_operators/fin.lean
@@ -208,12 +208,6 @@ begin
     assoc_rw [hi, inv_mul_cancel_left] }
 end
 
-@[to_additive] lemma partial_prod_right_inv' {G : Type*} [group G]
-  (g : G) (f : fin n → G) (i : fin n) :
-  ((g • partial_prod f) i.cast_succ)⁻¹ * (g • partial_prod f) i.succ = f i :=
-by simp_rw [pi.smul_apply, smul_eq_mul, mul_inv_rev, mul_assoc, inv_mul_cancel_left,
-    partial_prod_right_inv]
-
 /-- Let `(g₀, g₁, ..., gₙ)` be a tuple of elements in `Gⁿ⁺¹`.
 Then if `k < j`, this says `(g₀g₁...gₖ₋₁)⁻¹ * g₀g₁...gₖ = gₖ`.
 If `k = j`, it says `(g₀g₁...gₖ₋₁)⁻¹ * g₀g₁...gₖ₊₁ = gₖgₖ₊₁`.

--- a/src/algebra/big_operators/fin.lean
+++ b/src/algebra/big_operators/fin.lean
@@ -193,7 +193,6 @@ begin
   rw [partial_prod_succ, ←mul_assoc, hx, mul_inv_cancel_left],
 end)
 
-
 @[to_additive] lemma partial_prod_right_inv {G : Type*} [group G]
   (f : fin n → G) (i : fin n) :
   (partial_prod f i.cast_succ)⁻¹ * partial_prod f i.succ = f i :=

--- a/src/algebra/big_operators/fin.lean
+++ b/src/algebra/big_operators/fin.lean
@@ -193,20 +193,26 @@ begin
   rw [partial_prod_succ, ←mul_assoc, hx, mul_inv_cancel_left],
 end)
 
+
 @[to_additive] lemma partial_prod_right_inv {G : Type*} [group G]
-  (g : G) (f : fin n → G) (i : fin n) :
-  ((g • partial_prod f) i)⁻¹ * (g • partial_prod f) i.succ = f i :=
+  (f : fin n → G) (i : fin n) :
+  (partial_prod f i.cast_succ)⁻¹ * partial_prod f i.succ = f i :=
 begin
   cases i with i hn,
   induction i with i hi generalizing hn,
-  { simp [←fin.succ_mk, partial_prod_succ] },
+  { simp [-fin.succ_mk, partial_prod_succ] },
   { specialize hi (lt_trans (nat.lt_succ_self i) hn),
-    simp only [mul_inv_rev, fin.coe_eq_cast_succ, fin.succ_mk, fin.cast_succ_mk,
-      smul_eq_mul, pi.smul_apply] at hi ⊢,
+    simp only [fin.coe_eq_cast_succ, fin.succ_mk, fin.cast_succ_mk] at hi ⊢,
     rw [←fin.succ_mk _ _ (lt_trans (nat.lt_succ_self _) hn), ←fin.succ_mk],
     simp only [partial_prod_succ, mul_inv_rev, fin.cast_succ_mk],
     assoc_rw [hi, inv_mul_cancel_left] }
 end
+
+@[to_additive] lemma partial_prod_right_inv' {G : Type*} [group G]
+  (g : G) (f : fin n → G) (i : fin n) :
+  ((g • partial_prod f) i.cast_succ)⁻¹ * (g • partial_prod f) i.succ = f i :=
+by simp_rw [pi.smul_apply, smul_eq_mul, mul_inv_rev, mul_assoc, inv_mul_cancel_left,
+    partial_prod_right_inv]
 
 /-- Let `(g₀, g₁, ..., gₙ)` be a tuple of elements in `Gⁿ⁺¹`.
 Then if `k < j`, this says `(g₀g₁...gₖ₋₁)⁻¹ * g₀g₁...gₖ = gₖ`.
@@ -223,8 +229,7 @@ lemma inv_partial_prod_mul_eq_contract_nth {G : Type*} [group G]
   (partial_prod g (j.succ.succ_above k.cast_succ))⁻¹ * partial_prod g (j.succ_above k).succ
     = j.contract_nth has_mul.mul g k :=
 begin
-  have := partial_prod_right_inv (1 : G) g,
-  simp only [one_smul, coe_eq_cast_succ] at this,
+  have := partial_prod_right_inv g,
   rcases lt_trichotomy (k : ℕ) j with (h|h|h),
   { rwa [succ_above_below, succ_above_below, this, contract_nth_apply_of_lt],
     { assumption },

--- a/src/algebra/big_operators/fin.lean
+++ b/src/algebra/big_operators/fin.lean
@@ -222,14 +222,13 @@ lemma inv_partial_prod_mul_eq_contract_nth {G : Type*} [group G]
   (partial_prod g (j.succ.succ_above k.cast_succ))⁻¹ * partial_prod g (j.succ_above k).succ
     = j.contract_nth has_mul.mul g k :=
 begin
-  have := partial_prod_right_inv g,
   rcases lt_trichotomy (k : ℕ) j with (h|h|h),
-  { rwa [succ_above_below, succ_above_below, this, contract_nth_apply_of_lt],
+  { rwa [succ_above_below, succ_above_below, partial_prod_right_inv, contract_nth_apply_of_lt],
     { assumption },
     { rw [cast_succ_lt_iff_succ_le, succ_le_succ_iff, le_iff_coe_le_coe],
       exact le_of_lt h }},
   { rwa [succ_above_below, succ_above_above, partial_prod_succ, cast_succ_fin_succ, ←mul_assoc,
-      this, contract_nth_apply_of_eq],
+      partial_prod_right_inv, contract_nth_apply_of_eq],
     { simpa only [le_iff_coe_le_coe, ←h] },
     { rw [cast_succ_lt_iff_succ_le, succ_le_succ_iff, le_iff_coe_le_coe],
       exact le_of_eq h }},

--- a/src/representation_theory/group_cohomology/basic.lean
+++ b/src/representation_theory/group_cohomology/basic.lean
@@ -126,8 +126,8 @@ begin
   congr' 1,
   { congr,
     ext,
-    have := fin.partial_prod_right_inv (1 : G) g (fin.cast_succ x),
-    simp only [mul_inv_rev, fin.coe_eq_cast_succ, one_smul, fin.cast_succ_fin_succ] at *,
+    have := fin.partial_prod_right_inv g (fin.cast_succ x),
+    simp only [fin.cast_succ_fin_succ] at *,
     rw [mul_assoc, ←mul_assoc _ _ (g x.succ), this, inv_mul_cancel_left] },
   { exact finset.sum_congr rfl (λ j hj,
       by rw [diagonal_hom_equiv_symm_partial_prod_succ, fin.coe_succ]) }

--- a/src/representation_theory/group_cohomology/basic.lean
+++ b/src/representation_theory/group_cohomology/basic.lean
@@ -127,7 +127,7 @@ begin
   { congr,
     ext,
     have := fin.partial_prod_right_inv g (fin.cast_succ x),
-    simp only [fin.cast_succ_fin_succ] at *,
+    simp only [mul_inv_rev, fin.cast_succ_fin_succ] at *,
     rw [mul_assoc, ←mul_assoc _ _ (g x.succ), this, inv_mul_cancel_left] },
   { exact finset.sum_congr rfl (λ j hj,
       by rw [diagonal_hom_equiv_symm_partial_prod_succ, fin.coe_succ]) }

--- a/src/representation_theory/group_cohomology/resolution.lean
+++ b/src/representation_theory/group_cohomology/resolution.lean
@@ -89,7 +89,7 @@ def Action_diagonal_succ (G : Type u) [group G] : Π (n : ℕ),
   (equiv.pi_fin_succ_above_equiv (λ j, G) 0).symm.to_iso (λ g, rfl))
 
 lemma Action_diagonal_succ_hom_apply {G : Type u} [group G] {n : ℕ} (f : fin (n + 1) → G) :
-  (Action_diagonal_succ G n).hom.hom f = (f 0, λ i, (f i)⁻¹ * f i.succ) :=
+  (Action_diagonal_succ G n).hom.hom f = (f 0, λ i, (f i.cast_succ)⁻¹ * f i.succ) :=
 begin
   induction n with n hn,
   { exact prod.ext rfl (funext $ λ x, fin.elim0 x) },
@@ -100,7 +100,7 @@ begin
         left_regular_tensor_iso_hom_hom, tensor_iso_hom, mk_iso_hom_hom, equiv.to_iso_hom,
         tensor_hom, equiv.pi_fin_succ_above_equiv_symm_apply, tensor_apply, types_id_apply,
         tensor_rho, monoid_hom.one_apply, End.one_def, hn (λ (j : fin (n + 1)), f j.succ),
-        fin.coe_eq_cast_succ, fin.insert_nth_zero'],
+        fin.insert_nth_zero'],
       refine fin.cases (fin.cons_zero _ _) (λ i, _) x,
       { simp only [fin.cons_succ, mul_left_inj, inv_inj, fin.cast_succ_fin_succ], }}}
 end
@@ -145,7 +145,7 @@ variables {k G n}
 
 lemma diagonal_succ_hom_single (f : Gⁿ⁺¹) (a : k) :
   (diagonal_succ k G n).hom.hom (single f a) =
-  single (f 0) 1 ⊗ₜ single (λ i, (f i)⁻¹ * f i.succ) a :=
+  single (f 0) 1 ⊗ₜ single (λ i, (f i.cast_succ)⁻¹ * f i.succ) a :=
 begin
   dunfold diagonal_succ,
   simpa only [iso.trans_hom, iso.symm_hom, Action.comp_hom, Module.comp_def, linear_map.comp_apply,
@@ -268,7 +268,7 @@ inverse map sends a function `f : Gⁿ → A` to the representation morphism sen
 to `A`. -/
 lemma diagonal_hom_equiv_symm_apply (f : (fin n → G) → A) (x : fin (n + 1) → G) :
   ((diagonal_hom_equiv n A).symm f).hom (finsupp.single x 1)
-    = A.ρ (x 0) (f (λ (i : fin n), (x ↑i)⁻¹ * x i.succ)) :=
+    = A.ρ (x 0) (f (λ (i : fin n), (x i.cast_succ)⁻¹ * x i.succ)) :=
 begin
   unfold diagonal_hom_equiv,
   simp only [linear_equiv.trans_symm, linear_equiv.symm_symm, linear_equiv.trans_apply,
@@ -290,7 +290,7 @@ lemma diagonal_hom_equiv_symm_partial_prod_succ
     = f (fin.contract_nth a (*) g) :=
 begin
   simp only [diagonal_hom_equiv_symm_apply, function.comp_app, fin.succ_succ_above_zero,
-    fin.partial_prod_zero, map_one, fin.coe_eq_cast_succ, fin.succ_succ_above_succ,
+    fin.partial_prod_zero, map_one, fin.succ_succ_above_succ,
     linear_map.one_apply, fin.partial_prod_succ],
   congr,
   ext,


### PR DESCRIPTION
This replaces the cast from `fin n` to `fin (n + 1)` (defined as `⟨↑i % (n + 1), _⟩`) with `fin.cast_succ` (defined as `⟨↑i, _⟩`).
This is the preferred spelling, and using it lets us simplify some proofs.

This also removes the `g` argument from  `partial_prod_right_inv`, as it was not used, and the interesting statement is the one without it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I've tagged this `mathport` since the proof of `partial_prod_right_inv` is proving difficult to port.