### PR TITLE
chore(*): remove redundant covariant_class instances

### DIFF
--- a/src/algebra/order/lattice_group.lean
+++ b/src/algebra/order/lattice_group.lean
@@ -62,12 +62,6 @@ lattice, ordered, group
 
 universe u
 
--- A linearly ordered additive commutative group is a lattice ordered commutative group
-@[priority 100, to_additive] -- see Note [lower instance priority]
-instance linear_ordered_comm_group.to_covariant_class (α : Type u)
-  [linear_ordered_comm_group α] : covariant_class α α (*) (≤) :=
-{ elim := λ a b c bc, linear_ordered_comm_group.mul_le_mul_left _ _ bc a }
-
 variables {α : Type u} [lattice α] [comm_group α]
 
 -- Special case of Bourbaki A.VI.9 (1)

--- a/src/algebra/order/monoid/cancel/defs.lean
+++ b/src/algebra/order/monoid/cancel/defs.lean
@@ -63,7 +63,7 @@ instance. -/
 instance ordered_cancel_comm_monoid.to_contravariant_class_right
   (M : Type*) [ordered_cancel_comm_monoid M] :
   contravariant_class M M (swap (*)) (<) :=
-contravariant_swap_mul_lt_of_contravariant_mul_lt M
+by apply_instance -- As of 2023 May 6, this is not needed anywhere in mathlib.
 
 @[priority 100, to_additive]    -- see Note [lower instance priority]
 instance ordered_cancel_comm_monoid.to_ordered_comm_monoid : ordered_comm_monoid α :=

--- a/src/algebra/order/monoid/order_dual.lean
+++ b/src/algebra/order/monoid/order_dual.lean
@@ -10,7 +10,8 @@ import algebra.order.monoid.cancel.defs
 /-! # Ordered monoid structures on the order dual.
 
 > THIS FILE IS SYNCHRONIZED WITH MATHLIB4.
-> Any changes to this file require a corresponding PR to mathlib4.-/
+> Any changes to this file require a corresponding PR to mathlib4.
+-/
 
 universes u
 variables {α : Type u}

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -87,6 +87,11 @@ def coe_add_hom : add_hom ℕ+ ℕ :=
   map_add' := add_coe }
 
 instance : covariant_class ℕ+ ℕ+ (+) (≤) := positive.covariant_class_add_le
+-- We add shortcut instances here, hoping they help performance,
+-- even though they are already found by TC synthesis.
+instance : covariant_class ℕ+ ℕ+ (+) (<) := by apply_instance
+instance : contravariant_class ℕ+ ℕ+ (+) (≤) := by apply_instance
+instance : contravariant_class ℕ+ ℕ+ (+) (<) := by apply_instance
 
 /-- An equivalence between `ℕ+` and `ℕ` given by `pnat.nat_pred` and `nat.succ_pnat`. -/
 @[simps { fully_applied := ff }] def _root_.equiv.pnat_equiv_nat : ℕ+ ≃ ℕ :=

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -87,9 +87,6 @@ def coe_add_hom : add_hom ℕ+ ℕ :=
   map_add' := add_coe }
 
 instance : covariant_class ℕ+ ℕ+ (+) (≤) := positive.covariant_class_add_le
-instance : covariant_class ℕ+ ℕ+ (+) (<) := positive.covariant_class_add_lt
-instance : contravariant_class ℕ+ ℕ+ (+) (≤) := positive.contravariant_class_add_le
-instance : contravariant_class ℕ+ ℕ+ (+) (<) := positive.contravariant_class_add_lt
 
 /-- An equivalence between `ℕ+` and `ℕ` given by `pnat.nat_pred` and `nat.succ_pnat`. -/
 @[simps { fully_applied := ff }] def _root_.equiv.pnat_equiv_nat : ℕ+ ≃ ℕ :=

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -92,13 +92,6 @@ localized "notation (name := ennreal.top) `∞` := (⊤ : ennreal)" in ennreal
 namespace ennreal
 variables {a b c d : ℝ≥0∞} {r p q : ℝ≥0}
 
--- TODO: why are the two covariant instances necessary? why aren't they inferred?
-instance covariant_class_mul_le : covariant_class ℝ≥0∞ ℝ≥0∞ (*) (≤) :=
-canonically_ordered_comm_semiring.to_covariant_mul_le
-
-instance covariant_class_add_le : covariant_class ℝ≥0∞ ℝ≥0∞ (+) (≤) :=
-ordered_add_comm_monoid.to_covariant_class_left ℝ≥0∞
-
 noncomputable instance : linear_ordered_comm_monoid_with_zero ℝ≥0∞ :=
 { mul_le_mul_left := λ a b, mul_le_mul_left',
   zero_le_one := zero_le 1,

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -347,19 +347,9 @@ end
 
 example : archimedean ℝ≥0 := by apply_instance
 
--- TODO: why are these three instances necessary? why aren't they inferred?
-instance covariant_add : covariant_class ℝ≥0 ℝ≥0 (+) (≤) :=
-ordered_add_comm_monoid.to_covariant_class_left ℝ≥0
-
-instance contravariant_add : contravariant_class ℝ≥0 ℝ≥0 (+) (<) :=
-ordered_cancel_add_comm_monoid.to_contravariant_class_left ℝ≥0
-
-instance covariant_mul : covariant_class ℝ≥0 ℝ≥0 (*) (≤) :=
-ordered_comm_monoid.to_covariant_class_left ℝ≥0
-
--- Why isn't `nnreal.contravariant_add` inferred?
+-- Why isn't the instance inferred?
 lemma le_of_forall_pos_le_add {a b : ℝ≥0} (h : ∀ε, 0 < ε → a ≤ b + ε) : a ≤ b :=
-@le_of_forall_pos_le_add _ _ _ _ _ _ nnreal.contravariant_add _ _ h
+@le_of_forall_pos_le_add _ _ _ _ _ _ (by apply_instance : contravariant_class ℝ≥0 ℝ≥0 (+) (<)) _ _ h
 
 lemma lt_iff_exists_rat_btwn (a b : ℝ≥0) :
   a < b ↔ (∃q:ℚ, 0 ≤ q ∧ a < real.to_nnreal q ∧ real.to_nnreal q < b) :=

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -463,9 +463,6 @@ by rintros ⟨α⟩ ⟨β⟩ ⟨γ⟩ ⟨δ⟩ ⟨e₁⟩ ⟨e₂⟩; exact ⟨e
 instance add_covariant_class : covariant_class cardinal cardinal (+) (≤) :=
 ⟨λ a b c, add_le_add' le_rfl⟩
 
-instance add_swap_covariant_class : covariant_class cardinal cardinal (swap (+)) (≤) :=
-⟨λ a b c h, add_le_add' h le_rfl⟩
-
 instance : canonically_ordered_comm_semiring cardinal.{u} :=
 { bot                   := 0,
   bot_le                := cardinal.zero_le,

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -105,15 +105,6 @@ theorem _root_.pgame.fuzzy_iff_game_fuzzy {x y : pgame} : pgame.fuzzy x y ↔ �
 instance covariant_class_add_le : covariant_class game game (+) (≤) :=
 ⟨by { rintro ⟨a⟩ ⟨b⟩ ⟨c⟩ h, exact @add_le_add_left _ _ _ _ b c h a }⟩
 
-instance covariant_class_swap_add_le : covariant_class game game (swap (+)) (≤) :=
-⟨by { rintro ⟨a⟩ ⟨b⟩ ⟨c⟩ h, exact @add_le_add_right _ _ _ _ b c h a }⟩
-
-instance covariant_class_add_lt : covariant_class game game (+) (<) :=
-⟨by { rintro ⟨a⟩ ⟨b⟩ ⟨c⟩ h, exact @add_lt_add_left _ _ _ _ b c h a }⟩
-
-instance covariant_class_swap_add_lt : covariant_class game game (swap (+)) (<) :=
-⟨by { rintro ⟨a⟩ ⟨b⟩ ⟨c⟩ h, exact @add_lt_add_right _ _ _ _ b c h a }⟩
-
 theorem add_lf_add_right : ∀ {b c : game} (h : b ⧏ c) (a), b + a ⧏ c + a :=
 by { rintro ⟨b⟩ ⟨c⟩ h ⟨a⟩, apply add_lf_add_right h }
 

--- a/src/set_theory/ordinal/arithmetic.lean
+++ b/src/set_theory/ordinal/arithmetic.lean
@@ -103,12 +103,6 @@ by simp only [le_antisymm_iff, add_le_add_iff_left]
 private theorem add_lt_add_iff_left' (a) {b c : ordinal} : a + b < a + c ↔ b < c :=
 by rw [← not_le, ← not_le, add_le_add_iff_left]
 
-instance add_covariant_class_lt : covariant_class ordinal.{u} ordinal.{u} (+) (<) :=
-⟨λ a b c, (add_lt_add_iff_left' a).2⟩
-
-instance add_contravariant_class_lt : contravariant_class ordinal.{u} ordinal.{u} (+) (<) :=
-⟨λ a b c, (add_lt_add_iff_left' a).1⟩
-
 instance add_swap_contravariant_class_lt :
   contravariant_class ordinal.{u} ordinal.{u} (swap (+)) (<) :=
 ⟨λ a b c, lt_imp_lt_of_le_imp_le (λ h, add_le_add_right h _)⟩


### PR DESCRIPTION
Following up on #18951, this removes some redundant instances of `co(ntra)variant_class`. I don't know these are problematic, but in any case they are unneeded.

I wish we had a linter for this. I guess it would be possible in mathlib4. (If an `instance` can be generated by `infer_instance`, require a `@[nolint]`.)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
