### PR TITLE
[Merged by Bors] - [Merged by Bors] - feat(number_theory/legendre_symbol/*): add some API for the Legendre and the Jacobi symbol

### DIFF
--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -211,7 +211,7 @@ begin
 end
 
 /-- We can pull out a product over a list in the first argument of the Jacobi symbol. -/
-lemma mul_left_list {l : list ℤ} {n : ℕ} :
+lemma list_prod_left {l : list ℤ} {n : ℕ} :
   J(l.prod | n) = (l.map (λ a, J(a | n))).prod :=
 begin
   induction l with n l' ih,
@@ -220,7 +220,7 @@ begin
 end
 
 /-- We can pull out a product over a list in the second argument of the Jacobi symbol. -/
-lemma mul_right_list {a : ℤ} {l : list ℕ} (hl : ∀ n ∈ l, n ≠ 0) :
+lemma list_prod_right {a : ℤ} {l : list ℕ} (hl : ∀ n ∈ l, n ≠ 0) :
   J(a | l.prod) = (l.map (λ n, J(a | n))).prod :=
 begin
   induction l with n l' ih,
@@ -240,7 +240,7 @@ begin
     rw [zero_right, eq_neg_self_iff] at h,
     exact one_ne_zero h, },
   have hf₀ : ∀ p ∈ n.factors, p ≠ 0 := λ p hp, (nat.pos_of_mem_factors hp).ne.symm,
-  rw [← nat.prod_factors hn₀, mul_right_list hf₀] at h,
+  rw [← nat.prod_factors hn₀, list_prod_right hf₀] at h,
   obtain ⟨p, hmem, hj⟩ := list.mem_map.mp (list.neg_one_mem_of_prod_eq_neg_one h),
   exact ⟨p, nat.prime_of_mem_factors hmem, nat.dvd_of_mem_factors hmem, hj⟩,
 end

--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -201,6 +201,15 @@ end
 lemma mod_left' {a₁ a₂ : ℤ} {b : ℕ} (h : a₁ % b = a₂ % b) : J(a₁ | b) = J(a₂ | b) :=
 by rw [mod_left, h, ← mod_left]
 
+/-- If `p` is prime, `J(a | p) = -1` and `p` divides `x^2 - a*y^2`, then `p` must divide
+`x` and `y`. -/
+lemma prime_dvd_of_eq_neg_one {p : ℕ} [fact p.prime] {a : ℤ} (h : J(a | p) = -1)
+  {x y : ℤ} (hxy : ↑p ∣ x ^ 2 - a * y ^ 2) : ↑p ∣ x ∧ ↑p ∣ y :=
+begin
+  rw [← legendre_sym.to_jacobi_sym] at h,
+  exact legendre_sym.prime_dvd_of_eq_neg_one h hxy,
+end
+
 end jacobi_sym
 
 namespace zmod

--- a/src/number_theory/legendre_symbol/jacobi_symbol.lean
+++ b/src/number_theory/legendre_symbol/jacobi_symbol.lean
@@ -210,6 +210,41 @@ begin
   exact legendre_sym.prime_dvd_of_eq_neg_one h hxy,
 end
 
+/-- We can pull out a product over a list in the first argument of the Jacobi symbol. -/
+lemma mul_left_list {l : list ℤ} {n : ℕ} :
+  J(l.prod | n) = (l.map (λ a, J(a | n))).prod :=
+begin
+  induction l with n l' ih,
+  { simp only [list.prod_nil, list.map_nil, one_left], },
+  { rw [list.map, list.prod_cons, list.prod_cons, mul_left, ih], }
+end
+
+/-- We can pull out a product over a list in the second argument of the Jacobi symbol. -/
+lemma mul_right_list {a : ℤ} {l : list ℕ} (hl : ∀ n ∈ l, n ≠ 0) :
+  J(a | l.prod) = (l.map (λ n, J(a | n))).prod :=
+begin
+  induction l with n l' ih,
+  { simp only [list.prod_nil, one_right, list.map_nil], },
+  { have hn := hl n (list.mem_cons_self n l'), -- `n ≠ 0`
+    have hl' := list.prod_ne_zero (λ hf, hl 0 (list.mem_cons_of_mem _ hf) rfl), -- `l'.prod ≠ 0`
+    have h := λ m hm, hl m (list.mem_cons_of_mem _ hm), -- `∀ (m : ℕ), m ∈ l' → m ≠ 0`
+    rw [list.map, list.prod_cons, list.prod_cons, mul_right' a hn hl', ih h], }
+end
+
+/-- If `J(a | n) = -1`, then `n` has a prime divisor `p` such that `J(a | p) = -1`. -/
+lemma eq_neg_one_at_prime_divisor_of_eq_neg_one {a : ℤ} {n : ℕ} (h : J(a | n) = -1) :
+  ∃ (p : ℕ) (hp : p.prime), p ∣ n ∧ J(a | p) = -1 :=
+begin
+  have hn₀ : n ≠ 0,
+  { rintro rfl,
+    rw [zero_right, eq_neg_self_iff] at h,
+    exact one_ne_zero h, },
+  have hf₀ : ∀ p ∈ n.factors, p ≠ 0 := λ p hp, (nat.pos_of_mem_factors hp).ne.symm,
+  rw [← nat.prod_factors hn₀, mul_right_list hf₀] at h,
+  obtain ⟨p, hmem, hj⟩ := list.mem_map.mp (list.neg_one_mem_of_prod_eq_neg_one h),
+  exact ⟨p, nat.prime_of_mem_factors hmem, nat.dvd_of_mem_factors hmem, hj⟩,
+end
+
 end jacobi_sym
 
 namespace zmod

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -199,6 +199,71 @@ end legendre_sym
 
 end legendre
 
+section quadratic_form
+
+/-!
+### Applications to binary quadratic forms
+-/
+
+namespace legendre_sym
+
+/-- The Legendre symbol `legendre_sym p a = 1` if there is a nontrivial solution in `ℤ/pℤ`
+of the equation `x^2 - a*y^2 = 0`. -/
+lemma eq_one_of_sq_sub_mul_sq_eq_zero {p : ℕ} [fact p.prime]
+  {a : ℤ} (ha : (a : zmod p) ≠ 0) {x y : zmod p} (hy : y ≠ 0) (hxy : x ^ 2 - a * y ^ 2 = 0) :
+  legendre_sym p a = 1 :=
+begin
+  apply_fun (* y⁻¹ ^ 2) at hxy,
+  simp only [zero_mul] at hxy,
+  rw [(by ring : (x ^ 2 - ↑a * y ^ 2) * y⁻¹ ^ 2 = (x * y⁻¹) ^ 2 - a * (y * y⁻¹) ^ 2),
+      mul_inv_cancel hy, one_pow, mul_one, sub_eq_zero, pow_two] at hxy,
+  exact (eq_one_iff p ha).mpr ⟨x * y⁻¹, hxy.symm⟩,
+end
+
+/-- The Legendre symbol `legendre_sym p a = 1` if there is a nontrivial solution in `ℤ/pℤ`
+of the equation `x^2 - a*y^2 = 0`. -/
+lemma eq_one_of_sq_sub_mul_sq_eq_zero' {p : ℕ} [fact p.prime]
+  {a : ℤ} (ha : (a : zmod p) ≠ 0) {x y : zmod p} (hx : x ≠ 0) (hxy : x ^ 2 - a * y ^ 2 = 0) :
+  legendre_sym p a = 1 :=
+begin
+  have hy : y ≠ 0,
+  { rintro rfl,
+    rw [zero_pow' 2 (by norm_num), mul_zero, sub_zero, pow_eq_zero_iff (by norm_num : 0 < 2)]
+      at hxy,
+    exacts [hx hxy, infer_instance], }, -- why is the instance not inferred automatically?
+  exact eq_one_of_sq_sub_mul_sq_eq_zero ha hy hxy,
+end
+
+/-- If `legendre_sym p a = -1`, then the only solution of `x^2 - a*y^2 = 0` in `ℤ/pℤ`
+is the trivial one. -/
+lemma eq_zero_mod_of_eq_neg_one {p : ℕ} [fact p.prime] {a : ℤ}
+  (h : legendre_sym p a = -1) {x y : zmod p} (hxy : x ^ 2 - a * y ^ 2 = 0) : x = 0 ∧ y = 0 :=
+begin
+  have ha : (a : zmod p) ≠ 0,
+  { intro hf,
+    rw (eq_zero_iff p a).mpr hf at h,
+    exact int.zero_ne_neg_of_ne zero_ne_one h, },
+  by_contra hf,
+  cases not_and_distrib.mp hf with hx hy,
+  { rw [eq_one_of_sq_sub_mul_sq_eq_zero' ha hx hxy, eq_neg_self_iff] at h,
+    exact one_ne_zero h, },
+  { rw [eq_one_of_sq_sub_mul_sq_eq_zero ha hy hxy, eq_neg_self_iff] at h,
+    exact one_ne_zero h, }
+end
+
+/-- If `legendre_sym p a = -1` and `p` divides `x^2 - a*y^2`, then `p` must divide `x` and `y`. -/
+lemma prime_dvd_of_eq_neg_one {p : ℕ} [fact p.prime] {a : ℤ}
+  (h : legendre_sym p a = -1) {x y : ℤ} (hxy : ↑p ∣ x ^ 2 - a * y ^ 2) : ↑p ∣ x ∧ ↑p ∣ y :=
+begin
+  simp_rw ← zmod.int_coe_zmod_eq_zero_iff_dvd at hxy ⊢,
+  push_cast at hxy,
+  exact eq_zero_mod_of_eq_neg_one h hxy,
+end
+
+end legendre_sym
+
+end quadratic_form
+
 section values
 
 /-!

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -207,8 +207,8 @@ section quadratic_form
 
 namespace legendre_sym
 
-/-- The Legendre symbol `legendre_sym p a = 1` if there is a nontrivial solution in `ℤ/pℤ`
-of the equation `x^2 - a*y^2 = 0`. -/
+/-- The Legendre symbol `legendre_sym p a = 1` if there is a solution in `ℤ/pℤ`
+of the equation `x^2 - a*y^2 = 0` with `y ≠ 0`. -/
 lemma eq_one_of_sq_sub_mul_sq_eq_zero {p : ℕ} [fact p.prime]
   {a : ℤ} (ha : (a : zmod p) ≠ 0) {x y : zmod p} (hy : y ≠ 0) (hxy : x ^ 2 - a * y ^ 2 = 0) :
   legendre_sym p a = 1 :=
@@ -220,8 +220,8 @@ begin
   exact (eq_one_iff p ha).mpr ⟨x * y⁻¹, hxy.symm⟩,
 end
 
-/-- The Legendre symbol `legendre_sym p a = 1` if there is a nontrivial solution in `ℤ/pℤ`
-of the equation `x^2 - a*y^2 = 0`. -/
+/-- The Legendre symbol `legendre_sym p a = 1` if there is a solution in `ℤ/pℤ`
+of the equation `x^2 - a*y^2 = 0` with `x ≠ 0`. -/
 lemma eq_one_of_sq_sub_mul_sq_eq_zero' {p : ℕ} [fact p.prime]
   {a : ℤ} (ha : (a : zmod p) ≠ 0) {x y : zmod p} (hx : x ≠ 0) (hxy : x ^ 2 - a * y ^ 2 = 0) :
   legendre_sym p a = 1 :=


### PR DESCRIPTION
This PR adds some additional API lemmas for the Legendre symbol (related to solutions mod `p` of `x^2-a*y^2 = 0`) and for the Jacobi symbol. These are useful for a project formalizing the proof that a certain diophantine equation has no integral solutions, but also appear to make sense more generally.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
