### PR TITLE
feat(logic/function,topology/continuous_function): define `factors_through.surj_lift`

### DIFF
--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -308,6 +308,32 @@ end gluing
 
 end continuous_map
 
+namespace quotient_map
+
+variables {X Y Z Z' : Type*} [topological_space X] [topological_space Y] [topological_space Z]
+  [topological_space Z']
+
+/-- Lift a continuous map that factors through a quotient map. See the docstring of
+`function.factors_through.surj_lift` for similar constructions with other assumptions. -/
+@[simps { fully_applied := ff }]
+noncomputable def lift {f : X → Y} (hf : quotient_map f) (g : C(X, Z)) (hg : factors_through g f) :
+  C(Y, Z) :=
+⟨hg.surj_lift hf.1, (hf.continuous_surj_lift hg).2 g.continuous⟩
+
+@[simp] lemma lift_comp {f : C(X, Y)} (hf : quotient_map f) (g : C(X, Z))
+  (hg : factors_through g f) : (hf.lift g hg).comp f = g :=
+fun_like.ext _ _ $ hg.surj_lift_eq _
+
+lemma comp_lift {f : C(X, Y)} (hf : quotient_map f) {g : C(X, Z)} (hg : factors_through g f)
+  (g' : C(Z, Z')) : g'.comp (hf.lift g hg) = hf.lift (g'.comp g) (hg.comp_left g') :=
+fun_like.ext' $ hg.comp_surj_lift _ _
+
+lemma lift_uniq {f : C(X, Y)} (hf : quotient_map f) {g : C(X, Z)} {g' : C(Y, Z)}
+  (h : g'.comp f = g) : g' = hf.lift g (factors_through.of_comp_eq $ fun_like.ext'_iff.1 h) :=
+fun_like.ext' $ factors_through.surj_lift_uniq _ (fun_like.ext'_iff.1 h)
+
+end quotient_map
+
 namespace homeomorph
 variables {α β γ : Type*} [topological_space α] [topological_space β] [topological_space γ]
 variables (f : α ≃ₜ β) (g : β ≃ₜ γ)

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -259,6 +259,10 @@ protected lemma continuous_iff (hf : quotient_map f) :
   continuous g ↔ continuous (g ∘ f) :=
 by rw [continuous_iff_coinduced_le, continuous_iff_coinduced_le, hf.right, coinduced_compose]
 
+lemma continuous_surj_lift {g : α → γ} (hf : quotient_map f) (hg : factors_through g f) :
+  continuous (hg.surj_lift hf.1) ↔ continuous g :=
+by rw [hf.continuous_iff, hg.surj_lift_comp]
+
 protected lemma continuous (hf : quotient_map f) : continuous f :=
 hf.continuous_iff.mp continuous_id
 


### PR DESCRIPTION
Define `function.factors_through.surj_lift` and `quotient_map.lift`,
provide basic API.

Motivated by the code in Shamrock-Frost/BrouwerFixedPoint

Co-authored-by: @Shamrock-Frost

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)