### PR TITLE
refactor(category_theory/structured_arrow): make `structure_arrow` reducible

### DIFF
--- a/src/category_theory/structured_arrow.lean
+++ b/src/category_theory/structured_arrow.lean
@@ -33,7 +33,7 @@ The category of `T`-structured arrows with domain `S : D` (here `T : C ⥤ D`),
 has as its objects `D`-morphisms of the form `S ⟶ T Y`, for some `Y : C`,
 and morphisms `C`-morphisms `Y ⟶ Y'` making the obvious triangle commute.
 -/
-@[derive category, nolint has_nonempty_instance]
+@[reducible]
 def structured_arrow (S : D) (T : C ⥤ D) := comma (functor.from_punit S) T
 
 namespace structured_arrow
@@ -188,7 +188,7 @@ The category of `S`-costructured arrows with target `T : D` (here `S : C ⥤ D`)
 has as its objects `D`-morphisms of the form `S Y ⟶ T`, for some `Y : C`,
 and morphisms `C`-morphisms `Y ⟶ Y'` making the obvious triangle commute.
 -/
-@[derive category, nolint has_nonempty_instance]
+@[reducible]
 def costructured_arrow (S : C ⥤ D) (T : D) := comma S (functor.from_punit T)
 
 namespace costructured_arrow


### PR DESCRIPTION
This doesn't look like it was intended as type synonym like `mul_opposite`; instead, it's just a shorthand like `module.dual`.

Unless these shorthands are reducible, they are not matched by Lean 4's discrimination trees in simp. This is a problem because we mix and match the `structure_arrow` and `comma` API; which is itself an indication that the APIs are intended to be convenience shorthands for one another.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
