### PR TITLE
[Merged by Bors] - chore(analysis/normed_space/pi_Lp): add `pi_Lp.continuous_linear_equiv`

### DIFF
--- a/src/analysis/normed_space/pi_Lp.lean
+++ b/src/analysis/normed_space/pi_Lp.lean
@@ -707,12 +707,19 @@ lemma norm_equiv_symm_one {β} [seminormed_add_comm_group β] (hp : p ≠ ∞) [
 
 variables (𝕜 p)
 
-/-- `pi_Lp.equiv` as a linear map. -/
+/-- `pi_Lp.equiv` as a linear equivalence. -/
 @[simps {fully_applied := ff}]
 protected def linear_equiv : pi_Lp p β ≃ₗ[𝕜] Π i, β i :=
 { to_fun := pi_Lp.equiv _ _,
   inv_fun := (pi_Lp.equiv _ _).symm,
   ..linear_equiv.refl _ _}
+
+/-- `pi_Lp.equiv` as a continuous linear equivalence. -/
+@[simps {fully_applied := ff}]
+protected def continuous_linear_equiv : pi_Lp p β ≃L[𝕜] Π i, β i :=
+{ to_linear_equiv := pi_Lp.linear_equiv _ _ _,
+  continuous_to_fun := continuous_equiv _ _,
+  continuous_inv_fun := continuous_equiv_symm _ _ }
 
 section basis
 


### PR DESCRIPTION
This bundling is often useful to have.
We keep around `pi_Lp.linear_equiv` as this is shorter to write than `pi_Lp.continuous_linear_equiv.to_linear_equiv`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
