### PR TITLE
chore(category_theory/monoidal/coherence): temporarily remove support for bicategories in coherence tactic

### DIFF
--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -217,7 +217,8 @@ example {C : Type} [category C] [monoidal_category C] :
 by pure_coherence
 ```
 
-Users will typically just use the `coherence` tactic, which can also cope with identities of the form
+Users will typically just use the `coherence` tactic,
+which can also cope with identities of the form
 `a ≫ f ≫ b ≫ g ≫ c = a' ≫ f ≫ b' ≫ g ≫ c'`
 where `a = a'`, `b = b'`, and `c = c'` can be proved using `pure_coherence`
 

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Yuma Mizuno, Oleksandr Manzyuk
 -/
 import category_theory.monoidal.free.coherence
-import category_theory.bicategory.coherence_tactic
 
 /-!
 # A `coherence` tactic for monoidal categories, and `⊗≫` (composition up to associators)
@@ -22,6 +21,10 @@ are equal.
 We also provide `f ⊗≫ g`, the `monoidal_comp` operation,
 which automatically inserts associators and unitors as needed
 to make the target of `f` match the source of `g`.
+
+Porting note:
+This file used to import `category_theory.bicategory.coherence_tactic`,
+but this has been removed to avoid holding up the port.
 -/
 
 noncomputable theory
@@ -214,11 +217,14 @@ example {C : Type} [category C] [monoidal_category C] :
 by pure_coherence
 ```
 
-Users will typicall just use the `coherence` tactic, which can also cope with identities of the form
+Users will typically just use the `coherence` tactic, which can also cope with identities of the form
 `a ≫ f ≫ b ≫ g ≫ c = a' ≫ f ≫ b' ≫ g ≫ c'`
 where `a = a'`, `b = b'`, and `c = c'` can be proved using `pure_coherence`
+
+Porting note: once `category_theory.bicategory.coherence_tactic` is ported,
+change the definition here back to `monoidal_coherence <|> bicategorical_coherence`.
 -/
-meta def pure_coherence : tactic unit := monoidal_coherence <|> bicategorical_coherence
+meta def pure_coherence : tactic unit := monoidal_coherence
 
 example (X₁ X₂ : C) :
   ((λ_ (𝟙_ C)).inv ⊗ 𝟙 (X₁ ⊗ X₂)) ≫ (α_ (𝟙_ C) (𝟙_ C) (X₁ ⊗ X₂)).hom ≫
@@ -254,7 +260,10 @@ do
   o ← get_options, set_options $ o.set_nat `class.instance_max_depth 128,
   try `[simp only [monoidal_comp, category_theory.category.assoc]] >>
     `[apply (cancel_epi (𝟙 _)).1; try { apply_instance }] >>
-    try `[simp only [tactic.coherence.assoc_lift_hom, tactic.bicategory.coherence.assoc_lift_hom₂]]
+    -- Porting note: in the next line add back in
+    -- `tactic.bicategory.coherence.assoc_lift_hom₂` to the simp set
+    -- once `category_theory.bicategory.coherence_tactic` is ported.
+    try `[simp only [tactic.coherence.assoc_lift_hom]]
 
 example {W X Y Z : C} (f : Y ⟶ Z) (g) (w : false) : (λ_ _).hom ≫ f = g :=
 begin
@@ -318,10 +327,12 @@ using e.g. `set_option class.instance_max_depth 500`.)
 -/
 meta def coherence : tactic unit :=
 do
-  try `[simp only [bicategorical_comp]],
+  -- Porting note: restore this line when `category_theory.bicategory.coherence_tactic` is ported.
+  -- try `[simp only [bicategorical_comp]],
   try `[simp only [monoidal_comp]],
   -- TODO: put similar normalization simp lemmas for monoidal categories
-  try bicategory.whisker_simps,
+  -- Porting note: restore this line when `category_theory.bicategory.coherence_tactic` is ported.
+  -- try bicategory.whisker_simps,
   coherence_loop
 
 run_cmd add_interactive [`pure_coherence, `coherence]

--- a/test/coherence.lean
+++ b/test/coherence.lean
@@ -1,47 +1,51 @@
 import category_theory.monoidal.coherence
+import category_theory.bicategory.coherence_tactic
 
 open category_theory
 
 universes w v u
 
-section bicategory
-open_locale bicategory
-variables {B : Type u} [bicategory.{w v} B] {a b c d e : B}
+-- Porting note: when `category_theory.bicategory.coherence_tactic` is ported,
+-- these tests need to be restored.
 
-example : (λ_ (𝟙 a)).hom = (ρ_ (𝟙 a)).hom := by coherence
-example : (λ_ (𝟙 a)).inv = (ρ_ (𝟙 a)).inv := by coherence
-example (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) :
-  (α_ f g h).inv ≫ (α_ f g h).hom = 𝟙 (f ≫ g ≫ h) :=
-by coherence
-example (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e) :
-  f ◁ (α_ g h i).hom ≫ (α_ f g (h ≫ i)).inv ≫ (α_ (f ≫ g) h i).inv =
-    (α_ f (g ≫ h) i).inv ≫ (α_ f g h).inv ▷ i :=
-by coherence
-example (f : a ⟶ b) (g : b ⟶ c) :
-  f ◁ (λ_ g).inv ≫ (α_ f (𝟙 b) g).inv = (ρ_ f).inv ▷ g :=
-by coherence
-example (f g : a ⟶ a) (η : 𝟙 a ⟶ f) (θ : f ⟶ g) (w : false) :
-  (λ_ (𝟙 a)).hom ≫ η ≫ 𝟙 f ≫ θ = (ρ_ (𝟙 a)).hom ≫ η ≫ θ :=
-by coherence
+-- section bicategory
+-- open_locale bicategory
+-- variables {B : Type u} [bicategory.{w v} B] {a b c d e : B}
 
-example (f₁ : a ⟶ b) (g₁ : b ⟶ a) (f₂ : b ⟶ c) (g₂ : c ⟶ b) :
-  (α_ (𝟙 a) (𝟙 a) (f₁ ≫ f₂)).hom ≫
-    𝟙 a ◁ (α_ (𝟙 a) f₁ f₂).inv ≫
-      𝟙 a ◁ ((λ_ f₁).hom ≫ (ρ_ f₁).inv) ▷ f₂ ≫
-        𝟙 a ◁ (α_ f₁ (𝟙 b) f₂).hom ≫
-          (α_ (𝟙 a) f₁ (𝟙 b ≫ f₂)).inv ≫
-            ((λ_ f₁).hom ≫ (ρ_ f₁).inv) ▷ (𝟙 b ≫ f₂) ≫
-              (α_ f₁ (𝟙 b) (𝟙 b ≫ f₂)).hom ≫
-                f₁ ◁ 𝟙 b ◁ ((λ_ f₂).hom ≫ (ρ_ f₂).inv) ≫
-                  f₁ ◁ (α_ (𝟙 b) f₂ (𝟙 c)).inv ≫
-                    f₁ ◁ ((λ_ f₂).hom ≫ (ρ_ f₂).inv) ▷ 𝟙 c ≫
-                      (f₁ ◁ (α_ f₂ (𝟙 c) (𝟙 c)).hom) ≫
-                        (α_ f₁ f₂ (𝟙 c ≫ 𝟙 c)).inv =
-  ((λ_ (𝟙 a)).hom ▷ (f₁ ≫ f₂) ≫ (λ_ (f₁ ≫ f₂)).hom ≫ (ρ_ (f₁ ≫ f₂)).inv) ≫
-    (f₁ ≫ f₂) ◁ (λ_ (𝟙 c)).inv :=
-by coherence
+-- example : (λ_ (𝟙 a)).hom = (ρ_ (𝟙 a)).hom := by coherence
+-- example : (λ_ (𝟙 a)).inv = (ρ_ (𝟙 a)).inv := by coherence
+-- example (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) :
+--   (α_ f g h).inv ≫ (α_ f g h).hom = 𝟙 (f ≫ g ≫ h) :=
+-- by coherence
+-- example (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e) :
+--   f ◁ (α_ g h i).hom ≫ (α_ f g (h ≫ i)).inv ≫ (α_ (f ≫ g) h i).inv =
+--     (α_ f (g ≫ h) i).inv ≫ (α_ f g h).inv ▷ i :=
+-- by coherence
+-- example (f : a ⟶ b) (g : b ⟶ c) :
+--   f ◁ (λ_ g).inv ≫ (α_ f (𝟙 b) g).inv = (ρ_ f).inv ▷ g :=
+-- by coherence
+-- example (f g : a ⟶ a) (η : 𝟙 a ⟶ f) (θ : f ⟶ g) (w : false) :
+--   (λ_ (𝟙 a)).hom ≫ η ≫ 𝟙 f ≫ θ = (ρ_ (𝟙 a)).hom ≫ η ≫ θ :=
+-- by coherence
 
-end bicategory
+-- example (f₁ : a ⟶ b) (g₁ : b ⟶ a) (f₂ : b ⟶ c) (g₂ : c ⟶ b) :
+--   (α_ (𝟙 a) (𝟙 a) (f₁ ≫ f₂)).hom ≫
+--     𝟙 a ◁ (α_ (𝟙 a) f₁ f₂).inv ≫
+--       𝟙 a ◁ ((λ_ f₁).hom ≫ (ρ_ f₁).inv) ▷ f₂ ≫
+--         𝟙 a ◁ (α_ f₁ (𝟙 b) f₂).hom ≫
+--           (α_ (𝟙 a) f₁ (𝟙 b ≫ f₂)).inv ≫
+--             ((λ_ f₁).hom ≫ (ρ_ f₁).inv) ▷ (𝟙 b ≫ f₂) ≫
+--               (α_ f₁ (𝟙 b) (𝟙 b ≫ f₂)).hom ≫
+--                 f₁ ◁ 𝟙 b ◁ ((λ_ f₂).hom ≫ (ρ_ f₂).inv) ≫
+--                   f₁ ◁ (α_ (𝟙 b) f₂ (𝟙 c)).inv ≫
+--                     f₁ ◁ ((λ_ f₂).hom ≫ (ρ_ f₂).inv) ▷ 𝟙 c ≫
+--                       (f₁ ◁ (α_ f₂ (𝟙 c) (𝟙 c)).hom) ≫
+--                         (α_ f₁ f₂ (𝟙 c ≫ 𝟙 c)).inv =
+--   ((λ_ (𝟙 a)).hom ▷ (f₁ ≫ f₂) ≫ (λ_ (f₁ ≫ f₂)).hom ≫ (ρ_ (f₁ ≫ f₂)).inv) ≫
+--     (f₁ ≫ f₂) ◁ (λ_ (𝟙 c)).inv :=
+-- by coherence
+
+-- end bicategory
 
 section monoidal
 variables {C : Type u} [category.{v} C] [monoidal_category C]


### PR DESCRIPTION
We currently have two related tactics, for applying the coherence theorem in monoidal categories, and for applying the coherence theorem in bicategories. Their current implementation is tied together.

We do not currently use the coherence tactic for bicategories in the library, only in the test files. We seem to be a bit stuck on https://github.com/leanprover-community/mathlib4/pull/4062, which is holding up some things that people are keen on, e.g. https://tqft.net/mathlib4/2023-05-24/representation_theory.group_cohomology.basic.pdf.

This PR temporarily disables the coherence tactic for bicategories. It is carefully annotated with porting notes, so once the two relevant files get unstuck we can just turn the tactic back on.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
