### PR TITLE
[Merged by Bors] - chore(algebra/order/lattice_group): remove redundant instance

### DIFF
--- a/src/algebra/order/lattice_group.lean
+++ b/src/algebra/order/lattice_group.lean
@@ -62,12 +62,6 @@ lattice, ordered, group
 
 universe u
 
--- A linearly ordered additive commutative group is a lattice ordered commutative group
-@[priority 100, to_additive] -- see Note [lower instance priority]
-instance linear_ordered_comm_group.to_covariant_class (α : Type u)
-  [linear_ordered_comm_group α] : covariant_class α α (*) (≤) :=
-{ elim := λ a b c bc, linear_ordered_comm_group.mul_le_mul_left _ _ bc a }
-
 variables {α : Type u} [lattice α] [comm_group α]
 
 -- Special case of Bourbaki A.VI.9 (1)


### PR DESCRIPTION
This instance was redundant. It can be synthesised at the declaration site via:

```
example (α : Type u) [linear_ordered_comm_group α] : covariant_class α α (*) (≤) := by show_term {apply_instance}
-- ordered_comm_group.to_covariant_class_left_le α
```

Moreover, it is implicated in a timeout in the reenableeta branches, so I want it gone!

This PR is just a verification that mathlib still compiles. I don't care if it is merged.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
