### PR TITLE
[Merged by Bors] - chore(algebra/order/group/defs): remove some instances that cause timeouts with etaExperiment

### DIFF
--- a/src/algebra/order/group/defs.lean
+++ b/src/algebra/order/group/defs.lean
@@ -55,15 +55,19 @@ instance ordered_comm_group.to_ordered_cancel_comm_monoid [ordered_comm_group α
 example (α : Type u) [ordered_add_comm_group α] : covariant_class α α (swap (+)) (<) :=
 add_right_cancel_semigroup.covariant_swap_add_lt_of_covariant_swap_add_le α
 
+-- Backporting note: this instance is not used,
+-- and causes timeouts when interacting with etaExperiment.
 /-- A choice-free shortcut instance. -/
 @[to_additive "A choice-free shortcut instance."]
-instance ordered_comm_group.to_contravariant_class_left_le (α : Type u) [ordered_comm_group α] :
+theorem ordered_comm_group.to_contravariant_class_left_le (α : Type u) [ordered_comm_group α] :
   contravariant_class α α (*) (≤) :=
 { elim := λ a b c bc, by simpa using mul_le_mul_left' bc a⁻¹, }
 
+-- Backporting note: this instance is not used,
+-- and causes timeouts when interacting with etaExperiment.
 /-- A choice-free shortcut instance. -/
 @[to_additive "A choice-free shortcut instance."]
-instance ordered_comm_group.to_contravariant_class_right_le (α : Type u) [ordered_comm_group α] :
+theorem ordered_comm_group.to_contravariant_class_right_le (α : Type u) [ordered_comm_group α] :
   contravariant_class α α (swap (*)) (≤) :=
 { elim := λ a b c bc, by simpa using mul_le_mul_right' bc a⁻¹, }
 


### PR DESCRIPTION
Seeing what CI thinks about removing these instances.

This is a backport of https://github.com/leanprover-community/mathlib4/pull/3905


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
