### PR TITLE
[Merged by Bors] - chore(category_theory/sites/dense_subsite): minor refactor

### DIFF
--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -473,6 +473,7 @@ variables {A : Type w} [category.{max u v} A] [limits.has_limits A]
 variables (Hd : cover_dense K G) (Hp : cover_preserving J K G) (Hl : cover_lifting J K G)
 
 include Hd Hp Hl
+
 /--
 Given a functor between small sites that is cover-dense, cover-preserving, and cover-lifting,
 it induces an equivalence of category of sheaves valued in a complete category.

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -153,8 +153,6 @@ def pushforward_family {X} (x : ℱ.obj (op X)) :
   family_of_elements ℱ'.val (cover_by_image G X) := λ Y f hf,
 ℱ'.val.map hf.some.lift.op $ α.app (op _) (ℱ.map hf.some.map.op x : _)
 
-include H
-
 /-- (Implementation). The `pushforward_family` defined is compatible. -/
 lemma pushforward_family_compatible {X} (x : ℱ.obj (op X)) :
   (pushforward_family α x).compatible :=
@@ -461,8 +459,6 @@ variables {G : C ⥤ D} [full G] [faithful G]
 variables {J : grothendieck_topology C} {K : grothendieck_topology D}
 variables {A : Type w} [category.{max u v} A] [limits.has_limits A]
 variables (Hd : cover_dense K G) (Hp : cover_preserving J K G) (Hl : cover_lifting J K G)
-
-include Hd Hp Hl
 
 /--
 Given a functor between small sites that is cover-dense, cover-preserving, and cover-lifting,

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -154,7 +154,7 @@ def pushforward_family {X} (x : ℱ.obj (op X)) :
 ℱ'.val.map hf.some.lift.op $ α.app (op _) (ℱ.map hf.some.map.op x : _)
 
 /-- (Implementation). The `pushforward_family` defined is compatible. -/
-lemma pushforward_family_compatible {X} (x : ℱ.obj (op X)) :
+lemma pushforward_family_compatible (H : cover_dense K G) {X} (x : ℱ.obj (op X)) :
   (pushforward_family α x).compatible :=
 begin
   intros Y₁ Y₂ Z g₁ g₂ f₁ f₂ h₁ h₂ e,
@@ -179,7 +179,7 @@ noncomputable
 def app_hom (X : D) : ℱ.obj (op X) ⟶ ℱ'.val.obj (op X) := λ x,
   (ℱ'.cond _ (H.is_cover X)).amalgamate
     (pushforward_family α x)
-    (pushforward_family_compatible H α x)
+    (pushforward_family_compatible α H x)
 
 @[simp] lemma pushforward_family_apply {X} (x : ℱ.obj (op X)) {Y : C} (f : G.obj Y ⟶ X) :
   pushforward_family α x f (presieve.in_cover_by_image G f) = α.app (op Y) (ℱ.map f.op x) :=
@@ -197,8 +197,8 @@ end
   ℱ'.val.map f (app_hom H α X x) = α.app (op Y) (ℱ.map f x) :=
 begin
   refine ((ℱ'.cond _ (H.is_cover X)).valid_glue
-    (pushforward_family_compatible H α x) f.unop (presieve.in_cover_by_image G f.unop)).trans _,
-  apply pushforward_family_apply H,
+    (pushforward_family_compatible α H x) f.unop (presieve.in_cover_by_image G f.unop)).trans _,
+  apply pushforward_family_apply,
 end
 
 @[simp] lemma app_hom_valid_glue {X : D} {Y : C} (f : op X ⟶ op (G.obj Y)) :
@@ -460,6 +460,7 @@ variables {J : grothendieck_topology C} {K : grothendieck_topology D}
 variables {A : Type w} [category.{max u v} A] [limits.has_limits A]
 variables (Hd : cover_dense K G) (Hp : cover_preserving J K G) (Hl : cover_lifting J K G)
 
+include Hd Hp Hl
 /--
 Given a functor between small sites that is cover-dense, cover-preserving, and cover-lifting,
 it induces an equivalence of category of sheaves valued in a complete category.

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -153,8 +153,10 @@ def pushforward_family {X} (x : ℱ.obj (op X)) :
   family_of_elements ℱ'.val (cover_by_image G X) := λ Y f hf,
 ℱ'.val.map hf.some.lift.op $ α.app (op _) (ℱ.map hf.some.map.op x : _)
 
+include H
+
 /-- (Implementation). The `pushforward_family` defined is compatible. -/
-lemma pushforward_family_compatible (H : cover_dense K G) {X} (x : ℱ.obj (op X)) :
+lemma pushforward_family_compatible {X} (x : ℱ.obj (op X)) :
   (pushforward_family α x).compatible :=
 begin
   intros Y₁ Y₂ Z g₁ g₂ f₁ f₂ h₁ h₂ e,
@@ -174,12 +176,14 @@ begin
   simp [e]
 end
 
+omit H
+
 /-- (Implementation). The morphism `ℱ(X) ⟶ ℱ'(X)` given by gluing the `pushforward_family`. -/
 noncomputable
 def app_hom (X : D) : ℱ.obj (op X) ⟶ ℱ'.val.obj (op X) := λ x,
   (ℱ'.cond _ (H.is_cover X)).amalgamate
     (pushforward_family α x)
-    (pushforward_family_compatible α H x)
+    (pushforward_family_compatible H α x)
 
 @[simp] lemma pushforward_family_apply {X} (x : ℱ.obj (op X)) {Y : C} (f : G.obj Y ⟶ X) :
   pushforward_family α x f (presieve.in_cover_by_image G f) = α.app (op Y) (ℱ.map f.op x) :=
@@ -197,7 +201,7 @@ end
   ℱ'.val.map f (app_hom H α X x) = α.app (op Y) (ℱ.map f x) :=
 begin
   refine ((ℱ'.cond _ (H.is_cover X)).valid_glue
-    (pushforward_family_compatible α H x) f.unop (presieve.in_cover_by_image G f.unop)).trans _,
+    (pushforward_family_compatible H α x) f.unop (presieve.in_cover_by_image G f.unop)).trans _,
   apply pushforward_family_apply,
 end
 

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -412,11 +412,12 @@ def restrict_hom_equiv_hom : (G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) ≃ (ℱ ⟶ �
   left_inv := sheaf_hom_restrict_eq H,
   right_inv := sheaf_hom_eq H }
 
+include H
 /--
 Given a full and cover-dense functor `G` and a natural transformation of sheaves `α : ℱ ⟶ ℱ'`,
 if the pullback of `α` along `G` is iso, then `α` is also iso.
 -/
-lemma iso_of_restrict_iso (H : cover_dense K G) {ℱ ℱ' : Sheaf K A} (α : ℱ ⟶ ℱ')
+lemma iso_of_restrict_iso {ℱ ℱ' : Sheaf K A} (α : ℱ ⟶ ℱ')
   (i : is_iso (whisker_left G.op α.val)) : is_iso α :=
 begin
   convert is_iso.of_iso (sheaf_iso H (as_iso (whisker_left G.op α.val))) using 1,
@@ -425,7 +426,7 @@ begin
 end
 
 /-- A fully faithful cover-dense functor preserves compatible families. -/
-lemma compatible_preserving [faithful G] (H : cover_dense K G) : compatible_preserving K G :=
+lemma compatible_preserving [faithful G] : compatible_preserving K G :=
 begin
   constructor,
   intros ℱ Z T x hx Y₁ Y₂ X f₁ f₂ g₁ g₂ hg₁ hg₂ eq,
@@ -438,6 +439,8 @@ begin
   apply G.map_injective,
   simp [eq]
 end
+
+omit H
 
 noncomputable
 instance sites.pullback.full [faithful G] (Hp : cover_preserving J K G) :

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -141,7 +141,6 @@ lemma sheaf_eq_amalgamation (ℱ : Sheaf K A) {X : A} {U : D} {T : sieve U} (hT)
   t = (ℱ.cond X T hT).amalgamate x hx :=
 (ℱ.cond X T hT).is_separated_for x t _ h ((ℱ.cond X T hT).is_amalgamation hx)
 
-include H
 variable [full G]
 namespace types
 variables {ℱ : Dᵒᵖ ⥤ Type v} {ℱ' : SheafOfTypes.{v} K} (α : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val)
@@ -154,9 +153,11 @@ def pushforward_family {X} (x : ℱ.obj (op X)) :
   family_of_elements ℱ'.val (cover_by_image G X) := λ Y f hf,
 ℱ'.val.map hf.some.lift.op $ α.app (op _) (ℱ.map hf.some.map.op x : _)
 
+include H
+
 /-- (Implementation). The `pushforward_family` defined is compatible. -/
 lemma pushforward_family_compatible {X} (x : ℱ.obj (op X)) :
-  (pushforward_family H α x).compatible :=
+  (pushforward_family α x).compatible :=
 begin
   intros Y₁ Y₂ Z g₁ g₂ f₁ f₂ h₁ h₂ e,
   apply H.ext,
@@ -179,11 +180,11 @@ end
 noncomputable
 def app_hom (X : D) : ℱ.obj (op X) ⟶ ℱ'.val.obj (op X) := λ x,
   (ℱ'.cond _ (H.is_cover X)).amalgamate
-    (pushforward_family H α x)
+    (pushforward_family α x)
     (pushforward_family_compatible H α x)
 
 @[simp] lemma pushforward_family_apply {X} (x : ℱ.obj (op X)) {Y : C} (f : G.obj Y ⟶ X) :
-  pushforward_family H α x f (presieve.in_cover_by_image G f) = α.app (op Y) (ℱ.map f.op x) :=
+  pushforward_family α x f (presieve.in_cover_by_image G f) = α.app (op Y) (ℱ.map f.op x) :=
 begin
   unfold pushforward_family,
   refine congr_fun _ x,
@@ -199,7 +200,7 @@ end
 begin
   refine ((ℱ'.cond _ (H.is_cover X)).valid_glue
     (pushforward_family_compatible H α x) f.unop (presieve.in_cover_by_image G f.unop)).trans _,
-  apply pushforward_family_apply
+  apply pushforward_family_apply H,
 end
 
 @[simp] lemma app_hom_valid_glue {X : D} {Y : C} (f : op X ⟶ op (G.obj Y)) :
@@ -287,7 +288,7 @@ def sheaf_coyoneda_hom (α : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) :
 (Implementation). `sheaf_coyoneda_hom` but the order of the arguments of the functor are swapped.
 -/
 noncomputable
-def sheaf_yoneda_hom (α : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) :
+def sheaf_yoneda_hom (H : cover_dense K G) (α : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) :
   ℱ ⋙ yoneda ⟶ ℱ'.val ⋙ yoneda :=
 begin
   let α := sheaf_coyoneda_hom H α,
@@ -318,7 +319,7 @@ where `G` is full and cover-dense, and `ℱ', ℱ` are sheaves,
 we may obtain a natural isomorphism between presheaves.
 -/
 @[simps] noncomputable
-def presheaf_iso {ℱ ℱ' : Sheaf K A} (i : G.op ⋙ ℱ.val ≅ G.op ⋙ ℱ'.val) :
+def presheaf_iso (H : cover_dense K G) {ℱ ℱ' : Sheaf K A} (i : G.op ⋙ ℱ.val ≅ G.op ⋙ ℱ'.val) :
   ℱ.val ≅ ℱ'.val :=
 begin
   haveI : ∀ (X : Dᵒᵖ), is_iso ((sheaf_hom H i.hom).app X),
@@ -408,7 +409,7 @@ def restrict_hom_equiv_hom : (G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) ≃ (ℱ ⟶ �
 Given a full and cover-dense functor `G` and a natural transformation of sheaves `α : ℱ ⟶ ℱ'`,
 if the pullback of `α` along `G` is iso, then `α` is also iso.
 -/
-lemma iso_of_restrict_iso {ℱ ℱ' : Sheaf K A} (α : ℱ ⟶ ℱ')
+lemma iso_of_restrict_iso (H : cover_dense K G) {ℱ ℱ' : Sheaf K A} (α : ℱ ⟶ ℱ')
   (i : is_iso (whisker_left G.op α.val)) : is_iso α :=
 begin
   convert is_iso.of_iso (sheaf_iso H (as_iso (whisker_left G.op α.val))) using 1,
@@ -417,7 +418,7 @@ begin
 end
 
 /-- A fully faithful cover-dense functor preserves compatible families. -/
-lemma compatible_preserving [faithful G] : compatible_preserving K G :=
+lemma compatible_preserving [faithful G] (H : cover_dense K G) : compatible_preserving K G :=
 begin
   constructor,
   intros ℱ Z T x hx Y₁ Y₂ X f₁ f₂ g₁ g₂ hg₁ hg₂ eq,

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -286,11 +286,12 @@ def sheaf_coyoneda_hom (α : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) :
     simp
   end }
 
+include H
 /--
 (Implementation). `sheaf_coyoneda_hom` but the order of the arguments of the functor are swapped.
 -/
 noncomputable
-def sheaf_yoneda_hom (H : cover_dense K G) (α : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) :
+def sheaf_yoneda_hom (α : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) :
   ℱ ⋙ yoneda ⟶ ℱ'.val ⋙ yoneda :=
 begin
   let α := sheaf_coyoneda_hom H α,
@@ -302,6 +303,8 @@ begin
     ext X x,
     exact congr_fun ((α.app X).naturality i) x },
 end
+
+omit H
 
 /--
 Given an natural transformation `G ⋙ ℱ ⟶ G ⋙ ℱ'` between presheaves of arbitrary category,
@@ -315,13 +318,14 @@ let α' := sheaf_yoneda_hom H α in
   { app := λ X, yoneda.preimage (α'.app X),
     naturality' := λ X Y f, yoneda.map_injective (by simpa using α'.naturality f) }
 
+include H
 /--
 Given an natural isomorphism `G ⋙ ℱ ≅ G ⋙ ℱ'` between presheaves of arbitrary category,
 where `G` is full and cover-dense, and `ℱ', ℱ` are sheaves,
 we may obtain a natural isomorphism between presheaves.
 -/
 @[simps] noncomputable
-def presheaf_iso (H : cover_dense K G) {ℱ ℱ' : Sheaf K A} (i : G.op ⋙ ℱ.val ≅ G.op ⋙ ℱ'.val) :
+def presheaf_iso {ℱ ℱ' : Sheaf K A} (i : G.op ⋙ ℱ.val ≅ G.op ⋙ ℱ'.val) :
   ℱ.val ≅ ℱ'.val :=
 begin
   haveI : ∀ (X : Dᵒᵖ), is_iso ((sheaf_hom H i.hom).app X),
@@ -338,6 +342,7 @@ begin
   apply as_iso (sheaf_hom H i.hom),
 end
 
+omit H
 /--
 Given an natural isomorphism `G ⋙ ℱ ≅ G ⋙ ℱ'` between presheaves of arbitrary category,
 where `G` is full and cover-dense, and `ℱ', ℱ` are sheaves,

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -202,7 +202,7 @@ end
 begin
   refine ((ℱ'.cond _ (H.is_cover X)).valid_glue
     (pushforward_family_compatible H α x) f.unop (presieve.in_cover_by_image G f.unop)).trans _,
-  apply pushforward_family_apply,
+  apply pushforward_family_apply
 end
 
 @[simp] lemma app_hom_valid_glue {X : D} {Y : C} (f : op X ⟶ op (G.obj Y)) :


### PR DESCRIPTION
Lean 4 pointed out that `include H` came slightly too early in `category_theory/sites_dense_subsite`; it doesn't need to be in the definition of https://leanprover-community.github.io/mathlib_docs/category_theory/sites/dense_subsite.html#category_theory.cover_dense.types.pushforward_family , for example. I removed both the `include`s in the file, which changes the types of at least one declaration (a superfluous `H` is no longer there). This file is not a leaf file -- it's imported by all the algebraic geometry hierarchy for example -- but mathlib still compiles with these edits and I propose making this change in the ported version of this file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
