### PR TITLE
chore(analysis/inner_product_space): remove two redundant definitions (again)

### DIFF
--- a/src/analysis/fourier/riemann_lebesgue_lemma.lean
+++ b/src/analysis/fourier/riemann_lebesgue_lemma.lean
@@ -60,10 +60,14 @@ variables [normed_add_comm_group V] [measurable_space V] [borel_space V]
 lemma fourier_integrand_integrable (w : V) :
   integrable f ↔ integrable (λ v : V, e [-⟪v, w⟫] • f v) :=
 begin
-  have hL : continuous (λ p : V × V, bilin_form_of_real_inner.to_lin p.1 p.2) := continuous_inner,
+  have hL : continuous (λ p : V × V, innerₛₗ ℝ p.1 p.2) := continuous_inner,
+  -- TODO: remove the continuity assumption from `vector_fourier.fourier_integral_convergent_iff`
   rw vector_fourier.fourier_integral_convergent_iff real.continuous_fourier_char hL w,
-  { simp only [bilin_form.to_lin_apply, bilin_form_of_real_inner_apply] },
+  { simp only [innerₛₗ_apply] },
   { apply_instance },
+  -- Porting note: proof is just
+  -- `exact vector_fourier.fourier_integral_convergent_iff real.continuous_fourier_char hL w`
+  -- but this elaborates very slowly in mathlib3
 end
 
 variables [complete_space E]
@@ -212,8 +216,7 @@ begin
     simp_rw [←integral_sub ((fourier_integrand_integrable w).mp hfi)
       ((fourier_integrand_integrable w).mp (hg_cont.integrable_of_has_compact_support hg_supp)),
       ←smul_sub, ←pi.sub_apply],
-    exact vector_fourier.norm_fourier_integral_le_integral_norm e volume
-      bilin_form_of_real_inner.to_lin (f - g) w },
+    exact vector_fourier.norm_fourier_integral_le_integral_norm e volume (innerₛₗ ℝ) (f - g) w },
   replace := add_lt_add_of_le_of_lt this hI,
   rw add_halves at this,
   refine ((le_of_eq _).trans (norm_add_le _ _)).trans_lt this,

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -205,21 +205,9 @@ instance : cstar_ring (E →L[𝕜] E) :=
             : by rw [mul_assoc, real.sqrt_mul (norm_nonneg _), real.sqrt_mul_self (norm_nonneg _)] }
 end⟩
 
-section real
-
-variables {E' : Type*} {F' : Type*}
-variables [normed_add_comm_group E'] [normed_add_comm_group F']
-variables [inner_product_space ℝ E'] [inner_product_space ℝ F']
-variables [complete_space E'] [complete_space F']
-
--- Todo: Generalize this to `is_R_or_C`.
-lemma is_adjoint_pair_inner (A : E' →L[ℝ] F') :
-  linear_map.is_adjoint_pair (sesq_form_of_inner : E' →ₗ[ℝ] E' →ₗ[ℝ] ℝ)
-  (sesq_form_of_inner : F' →ₗ[ℝ] F' →ₗ[ℝ] ℝ) A (A†) :=
-λ x y, by simp only [sesq_form_of_inner_apply_apply, adjoint_inner_left, to_linear_map_eq_coe,
-  coe_coe]
-
-end real
+lemma is_adjoint_pair_innerₛₗ (A : E →L[𝕜] F) :
+  (@innerₛₗ 𝕜 E _ _ _).flip.is_adjoint_pair (@innerₛₗ 𝕜 F _ _ _).flip A (A†) :=
+λ _ _, by simp only [adjoint_inner_left, coe_coe, linear_map.flip_apply, innerₛₗ_apply]
 
 end continuous_linear_map
 
@@ -403,20 +391,9 @@ lemma is_symmetric_iff_is_self_adjoint (A : E →ₗ[𝕜] E) :
   is_symmetric A ↔ is_self_adjoint A :=
 by { rw [is_self_adjoint_iff', is_symmetric, ← linear_map.eq_adjoint_iff], exact eq_comm }
 
-section real
-
-variables {E' : Type*} {F' : Type*}
-variables [normed_add_comm_group E'] [normed_add_comm_group F']
-variables [inner_product_space ℝ E'] [inner_product_space ℝ F']
-variables [finite_dimensional ℝ E'] [finite_dimensional ℝ F']
-
--- Todo: Generalize this to `is_R_or_C`.
-lemma is_adjoint_pair_inner (A : E' →ₗ[ℝ] F') :
-  is_adjoint_pair (sesq_form_of_inner : E' →ₗ[ℝ] E' →ₗ[ℝ] ℝ)
-  (sesq_form_of_inner : F' →ₗ[ℝ] F' →ₗ[ℝ] ℝ) A A.adjoint :=
-λ x y, by simp only [sesq_form_of_inner_apply_apply, adjoint_inner_left]
-
-end real
+lemma is_adjoint_pair_innerₛₗ (A : E →ₗ[𝕜] F) :
+  (@innerₛₗ 𝕜 E _ _ _).flip.is_adjoint_pair (@innerₛₗ 𝕜 F _ _ _).flip A A.adjoint :=
+λ _ _, by simp only [adjoint_inner_left, coe_coe, linear_map.flip_apply, innerₛₗ_apply]
 
 /-- The Gram operator T†T is symmetric. -/
 lemma is_symmetric_adjoint_mul_self (T : E →ₗ[𝕜] E) : is_symmetric (T.adjoint * T) :=

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -414,7 +414,7 @@ variables {𝕜}
 
 /-- An inner product with a sum on the left. -/
 lemma sum_inner {ι : Type*} (s : finset ι) (f : ι → E) (x : E) :
-  ⟪∑ i in s, f i, x⟫ = ∑ i in s, ⟪f i, x⟫ := (linear_map.flip (innerₛₗ 𝕜) x).map_sum
+  ⟪∑ i in s, f i, x⟫ = ∑ i in s, ⟪f i, x⟫ := ((innerₛₗ 𝕜).flip x).map_sum
 
 /-- An inner product with a sum on the right. -/
 lemma inner_sum {ι : Type*} (s : finset ι) (f : ι → E) (x : E) :

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -8,7 +8,6 @@ import analysis.complex.basic
 import analysis.convex.uniform
 import analysis.normed_space.completion
 import analysis.normed_space.bounded_linear_maps
-import linear_algebra.bilinear_form
 
 /-!
 # Inner product space
@@ -411,15 +410,6 @@ linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) (star_ring_end _)
   (λ r x y, inner_smul_right _ _ _)
   (λ x y z, inner_add_left _ _ _)
   (λ r x y, inner_smul_left _ _ _)
-
-/-- The real inner product as a bilinear form. -/
-@[simps]
-def bilin_form_of_real_inner : bilin_form ℝ F :=
-{ bilin := inner,
-  bilin_add_left := inner_add_left,
-  bilin_smul_left := λ a x y, inner_smul_left _ _ _,
-  bilin_add_right := inner_add_right,
-  bilin_smul_right := λ a x y, inner_smul_right _ _ _ }
 
 /-- An inner product with a sum on the left. -/
 lemma sum_inner {ι : Type*} (s : finset ι) (f : ι → E) (x : E) :

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -399,25 +399,26 @@ inner_smul_right _ _ _
 lemma inner_smul_real_right (x y : E) (r : ℝ) : ⟪x, (r : 𝕜) • y⟫ = r • ⟪x, y⟫ :=
 by { rw [inner_smul_right, algebra.smul_def], refl }
 
-/-- The inner product as a sesquilinear form.
+variables (𝕜)
 
-Note that in the case `𝕜 = ℝ` this is a bilinear form. -/
-@[simps]
-def sesq_form_of_inner : E →ₗ[𝕜] E →ₗ⋆[𝕜] 𝕜 :=
-linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) (star_ring_end _)
-  (λ x y, ⟪y, x⟫)
-  (λ x y z, inner_add_right _ _ _)
-  (λ r x y, inner_smul_right _ _ _)
-  (λ x y z, inner_add_left _ _ _)
-  (λ r x y, inner_smul_left _ _ _)
+/-- The inner product as a sesquilinear map. -/
+def innerₛₗ : E →ₗ⋆[𝕜] E →ₗ[𝕜] 𝕜 :=
+linear_map.mk₂'ₛₗ _ _ (λ v w, ⟪v, w⟫) inner_add_left (λ _ _ _, inner_smul_left _ _ _)
+  inner_add_right (λ _ _ _, inner_smul_right _ _ _)
+
+@[simp] lemma innerₛₗ_apply_coe (v : E) : ⇑(innerₛₗ 𝕜 v) = λ w, ⟪v, w⟫ := rfl
+
+@[simp] lemma innerₛₗ_apply (v w : E) : innerₛₗ 𝕜 v w = ⟪v, w⟫ := rfl
+
+variables {𝕜}
 
 /-- An inner product with a sum on the left. -/
 lemma sum_inner {ι : Type*} (s : finset ι) (f : ι → E) (x : E) :
-  ⟪∑ i in s, f i, x⟫ = ∑ i in s, ⟪f i, x⟫ := (sesq_form_of_inner x).map_sum
+  ⟪∑ i in s, f i, x⟫ = ∑ i in s, ⟪f i, x⟫ := (linear_map.flip (innerₛₗ 𝕜) x).map_sum
 
 /-- An inner product with a sum on the right. -/
 lemma inner_sum {ι : Type*} (s : finset ι) (f : ι → E) (x : E) :
-  ⟪x, ∑ i in s, f i⟫ = ∑ i in s, ⟪x, f i⟫ := (linear_map.flip sesq_form_of_inner x).map_sum
+  ⟪x, ∑ i in s, f i⟫ = ∑ i in s, ⟪x, f i⟫ := (innerₛₗ 𝕜 x).map_sum
 
 /-- An inner product with a sum on the left, `finsupp` version. -/
 lemma finsupp.sum_inner {ι : Type*} (l : ι →₀ 𝕜) (v : ι → E) (x : E) :
@@ -1513,15 +1514,6 @@ by simp_rw [sum_inner, inner_sum, real_inner_smul_left, real_inner_smul_right,
             neg_div, finset.sum_div, mul_div_assoc, mul_assoc]
 
 variables (𝕜)
-
-/-- The inner product as a sesquilinear map. -/
-def innerₛₗ : E →ₗ⋆[𝕜] E →ₗ[𝕜] 𝕜 :=
-linear_map.mk₂'ₛₗ _ _ (λ v w, ⟪v, w⟫) inner_add_left (λ _ _ _, inner_smul_left _ _ _)
-  inner_add_right (λ _ _ _, inner_smul_right _ _ _)
-
-@[simp] lemma innerₛₗ_apply_coe (v : E) : ⇑(innerₛₗ 𝕜 v) = λ w, ⟪v, w⟫ := rfl
-
-@[simp] lemma innerₛₗ_apply (v w : E) : innerₛₗ 𝕜 v w = ⟪v, w⟫ := rfl
 
 /-- The inner product as a continuous sesquilinear map. Note that `to_dual_map` (resp. `to_dual`)
 in `inner_product_space.dual` is a version of this given as a linear isometry (resp. linear

--- a/src/analysis/inner_product_space/orthogonal.lean
+++ b/src/analysis/inner_product_space/orthogonal.lean
@@ -3,8 +3,8 @@ Copyright (c) 2019 Zhouhang Zhou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou, Sébastien Gouëzel, Frédéric Dupuis
 -/
-import linear_algebra.bilinear_form
 import analysis.inner_product_space.basic
+import linear_algebra.sesquilinear_form
 
 /-!
 # Orthogonal complements of submodules
@@ -201,9 +201,15 @@ lemma orthogonal_family_self :
 end submodule
 
 @[simp]
-lemma bilin_form_of_real_inner_orthogonal {E} [normed_add_comm_group E] [inner_product_space ℝ E]
-  (K : submodule ℝ E) :
-  bilin_form_of_real_inner.orthogonal K = Kᗮ := rfl
+lemma sesq_form_of_inner_orthogonal (K : submodule 𝕜 E) :
+  K.orthogonal_bilin sesq_form_of_inner = Kᗮ :=
+begin
+  ext x,
+  rw [submodule.mem_orthogonal_bilin_iff, submodule.mem_orthogonal],
+  refine forall₂_congr (λ y hy, _),
+  rw [linear_map.is_ortho_def, sesq_form_of_inner_apply_apply],
+  exact inner_eq_zero_symm,
+end
 
 /-!
 ### Orthogonality of submodules

--- a/src/analysis/inner_product_space/orthogonal.lean
+++ b/src/analysis/inner_product_space/orthogonal.lean
@@ -202,14 +202,7 @@ end submodule
 
 @[simp]
 lemma sesq_form_of_inner_orthogonal (K : submodule 𝕜 E) :
-  K.orthogonal_bilin sesq_form_of_inner = Kᗮ :=
-begin
-  ext x,
-  rw [submodule.mem_orthogonal_bilin_iff, submodule.mem_orthogonal],
-  refine forall₂_congr (λ y hy, _),
-  rw [linear_map.is_ortho_def, sesq_form_of_inner_apply_apply],
-  exact inner_eq_zero_symm,
-end
+  K.orthogonal_bilin (innerₛₗ 𝕜) = Kᗮ := rfl
 
 /-!
 ### Orthogonality of submodules

--- a/src/analysis/inner_product_space/symmetric.lean
+++ b/src/analysis/inner_product_space/symmetric.lean
@@ -55,9 +55,8 @@ variables
 
 /-- An operator `T` on an inner product space is symmetric if and only if it is
 `linear_map.is_self_adjoint` with respect to the sesquilinear form given by the inner product. -/
-lemma is_symmetric_iff_sesq_form (T : E →ₗ[𝕜] E) :
-  T.is_symmetric ↔
-  @linear_map.is_self_adjoint 𝕜 E _ _ _ (star_ring_end 𝕜) sesq_form_of_inner T :=
+lemma is_symmetric_iff_innerₛₗ_flip_is_self_adjoint (T : E →ₗ[𝕜] E) :
+  T.is_symmetric ↔ (innerₛₗ 𝕜).flip.is_self_adjoint T :=
 ⟨λ h x y, (h y x).symm, λ h x y, (h y x).symm⟩
 
 end real


### PR DESCRIPTION
This PR removes `sesq_form_of_inner` and `bilin_form_of_real_inner`. The former one is just `(innerₛₗ 𝕜).flip` and the later one can be easily replaced by `innerₛₗ 𝕜`. The definition `bilin_form_of_real_inner` was earlier removed in #15780, but then restored in #18093. Since then nothing has been added to mathlib that makes `bilin_form_of_real_inner` necessary. In particular the mentioned quadratic form is just the square of the norm.

We also generalize `bilin_form_of_real_inner_orthogonal` and the two versions of `is_adjoint_pair_inner` so that they hold for complex inner products and not just the reals.

Add a few comments for a proof in the Riemann-Lebesgue lemma which is unnecessarily complicated, but fixing this is not in the scope of this PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
