### PR TITLE
[Merged by Bors] - doc(number_theory/pell): fix links in module docstring

### DIFF
--- a/src/number_theory/pell.lean
+++ b/src/number_theory/pell.lean
@@ -28,13 +28,13 @@ We then prove the following
 **Theorem.** Let $d$ be a positive integer that is not a square. Then the equation
 $x^2 - d y^2 = 1$ has a nontrivial (i.e., with $y \ne 0$) solution in integers.
 
-See `pell.exists_of_not_is_square` and `pell.exists_nontrivial_of_not_is_square`.
+See `pell.exists_of_not_is_square` and `pell.solution₁.exists_nontrivial_of_not_is_square`.
 
 We then define the *fundamental solution* to be the solution
 with smallest $x$ among all solutions satisfying $x > 1$ and $y > 0$.
 We show that every solution is a power (in the sense of the group structure mentioned above)
 of the fundamental solution up to a (common) sign,
-see `pell.fundamental.eq_zpow_or_neg_zpow`, and that a (positive) solution has this property
+see `pell.is_fundamental.eq_zpow_or_neg_zpow`, and that a (positive) solution has this property
 if and only if it is fundamental, see `pell.pos_generator_iff_fundamental`.
 
 ## References


### PR DESCRIPTION
This PR fixes two typos in the module docstring of `number_theory.pell` (a missing and a mis-spelt namespace part), which prevented doc-gen from linking to the relevant statements.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
