### PR TITLE
[Merged by Bors] - refactor(analysis/normed_space/basic): generalize some results to actions by normed_rings

### DIFF
--- a/src/analysis/normed/mul_action.lean
+++ b/src/analysis/normed/mul_action.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2023 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import topology.metric_space.algebra
+import analysis.normed.field.basic
+
+/-!
+# Lemmas for `has_bounded_smul` over normed additive groups
+
+Lemmas which hold only in `normed_space α β` are provided in another file.
+
+-/
+
+variables {α β : Type*}
+
+section seminormed_add_group
+variables [seminormed_add_group α] [seminormed_add_group β] [smul_zero_class α β]
+variables [has_bounded_smul α β]
+
+lemma norm_smul_le (r : α) (x : β) : ‖r • x‖ ≤ ‖r‖ * ‖x‖ :=
+by simpa [smul_zero] using dist_smul_pair r 0 x
+
+lemma nnnorm_smul_le (r : α) (x : β) : ‖r • x‖₊ ≤ ‖r‖₊ * ‖x‖₊ :=
+norm_smul_le _ _
+
+lemma dist_smul_le (s : α) (x y : β) : dist (s • x) (s • y) ≤ ‖s‖ * dist x y :=
+by simpa only [dist_eq_norm, sub_zero] using dist_smul_pair s x y
+
+lemma nndist_smul_le (s : α) (x y : β) : nndist (s • x) (s • y) ≤ ‖s‖₊ * nndist x y :=
+dist_smul_le s x y
+
+lemma lipschitz_with_smul  (s : α) : lipschitz_with ‖s‖₊ ((•) s : β → β) :=
+lipschitz_with_iff_dist_le_mul.2 $ dist_smul_le _
+
+end seminormed_add_group
+
+/-- Left multiplication is bounded. -/
+instance non_unital_semi_normed_ring.to_has_bounded_smul [non_unital_semi_normed_ring α] :
+  has_bounded_smul α α :=
+{ dist_smul_pair' := λ x y₁ y₂, by simpa [mul_sub, dist_eq_norm] using norm_mul_le x (y₁ - y₂),
+  dist_pair_smul' := λ x₁ x₂ y, by simpa [sub_mul, dist_eq_norm] using norm_mul_le (x₁ - x₂) y, }
+
+/-- Right multiplication is bounded. -/
+instance non_unital_semi_normed_ring.to_has_bounded_op_smul [non_unital_semi_normed_ring α] :
+  has_bounded_smul αᵐᵒᵖ α :=
+{ dist_smul_pair' := λ x y₁ y₂,
+    by simpa [sub_mul, dist_eq_norm, mul_comm] using norm_mul_le (y₁ - y₂) x.unop,
+  dist_pair_smul' := λ x₁ x₂ y,
+    by simpa [mul_sub, dist_eq_norm, mul_comm] using norm_mul_le y (x₁ - x₂).unop, }
+
+section semi_normed_ring
+variables [semi_normed_ring α] [seminormed_add_comm_group β] [module α β]
+
+lemma has_bounded_smul.of_norm_smul_le (h : ∀ (r : α) (x : β), ‖r • x‖ ≤ ‖r‖ * ‖x‖) :
+  has_bounded_smul α β :=
+{ dist_smul_pair' := λ a b₁ b₂, by simpa [smul_sub, dist_eq_norm] using h a (b₁ - b₂),
+  dist_pair_smul' := λ a₁ a₂ b, by simpa [sub_smul, dist_eq_norm] using h (a₁ - a₂) b }
+
+end semi_normed_ring
+
+section normed_division_ring
+variables [normed_division_ring α] [seminormed_add_group β]
+variables [mul_action_with_zero α β] [has_bounded_smul α β]
+
+lemma norm_smul (r : α) (x : β) : ‖r • x‖ = ‖r‖ * ‖x‖ :=
+begin
+  by_cases h : r = 0,
+  { simp [h, zero_smul α x] },
+  { refine le_antisymm (norm_smul_le r x) _,
+    calc ‖r‖ * ‖x‖ = ‖r‖ * ‖r⁻¹ • r • x‖     : by rw [inv_smul_smul₀ h]
+               ... ≤ ‖r‖ * (‖r⁻¹‖ * ‖r • x‖) :
+      mul_le_mul_of_nonneg_left (norm_smul_le _ _) (norm_nonneg _)
+               ... = ‖r • x‖                 :
+      by rw [norm_inv, ← mul_assoc, mul_inv_cancel (mt norm_eq_zero.1 h), one_mul] }
+end
+
+lemma nnnorm_smul (r : α) (x : β) : ‖r • x‖₊ = ‖r‖₊ * ‖x‖₊ :=
+nnreal.eq $ norm_smul r x
+
+end normed_division_ring
+
+section normed_division_ring_module
+variables [normed_division_ring α] [seminormed_add_comm_group β]
+variables [module α β] [has_bounded_smul α β]
+
+lemma dist_smul₀ (s : α) (x y : β) : dist (s • x) (s • y) = ‖s‖ * dist x y :=
+by simp_rw [dist_eq_norm, (norm_smul _ _).symm, smul_sub]
+
+lemma nndist_smul₀ (s : α) (x y : β) :
+  nndist (s • x) (s • y) = ‖s‖₊ * nndist x y :=
+nnreal.eq $ dist_smul₀ s x y
+
+end normed_division_ring_module

--- a/src/analysis/normed/mul_action.lean
+++ b/src/analysis/normed/mul_action.lean
@@ -11,6 +11,9 @@ import analysis.normed.field.basic
 
 Lemmas which hold only in `normed_space α β` are provided in another file.
 
+Notably we prove that `non_unital_semi_normed_ring`s have bounded actions by left- and right-
+multiplication. This allows downstream files to write general results about `bounded_smul`, and then
+deduce `const_mul` and `mul_const` results as an immediate corollary.
 -/
 
 variables {α β : Type*}

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -6,6 +6,7 @@ Authors: Patrick Massot, Johannes Hölzl
 import algebra.algebra.pi
 import algebra.algebra.restrict_scalars
 import analysis.normed.field.basic
+import analysis.normed.mul_action
 import data.real.sqrt
 import topology.algebra.module.basic
 
@@ -45,31 +46,9 @@ end prio
 
 variables [normed_field α] [seminormed_add_comm_group β]
 
--- note: while these are currently strictly weaker than the versions without `le`, they will cease
--- to be if we eventually generalize `normed_space` from `normed_field α` to `normed_ring α`.
-section le
-
-lemma norm_smul_le [normed_space α β] (r : α) (x : β) : ‖r • x‖ ≤ ‖r‖ * ‖x‖ :=
-normed_space.norm_smul_le _ _
-
-lemma nnnorm_smul_le [normed_space α β] (s : α) (x : β) : ‖s • x‖₊ ≤ ‖s‖₊ * ‖x‖₊ :=
-norm_smul_le s x
-
-lemma dist_smul_le [normed_space α β] (s : α) (x y : β) : dist (s • x) (s • y) ≤ ‖s‖ * dist x y :=
-by simpa only [dist_eq_norm, ←smul_sub] using norm_smul_le _ _
-
-lemma nndist_smul_le [normed_space α β] (s : α) (x y : β) :
-  nndist (s • x) (s • y) ≤ ‖s‖₊ * nndist x y :=
-dist_smul_le s x y
-
-end le
-
 @[priority 100] -- see Note [lower instance priority]
 instance normed_space.has_bounded_smul [normed_space α β] : has_bounded_smul α β :=
-{ dist_smul_pair' := λ x y₁ y₂,
-    by simpa [dist_eq_norm, smul_sub] using norm_smul_le x (y₁ - y₂),
-  dist_pair_smul' := λ x₁ x₂ y,
-    by simpa [dist_eq_norm, sub_smul] using norm_smul_le (x₁ - x₂) y }
+has_bounded_smul.of_norm_smul_le normed_space.norm_smul_le
 
 -- Shortcut instance, as otherwise this will be found by `normed_space.to_module` and be
 -- noncomputable.
@@ -77,18 +56,6 @@ instance : module ℝ ℝ := by apply_instance
 
 instance normed_field.to_normed_space : normed_space α α :=
 { norm_smul_le := λ a b, norm_mul_le a b }
-
-lemma norm_smul [normed_space α β] (s : α) (x : β) : ‖s • x‖ = ‖s‖ * ‖x‖ :=
-begin
-  by_cases h : s = 0,
-  { simp [h] },
-  { refine le_antisymm (norm_smul_le s x) _,
-    calc ‖s‖ * ‖x‖ = ‖s‖ * ‖s⁻¹ • s • x‖     : by rw [inv_smul_smul₀ h]
-               ... ≤ ‖s‖ * (‖s⁻¹‖ * ‖s • x‖) :
-      mul_le_mul_of_nonneg_left (norm_smul_le _ _) (norm_nonneg _)
-               ... = ‖s • x‖                 :
-      by rw [norm_inv, ← mul_assoc, mul_inv_cancel (mt norm_eq_zero.1 h), one_mul] }
-end
 
 lemma norm_zsmul (α) [normed_field α] [normed_space α β] (n : ℤ) (x : β) :
   ‖n • x‖ = ‖(n : α)‖ * ‖x‖ :=
@@ -101,19 +68,6 @@ lemma inv_norm_smul_mem_closed_unit_ball [normed_space ℝ β] (x : β) :
   ‖x‖⁻¹ • x ∈ closed_ball (0 : β) 1 :=
 by simp only [mem_closed_ball_zero_iff, norm_smul, norm_inv, norm_norm, ← div_eq_inv_mul,
   div_self_le_one]
-
-lemma dist_smul₀ [normed_space α β] (s : α) (x y : β) : dist (s • x) (s • y) = ‖s‖ * dist x y :=
-by simp only [dist_eq_norm, (norm_smul _ _).symm, smul_sub]
-
-lemma nnnorm_smul [normed_space α β] (s : α) (x : β) : ‖s • x‖₊ = ‖s‖₊ * ‖x‖₊ :=
-nnreal.eq $ norm_smul s x
-
-lemma nndist_smul₀ [normed_space α β] (s : α) (x y : β) :
-  nndist (s • x) (s • y) = ‖s‖₊ * nndist x y :=
-nnreal.eq $ dist_smul₀ s x y
-
-lemma lipschitz_with_smul [normed_space α β] (s : α) : lipschitz_with ‖s‖₊ ((•) s : β → β) :=
-lipschitz_with_iff_dist_le_mul.2 $ λ x y, by rw [dist_smul₀, coe_nnnorm]
 
 lemma norm_smul_of_nonneg [normed_space ℝ β] {t : ℝ} (ht : 0 ≤ t) (x : β) :
   ‖t • x‖ = t * ‖x‖ := by rw [norm_smul, real.norm_eq_abs, abs_of_nonneg ht]
@@ -279,7 +233,7 @@ instance pi.normed_space {E : ι → Type*} [fintype ι] [∀i, seminormed_add_c
   end }
 
 instance mul_opposite.normed_space : normed_space α Eᵐᵒᵖ :=
-{ norm_smul_le := λ s x, norm_smul_le s x.unop,
+{ norm_smul_le := λ s x, (norm_smul_le s x.unop : _),
   ..mul_opposite.normed_add_comm_group,
   ..mul_opposite.module _ }
 
@@ -288,7 +242,7 @@ instance submodule.normed_space {𝕜 R : Type*} [has_smul 𝕜 R] [normed_field
   {E : Type*} [seminormed_add_comm_group E] [normed_space 𝕜 E] [module R E]
   [is_scalar_tower 𝕜 R E] (s : submodule R E) :
   normed_space 𝕜 s :=
-{ norm_smul_le := λc x, norm_smul_le c (x : E) }
+{ norm_smul_le := λc x, (norm_smul_le c (x : E) : _) }
 
 /-- If there is a scalar `c` with `‖c‖>1`, then any element with nonzero norm can be
 moved by scalar multiplication to any shell of width `‖c‖`. Also recap information on the norm of

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -57,6 +57,10 @@ instance : module ℝ ℝ := by apply_instance
 instance normed_field.to_normed_space : normed_space α α :=
 { norm_smul_le := λ a b, norm_mul_le a b }
 
+-- shortcut instance
+instance normed_field.to_has_bounded_smul : has_bounded_smul α α :=
+normed_space.has_bounded_smul
+
 lemma norm_zsmul (α) [normed_field α] [normed_space α β] (n : ℤ) (x : β) :
   ‖n • x‖ = ‖(n : α)‖ * ‖x‖ :=
 by rw [← norm_smul, ← int.smul_one_eq_coe, smul_assoc, one_smul]

--- a/src/analysis/normed_space/star/multiplier.lean
+++ b/src/analysis/normed_space/star/multiplier.lean
@@ -383,7 +383,7 @@ lemma norm_def' (a : 𝓜(𝕜, A)) : ‖a‖ = ‖a.to_prod_mul_opposite_hom‖
 lemma nnnorm_def' (a : 𝓜(𝕜, A)) : ‖a‖₊ = ‖a.to_prod_mul_opposite_hom‖₊ := rfl
 
 instance : normed_space 𝕜 𝓜(𝕜, A) :=
-{ norm_smul_le := λ k a, norm_smul_le k a.to_prod_mul_opposite,
+{ norm_smul_le := λ k a, (norm_smul_le k a.to_prod_mul_opposite : _),
   .. double_centralizer.module }
 
 instance : normed_algebra 𝕜 𝓜(𝕜, A) :=

--- a/src/analysis/special_functions/exp.lean
+++ b/src/analysis/special_functions/exp.lean
@@ -48,8 +48,8 @@ begin
   have h_sq : ∀ z, ‖z‖ ≤ 1 → ‖exp (x + z) - exp x‖ ≤ ‖z‖ * ‖exp x‖ + ‖exp x‖ * ‖z‖ ^ 2,
   { intros z hz,
     have : ‖exp (x + z) - exp x - z • exp x‖ ≤ ‖exp x‖ * ‖z‖ ^ 2, from exp_bound_sq x z hz,
-    rw [← sub_le_iff_le_add',  ← norm_smul z],
-    exact (norm_sub_norm_le _ _).trans this, },
+    rw [← sub_le_iff_le_add',  ← norm_smul z (_ : ℂ)],
+    exact (norm_sub_norm_le _ _).trans this },
   calc ‖exp y - exp x‖ = ‖exp (x + (y - x)) - exp x‖ : by nth_rewrite 0 hy_eq
   ... ≤ ‖y - x‖ * ‖exp x‖ + ‖exp x‖ * ‖y - x‖ ^ 2 : h_sq (y - x) (hyx.le.trans hr_le)
   ... ≤ ‖y - x‖ * ‖exp x‖ + ‖exp x‖ * (r * ‖y - x‖) :

--- a/src/topology/continuous_function/zero_at_infty.lean
+++ b/src/topology/continuous_function/zero_at_infty.lean
@@ -411,7 +411,7 @@ normed_add_comm_group.induced C₀(α, β) (α →ᵇ β) (⟨to_bcf, rfl, λ x 
 lemma norm_to_bcf_eq_norm {f : C₀(α, β)} : ‖f.to_bcf‖ = ‖f‖ := rfl
 
 instance : normed_space 𝕜 C₀(α, β) :=
-{ norm_smul_le := λ k f, norm_smul_le k f.to_bcf }
+{ norm_smul_le := λ k f, (norm_smul_le k f.to_bcf : _) }
 
 end normed_space
 


### PR DESCRIPTION
This only moves the very basic lemmas for now.

This should be very easy to forward-port:

* Let someone port the new file via the normal mechanism
* Have them delete the duplicate lemmas that appear in CI

A few downstream proofs need some small help with unification, as while the old `normed_space` argument was found by unification, the new `has_bounded_smul` has to be found by typeclass search.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
