### PR TITLE
[Merged by Bors] - feat(topology/algebra/module/star): continuity results for star_modules

### DIFF
--- a/src/algebra/star/module.lean
+++ b/src/algebra/star/module.lean
@@ -63,7 +63,8 @@ end smul_lemmas
 then `star` is a semilinear equivalence. -/
 @[simps]
 def star_linear_equiv (R : Type*) {A : Type*}
-  [comm_ring R] [star_ring R] [semiring A] [star_ring A] [module R A] [star_module R A]  :
+  [comm_semiring R] [star_ring R] [add_comm_monoid A] [star_add_monoid A] [module R A]
+  [star_module R A] :
     A ≃ₗ⋆[R] A :=
 { to_fun := star,
   map_smul' := star_smul,

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -10,6 +10,7 @@ import analysis.normed_space.linear_isometry
 import algebra.star.self_adjoint
 import algebra.star.unitary
 import topology.algebra.star_subalgebra
+import topology.algebra.module.star
 
 /-!
 # Normed star rings and algebras
@@ -256,6 +257,13 @@ variables {𝕜}
 @[simp] lemma coe_starₗᵢ : (starₗᵢ 𝕜 : E → E) = star := rfl
 
 lemma starₗᵢ_apply {x : E} : starₗᵢ 𝕜 x = star x := rfl
+
+@[simp] lemma starₗᵢ_to_continuous_linear_equiv :
+  (starₗᵢ 𝕜 : E ≃ₗᵢ⋆[𝕜] E).to_continuous_linear_equiv = (begin
+      have := starL 𝕜,
+
+  end) :=
+continuous_linear_equiv.ext $ λ _, rfl
 
 end starₗᵢ
 

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -259,11 +259,8 @@ variables {𝕜}
 lemma starₗᵢ_apply {x : E} : starₗᵢ 𝕜 x = star x := rfl
 
 @[simp] lemma starₗᵢ_to_continuous_linear_equiv :
-  (starₗᵢ 𝕜 : E ≃ₗᵢ⋆[𝕜] E).to_continuous_linear_equiv = (begin
-      have := starL 𝕜,
-
-  end) :=
-continuous_linear_equiv.ext $ λ _, rfl
+  (starₗᵢ 𝕜 : E ≃ₗᵢ⋆[𝕜] E).to_continuous_linear_equiv = (starL 𝕜 : E ≃L⋆[𝕜] E) :=
+continuous_linear_equiv.ext rfl
 
 end starₗᵢ
 

--- a/src/topology/algebra/module/star.lean
+++ b/src/topology/algebra/module/star.lean
@@ -15,10 +15,12 @@ import topology.algebra.star
 then `star` is a continuous semilinear equivalence. -/
 @[simps]
 def starL (R : Type*) {A : Type*}
-  [comm_semiring R] [star_ring R] [semiring A] [star_ring A] [module R A] [star_module R A]
-  [topological_space A] [has_continuous_star A]:
+  [comm_semiring R] [star_ring R] [add_comm_monoid A] [star_add_monoid A] [module R A]
+  [star_module R A] [topological_space A] [has_continuous_star A] :
     A ≃SL[star_ring_end R] A :=
-{ to_linear_equiv := (star_linear_equiv R : A ≃ₗ⋆[R] A),
+{ to_linear_equiv :=
+  -- TODO: can't use `star_linear_equiv` here, it needs stronger typceclass assumptions?
+  { map_smul' := star_smul, ..star_add_equiv },
   continuous_to_fun := continuous_star,
   continuous_inv_fun := continuous_star }
 

--- a/src/topology/algebra/module/star.lean
+++ b/src/topology/algebra/module/star.lean
@@ -15,7 +15,7 @@ import topology.algebra.star
 then `star` is a continuous semilinear equivalence. -/
 @[simps]
 def starL (R : Type*) {A : Type*}
-  [comm_ring R] [star_ring R] [semiring A] [star_ring A] [module R A] [star_module R A]
+  [comm_semiring R] [star_ring R] [semiring A] [star_ring A] [module R A] [star_module R A]
   [topological_space A] [has_continuous_star A]:
     A ≃SL[star_ring_end R] A :=
 { to_linear_equiv := (star_linear_equiv R : A ≃ₗ⋆[R] A),
@@ -57,8 +57,8 @@ lemma continuous_decompose_prod_adjoint_symm [topological_add_group A] :
 
 /-- The decomposition of elements of a star module into their self- and skew-adjoint parts,
 as a continuous linear equivalence. -/
-def star_module.decompose_prod_adjointL[topological_add_group A] :
-    A ≃L[R] self_adjoint A × skew_adjoint A :=
+@[simps] def star_module.decompose_prod_adjointL [topological_add_group A] :
+  A ≃L[R] self_adjoint A × skew_adjoint A :=
 { to_linear_equiv := star_module.decompose_prod_adjoint R A,
   continuous_to_fun := continuous_decompose_prod_adjoint _ _,
   continuous_inv_fun := continuous_decompose_prod_adjoint_symm _ _ }

--- a/src/topology/algebra/module/star.lean
+++ b/src/topology/algebra/module/star.lean
@@ -17,7 +17,7 @@ then `star` is a continuous semilinear equivalence. -/
 def starL (R : Type*) {A : Type*}
   [comm_semiring R] [star_ring R] [add_comm_monoid A] [star_add_monoid A] [module R A]
   [star_module R A] [topological_space A] [has_continuous_star A] :
-    A ≃SL[star_ring_end R] A :=
+    A ≃L⋆[R] A :=
 { to_linear_equiv := star_linear_equiv R,
   continuous_to_fun := continuous_star,
   continuous_inv_fun := continuous_star }

--- a/src/topology/algebra/module/star.lean
+++ b/src/topology/algebra/module/star.lean
@@ -18,9 +18,7 @@ def starL (R : Type*) {A : Type*}
   [comm_semiring R] [star_ring R] [add_comm_monoid A] [star_add_monoid A] [module R A]
   [star_module R A] [topological_space A] [has_continuous_star A] :
     A ≃SL[star_ring_end R] A :=
-{ to_linear_equiv :=
-  -- TODO: can't use `star_linear_equiv` here, it needs stronger typceclass assumptions?
-  { map_smul' := star_smul, ..star_add_equiv },
+{ to_linear_equiv := star_linear_equiv R,
   continuous_to_fun := continuous_star,
   continuous_inv_fun := continuous_star }
 

--- a/src/topology/algebra/module/star.lean
+++ b/src/topology/algebra/module/star.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2023 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser, Frédéric Dupuis
+-/
+import algebra.star.module
+import topology.algebra.module.basic
+import topology.algebra.star
+
+/-!
+# The star operation, bundled as a continuous star-linear equiv
+-/
+
+/-- If `A` is a topological module over a commutative `R` with compatible actions,
+then `star` is a continuous semilinear equivalence. -/
+@[simps]
+def starL (R : Type*) {A : Type*}
+  [comm_ring R] [star_ring R] [semiring A] [star_ring A] [module R A] [star_module R A]
+  [topological_space A] [has_continuous_star A]:
+    A ≃SL[star_ring_end R] A :=
+{ to_linear_equiv := (star_linear_equiv R : A ≃ₗ⋆[R] A),
+  continuous_to_fun := continuous_star,
+  continuous_inv_fun := continuous_star }
+
+variables (R : Type*) (A : Type*)
+  [semiring R] [star_semigroup R] [has_trivial_star R]
+  [add_comm_group A] [module R A] [star_add_monoid A] [star_module R A]
+  [invertible (2 : R)]
+  [topological_space A] [has_continuous_star A]
+  [has_continuous_const_smul R A]
+
+lemma continuous_self_adjoint_part [has_continuous_add A] :
+  continuous (@self_adjoint_part R A _ _ _ _ _ _ _ _) :=
+((continuous_const_smul _).comp $ continuous_id.add continuous_star).subtype_mk _
+
+lemma continuous_skew_adjoint_part [has_continuous_sub A] :
+  continuous (@skew_adjoint_part R A _ _ _ _ _ _ _ _) :=
+((continuous_const_smul _).comp $ continuous_id.sub continuous_star).subtype_mk _
+
+lemma continuous_decompose_prod_adjoint [topological_add_group A] :
+  continuous (@star_module.decompose_prod_adjoint R A _ _ _ _ _ _ _ _) :=
+(continuous_self_adjoint_part R A).prod_mk (continuous_skew_adjoint_part R A)
+
+lemma continuous_decompose_prod_adjoint_symm [topological_add_group A] :
+  continuous (@star_module.decompose_prod_adjoint R A _ _ _ _ _ _ _ _).symm :=
+(continuous_subtype_coe.comp continuous_fst).add (continuous_subtype_coe.comp continuous_snd)
+
+/-- The self-adjoint part of an element of a star module, as a continuous linear map. -/
+@[simps] def self_adjoint_partL [has_continuous_add A] : A →L[R] self_adjoint A :=
+{ to_linear_map := self_adjoint_part R,
+  cont := continuous_self_adjoint_part _ _ }
+
+/-- The skew-adjoint part of an element of a star module, as a continuous linear map. -/
+@[simps] def skew_adjoint_partL [has_continuous_sub A] : A →L[R] skew_adjoint A :=
+{ to_linear_map := skew_adjoint_part R,
+  cont := continuous_skew_adjoint_part _ _ }
+
+/-- The decomposition of elements of a star module into their self- and skew-adjoint parts,
+as a continuous linear equivalence. -/
+def star_module.decompose_prod_adjointL[topological_add_group A] :
+    A ≃L[R] self_adjoint A × skew_adjoint A :=
+{ to_linear_equiv := star_module.decompose_prod_adjoint R A,
+  continuous_to_fun := continuous_decompose_prod_adjoint _ _,
+  continuous_inv_fun := continuous_decompose_prod_adjoint_symm _ _ }

--- a/src/topology/algebra/module/star.lean
+++ b/src/topology/algebra/module/star.lean
@@ -26,18 +26,20 @@ variables (R : Type*) (A : Type*)
   [semiring R] [star_semigroup R] [has_trivial_star R]
   [add_comm_group A] [module R A] [star_add_monoid A] [star_module R A]
   [invertible (2 : R)]
-  [topological_space A] [has_continuous_star A]
-  [has_continuous_const_smul R A]
+  [topological_space A]
 
-lemma continuous_self_adjoint_part [has_continuous_add A] :
+lemma continuous_self_adjoint_part [has_continuous_add A] [has_continuous_star A]
+  [has_continuous_const_smul R A] :
   continuous (@self_adjoint_part R A _ _ _ _ _ _ _ _) :=
 ((continuous_const_smul _).comp $ continuous_id.add continuous_star).subtype_mk _
 
-lemma continuous_skew_adjoint_part [has_continuous_sub A] :
+lemma continuous_skew_adjoint_part [has_continuous_sub A] [has_continuous_star A]
+  [has_continuous_const_smul R A] :
   continuous (@skew_adjoint_part R A _ _ _ _ _ _ _ _) :=
 ((continuous_const_smul _).comp $ continuous_id.sub continuous_star).subtype_mk _
 
-lemma continuous_decompose_prod_adjoint [topological_add_group A] :
+lemma continuous_decompose_prod_adjoint [topological_add_group A] [has_continuous_star A]
+  [has_continuous_const_smul R A] :
   continuous (@star_module.decompose_prod_adjoint R A _ _ _ _ _ _ _ _) :=
 (continuous_self_adjoint_part R A).prod_mk (continuous_skew_adjoint_part R A)
 
@@ -46,18 +48,21 @@ lemma continuous_decompose_prod_adjoint_symm [topological_add_group A] :
 (continuous_subtype_coe.comp continuous_fst).add (continuous_subtype_coe.comp continuous_snd)
 
 /-- The self-adjoint part of an element of a star module, as a continuous linear map. -/
-@[simps] def self_adjoint_partL [has_continuous_add A] : A →L[R] self_adjoint A :=
+@[simps] def self_adjoint_partL [has_continuous_add A] [has_continuous_star A]
+  [has_continuous_const_smul R A] : A →L[R] self_adjoint A :=
 { to_linear_map := self_adjoint_part R,
   cont := continuous_self_adjoint_part _ _ }
 
 /-- The skew-adjoint part of an element of a star module, as a continuous linear map. -/
-@[simps] def skew_adjoint_partL [has_continuous_sub A] : A →L[R] skew_adjoint A :=
+@[simps] def skew_adjoint_partL [has_continuous_sub A] [has_continuous_star A]
+  [has_continuous_const_smul R A] : A →L[R] skew_adjoint A :=
 { to_linear_map := skew_adjoint_part R,
   cont := continuous_skew_adjoint_part _ _ }
 
 /-- The decomposition of elements of a star module into their self- and skew-adjoint parts,
 as a continuous linear equivalence. -/
-@[simps] def star_module.decompose_prod_adjointL [topological_add_group A] :
+@[simps] def star_module.decompose_prod_adjointL [topological_add_group A] [has_continuous_star A]
+  [has_continuous_const_smul R A] :
   A ≃L[R] self_adjoint A × skew_adjoint A :=
 { to_linear_equiv := star_module.decompose_prod_adjoint R A,
   continuous_to_fun := continuous_decompose_prod_adjoint _ _,


### PR DESCRIPTION
Notably this adds `starL`.

This also fixes some unnecessary typeclass arguments in `star_linear_equiv`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
