### PR TITLE
[Merged by Bors] - chore(data/multiset/pi): correct names and reorder

### DIFF
--- a/src/algebra/big_operators/ring.lean
+++ b/src/algebra/big_operators/ring.lean
@@ -101,7 +101,7 @@ begin
     rw [prod_insert ha, pi_insert ha, ih, sum_mul, sum_bUnion h₁],
     refine sum_congr rfl (λ b _, _),
     have h₂ : ∀p₁∈pi s t, ∀p₂∈pi s t, pi.cons s a b p₁ = pi.cons s a b p₂ → p₁ = p₂, from
-      assume p₁ h₁ p₂ h₂ eq, pi_cons_injective ha eq,
+      assume p₁ h₁ p₂ h₂ eq, pi.cons_injective ha eq,
     rw [sum_image h₂, mul_sum],
     refine sum_congr rfl (λ g _, _),
     rw [attach_insert, prod_insert, prod_image],

--- a/src/data/finset/pi.lean
+++ b/src/data/finset/pi.lean
@@ -58,10 +58,10 @@ lemma pi.cons_ne {s : finset α} {a a' : α} {b : δ a} {f : Πa, a ∈ s → δ
   pi.cons s a b f a' h = f a' ((mem_insert.1 h).resolve_left ha.symm) :=
 multiset.pi.cons_ne _ _
 
-lemma pi_cons_injective  {a : α} {b : δ a} {s : finset α} (hs : a ∉ s) :
+lemma pi.cons_injective  {a : α} {b : δ a} {s : finset α} (hs : a ∉ s) :
   function.injective (pi.cons s a b) :=
 assume e₁ e₂ eq,
-@multiset.pi_cons_injective α _ δ a b s.1 hs _ _ $
+@multiset.pi.cons_injective α _ δ a b s.1 hs _ _ $
   funext $ assume e, funext $ assume h,
   have pi.cons s a b e₁ e (by simpa only [multiset.mem_cons, mem_insert] using h) =
     pi.cons s a b e₂ e (by simpa only [multiset.mem_cons, mem_insert] using h),
@@ -84,7 +84,7 @@ begin
   subst s', rw pi_cons,
   congr, funext b,
   refine ((pi s t).nodup.map _).dedup.symm,
-  exact multiset.pi_cons_injective ha,
+  exact multiset.pi.cons_injective ha,
 end
 
 lemma pi_singletons {β : Type*} (s : finset α) (f : α → β) :


### PR DESCRIPTION
* `multiset.pi_cons_injective` is about `multiset.pi.cons` so should have a `.` in its name.
* `multiset.pi.cons_ext` is not an ext lemma, but more closely resembles eta-reduction.

This also groups together the lemmas about `pi.cons`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The purpose of this PR is to split #18417 in half so that it's easier to cut out the style noise from that PR (which is an impediment to forward-porting)
