### PR TITLE
[Merged by Bors] - doc(algebra/euclidean_domain/defs): correct typos in doc

### DIFF
--- a/src/algebra/euclidean_domain/defs.lean
+++ b/src/algebra/euclidean_domain/defs.lean
@@ -32,10 +32,10 @@ don't satisfy the classical notion were provided independently by Hiblot and Nag
 
 ## Main statements
 
-See `algebra.euclidean_domain.basic` for most of the theorems about Eucliean domains,
+See `algebra.euclidean_domain.basic` for most of the theorems about Euclidean domains,
 including Bézout's lemma.
 
-See `algebra.euclidean_domain.instances` for that facts that `ℤ` is a Euclidean domain,
+See `algebra.euclidean_domain.instances` for the fact that `ℤ` is a Euclidean domain,
 as is any field.
 
 ## Notation


### PR DESCRIPTION
Correct two typos in the doc about the Main Statements about Euclidean Domains. The corresponding `mathlib-4` PR is [#3945. ](https://github.com/leanprover-community/mathlib4/pull/3945)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
