### PR TITLE
[Merged by Bors] - feat(probability/kernel/cond_distrib): regular conditional probability distributions

### DIFF
--- a/src/measure_theory/constructions/prod/basic.lean
+++ b/src/measure_theory/constructions/prod/basic.lean
@@ -746,6 +746,21 @@ instance [is_finite_measure ρ] : is_finite_measure ρ.fst := by { rw fst, apply
 instance [is_probability_measure ρ] : is_probability_measure ρ.fst :=
 { measure_univ := by { rw fst_univ, exact measure_univ, } }
 
+lemma fst_map_prod_mk₀ {X : α → β} {Y : α → γ} {μ : measure α}
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ) :
+  (μ.map (λ a, (X a, Y a))).fst = μ.map X :=
+begin
+  ext1 s hs,
+  rw [measure.fst_apply hs, measure.map_apply_of_ae_measurable (hX.prod_mk hY) (measurable_fst hs),
+    measure.map_apply_of_ae_measurable hX hs, ← prod_univ, mk_preimage_prod, preimage_univ,
+    inter_univ],
+end
+
+lemma fst_map_prod_mk {X : α → β} {Y : α → γ} {μ : measure α}
+  (hX : measurable X) (hY : measurable Y) :
+  (μ.map (λ a, (X a, Y a))).fst = μ.map X :=
+fst_map_prod_mk₀ hX.ae_measurable hY.ae_measurable
+
 /-- Marginal measure on `β` obtained from a measure on `ρ` `α × β`, defined by `ρ.map prod.snd`. -/
 noncomputable
 def snd (ρ : measure (α × β)) : measure β := ρ.map prod.snd
@@ -760,6 +775,21 @@ instance [is_finite_measure ρ] : is_finite_measure ρ.snd := by { rw snd, apply
 
 instance [is_probability_measure ρ] : is_probability_measure ρ.snd :=
 { measure_univ := by { rw snd_univ, exact measure_univ, } }
+
+lemma snd_map_prod_mk₀ {X : α → β} {Y : α → γ} {μ : measure α}
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ) :
+  (μ.map (λ a, (X a, Y a))).snd = μ.map Y :=
+begin
+  ext1 s hs,
+  rw [measure.snd_apply hs, measure.map_apply_of_ae_measurable (hX.prod_mk hY) (measurable_snd hs),
+    measure.map_apply_of_ae_measurable hY hs, ← univ_prod, mk_preimage_prod, preimage_univ,
+    univ_inter],
+end
+
+lemma snd_map_prod_mk {X : α → β} {Y : α → γ} {μ : measure α}
+  (hX : measurable X) (hY : measurable Y) :
+  (μ.map (λ a, (X a, Y a))).snd = μ.map Y :=
+snd_map_prod_mk₀ hX.ae_measurable hY.ae_measurable
 
 end measure
 

--- a/src/measure_theory/function/conditional_expectation/basic.lean
+++ b/src/measure_theory/function/conditional_expectation/basic.lean
@@ -187,6 +187,14 @@ lemma ae_eq_trim_iff_of_ae_strongly_measurable' {α β} [topological_space β] [
 ⟨λ h, hfm.ae_eq_mk.trans (h.trans hgm.ae_eq_mk.symm),
   λ h, hfm.ae_eq_mk.symm.trans (h.trans hgm.ae_eq_mk)⟩
 
+lemma ae_strongly_measurable.comp_ae_measurable'
+  {α β γ : Type*} [topological_space β] {mα : measurable_space α} {mγ : measurable_space γ}
+  {f : α → β} {μ : measure γ} {g : γ → α}
+  (hf : ae_strongly_measurable f (μ.map g)) (hg : ae_measurable g μ) :
+  ae_strongly_measurable' (mα.comap g ) (f ∘ g) μ :=
+⟨(hf.mk f) ∘ g, hf.strongly_measurable_mk.comp_measurable (measurable_iff_comap_le.mpr le_rfl),
+  ae_eq_comp hg hf.ae_eq_mk⟩
+
 /-- If the restriction to a set `s` of a σ-algebra `m` is included in the restriction to `s` of
 another σ-algebra `m₂` (hypothesis `hs`), the set `s` is `m` measurable and a function `f` almost
 everywhere supported on `s` is `m`-ae-strongly-measurable, then `f` is also

--- a/src/measure_theory/function/conditional_expectation/basic.lean
+++ b/src/measure_theory/function/conditional_expectation/basic.lean
@@ -191,7 +191,7 @@ lemma ae_strongly_measurable.comp_ae_measurable'
   {α β γ : Type*} [topological_space β] {mα : measurable_space α} {mγ : measurable_space γ}
   {f : α → β} {μ : measure γ} {g : γ → α}
   (hf : ae_strongly_measurable f (μ.map g)) (hg : ae_measurable g μ) :
-  ae_strongly_measurable' (mα.comap g ) (f ∘ g) μ :=
+  ae_strongly_measurable' (mα.comap g) (f ∘ g) μ :=
 ⟨(hf.mk f) ∘ g, hf.strongly_measurable_mk.comp_measurable (measurable_iff_comap_le.mpr le_rfl),
   ae_eq_comp hg hf.ae_eq_mk⟩
 

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -45,7 +45,7 @@ lemma ae_strongly_measurable.comp_ae_measurable'
   {α β γ : Type*} [topological_space β] {m0 : measurable_space α} {mγ : measurable_space γ}
   {f : α → β} {μ : measure γ} {g : γ → α}
   (hf : ae_strongly_measurable f (μ.map g)) (hg : ae_measurable g μ) :
-  ae_strongly_measurable' (measurable_space.comap g m0) (f ∘ g) μ :=
+  ae_strongly_measurable' (m0.comap g ) (f ∘ g) μ :=
 ⟨(hf.mk f) ∘ g, hf.strongly_measurable_mk.comp_measurable (measurable_iff_comap_le.mpr le_rfl),
   ae_eq_comp hg hf.ae_eq_mk⟩
 
@@ -138,16 +138,13 @@ lemma ae_strongly_measurable'_integral_cond_distrib
 lemma set_lintegral_preimage_cond_distrib (hX : measurable X) (hY : ae_measurable Y μ)
   (hs : measurable_set s) (ht : measurable_set t) :
   ∫⁻ a in X ⁻¹' t, cond_distrib Y X μ (X a) s ∂μ = μ (X ⁻¹' t ∩ Y ⁻¹' s) :=
-begin
-  change ∫⁻ a in X ⁻¹' t, ((λ x, cond_distrib Y X μ x s) ∘ X) a ∂μ = μ (X ⁻¹' t ∩ Y ⁻¹' s),
-  rw [lintegral_comp (kernel.measurable_coe _ hs) hX, cond_distrib,
-    ← measure.restrict_map hX ht, ← fst_map_prod_mk₀ hX.ae_measurable hY,
-    set_lintegral_cond_kernel_eq_measure_prod _ ht hs,
-    measure.map_apply_of_ae_measurable (hX.ae_measurable.prod_mk hY) (ht.prod hs),
-    mk_preimage_prod],
-end
+by rw [lintegral_comp (kernel.measurable_coe _ hs) hX, cond_distrib,
+  ← measure.restrict_map hX ht, ← fst_map_prod_mk₀ hX.ae_measurable hY,
+  set_lintegral_cond_kernel_eq_measure_prod _ ht hs,
+  measure.map_apply_of_ae_measurable (hX.ae_measurable.prod_mk hY) (ht.prod hs),
+  mk_preimage_prod]
 
-lemma set_lintegral_cond_distrib_of_measurable (hX : measurable X) (hY : ae_measurable Y μ)
+lemma set_lintegral_cond_distrib_of_measurable_set (hX : measurable X) (hY : ae_measurable Y μ)
   (hs : measurable_set s) {t : set α} (ht : measurable_set[mβ.comap X] t) :
   ∫⁻ a in t, cond_distrib Y X μ (X a) s ∂μ = μ (t ∩ Y ⁻¹' s) :=
 by { obtain ⟨tₑ, htₑ, rfl⟩ := ht, rw set_lintegral_preimage_cond_distrib hX hY hs htₑ, }
@@ -162,7 +159,7 @@ begin
     rw [integral_to_real ((measurable_cond_distrib hs).mono hX.comap_le le_rfl).ae_measurable
         (eventually_of_forall (λ ω, measure_lt_top (cond_distrib Y X μ (X ω)) _)),
       integral_indicator_const _ (hY hs), measure.restrict_apply (hY hs), smul_eq_mul, mul_one,
-      inter_comm, set_lintegral_cond_distrib_of_measurable hX hY.ae_measurable hs ht], },
+      inter_comm, set_lintegral_cond_distrib_of_measurable_set hX hY.ae_measurable hs ht], },
   { refine (measurable.strongly_measurable _).ae_strongly_measurable',
     exact @measurable.ennreal_to_real _ (mβ.comap X) _ (measurable_cond_distrib hs), },
 end

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -111,10 +111,12 @@ by rw [lintegral_comp (kernel.measurable_coe _ hs) hX, cond_distrib,
 lemma set_lintegral_cond_distrib_of_measurable_set (hX : measurable X) (hY : ae_measurable Y μ)
   (hs : measurable_set s) {t : set α} (ht : measurable_set[mβ.comap X] t) :
   ∫⁻ a in t, cond_distrib Y X μ (X a) s ∂μ = μ (t ∩ Y ⁻¹' s) :=
-by { obtain ⟨tₑ, htₑ, rfl⟩ := ht, rw set_lintegral_preimage_cond_distrib hX hY hs htₑ, }
+by { obtain ⟨t', ht', rfl⟩ := ht, rw set_lintegral_preimage_cond_distrib hX hY hs ht', }
 
+/-- For almost every `a : α`, the `cond_distrib Y X μ` kernel applied to `X a` and a measurable set
+`s` is equal to the conditional expectation of the indicator of `Y ⁻¹' s`. -/
 lemma cond_distrib_ae_eq_condexp (hX : measurable X) (hY : measurable Y) (hs : measurable_set s) :
-  (λ ω, (cond_distrib Y X μ (X ω) s).to_real) =ᵐ[μ] μ⟦Y ∈ₘ s | mβ.comap X⟧ :=
+  (λ a, (cond_distrib Y X μ (X a) s).to_real) =ᵐ[μ] μ⟦Y ∈ₘ s | mβ.comap X⟧ :=
 begin
   refine ae_eq_condexp_of_forall_set_integral_eq hX.comap_le _ _ _ _,
   { exact (integrable_const _).indicator (hY hs),  },
@@ -128,6 +130,8 @@ begin
     exact @measurable.ennreal_to_real _ (mβ.comap X) _ (measurable_cond_distrib hs), },
 end
 
+/-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
+to the integral of `y ↦ f(X, y)` against the `cond_distrib` kernel. -/
 lemma condexp_prod_ae_eq_integral_cond_distrib' (hX : measurable X) (hY : ae_measurable Y μ)
   (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
   μ[(λ a, f (X a, Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
@@ -150,6 +154,8 @@ begin
   { exact ae_strongly_measurable'_integral_cond_distrib hX.ae_measurable hY hf_int, },
 end
 
+/-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
+to the integral of `y ↦ f(X, y)` against the `cond_distrib` kernel. -/
 lemma condexp_prod_ae_eq_integral_cond_distrib₀ (hX : measurable X) (hY : ae_measurable Y μ)
   (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a))))
   (hf_int : integrable (λ a, f (X a, Y a)) μ) :
@@ -160,6 +166,8 @@ begin
   exact condexp_prod_ae_eq_integral_cond_distrib' hX hY hf_int',
 end
 
+/-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
+to the integral of `y ↦ f(X, y)` against the `cond_distrib` kernel. -/
 lemma condexp_prod_ae_eq_integral_cond_distrib (hX : measurable X) (hY : ae_measurable Y μ)
   (hf : strongly_measurable f) (hf_int : integrable (λ a, f (X a, Y a)) μ) :
   μ[(λ a, f (X a, Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
@@ -174,6 +182,8 @@ lemma condexp_ae_eq_integral_cond_distrib (hX : measurable X) (hY : ae_measurabl
   μ[(λ a, f (Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib Y X μ (X a)) :=
 condexp_prod_ae_eq_integral_cond_distrib hX hY (hf.comp_measurable measurable_snd) hf_int
 
+/-- The conditional expectation of `Y` given `X` is almost everywhere equal to the integral
+`∫ y, y ∂(cond_distrib Y X μ (X a))`. -/
 lemma condexp_ae_eq_integral_cond_distrib' {Ω} [normed_add_comm_group Ω] [normed_space ℝ Ω]
   [complete_space Ω] [measurable_space Ω] [borel_space Ω] [second_countable_topology Ω] {Y : α → Ω}
   (hX : measurable X) (hY_int : integrable Y μ) :

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -12,9 +12,9 @@ import probability.notation
 We define the regular conditional probability distribution of `Y : α → Ω` given `X : α → β`, where
 `Ω` is a standard Borel space. This is a `kernel β Ω` such that for almost all `a`, `cond_distrib`
 evaluated at `X a` and a measurable set `s` is equal to the conditional expectation
-`μ⟦Y ∈ₘ s | mβ.comap X⟧` evaluated at `a`.
+`μ⟦Y ⁻¹' s | mβ.comap X⟧` evaluated at `a`.
 
-`μ⟦Y ∈ₘ s | mβ.comap X⟧` maps a measurable set `s` to a function `α → ℝ≥0∞`, and for all `s` that
+`μ⟦Y ⁻¹' s | mβ.comap X⟧` maps a measurable set `s` to a function `α → ℝ≥0∞`, and for all `s` that
 map is unique up tu a `μ`-null set. For all `a`, the map from sets to `ℝ≥0∞` that we obtain that way
 verifies some of the properties of a measure, but in general the fact that the `μ`-null set depends
 on `s` can prevent us from finding versions of the conditional expectation that combine into a true
@@ -28,7 +28,7 @@ measure. The standard Borel space assumption on `Ω` allows us to do so.
 ## Main statements
 
 * `cond_distrib_ae_eq_condexp`: for almost all `a`, `cond_distrib` evaluated at `X a` and a
-  measurable set `s` is equal to the conditional expectation `μ⟦Y ∈ₘ s | mβ.comap X⟧ a`.
+  measurable set `s` is equal to the conditional expectation `μ⟦Y ⁻¹' s | mβ.comap X⟧ a`.
 * `condexp_prod_ae_eq_integral_cond_distrib`: the conditional expectation
   `μ[(λ a, f (X a, Y a)) | X ; mβ]` is almost everywhere equal to the integral
   `∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))`.
@@ -116,7 +116,7 @@ by { obtain ⟨t', ht', rfl⟩ := ht, rw set_lintegral_preimage_cond_distrib hX 
 /-- For almost every `a : α`, the `cond_distrib Y X μ` kernel applied to `X a` and a measurable set
 `s` is equal to the conditional expectation of the indicator of `Y ⁻¹' s`. -/
 lemma cond_distrib_ae_eq_condexp (hX : measurable X) (hY : measurable Y) (hs : measurable_set s) :
-  (λ a, (cond_distrib Y X μ (X a) s).to_real) =ᵐ[μ] μ⟦Y ∈ₘ s | mβ.comap X⟧ :=
+  (λ a, (cond_distrib Y X μ (X a) s).to_real) =ᵐ[μ] μ⟦Y ⁻¹' s | mβ.comap X⟧ :=
 begin
   refine ae_eq_condexp_of_forall_set_integral_eq hX.comap_le _ _ _ _,
   { exact (integrable_const _).indicator (hY hs),  },

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -199,4 +199,57 @@ lemma condexp_ae_eq_integral_cond_distrib' {Ω} [normed_add_comm_group Ω] [norm
   μ[Y | mβ.comap X] =ᵐ[μ] λ a, ∫ y, y ∂(cond_distrib Y X μ (X a)) :=
 condexp_ae_eq_integral_cond_distrib hX hY_int.1.ae_measurable strongly_measurable_id hY_int
 
+lemma ae_strongly_measurable_comp_snd_map_prod_mk {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
+  (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
+  ae_strongly_measurable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
+begin
+  let f' := hf_int.1.mk f,
+  refine ⟨λ x, f' x.2, hf_int.1.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
+  suffices h : measure.quasi_measure_preserving prod.snd (μ.map (λ ω, (X ω, ω))) μ,
+  { exact measure.quasi_measure_preserving.ae_eq h hf_int.1.ae_eq_mk, },
+  refine ⟨measurable_snd, measure.absolutely_continuous.mk (λ s hs hμs, _)⟩,
+  rw measure.map_apply _ hs,
+  swap, { exact measurable_snd, },
+  rw measure.map_apply,
+  { rw [← univ_prod, mk_preimage_prod, preimage_univ, univ_inter, preimage_id'],
+    exact hμs, },
+  { exact hX.prod_mk measurable_id, },
+  { exact measurable_snd hs, },
+end
+
+lemma integrable_comp_snd_map_prod_mk {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
+  (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
+  integrable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
+begin
+  have hY : measurable (id : Ω → Ω) := measurable_id,
+  have hf := ae_strongly_measurable_comp_snd_map_prod_mk hX hf_int,
+  refine ⟨hf, _⟩,
+  rw [has_finite_integral, lintegral_map' hf.ennnorm (hX.prod_mk measurable_id).ae_measurable],
+  exact hf_int.2,
+end
+
+lemma condexp_ae_eq_integral_cond_distrib'' {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
+  (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
+  μ[f | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib id X μ (X a)) :=
+begin
+  suffices hf_int' : integrable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))),
+  { exact condexp_prod_ae_eq_integral_cond_distrib' hX ae_measurable_id hf_int', },
+  have hf_ae : ae_strongly_measurable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))),
+  { let f' := hf_int.1.mk f,
+    refine ⟨λ x, f' x.2, hf_int.1.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
+    suffices h : measure.quasi_measure_preserving prod.snd (μ.map (λ ω, (X ω, ω))) μ,
+    { exact measure.quasi_measure_preserving.ae_eq h hf_int.1.ae_eq_mk, },
+    refine ⟨measurable_snd, measure.absolutely_continuous.mk (λ s hs hμs, _)⟩,
+    rw measure.map_apply _ hs,
+    swap, { exact measurable_snd, },
+    rw measure.map_apply,
+    { rw [← univ_prod, mk_preimage_prod, preimage_univ, univ_inter, preimage_id'],
+      exact hμs, },
+    { exact hX.prod_mk measurable_id, },
+    { exact measurable_snd hs, }, },
+  refine ⟨hf_ae, _⟩,
+  rw [has_finite_integral, lintegral_map' hf_ae.ennnorm (hX.prod_mk measurable_id).ae_measurable],
+  exact hf_int.2,
+end
+
 end probability_theory

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -1,0 +1,232 @@
+/-
+Copyright (c) 2023 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne
+-/
+import probability.kernel.disintegration
+import probability.notation
+
+/-!
+# Regular conditional probability distribution
+
+We define the regular conditional probability distribution of `Y : α → Ω` given `X : α → β`, where
+`Ω` is a standard Borel space. This is a `kernel β Ω` such that for almost all `a`, `cond_distrib`
+evaluated at `X a` and a measurable set `s` is equal to the conditional expectation
+`μ⟦Y ∈ₘ s | mβ.comap X⟧` evaluated at `a`.
+
+`μ⟦Y ∈ₘ s | mβ.comap X⟧` maps a measurable set `s` to a function `α → ℝ≥0∞`, and for all `s` that
+map is unique up tu a `μ`-null set. For all `a`, the map from sets to `ℝ≥0∞` that we obtain that way
+verifies some of the properties of a measure, but in general the fact that the `μ`-null set depends
+on `s` can prevent us from finding versions of the conditional expectation that combine into a true
+measure. The standard Borel space assumption on `Ω` allows us to do so.
+
+## Main definitions
+
+* `cond_distrib Y X μ`: regular conditional probability distribution of `Y : α → Ω` given
+  `X : α → β`, where `Ω` is a standard Borel space.
+
+## Main statements
+
+* `cond_distrib_ae_eq_condexp`: for almost all `a`, `cond_distrib` evaluated at `X a` and a
+  measurable set `s` is equal to the conditional expectation `μ⟦Y ∈ₘ s | mβ.comap X⟧ a`.
+* `condexp_prod_ae_eq_integral_cond_distrib`: the conditional expectation
+  `μ[(λ a, f (X a, Y a)) | X ; mβ]` is almost everywhere equal to the integral
+  `∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))`.
+
+-/
+
+open measure_theory set filter topological_space
+
+open_locale ennreal measure_theory probability_theory
+
+namespace measure_theory
+
+lemma ae_strongly_measurable.comp_ae_measurable'
+  {α β γ : Type*} [topological_space β] {m0 : measurable_space α} {mγ : measurable_space γ}
+  {f : α → β} {μ : measure γ} {g : γ → α}
+  (hf : ae_strongly_measurable f (μ.map g)) (hg : ae_measurable g μ) :
+  ae_strongly_measurable' (measurable_space.comap g m0) (f ∘ g) μ :=
+⟨(hf.mk f) ∘ g, hf.strongly_measurable_mk.comp_measurable (measurable_iff_comap_le.mpr le_rfl),
+  ae_eq_comp hg hf.ae_eq_mk⟩
+
+section fst_snd
+
+variables {α β γ : Type*} {Y : α → γ} {mγ : measurable_space γ} {mβ : measurable_space β}
+  {mα : measurable_space α} {X : α → β} {μ : measure α}
+
+include mβ mγ
+
+lemma fst_map_prod_mk₀ (hX : ae_measurable X μ) (hY : ae_measurable Y μ) :
+  (μ.map (λ a, (X a, Y a))).fst = μ.map X :=
+begin
+  ext1 s hs,
+  rw [measure.fst_apply hs, measure.map_apply_of_ae_measurable (hX.prod_mk hY) (measurable_fst hs),
+    measure.map_apply_of_ae_measurable hX hs, ← prod_univ, mk_preimage_prod, preimage_univ,
+    inter_univ],
+end
+
+lemma fst_map_prod_mk (hX : measurable X) (hY : measurable Y) :
+  (μ.map (λ a, (X a, Y a))).fst = μ.map X :=
+fst_map_prod_mk₀ hX.ae_measurable hY.ae_measurable
+
+end fst_snd
+
+end measure_theory
+
+open measure_theory
+
+namespace probability_theory
+
+localized "notation (name := condexp_fun_comap')
+  P `[` Y `|` X `;` m `]` := P[ Y | m.comap X]" in probability_theory
+
+localized "notation (name := condexp_indicator)
+  P `⟦` s `|` m `⟧` := P[ s.indicator (λ ω, (1 : ℝ)) | m]" in probability_theory
+
+localized "notation (name := condexp_fun_mem_comap)
+  P `⟦` Y `∈ₘ` s `|` m `⟧` := P[ (Y ⁻¹' s).indicator (λ ω, (1 : ℝ)) | m]"
+  in probability_theory
+
+variables {α β Ω F : Type*}
+  [topological_space Ω] [measurable_space Ω] [polish_space Ω] [borel_space Ω] [nonempty Ω]
+  [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
+  {mα : measurable_space α} {μ : measure α} [is_finite_measure μ] {X : α → β} {Y : α → Ω}
+
+/-- **Regular conditional probability distribution**: kernel associated with the conditional
+expectation of `Y` given `X`. -/
+@[irreducible] noncomputable
+def cond_distrib {mα : measurable_space α} [measurable_space β]
+  (Y : α → Ω) (X : α → β) (μ : measure α) [is_finite_measure μ] :
+  kernel β Ω :=
+(μ.map (λ a, (X a, Y a))).cond_kernel
+
+instance [measurable_space β] : is_markov_kernel (cond_distrib Y X μ) :=
+by { rw cond_distrib, apply_instance, }
+
+variables {mβ : measurable_space β} {s : set Ω} {t : set β} {f : β × Ω → F}
+include mβ
+
+lemma measurable_cond_distrib (hs : measurable_set s) :
+  measurable[mβ.comap X] (λ a, cond_distrib Y X μ (X a) s) :=
+(kernel.measurable_coe _ hs).comp (measurable.of_comap_le le_rfl)
+
+lemma integrable_to_real_cond_distrib (hX : ae_measurable X μ) (hs : measurable_set s) :
+  integrable (λ a, (cond_distrib Y X μ (X a) s).to_real) μ :=
+begin
+  refine integrable_to_real_of_lintegral_ne_top _ _,
+  { exact measurable.comp_ae_measurable (kernel.measurable_coe _ hs) hX, },
+  { refine ne_of_lt _,
+    calc ∫⁻ a, cond_distrib Y X μ (X a) s ∂μ
+        ≤ ∫⁻ a, 1 ∂μ : lintegral_mono (λ a, prob_le_one)
+    ... = μ univ : lintegral_one
+    ... < ∞ : measure_lt_top _ _, },
+end
+
+lemma _root_.measure_theory.integrable.integral_cond_distrib
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  integrable (λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))) μ :=
+begin
+  change integrable ((λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) ∘ X) μ,
+  refine integrable.comp_ae_measurable _ hX,
+  rw [← fst_map_prod_mk₀ hX hY, cond_distrib],
+  exact hf_int.integral_cond_kernel,
+end
+
+lemma _root_.measure_theory.ae_strongly_measurable.integral_cond_distrib
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a)))) :
+  ae_strongly_measurable (λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) (μ.map X) :=
+by { rw ← fst_map_prod_mk₀ hX hY, rw cond_distrib, exact hf.integral_cond_kernel, }
+
+lemma ae_strongly_measurable'_integral_cond_distrib
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  ae_strongly_measurable' (mβ.comap X) (λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))) μ :=
+(hf_int.1.integral_cond_distrib hX hY).comp_ae_measurable' hX
+
+lemma set_lintegral_preimage_cond_distrib (hX : measurable X) (hY : ae_measurable Y μ)
+  (hs : measurable_set s) (ht : measurable_set t) :
+  ∫⁻ a in X ⁻¹' t, cond_distrib Y X μ (X a) s ∂μ = μ (X ⁻¹' t ∩ Y ⁻¹' s) :=
+begin
+  change ∫⁻ a in X ⁻¹' t, ((λ x, cond_distrib Y X μ x s) ∘ X) a ∂μ = μ (X ⁻¹' t ∩ Y ⁻¹' s),
+  rw [lintegral_comp (kernel.measurable_coe _ hs) hX, cond_distrib,
+    ← measure.restrict_map hX ht, ← fst_map_prod_mk₀ hX.ae_measurable hY,
+    set_lintegral_cond_kernel_eq_measure_prod _ ht hs,
+    measure.map_apply_of_ae_measurable (hX.ae_measurable.prod_mk hY) (ht.prod hs),
+    mk_preimage_prod],
+end
+
+lemma set_lintegral_cond_distrib_of_measurable (hX : measurable X) (hY : ae_measurable Y μ)
+  (hs : measurable_set s) {t : set α} (ht : measurable_set[mβ.comap X] t) :
+  ∫⁻ a in t, cond_distrib Y X μ (X a) s ∂μ = μ (t ∩ Y ⁻¹' s) :=
+by { obtain ⟨tₑ, htₑ, rfl⟩ := ht, rw set_lintegral_preimage_cond_distrib hX hY hs htₑ, }
+
+lemma cond_distrib_ae_eq_condexp (hX : measurable X) (hY : measurable Y) (hs : measurable_set s) :
+  (λ ω, (cond_distrib Y X μ (X ω) s).to_real) =ᵐ[μ] μ⟦Y ∈ₘ s | mβ.comap X⟧ :=
+begin
+  refine ae_eq_condexp_of_forall_set_integral_eq hX.comap_le _ _ _ _,
+  { exact (integrable_const _).indicator (hY hs),  },
+  { exact λ t ht _, (integrable_to_real_cond_distrib hX.ae_measurable hs).integrable_on, },
+  { intros t ht _,
+    rw [integral_to_real ((measurable_cond_distrib hs).mono hX.comap_le le_rfl).ae_measurable
+        (eventually_of_forall (λ ω, measure_lt_top (cond_distrib Y X μ (X ω)) _)),
+      integral_indicator_const _ (hY hs), measure.restrict_apply (hY hs), smul_eq_mul, mul_one,
+      inter_comm, set_lintegral_cond_distrib_of_measurable hX hY.ae_measurable hs ht], },
+  { refine (measurable.strongly_measurable _).ae_strongly_measurable',
+    exact @measurable.ennreal_to_real _ (mβ.comap X) _ (measurable_cond_distrib hs), },
+end
+
+lemma condexp_prod_ae_eq_integral_cond_distrib' (hX : measurable X) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  μ[(λ a, f (X a, Y a)) | X; mβ] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
+begin
+  have hf_int' : integrable (λ a, f (X a, Y a)) μ,
+  { exact (integrable_map_measure hf_int.1 (hX.ae_measurable.prod_mk hY)).mp hf_int, },
+  refine (ae_eq_condexp_of_forall_set_integral_eq hX.comap_le hf_int' (λ s hs hμs, _) _ _).symm,
+  { exact (hf_int.integral_cond_distrib hX.ae_measurable hY).integrable_on, },
+  { rintros s ⟨t, ht, rfl⟩ _,
+    change ∫ a in X ⁻¹' t, ((λ x', ∫ y, f (x', y) ∂(cond_distrib Y X μ) x') ∘ X) a ∂μ
+      = ∫ a in X ⁻¹' t, f (X a, Y a) ∂μ,
+    rw ← integral_map hX.ae_measurable,
+    swap,
+    { rw ← measure.restrict_map hX ht,
+      exact (hf_int.1.integral_cond_distrib hX.ae_measurable hY).restrict, },
+    rw [← measure.restrict_map hX ht, ← fst_map_prod_mk₀ hX.ae_measurable hY, cond_distrib,
+      set_integral_cond_kernel_univ_right ht hf_int.integrable_on,
+      set_integral_map (ht.prod measurable_set.univ) hf_int.1 (hX.ae_measurable.prod_mk hY),
+      mk_preimage_prod, preimage_univ, inter_univ], },
+  { exact ae_strongly_measurable'_integral_cond_distrib hX.ae_measurable hY hf_int, },
+end
+
+lemma condexp_prod_ae_eq_integral_cond_distrib₀ (hX : measurable X) (hY : ae_measurable Y μ)
+  (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a))))
+  (hf_int : integrable (λ a, f (X a, Y a)) μ) :
+  μ[(λ a, f (X a, Y a)) | X; mβ] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
+begin
+  have hf_int' : integrable f (μ.map (λ a, (X a, Y a))),
+  { rwa integrable_map_measure hf (hX.ae_measurable.prod_mk hY), },
+  exact condexp_prod_ae_eq_integral_cond_distrib' hX hY hf_int',
+end
+
+lemma condexp_prod_ae_eq_integral_cond_distrib (hX : measurable X) (hY : ae_measurable Y μ)
+  (hf : strongly_measurable f) (hf_int : integrable (λ a, f (X a, Y a)) μ) :
+  μ[(λ a, f (X a, Y a)) | X; mβ] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
+begin
+  have hf_int' : integrable f (μ.map (λ a, (X a, Y a))),
+  { rwa integrable_map_measure hf.ae_strongly_measurable (hX.ae_measurable.prod_mk hY), },
+  exact condexp_prod_ae_eq_integral_cond_distrib' hX hY hf_int',
+end
+
+lemma condexp_ae_eq_integral_cond_distrib (hX : measurable X) (hY : ae_measurable Y μ)
+  {f : Ω → F} (hf : strongly_measurable f) (hf_int : integrable (λ a, f (Y a)) μ) :
+  μ[(λ a, f (Y a)) | X; mβ] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib Y X μ (X a)) :=
+condexp_prod_ae_eq_integral_cond_distrib hX hY (hf.comp_measurable measurable_snd) hf_int
+
+lemma condexp_ae_eq_integral_cond_distrib' {Ω} [normed_add_comm_group Ω] [normed_space ℝ Ω]
+  [complete_space Ω] [measurable_space Ω] [borel_space Ω] [second_countable_topology Ω] {Y : α → Ω}
+  (hX : measurable X) (hY_int : integrable Y μ) :
+  μ[Y | X; mβ] =ᵐ[μ] λ a, ∫ y, y ∂(cond_distrib Y X μ (X a)) :=
+condexp_ae_eq_integral_cond_distrib hX hY_int.1.ae_measurable strongly_measurable_id hY_int
+
+end probability_theory

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -203,8 +203,8 @@ lemma ae_strongly_measurable_comp_snd_map_prod_mk {X : Ω → β} {μ : measure 
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   ae_strongly_measurable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
 begin
-  let f' := hf_int.1.mk f,
-  refine ⟨λ x, f' x.2, hf_int.1.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
+  refine ⟨λ x, hf_int.1.mk f x.2,
+    hf_int.1.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
   suffices h : measure.quasi_measure_preserving prod.snd (μ.map (λ ω, (X ω, ω))) μ,
   { exact measure.quasi_measure_preserving.ae_eq h hf_int.1.ae_eq_mk, },
   refine ⟨measurable_snd, measure.absolutely_continuous.mk (λ s hs hμs, _)⟩,
@@ -221,7 +221,6 @@ lemma integrable_comp_snd_map_prod_mk {X : Ω → β} {μ : measure Ω} [is_fini
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   integrable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
 begin
-  have hY : measurable (id : Ω → Ω) := measurable_id,
   have hf := ae_strongly_measurable_comp_snd_map_prod_mk hX hf_int,
   refine ⟨hf, _⟩,
   rw [has_finite_integral, lintegral_map' hf.ennnorm (hX.prod_mk measurable_id).ae_measurable],
@@ -231,25 +230,7 @@ end
 lemma condexp_ae_eq_integral_cond_distrib'' {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   μ[f | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib id X μ (X a)) :=
-begin
-  suffices hf_int' : integrable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))),
-  { exact condexp_prod_ae_eq_integral_cond_distrib' hX ae_measurable_id hf_int', },
-  have hf_ae : ae_strongly_measurable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))),
-  { let f' := hf_int.1.mk f,
-    refine ⟨λ x, f' x.2, hf_int.1.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
-    suffices h : measure.quasi_measure_preserving prod.snd (μ.map (λ ω, (X ω, ω))) μ,
-    { exact measure.quasi_measure_preserving.ae_eq h hf_int.1.ae_eq_mk, },
-    refine ⟨measurable_snd, measure.absolutely_continuous.mk (λ s hs hμs, _)⟩,
-    rw measure.map_apply _ hs,
-    swap, { exact measurable_snd, },
-    rw measure.map_apply,
-    { rw [← univ_prod, mk_preimage_prod, preimage_univ, univ_inter, preimage_id'],
-      exact hμs, },
-    { exact hX.prod_mk measurable_id, },
-    { exact measurable_snd hs, }, },
-  refine ⟨hf_ae, _⟩,
-  rw [has_finite_integral, lintegral_map' hf_ae.ennnorm (hX.prod_mk measurable_id).ae_measurable],
-  exact hf_int.2,
-end
+condexp_prod_ae_eq_integral_cond_distrib' hX ae_measurable_id
+  (integrable_comp_snd_map_prod_mk hX hf_int)
 
 end probability_theory

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -41,14 +41,6 @@ open_locale ennreal measure_theory probability_theory
 
 namespace measure_theory
 
-lemma ae_strongly_measurable.comp_ae_measurable'
-  {α β γ : Type*} [topological_space β] {m0 : measurable_space α} {mγ : measurable_space γ}
-  {f : α → β} {μ : measure γ} {g : γ → α}
-  (hf : ae_strongly_measurable f (μ.map g)) (hg : ae_measurable g μ) :
-  ae_strongly_measurable' (m0.comap g ) (f ∘ g) μ :=
-⟨(hf.mk f) ∘ g, hf.strongly_measurable_mk.comp_measurable (measurable_iff_comap_le.mpr le_rfl),
-  ae_eq_comp hg hf.ae_eq_mk⟩
-
 section fst_snd
 
 variables {α β γ : Type*} {Y : α → γ} {mγ : measurable_space γ} {mβ : measurable_space β}

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -52,7 +52,11 @@ variables {α β Ω F : Type*}
   {mα : measurable_space α} {μ : measure α} [is_finite_measure μ] {X : α → β} {Y : α → Ω}
 
 /-- **Regular conditional probability distribution**: kernel associated with the conditional
-expectation of `Y` given `X`. -/
+expectation of `Y` given `X`.
+For almost all `a`, `cond_distrib Y X μ` evaluated at `X a` and a measurable set `s` is equal to
+the conditional expectation `μ⟦Y ⁻¹' s | mβ.comap X⟧ a`. It also satisfies the equality
+`μ[(λ a, f (X a, Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))` for
+all strongly measurable and integrable functions `f`. -/
 @[irreducible] noncomputable
 def cond_distrib {mα : measurable_space α} [measurable_space β]
   (Y : α → Ω) (X : α → β) (μ : measure α) [is_finite_measure μ] :

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -83,7 +83,7 @@ lemma _root_.measure_theory.integrable.integral_cond_distrib
 begin
   change integrable ((λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) ∘ X) μ,
   refine integrable.comp_ae_measurable _ hX,
-  rw [← fst_map_prod_mk₀ hX hY, cond_distrib],
+  rw [← measure.fst_map_prod_mk₀ hX hY, cond_distrib],
   exact hf_int.integral_cond_kernel,
 end
 
@@ -91,7 +91,7 @@ lemma _root_.measure_theory.ae_strongly_measurable.integral_cond_distrib
   (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
   (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a)))) :
   ae_strongly_measurable (λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) (μ.map X) :=
-by { rw ← fst_map_prod_mk₀ hX hY, rw cond_distrib, exact hf.integral_cond_kernel, }
+by { rw ← measure.fst_map_prod_mk₀ hX hY, rw cond_distrib, exact hf.integral_cond_kernel, }
 
 lemma ae_strongly_measurable'_integral_cond_distrib
   (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
@@ -103,7 +103,7 @@ lemma set_lintegral_preimage_cond_distrib (hX : measurable X) (hY : ae_measurabl
   (hs : measurable_set s) (ht : measurable_set t) :
   ∫⁻ a in X ⁻¹' t, cond_distrib Y X μ (X a) s ∂μ = μ (X ⁻¹' t ∩ Y ⁻¹' s) :=
 by rw [lintegral_comp (kernel.measurable_coe _ hs) hX, cond_distrib,
-  ← measure.restrict_map hX ht, ← fst_map_prod_mk₀ hX.ae_measurable hY,
+  ← measure.restrict_map hX ht, ← measure.fst_map_prod_mk₀ hX.ae_measurable hY,
   set_lintegral_cond_kernel_eq_measure_prod _ ht hs,
   measure.map_apply_of_ae_measurable (hX.ae_measurable.prod_mk hY) (ht.prod hs),
   mk_preimage_prod]
@@ -143,7 +143,7 @@ begin
     swap,
     { rw ← measure.restrict_map hX ht,
       exact (hf_int.1.integral_cond_distrib hX.ae_measurable hY).restrict, },
-    rw [← measure.restrict_map hX ht, ← fst_map_prod_mk₀ hX.ae_measurable hY, cond_distrib,
+    rw [← measure.restrict_map hX ht, ← measure.fst_map_prod_mk₀ hX.ae_measurable hY, cond_distrib,
       set_integral_cond_kernel_univ_right ht hf_int.integrable_on,
       set_integral_map (ht.prod measurable_set.univ) hf_int.1 (hX.ae_measurable.prod_mk hY),
       mk_preimage_prod, preimage_univ, inter_univ], },

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -199,7 +199,8 @@ lemma condexp_ae_eq_integral_cond_distrib' {Ω} [normed_add_comm_group Ω] [norm
   μ[Y | mβ.comap X] =ᵐ[μ] λ a, ∫ y, y ∂(cond_distrib Y X μ (X a)) :=
 condexp_ae_eq_integral_cond_distrib hX hY_int.1.ae_measurable strongly_measurable_id hY_int
 
-lemma ae_strongly_measurable_comp_snd_map_prod_mk {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
+lemma ae_strongly_measurable_comp_snd_map_prod_mk {Ω F} {mΩ : measurable_space Ω}
+  [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   ae_strongly_measurable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
 begin
@@ -217,7 +218,8 @@ begin
   { exact measurable_snd hs, },
 end
 
-lemma integrable_comp_snd_map_prod_mk {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
+lemma integrable_comp_snd_map_prod_mk {Ω F} {mΩ : measurable_space Ω}
+  [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   integrable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
 begin

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -15,10 +15,15 @@ evaluated at `X a` and a measurable set `s` is equal to the conditional expectat
 `μ⟦Y ⁻¹' s | mβ.comap X⟧` evaluated at `a`.
 
 `μ⟦Y ⁻¹' s | mβ.comap X⟧` maps a measurable set `s` to a function `α → ℝ≥0∞`, and for all `s` that
-map is unique up tu a `μ`-null set. For all `a`, the map from sets to `ℝ≥0∞` that we obtain that way
+map is unique up to a `μ`-null set. For all `a`, the map from sets to `ℝ≥0∞` that we obtain that way
 verifies some of the properties of a measure, but in general the fact that the `μ`-null set depends
 on `s` can prevent us from finding versions of the conditional expectation that combine into a true
 measure. The standard Borel space assumption on `Ω` allows us to do so.
+
+The case `Y = X = id` is developed in more detail in `probability/kernel/condexp.lean`: here `X` is
+understood as a map from `Ω` with a sub-σ-algebra to `Ω` with its default σ-algebra and the
+conditional distribution defines a kernel associated with the conditional expectation with respect
+to `m`.
 
 ## Main definitions
 

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -77,16 +77,6 @@ open measure_theory
 
 namespace probability_theory
 
-localized "notation (name := condexp_fun_comap')
-  P `[` Y `|` X `;` m `]` := P[ Y | m.comap X]" in probability_theory
-
-localized "notation (name := condexp_indicator)
-  P `⟦` s `|` m `⟧` := P[ s.indicator (λ ω, (1 : ℝ)) | m]" in probability_theory
-
-localized "notation (name := condexp_fun_mem_comap)
-  P `⟦` Y `∈ₘ` s `|` m `⟧` := P[ (Y ⁻¹' s).indicator (λ ω, (1 : ℝ)) | m]"
-  in probability_theory
-
 variables {α β Ω F : Type*}
   [topological_space Ω] [measurable_space Ω] [polish_space Ω] [borel_space Ω] [nonempty Ω]
   [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
@@ -179,7 +169,7 @@ end
 
 lemma condexp_prod_ae_eq_integral_cond_distrib' (hX : measurable X) (hY : ae_measurable Y μ)
   (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
-  μ[(λ a, f (X a, Y a)) | X; mβ] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
+  μ[(λ a, f (X a, Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
 begin
   have hf_int' : integrable (λ a, f (X a, Y a)) μ,
   { exact (integrable_map_measure hf_int.1 (hX.ae_measurable.prod_mk hY)).mp hf_int, },
@@ -202,7 +192,7 @@ end
 lemma condexp_prod_ae_eq_integral_cond_distrib₀ (hX : measurable X) (hY : ae_measurable Y μ)
   (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a))))
   (hf_int : integrable (λ a, f (X a, Y a)) μ) :
-  μ[(λ a, f (X a, Y a)) | X; mβ] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
+  μ[(λ a, f (X a, Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
 begin
   have hf_int' : integrable f (μ.map (λ a, (X a, Y a))),
   { rwa integrable_map_measure hf (hX.ae_measurable.prod_mk hY), },
@@ -211,7 +201,7 @@ end
 
 lemma condexp_prod_ae_eq_integral_cond_distrib (hX : measurable X) (hY : ae_measurable Y μ)
   (hf : strongly_measurable f) (hf_int : integrable (λ a, f (X a, Y a)) μ) :
-  μ[(λ a, f (X a, Y a)) | X; mβ] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
+  μ[(λ a, f (X a, Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
 begin
   have hf_int' : integrable f (μ.map (λ a, (X a, Y a))),
   { rwa integrable_map_measure hf.ae_strongly_measurable (hX.ae_measurable.prod_mk hY), },
@@ -220,13 +210,13 @@ end
 
 lemma condexp_ae_eq_integral_cond_distrib (hX : measurable X) (hY : ae_measurable Y μ)
   {f : Ω → F} (hf : strongly_measurable f) (hf_int : integrable (λ a, f (Y a)) μ) :
-  μ[(λ a, f (Y a)) | X; mβ] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib Y X μ (X a)) :=
+  μ[(λ a, f (Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib Y X μ (X a)) :=
 condexp_prod_ae_eq_integral_cond_distrib hX hY (hf.comp_measurable measurable_snd) hf_int
 
 lemma condexp_ae_eq_integral_cond_distrib' {Ω} [normed_add_comm_group Ω] [normed_space ℝ Ω]
   [complete_space Ω] [measurable_space Ω] [borel_space Ω] [second_countable_topology Ω] {Y : α → Ω}
   (hX : measurable X) (hY_int : integrable Y μ) :
-  μ[Y | X; mβ] =ᵐ[μ] λ a, ∫ y, y ∂(cond_distrib Y X μ (X a)) :=
+  μ[Y | mβ.comap X] =ᵐ[μ] λ a, ∫ y, y ∂(cond_distrib Y X μ (X a)) :=
 condexp_ae_eq_integral_cond_distrib hX hY_int.1.ae_measurable strongly_measurable_id hY_int
 
 end probability_theory

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -229,7 +229,7 @@ begin
   exact hf_int.2,
 end
 
-lemma condexp_ae_eq_integral_cond_distrib'' {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
+lemma condexp_ae_eq_integral_cond_distrib_id {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   μ[f | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib id X μ (X a)) :=
 condexp_prod_ae_eq_integral_cond_distrib' hX ae_measurable_id

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -39,34 +39,6 @@ open measure_theory set filter topological_space
 
 open_locale ennreal measure_theory probability_theory
 
-namespace measure_theory
-
-section fst_snd
-
-variables {α β γ : Type*} {Y : α → γ} {mγ : measurable_space γ} {mβ : measurable_space β}
-  {mα : measurable_space α} {X : α → β} {μ : measure α}
-
-include mβ mγ
-
-lemma fst_map_prod_mk₀ (hX : ae_measurable X μ) (hY : ae_measurable Y μ) :
-  (μ.map (λ a, (X a, Y a))).fst = μ.map X :=
-begin
-  ext1 s hs,
-  rw [measure.fst_apply hs, measure.map_apply_of_ae_measurable (hX.prod_mk hY) (measurable_fst hs),
-    measure.map_apply_of_ae_measurable hX hs, ← prod_univ, mk_preimage_prod, preimage_univ,
-    inter_univ],
-end
-
-lemma fst_map_prod_mk (hX : measurable X) (hY : measurable Y) :
-  (μ.map (λ a, (X a, Y a))).fst = μ.map X :=
-fst_map_prod_mk₀ hX.ae_measurable hY.ae_measurable
-
-end fst_snd
-
-end measure_theory
-
-open measure_theory
-
 namespace probability_theory
 
 variables {α β Ω F : Type*}

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -69,9 +69,90 @@ by { rw cond_distrib, apply_instance, }
 variables {mβ : measurable_space β} {s : set Ω} {t : set β} {f : β × Ω → F}
 include mβ
 
+section measurability
+
 lemma measurable_cond_distrib (hs : measurable_set s) :
   measurable[mβ.comap X] (λ a, cond_distrib Y X μ (X a) s) :=
 (kernel.measurable_coe _ hs).comp (measurable.of_comap_le le_rfl)
+
+lemma _root_.measure_theory.ae_strongly_measurable.ae_integrable_cond_distrib_map_iff
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a)))) :
+  (∀ᵐ a ∂(μ.map X), integrable (λ ω, f (a, ω)) (cond_distrib Y X μ a))
+    ∧ integrable (λ a, ∫ ω, ‖f (a, ω)‖ ∂(cond_distrib Y X μ a)) (μ.map X)
+  ↔ integrable f (μ.map (λ a, (X a, Y a))) :=
+by rw [cond_distrib, ← hf.ae_integrable_cond_kernel_iff, measure.fst_map_prod_mk₀ hX hY]
+
+lemma _root_.measure_theory.ae_strongly_measurable.integral_cond_distrib_map
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a)))) :
+  ae_strongly_measurable (λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) (μ.map X) :=
+by { rw [← measure.fst_map_prod_mk₀ hX hY, cond_distrib], exact hf.integral_cond_kernel, }
+
+lemma _root_.measure_theory.ae_strongly_measurable.integral_cond_distrib
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a)))) :
+  ae_strongly_measurable (λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))) μ :=
+(hf.integral_cond_distrib_map hX hY).comp_ae_measurable hX
+
+lemma ae_strongly_measurable'_integral_cond_distrib
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a)))) :
+  ae_strongly_measurable' (mβ.comap X) (λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))) μ :=
+(hf.integral_cond_distrib_map hX hY).comp_ae_measurable' hX
+
+end measurability
+
+section integrability
+
+lemma _root_.measure_theory.integrable.cond_distrib_ae_map
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  ∀ᵐ b ∂(μ.map X), integrable (λ ω, f (b, ω)) (cond_distrib Y X μ b) :=
+by { rw [cond_distrib, ← measure.fst_map_prod_mk₀ hX hY], exact hf_int.cond_kernel_ae, }
+
+lemma _root_.measure_theory.integrable.cond_distrib_ae
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  ∀ᵐ a ∂μ, integrable (λ ω, f (X a, ω)) (cond_distrib Y X μ (X a)) :=
+ae_of_ae_map hX (hf_int.cond_distrib_ae_map hX hY)
+
+lemma _root_.measure_theory.integrable.integral_norm_cond_distrib_map
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  integrable (λ x, ∫ y, ‖f (x, y)‖ ∂(cond_distrib Y X μ x)) (μ.map X) :=
+by { rw [cond_distrib, ← measure.fst_map_prod_mk₀ hX hY], exact hf_int.integral_norm_cond_kernel, }
+
+lemma _root_.measure_theory.integrable.integral_norm_cond_distrib
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  integrable (λ a, ∫ y, ‖f (X a, y)‖ ∂(cond_distrib Y X μ (X a))) μ :=
+(hf_int.integral_norm_cond_distrib_map hX hY).comp_ae_measurable hX
+
+lemma _root_.measure_theory.integrable.norm_integral_cond_distrib_map
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  integrable (λ x, ‖∫ y, f (x, y) ∂(cond_distrib Y X μ x)‖) (μ.map X) :=
+by { rw [cond_distrib, ← measure.fst_map_prod_mk₀ hX hY], exact hf_int.norm_integral_cond_kernel, }
+
+lemma _root_.measure_theory.integrable.norm_integral_cond_distrib
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  integrable (λ a, ‖∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))‖) μ :=
+(hf_int.norm_integral_cond_distrib_map hX hY).comp_ae_measurable hX
+
+lemma _root_.measure_theory.integrable.integral_cond_distrib_map
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  integrable (λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) (μ.map X) :=
+(integrable_norm_iff (hf_int.1.integral_cond_distrib_map hX hY)).mp
+  (hf_int.norm_integral_cond_distrib_map hX hY)
+
+lemma _root_.measure_theory.integrable.integral_cond_distrib
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  integrable (λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))) μ :=
+(hf_int.integral_cond_distrib_map hX hY).comp_ae_measurable hX
 
 lemma integrable_to_real_cond_distrib (hX : ae_measurable X μ) (hs : measurable_set s) :
   integrable (λ a, (cond_distrib Y X μ (X a) s).to_real) μ :=
@@ -85,28 +166,7 @@ begin
     ... < ∞ : measure_lt_top _ _, },
 end
 
-lemma _root_.measure_theory.integrable.integral_cond_distrib
-  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
-  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
-  integrable (λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))) μ :=
-begin
-  change integrable ((λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) ∘ X) μ,
-  refine integrable.comp_ae_measurable _ hX,
-  rw [← measure.fst_map_prod_mk₀ hX hY, cond_distrib],
-  exact hf_int.integral_cond_kernel,
-end
-
-lemma _root_.measure_theory.ae_strongly_measurable.integral_cond_distrib
-  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
-  (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a)))) :
-  ae_strongly_measurable (λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) (μ.map X) :=
-by { rw ← measure.fst_map_prod_mk₀ hX hY, rw cond_distrib, exact hf.integral_cond_kernel, }
-
-lemma ae_strongly_measurable'_integral_cond_distrib
-  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
-  (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
-  ae_strongly_measurable' (mβ.comap X) (λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))) μ :=
-(hf_int.1.integral_cond_distrib hX hY).comp_ae_measurable' hX
+end integrability
 
 lemma set_lintegral_preimage_cond_distrib (hX : measurable X) (hY : ae_measurable Y μ)
   (hs : measurable_set s) (ht : measurable_set t) :
@@ -155,12 +215,12 @@ begin
     rw ← integral_map hX.ae_measurable,
     swap,
     { rw ← measure.restrict_map hX ht,
-      exact (hf_int.1.integral_cond_distrib hX.ae_measurable hY).restrict, },
+      exact (hf_int.1.integral_cond_distrib_map hX.ae_measurable hY).restrict, },
     rw [← measure.restrict_map hX ht, ← measure.fst_map_prod_mk₀ hX.ae_measurable hY, cond_distrib,
       set_integral_cond_kernel_univ_right ht hf_int.integrable_on,
       set_integral_map (ht.prod measurable_set.univ) hf_int.1 (hX.ae_measurable.prod_mk hY),
       mk_preimage_prod, preimage_univ, inter_univ], },
-  { exact ae_strongly_measurable'_integral_cond_distrib hX.ae_measurable hY hf_int, },
+  { exact ae_strongly_measurable'_integral_cond_distrib hX.ae_measurable hY hf_int.1, },
 end
 
 /-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -222,7 +222,7 @@ lemma _root_.measure_theory.integrable.comp_snd_map_prod_mk {Ω F} {mΩ : measur
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   integrable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
 begin
-  have hf := hf_int.1.comp_snd_map_prod_mk hX ,
+  have hf := hf_int.1.comp_snd_map_prod_mk hX,
   refine ⟨hf, _⟩,
   rw [has_finite_integral, lintegral_map' hf.ennnorm (hX.prod_mk measurable_id).ae_measurable],
   exact hf_int.2,

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -56,7 +56,7 @@ expectation of `Y` given `X`.
 For almost all `a`, `cond_distrib Y X μ` evaluated at `X a` and a measurable set `s` is equal to
 the conditional expectation `μ⟦Y ⁻¹' s | mβ.comap X⟧ a`. It also satisfies the equality
 `μ[(λ a, f (X a, Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))` for
-all strongly measurable and integrable functions `f`. -/
+all integrable functions `f`. -/
 @[irreducible] noncomputable
 def cond_distrib {mα : measurable_space α} [measurable_space β]
   (Y : α → Ω) (X : α → β) (μ : measure α) [is_finite_measure μ] :

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -199,15 +199,14 @@ lemma condexp_ae_eq_integral_cond_distrib' {Ω} [normed_add_comm_group Ω] [norm
   μ[Y | mβ.comap X] =ᵐ[μ] λ a, ∫ y, y ∂(cond_distrib Y X μ (X a)) :=
 condexp_ae_eq_integral_cond_distrib hX hY_int.1.ae_measurable strongly_measurable_id hY_int
 
-lemma ae_strongly_measurable_comp_snd_map_prod_mk {Ω F} {mΩ : measurable_space Ω}
-  [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
-  (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
+lemma _root_.measure_theory.ae_strongly_measurable.comp_snd_map_prod_mk
+  {Ω F} {mΩ : measurable_space Ω} [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
+  (hX : measurable X) {f : Ω → F} (hf : ae_strongly_measurable f μ) :
   ae_strongly_measurable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
 begin
-  refine ⟨λ x, hf_int.1.mk f x.2,
-    hf_int.1.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
+  refine ⟨λ x, hf.mk f x.2, hf.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
   suffices h : measure.quasi_measure_preserving prod.snd (μ.map (λ ω, (X ω, ω))) μ,
-  { exact measure.quasi_measure_preserving.ae_eq h hf_int.1.ae_eq_mk, },
+  { exact measure.quasi_measure_preserving.ae_eq h hf.ae_eq_mk, },
   refine ⟨measurable_snd, measure.absolutely_continuous.mk (λ s hs hμs, _)⟩,
   rw measure.map_apply _ hs,
   swap, { exact measurable_snd, },
@@ -218,12 +217,12 @@ begin
   { exact measurable_snd hs, },
 end
 
-lemma integrable_comp_snd_map_prod_mk {Ω F} {mΩ : measurable_space Ω}
+lemma _root_.measure_theory.integrable.comp_snd_map_prod_mk {Ω F} {mΩ : measurable_space Ω}
   [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   integrable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
 begin
-  have hf := ae_strongly_measurable_comp_snd_map_prod_mk hX hf_int,
+  have hf := hf_int.1.comp_snd_map_prod_mk hX ,
   refine ⟨hf, _⟩,
   rw [has_finite_integral, lintegral_map' hf.ennnorm (hX.prod_mk measurable_id).ae_measurable],
   exact hf_int.2,
@@ -232,7 +231,6 @@ end
 lemma condexp_ae_eq_integral_cond_distrib_id {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   μ[f | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib id X μ (X a)) :=
-condexp_prod_ae_eq_integral_cond_distrib' hX ae_measurable_id
-  (integrable_comp_snd_map_prod_mk hX hf_int)
+condexp_prod_ae_eq_integral_cond_distrib' hX ae_measurable_id (hf_int.comp_snd_map_prod_mk hX)
 
 end probability_theory

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -48,7 +48,7 @@ namespace probability_theory
 
 variables {α β Ω F : Type*}
   [topological_space Ω] [measurable_space Ω] [polish_space Ω] [borel_space Ω] [nonempty Ω]
-  [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
+  [normed_add_comm_group F]
   {mα : measurable_space α} {μ : measure α} [is_finite_measure μ] {X : α → β} {Y : α → Ω}
 
 /-- **Regular conditional probability distribution**: kernel associated with the conditional
@@ -83,6 +83,8 @@ lemma _root_.measure_theory.ae_strongly_measurable.ae_integrable_cond_distrib_ma
   ↔ integrable f (μ.map (λ a, (X a, Y a))) :=
 by rw [cond_distrib, ← hf.ae_integrable_cond_kernel_iff, measure.fst_map_prod_mk₀ hX hY]
 
+variables [normed_space ℝ F] [complete_space F]
+
 lemma _root_.measure_theory.ae_strongly_measurable.integral_cond_distrib_map
   (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
   (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a)))) :
@@ -104,6 +106,18 @@ lemma ae_strongly_measurable'_integral_cond_distrib
 end measurability
 
 section integrability
+
+lemma integrable_to_real_cond_distrib (hX : ae_measurable X μ) (hs : measurable_set s) :
+  integrable (λ a, (cond_distrib Y X μ (X a) s).to_real) μ :=
+begin
+  refine integrable_to_real_of_lintegral_ne_top _ _,
+  { exact measurable.comp_ae_measurable (kernel.measurable_coe _ hs) hX, },
+  { refine ne_of_lt _,
+    calc ∫⁻ a, cond_distrib Y X μ (X a) s ∂μ
+        ≤ ∫⁻ a, 1 ∂μ : lintegral_mono (λ a, prob_le_one)
+    ... = μ univ : lintegral_one
+    ... < ∞ : measure_lt_top _ _, },
+end
 
 lemma _root_.measure_theory.integrable.cond_distrib_ae_map
   (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
@@ -129,6 +143,8 @@ lemma _root_.measure_theory.integrable.integral_norm_cond_distrib
   integrable (λ a, ∫ y, ‖f (X a, y)‖ ∂(cond_distrib Y X μ (X a))) μ :=
 (hf_int.integral_norm_cond_distrib_map hX hY).comp_ae_measurable hX
 
+variables [normed_space ℝ F] [complete_space F]
+
 lemma _root_.measure_theory.integrable.norm_integral_cond_distrib_map
   (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
   (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
@@ -153,18 +169,6 @@ lemma _root_.measure_theory.integrable.integral_cond_distrib
   (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
   integrable (λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a))) μ :=
 (hf_int.integral_cond_distrib_map hX hY).comp_ae_measurable hX
-
-lemma integrable_to_real_cond_distrib (hX : ae_measurable X μ) (hs : measurable_set s) :
-  integrable (λ a, (cond_distrib Y X μ (X a) s).to_real) μ :=
-begin
-  refine integrable_to_real_of_lintegral_ne_top _ _,
-  { exact measurable.comp_ae_measurable (kernel.measurable_coe _ hs) hX, },
-  { refine ne_of_lt _,
-    calc ∫⁻ a, cond_distrib Y X μ (X a) s ∂μ
-        ≤ ∫⁻ a, 1 ∂μ : lintegral_mono (λ a, prob_le_one)
-    ... = μ univ : lintegral_one
-    ... < ∞ : measure_lt_top _ _, },
-end
 
 end integrability
 
@@ -201,7 +205,8 @@ end
 
 /-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
 to the integral of `y ↦ f(X, y)` against the `cond_distrib` kernel. -/
-lemma condexp_prod_ae_eq_integral_cond_distrib' (hX : measurable X) (hY : ae_measurable Y μ)
+lemma condexp_prod_ae_eq_integral_cond_distrib' [normed_space ℝ F] [complete_space F]
+  (hX : measurable X) (hY : ae_measurable Y μ)
   (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
   μ[(λ a, f (X a, Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
 begin
@@ -225,7 +230,8 @@ end
 
 /-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
 to the integral of `y ↦ f(X, y)` against the `cond_distrib` kernel. -/
-lemma condexp_prod_ae_eq_integral_cond_distrib₀ (hX : measurable X) (hY : ae_measurable Y μ)
+lemma condexp_prod_ae_eq_integral_cond_distrib₀ [normed_space ℝ F] [complete_space F]
+  (hX : measurable X) (hY : ae_measurable Y μ)
   (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a))))
   (hf_int : integrable (λ a, f (X a, Y a)) μ) :
   μ[(λ a, f (X a, Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
@@ -237,7 +243,8 @@ end
 
 /-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
 to the integral of `y ↦ f(X, y)` against the `cond_distrib` kernel. -/
-lemma condexp_prod_ae_eq_integral_cond_distrib (hX : measurable X) (hY : ae_measurable Y μ)
+lemma condexp_prod_ae_eq_integral_cond_distrib [normed_space ℝ F] [complete_space F]
+  (hX : measurable X) (hY : ae_measurable Y μ)
   (hf : strongly_measurable f) (hf_int : integrable (λ a, f (X a, Y a)) μ) :
   μ[(λ a, f (X a, Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f (X a, y) ∂(cond_distrib Y X μ (X a)) :=
 begin
@@ -246,7 +253,8 @@ begin
   exact condexp_prod_ae_eq_integral_cond_distrib' hX hY hf_int',
 end
 
-lemma condexp_ae_eq_integral_cond_distrib (hX : measurable X) (hY : ae_measurable Y μ)
+lemma condexp_ae_eq_integral_cond_distrib [normed_space ℝ F] [complete_space F]
+  (hX : measurable X) (hY : ae_measurable Y μ)
   {f : Ω → F} (hf : strongly_measurable f) (hf_int : integrable (λ a, f (Y a)) μ) :
   μ[(λ a, f (Y a)) | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib Y X μ (X a)) :=
 condexp_prod_ae_eq_integral_cond_distrib hX hY (hf.comp_measurable measurable_snd) hf_int
@@ -260,8 +268,8 @@ lemma condexp_ae_eq_integral_cond_distrib' {Ω} [normed_add_comm_group Ω] [norm
 condexp_ae_eq_integral_cond_distrib hX hY_int.1.ae_measurable strongly_measurable_id hY_int
 
 lemma _root_.measure_theory.ae_strongly_measurable.comp_snd_map_prod_mk
-  {Ω F} {mΩ : measurable_space Ω} [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
-  (hX : measurable X) {f : Ω → F} (hf : ae_strongly_measurable f μ) :
+  {Ω F} {mΩ : measurable_space Ω} {X : Ω → β} {μ : measure Ω}
+  [topological_space F] (hX : measurable X) {f : Ω → F} (hf : ae_strongly_measurable f μ) :
   ae_strongly_measurable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
 begin
   refine ⟨λ x, hf.mk f x.2, hf.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
@@ -277,9 +285,8 @@ begin
   { exact measurable_snd hs, },
 end
 
-lemma _root_.measure_theory.integrable.comp_snd_map_prod_mk {Ω F} {mΩ : measurable_space Ω}
-  [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
-  (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
+lemma _root_.measure_theory.integrable.comp_snd_map_prod_mk {Ω} {mΩ : measurable_space Ω}
+  {X : Ω → β} {μ : measure Ω} (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   integrable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) :=
 begin
   have hf := hf_int.1.comp_snd_map_prod_mk hX,
@@ -289,19 +296,18 @@ begin
 end
 
 lemma ae_strongly_measurable_comp_snd_map_prod_mk_iff {Ω F} {mΩ : measurable_space Ω}
-  [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
-  (hX : measurable X) {f : Ω → F} :
+  [topological_space F] {X : Ω → β} {μ : measure Ω} (hX : measurable X) {f : Ω → F} :
   ae_strongly_measurable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω)))
     ↔ ae_strongly_measurable f μ :=
 ⟨λ h, h.comp_measurable (hX.prod_mk measurable_id), λ h, h.comp_snd_map_prod_mk hX⟩
 
-lemma integrable_comp_snd_map_prod_mk_iff {Ω F} {mΩ : measurable_space Ω}
-  [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
+lemma integrable_comp_snd_map_prod_mk_iff {Ω} {mΩ : measurable_space Ω} {X : Ω → β} {μ : measure Ω}
   (hX : measurable X) {f : Ω → F} :
   integrable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) ↔ integrable f μ :=
 ⟨λ h, h.comp_measurable (hX.prod_mk measurable_id), λ h, h.comp_snd_map_prod_mk hX⟩
 
-lemma condexp_ae_eq_integral_cond_distrib_id {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
+lemma condexp_ae_eq_integral_cond_distrib_id [normed_space ℝ F] [complete_space F]
+  {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   μ[f | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib id X μ (X a)) :=
 condexp_prod_ae_eq_integral_cond_distrib' hX ae_measurable_id (hf_int.comp_snd_map_prod_mk hX)

--- a/src/probability/kernel/cond_distrib.lean
+++ b/src/probability/kernel/cond_distrib.lean
@@ -288,6 +288,19 @@ begin
   exact hf_int.2,
 end
 
+lemma ae_strongly_measurable_comp_snd_map_prod_mk_iff {Ω F} {mΩ : measurable_space Ω}
+  [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
+  (hX : measurable X) {f : Ω → F} :
+  ae_strongly_measurable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω)))
+    ↔ ae_strongly_measurable f μ :=
+⟨λ h, h.comp_measurable (hX.prod_mk measurable_id), λ h, h.comp_snd_map_prod_mk hX⟩
+
+lemma integrable_comp_snd_map_prod_mk_iff {Ω F} {mΩ : measurable_space Ω}
+  [normed_add_comm_group F] {X : Ω → β} {μ : measure Ω}
+  (hX : measurable X) {f : Ω → F} :
+  integrable (λ x : β × Ω, f x.2) (μ.map (λ ω, (X ω, ω))) ↔ integrable f μ :=
+⟨λ h, h.comp_measurable (hX.prod_mk measurable_id), λ h, h.comp_snd_map_prod_mk hX⟩
+
 lemma condexp_ae_eq_integral_cond_distrib_id {X : Ω → β} {μ : measure Ω} [is_finite_measure μ]
   (hX : measurable X) {f : Ω → F} (hf_int : integrable f μ) :
   μ[f | mβ.comap X] =ᵐ[μ] λ a, ∫ y, f y ∂(cond_distrib id X μ (X a)) :=

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -3,247 +3,42 @@ Copyright (c) 2023 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
-import probability.kernel.disintegration
-import probability.notation
+import probability.kernel.cond_distrib
 
 /-!
 # Kernel associated with a conditional expectation
 
+We define `condexp_kernel μ m`, a kernel from `Ω` to `Ω` such that for all integrable, strongly
+measurable `f`, `μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`.
+
 ## Main definitions
 
-* `foo_bar`
+* `condexp_kernel μ m`: kernel such that `μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`.
 
 ## Main statements
 
-* `foo_bar_unique`
+* `condexp_ae_eq_integral_condexp_kernel`: `μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`.
 
-## References
-
-* [F. Bar, *Quuxes*][bibkey]
-
-## Tags
-
-Foobars, barfoos
 -/
-
 
 open measure_theory set filter topological_space
 
-open_locale nnreal ennreal measure_theory topology probability_theory
-
-namespace measure_theory
-
-lemma ae_strongly_measurable.comp_ae_measurable'
-  {α β γ : Type*} [topological_space β] {m0 : measurable_space α} {mγ : measurable_space γ}
-  {f : α → β} {μ : measure γ} {g : γ → α}
-  (hf : ae_strongly_measurable f (μ.map g)) (hg : ae_measurable g μ) :
-  ae_strongly_measurable' (measurable_space.comap g m0) (f ∘ g) μ :=
-begin
-  let f' := hf.mk f,
-  refine ⟨f' ∘ g, _, _⟩,
-  { exact hf.strongly_measurable_mk.comp_measurable (measurable_iff_comap_le.mpr le_rfl), },
-  { exact ae_eq_comp hg hf.ae_eq_mk, },
-end
-
-end measure_theory
-
-open measure_theory
+open_locale ennreal measure_theory probability_theory
 
 namespace probability_theory
 
-variables {α Ω β F : Type*}
-  [topological_space Ω] [measurable_space Ω] [polish_space Ω] [borel_space Ω] [nonempty Ω]
+variables {Ω F : Type*} [topological_space Ω] {m : measurable_space Ω} [mΩ : measurable_space Ω]
+  [polish_space Ω] [borel_space Ω] [nonempty Ω]
+  {μ : measure Ω} [is_finite_measure μ]
   [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
 
-section fst_snd
-
-lemma fst_map_prod_mk₀ {Ω : Type*} {Y : α → Ω} {mΩ : measurable_space Ω} {mβ : measurable_space β}
-  {mα : measurable_space α} {X : α → β} {μ : measure α}
-  (hX : ae_measurable X μ) (hY : ae_measurable Y μ) :
-  (μ.map (λ ω, (X ω, Y ω))).fst = μ.map X :=
-begin
-  ext1 s hs,
-  rw [measure.fst_apply hs, measure.map_apply_of_ae_measurable (hX.prod_mk hY) (measurable_fst hs),
-    measure.map_apply_of_ae_measurable hX hs, ← prod_univ, mk_preimage_prod, preimage_univ,
-    inter_univ],
-end
-
-lemma fst_map_prod_mk {Ω : Type*} {Y : α → Ω} {mΩ : measurable_space Ω} {mβ : measurable_space β}
-  {mα : measurable_space α} {X : α → β} {μ : measure α}
-  (hX : measurable X) (hY : measurable Y) :
-  (μ.map (λ ω, (X ω, Y ω))).fst = μ.map X :=
-fst_map_prod_mk₀ hX.ae_measurable hY.ae_measurable
-
-end fst_snd
-
-localized "notation (name := condexp_fun_comap')
-  P `[` Y `|` X `;` m `]` := P[ Y | m.comap X]" in probability_theory
-
-localized "notation (name := condexp_indicator)
-  P `⟦` s `|` m `⟧` := P[ s.indicator (λ ω, (1 : ℝ)) | m]" in probability_theory
-
-localized "notation (name := condexp_fun_mem)
-  P `⟦` Y `∈ₘ` s `|` X `;` m `⟧` := P ⟦ Y ⁻¹' s | m.comap X ⟧" in probability_theory
-
-variables {mα : measurable_space α} {μ : measure α} {X : α → β} {Y : α → Ω} [is_finite_measure μ]
-
-/-- **Regular conditional probability distribution**: kernel associated with the conditional
-expectation of `Y` given `X`. -/
-@[irreducible] noncomputable
-def cond_distrib {mα : measurable_space α} [measurable_space β]
-  (Y : α → Ω) (X : α → β) (μ : measure α) [is_finite_measure μ] :
-  kernel β Ω :=
-(μ.map (λ a, (X a, Y a))).cond_kernel
-
-instance [measurable_space β] : is_markov_kernel (cond_distrib Y X μ) :=
-by { rw cond_distrib, apply_instance, }
-
-lemma measurable_cond_distrib {mβ : measurable_space β}
-  {s : set Ω} (hs : measurable_set s) :
-  measurable[mβ.comap X] (λ ω, cond_distrib Y X μ (X ω) s) :=
-(kernel.measurable_coe _ hs).comp (measurable.of_comap_le le_rfl)
-
-lemma integrable_to_real_cond_distrib {mβ : measurable_space β}
-  (hX : ae_measurable X μ) {s : set Ω} (hs : measurable_set s) :
-  integrable (λ ω, (cond_distrib Y X μ (X ω) s).to_real) μ :=
-begin
-  refine integrable_to_real_of_lintegral_ne_top _ _,
-  { exact measurable.comp_ae_measurable (kernel.measurable_coe _ hs) hX, },
-  { refine ne_of_lt _,
-    calc ∫⁻ ω, cond_distrib Y X μ (X ω) s ∂μ
-        ≤ ∫⁻ ω, 1 ∂μ : lintegral_mono (λ ω, prob_le_one)
-    ... = μ univ : lintegral_one
-    ... < ∞ : measure_lt_top _ _, },
-end
-
-lemma _root_.measure_theory.integrable.integral_cond_distrib {mβ : measurable_space β}
-  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
-  {f : β × Ω → F} (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
-  integrable (λ ω, ∫ y, f (X ω, y) ∂(cond_distrib Y X μ (X ω))) μ :=
-begin
-  change integrable ((λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) ∘ X) μ,
-  refine integrable.comp_ae_measurable _ hX,
-  rw [← fst_map_prod_mk₀ hX hY, cond_distrib],
-  exact hf_int.integral_cond_kernel,
-end
-
-lemma _root_.measure_theory.ae_strongly_measurable.integral_cond_distrib {mβ : measurable_space β}
-  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
-  {f : β × Ω → F} (hf : ae_strongly_measurable f (μ.map (λ ω, (X ω, Y ω)))) :
-  ae_strongly_measurable (λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) (μ.map X) :=
-by { rw ← fst_map_prod_mk₀ hX hY, rw cond_distrib, exact hf.integral_cond_kernel, }
-
-lemma ae_strongly_measurable'_integral_cond_distrib {mβ : measurable_space β}
-  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
-  {f : β × Ω → F} (hf_int : integrable f (μ.map (λ ω, (X ω, Y ω)))) :
-  ae_strongly_measurable' (mβ.comap X) (λ ω, ∫ y, f (X ω, y) ∂(cond_distrib Y X μ (X ω))) μ :=
-(hf_int.1.integral_cond_distrib hX hY).comp_ae_measurable' hX
-
-lemma set_lintegral_preimage_cond_distrib {mβ : measurable_space β}
-  (hX : measurable X) (hY : ae_measurable Y μ)
-  {s : set Ω} (hs : measurable_set s) {t : set β} (ht : measurable_set t) :
-  ∫⁻ ω in X ⁻¹' t, cond_distrib Y X μ (X ω) s ∂μ = μ (X ⁻¹' t ∩ Y ⁻¹' s) :=
-begin
-  change ∫⁻ ω in X ⁻¹' t, ((λ x, cond_distrib Y X μ x s) ∘ X) ω ∂μ = μ (X ⁻¹' t ∩ Y ⁻¹' s),
-  rw [lintegral_comp (kernel.measurable_coe _ hs) hX, cond_distrib,
-    ← measure.restrict_map hX ht, ← fst_map_prod_mk₀ hX.ae_measurable hY,
-    set_lintegral_cond_kernel_eq_measure_prod _ ht hs,
-    measure.map_apply_of_ae_measurable (hX.ae_measurable.prod_mk hY) (ht.prod hs),
-    mk_preimage_prod],
-end
-
-lemma set_lintegral_cond_distrib_of_measurable {mβ : measurable_space β}
-  (hX : measurable X) (hY : ae_measurable Y μ)
-  {s : set Ω} (hs : measurable_set s) {t : set α} (ht : measurable_set[mβ.comap X] t) :
-  ∫⁻ ω in t, cond_distrib Y X μ (X ω) s ∂μ = μ (t ∩ Y ⁻¹' s) :=
-by { obtain ⟨tₑ, htₑ, rfl⟩ := ht, rw set_lintegral_preimage_cond_distrib hX hY hs htₑ, }
-
-lemma cond_distrib_ae_eq_condexp {mβ : measurable_space β} (hX : measurable X) (hY : measurable Y)
-  {s : set Ω} (hs : measurable_set s) :
-  (λ ω, (cond_distrib Y X μ (X ω) s).to_real) =ᵐ[μ] μ⟦Y ∈ₘ s | X ; mβ⟧ :=
-begin
-  refine ae_eq_condexp_of_forall_set_integral_eq hX.comap_le _ _ _ _,
-  { exact (integrable_const _).indicator (hY hs),  },
-  { exact λ t ht _, (integrable_to_real_cond_distrib hX.ae_measurable hs).integrable_on, },
-  { intros t ht _,
-    rw [integral_to_real ((measurable_cond_distrib hs).mono hX.comap_le le_rfl).ae_measurable
-        (eventually_of_forall (λ ω, measure_lt_top (cond_distrib Y X μ (X ω)) _)),
-      integral_indicator_const _ (hY hs), measure.restrict_apply (hY hs), smul_eq_mul, mul_one,
-      inter_comm, set_lintegral_cond_distrib_of_measurable hX hY.ae_measurable hs ht], },
-  { refine (measurable.strongly_measurable _).ae_strongly_measurable',
-    refine @measurable.ennreal_to_real _ (mβ.comap X) _ _,
-    exact measurable_cond_distrib hs, },
-end
-
-lemma todo'' {mβ : measurable_space β} (hX : measurable X) (hY : ae_measurable Y μ)
-  {f : β × Ω → F} (hf_int : integrable f (μ.map (λ ω, (X ω, Y ω)))) :
-  μ[(λ ω, f (X ω, Y ω)) | X; mβ] =ᵐ[μ] λ ω, ∫ y, f (X ω, y) ∂(cond_distrib Y X μ (X ω)) :=
-begin
-  have hf_int' : integrable (λ ω, f (X ω, Y ω)) μ,
-  { exact (integrable_map_measure hf_int.1 (hX.ae_measurable.prod_mk hY)).mp hf_int, },
-  refine (ae_eq_condexp_of_forall_set_integral_eq hX.comap_le hf_int' (λ s hs hμs, _) _ _).symm,
-  { exact (hf_int.integral_cond_distrib hX.ae_measurable hY).integrable_on, },
-  { rintros s ⟨t, ht, rfl⟩ _,
-    change ∫ ω in X ⁻¹' t, ((λ x', ∫ y, f (x', y) ∂(cond_distrib Y X μ) x') ∘ X) ω ∂μ
-      = ∫ ω in X ⁻¹' t, f (X ω, Y ω) ∂μ,
-    rw ← integral_map hX.ae_measurable,
-    swap,
-    { rw ← measure.restrict_map hX ht,
-      exact (hf_int.1.integral_cond_distrib hX.ae_measurable hY).restrict, },
-    rw [← measure.restrict_map hX ht, ← fst_map_prod_mk₀ hX.ae_measurable hY, cond_distrib,
-      set_integral_cond_kernel_univ_right ht hf_int.integrable_on,
-      set_integral_map (ht.prod measurable_set.univ) hf_int.1 (hX.ae_measurable.prod_mk hY),
-      mk_preimage_prod, preimage_univ, inter_univ], },
-  { exact ae_strongly_measurable'_integral_cond_distrib hX.ae_measurable hY hf_int, },
-end
-
-lemma todo₀ {mβ : measurable_space β} (hX : measurable X) (hY : ae_measurable Y μ)
-  {f : β × Ω → F} (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a))))
-  (hf_int : integrable (λ ω, f (X ω, Y ω)) μ) :
-  μ[(λ ω, f (X ω, Y ω)) | X; mβ] =ᵐ[μ] λ ω, ∫ y, f (X ω, y) ∂(cond_distrib Y X μ (X ω)) :=
-begin
-  have hf_int' : integrable f (μ.map (λ ω, (X ω, Y ω))),
-  { rwa integrable_map_measure hf (hX.ae_measurable.prod_mk hY), },
-  exact todo'' hX hY hf_int',
-end
-
-lemma todo {mβ : measurable_space β} (hX : measurable X) (hY : ae_measurable Y μ)
-  {f : β × Ω → F} (hf : strongly_measurable f) (hf_int : integrable (λ ω, f (X ω, Y ω)) μ) :
-  μ[(λ ω, f (X ω, Y ω)) | X; mβ] =ᵐ[μ] λ ω, ∫ y, f (X ω, y) ∂(cond_distrib Y X μ (X ω)) :=
-begin
-  have hf_int' : integrable f (μ.map (λ ω, (X ω, Y ω))),
-  { rwa integrable_map_measure hf.ae_strongly_measurable (hX.ae_measurable.prod_mk hY), },
-  exact todo'' hX hY hf_int',
-end
-
-lemma todo_right {mβ : measurable_space β} (hX : measurable X) (hY : ae_measurable Y μ)
-  {f : Ω → F} (hf : strongly_measurable f) (hf_int : integrable (λ ω, f (Y ω)) μ) :
-  μ[(λ ω, f (Y ω)) | X; mβ] =ᵐ[μ] λ ω, ∫ y, f y ∂(cond_distrib Y X μ (X ω)) :=
-todo hX hY (hf.comp_measurable measurable_snd) hf_int
-
-lemma todo' {Ω} [normed_add_comm_group Ω] [normed_space ℝ Ω] [complete_space Ω]
-  [measurable_space Ω] [borel_space Ω] [second_countable_topology Ω] {Y : α → Ω}
-  {mβ : measurable_space β}
-  (hX : measurable X) (hY_int : integrable Y μ) :
-  μ[Y | X; mβ] =ᵐ[μ] λ ω, ∫ y, y ∂(cond_distrib Y X μ (X ω)) :=
-todo_right hX hY_int.1.ae_measurable strongly_measurable_id hY_int
-
-/-! ### Kernel associated with the conditional expectation with respect to a σ-algebra
-
-We define `condexp_kernel`, a kernel from `Ω` to `Ω` such that for all integrable, strongly
-measurable `f`, `μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`. -/
-
 /-- Kernel associated with the conditional expectation with respect to a σ-algebra. -/
-noncomputable
-def condexp_kernel {Ω : Type*} [mΩ : measurable_space Ω] [topological_space Ω] [borel_space Ω]
-  [polish_space Ω] [nonempty Ω]
-  (μ : measure Ω) [is_finite_measure μ] (m : measurable_space Ω) :
+@[irreducible] noncomputable
+def condexp_kernel (μ : measure Ω) [is_finite_measure μ] (m : measurable_space Ω) :
   @kernel Ω Ω m mΩ :=
 @cond_distrib Ω Ω Ω _ mΩ _ _ _ mΩ m id id μ _
 
-lemma condexp_ae_eq_integral_condexp_kernel {Ω : Type*} [topological_space Ω]
-  (m : measurable_space Ω) {mΩ : measurable_space Ω} [borel_space Ω] [polish_space Ω] [nonempty Ω]
-  (hm : m ≤ mΩ) {μ : measure Ω} [is_finite_measure μ]
+lemma condexp_ae_eq_integral_condexp_kernel (hm : m ≤ mΩ)
   {f : Ω → F} (hf : strongly_measurable f) (hf_int : integrable f μ) :
   μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω) :=
 begin
@@ -251,7 +46,8 @@ begin
   have hY : ae_measurable (id : Ω → Ω) μ := ae_measurable_id,
   have hf' : @strongly_measurable (Ω × Ω) F _ (m.prod mΩ) (λ x : Ω × Ω, f x.2) :=
     hf.comp_measurable measurable_id.snd,
-  refine eventually_eq.trans _ (todo hX hY hf' hf_int),
+  rw condexp_kernel,
+  refine eventually_eq.trans _ (condexp_prod_ae_eq_integral_cond_distrib hX hY hf' hf_int),
   simp only [measurable_space.comap_id, id.def],
 end
 

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -38,6 +38,8 @@ def condexp_kernel (μ : measure Ω) [is_finite_measure μ] (m : measurable_spac
   @kernel Ω Ω m mΩ :=
 @cond_distrib Ω Ω Ω _ mΩ _ _ _ mΩ m id id μ _
 
+/-- The conditional expectation of `f` with respect to a σ-algebra `m` is almost everywhere equal to
+the integral `∫ y, f y ∂(condexp_kernel μ m ω)`. -/
 lemma condexp_ae_eq_integral_condexp_kernel (hm : m ≤ mΩ)
   {f : Ω → F} (hf : strongly_measurable f) (hf_int : integrable f μ) :
   μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω) :=

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -48,38 +48,52 @@ def condexp_kernel (μ : measure Ω) [is_finite_measure μ] (m : measurable_spac
   @kernel Ω Ω m mΩ :=
 @cond_distrib Ω Ω Ω _ mΩ _ _ _ mΩ m id id μ _
 
+lemma ae_strongly_measurable_comp_snd_map_prod_mk (hm : m ≤ mΩ)
+  {f : Ω → F} (hf_int : integrable f μ) :
+  @ae_strongly_measurable (Ω × Ω) F _ (m.prod mΩ) (λ x : Ω × Ω, f x.2)
+    (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ) :=
+begin
+  let f' := hf_int.1.mk f,
+  refine ⟨λ x, f' x.2, hf_int.1.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
+  suffices h : @measure.quasi_measure_preserving (Ω × Ω) Ω mΩ (m.prod mΩ) prod.snd
+    (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ) μ,
+  { exact measure.quasi_measure_preserving.ae_eq h hf_int.1.ae_eq_mk, },
+  refine ⟨measurable_snd, measure.absolutely_continuous.mk (λ s hs hμs, _)⟩,
+  rw measure.map_apply _ hs,
+  swap, { exact measurable_snd, },
+  rw measure.map_apply,
+  { rw [← univ_prod, mk_preimage_prod, preimage_univ, univ_inter, preimage_id'],
+    exact hμs, },
+  { exact (measurable_id.mono hm le_rfl).prod_mk measurable_id, },
+  { exact measurable_snd hs, },
+end
+
+lemma integrable_comp_snd_map_prod_mk (hm : m ≤ mΩ) {f : Ω → F} (hf_int : integrable f μ) :
+  @integrable F _ (Ω × Ω) (m.prod mΩ) (λ x : Ω × Ω, f x.2)
+    (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ) :=
+begin
+  have hX : @measurable Ω Ω mΩ m id := measurable_id.mono le_rfl hm,
+  have hY : measurable (id : Ω → Ω) := measurable_id,
+  have hXY : @ae_measurable Ω (Ω × Ω) (m.prod mΩ) mΩ (λ ω, (ω, ω)) μ :=
+    @measurable.ae_measurable Ω (Ω × Ω) mΩ (m.prod mΩ) _ μ (hX.prod_mk hY),
+  have hf := ae_strongly_measurable_comp_snd_map_prod_mk hm hf_int,
+  refine ⟨hf, _⟩,
+  rw [has_finite_integral, lintegral_map' hf.ennnorm hXY],
+  exact hf_int.2,
+end
+
 /-- The conditional expectation of `f` with respect to a σ-algebra `m` is almost everywhere equal to
 the integral `∫ y, f y ∂(condexp_kernel μ m ω)`. -/
 lemma condexp_ae_eq_integral_condexp_kernel (hm : m ≤ mΩ) {f : Ω → F} (hf_int : integrable f μ) :
   μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω) :=
 begin
   have hX : @measurable Ω Ω mΩ m id := measurable_id.mono le_rfl hm,
-  have hY : measurable (id : Ω → Ω) := measurable_id,
-  have hXY : @ae_measurable Ω (Ω × Ω) (m.prod mΩ) mΩ (λ ω, (ω, ω)) μ :=
-    @measurable.ae_measurable Ω (Ω × Ω) mΩ (m.prod mΩ) _ μ (hX.prod_mk hY),
-  have hf' : @ae_strongly_measurable (Ω × Ω) F _ (m.prod mΩ) (λ x : Ω × Ω, f x.2)
-    (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ),
-  { let f' := hf_int.1.mk f,
-    refine ⟨λ x, f' x.2, hf_int.1.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
-    suffices h : @measure.quasi_measure_preserving (Ω × Ω) Ω mΩ (m.prod mΩ) prod.snd
-      (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ) μ,
-    { exact measure.quasi_measure_preserving.ae_eq h hf_int.1.ae_eq_mk, },
-    refine ⟨measurable_snd, measure.absolutely_continuous.mk (λ s hs hμs, _)⟩,
-    rw measure.map_apply _ hs,
-    swap, { exact measurable_snd, },
-    rw measure.map_apply,
-    { rw [← univ_prod, mk_preimage_prod, preimage_univ, univ_inter, preimage_id'],
-      exact hμs, },
-    { exact hX.prod_mk hY, },
-    { exact measurable_snd hs, }, },
+  have hY : ae_measurable (id : Ω → Ω) μ := ae_measurable_id,
   have hf_int' : @integrable F _ (Ω × Ω) (m.prod mΩ) (λ x : Ω × Ω, f x.2)
     (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ),
-  { refine ⟨hf', _⟩,
-    rw [has_finite_integral, lintegral_map' hf'.ennnorm hXY],
-    exact hf_int.2, },
+  { exact integrable_comp_snd_map_prod_mk hm hf_int, },
   rw condexp_kernel,
-  refine eventually_eq.trans _
-    (condexp_prod_ae_eq_integral_cond_distrib' hX hY.ae_measurable hf_int'),
+  refine eventually_eq.trans _ (condexp_prod_ae_eq_integral_cond_distrib' hX hY hf_int'),
   simp only [measurable_space.comap_id, id.def],
 end
 

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -8,13 +8,15 @@ import probability.kernel.cond_distrib
 /-!
 # Kernel associated with a conditional expectation
 
-We define `condexp_kernel μ m`, a kernel from `Ω` to `Ω` such that for all integrable, strongly
-measurable `f`, `μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`. This kernel is defined if
-`Ω` is a standard Borel space. In general, `μ⟦s | m⟧` maps a measurable set `s` to a function
-`Ω → ℝ≥0∞`, and for all `s` that map is unique up to a `μ`-null set. For all `a`, the map from sets
-to `ℝ≥0∞` that we obtain that way verifies some of the properties of a measure, but the fact that
-the `μ`-null set depends on `s` can prevent us from finding versions of the conditional expectation
-that combine into a true measure. The standard Borel space assumption on `Ω` allows us to do so.
+We define `condexp_kernel μ m`, a kernel from `Ω` to `Ω` such that for all integrable functions `f`,
+`μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`.
+
+This kernel is defined if `Ω` is a standard Borel space. In general, `μ⟦s | m⟧` maps a measurable
+set `s` to a function `Ω → ℝ≥0∞`, and for all `s` that map is unique up to a `μ`-null set. For all
+`a`, the map from sets to `ℝ≥0∞` that we obtain that way verifies some of the properties of a
+measure, but the fact that the `μ`-null set depends on `s` can prevent us from finding versions of
+the conditional expectation that combine into a true measure. The standard Borel space assumption
+on `Ω` allows us to do so.
 
 ## Main definitions
 
@@ -48,16 +50,36 @@ def condexp_kernel (μ : measure Ω) [is_finite_measure μ] (m : measurable_spac
 
 /-- The conditional expectation of `f` with respect to a σ-algebra `m` is almost everywhere equal to
 the integral `∫ y, f y ∂(condexp_kernel μ m ω)`. -/
-lemma condexp_ae_eq_integral_condexp_kernel (hm : m ≤ mΩ)
-  {f : Ω → F} (hf : strongly_measurable f) (hf_int : integrable f μ) :
+lemma condexp_ae_eq_integral_condexp_kernel (hm : m ≤ mΩ) {f : Ω → F} (hf_int : integrable f μ) :
   μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω) :=
 begin
   have hX : @measurable Ω Ω mΩ m id := measurable_id.mono le_rfl hm,
-  have hY : ae_measurable (id : Ω → Ω) μ := ae_measurable_id,
-  have hf' : @strongly_measurable (Ω × Ω) F _ (m.prod mΩ) (λ x : Ω × Ω, f x.2) :=
-    hf.comp_measurable measurable_id.snd,
+  have hY : measurable (id : Ω → Ω) := measurable_id,
+  have hXY : @ae_measurable Ω (Ω × Ω) (m.prod mΩ) mΩ (λ ω, (ω, ω)) μ :=
+    @measurable.ae_measurable Ω (Ω × Ω) mΩ (m.prod mΩ) _ μ (hX.prod_mk hY),
+  have hf' : @ae_strongly_measurable (Ω × Ω) F _ (m.prod mΩ) (λ x : Ω × Ω, f x.2)
+    (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ),
+  { let f' := hf_int.1.mk f,
+    refine ⟨λ x, f' x.2, hf_int.1.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
+    suffices h : @measure.quasi_measure_preserving (Ω × Ω) Ω mΩ (m.prod mΩ) prod.snd
+      (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ) μ,
+    { exact measure.quasi_measure_preserving.ae_eq h hf_int.1.ae_eq_mk, },
+    refine ⟨measurable_snd, measure.absolutely_continuous.mk (λ s hs hμs, _)⟩,
+    rw measure.map_apply _ hs,
+    swap, { exact measurable_snd, },
+    rw measure.map_apply,
+    { rw [← univ_prod, mk_preimage_prod, preimage_univ, univ_inter, preimage_id'],
+      exact hμs, },
+    { exact hX.prod_mk hY, },
+    { exact measurable_snd hs, }, },
+  have hf_int' : @integrable F _ (Ω × Ω) (m.prod mΩ) (λ x : Ω × Ω, f x.2)
+    (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ),
+  { refine ⟨hf', _⟩,
+    rw [has_finite_integral, lintegral_map' hf'.ennnorm hXY],
+    exact hf_int.2, },
   rw condexp_kernel,
-  refine eventually_eq.trans _ (condexp_prod_ae_eq_integral_cond_distrib hX hY hf' hf_int),
+  refine eventually_eq.trans _
+    (condexp_prod_ae_eq_integral_cond_distrib' hX hY.ae_measurable hf_int'),
   simp only [measurable_space.comap_id, id.def],
 end
 

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -37,7 +37,10 @@ variables {Ω F : Type*} [topological_space Ω] {m : measurable_space Ω} [mΩ :
   {μ : measure Ω} [is_finite_measure μ]
   [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
 
-/-- Kernel associated with the conditional expectation with respect to a σ-algebra. -/
+/-- Kernel associated with the conditional expectation with respect to a σ-algebra. It satisfies
+`μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`.
+It is defined as the conditional distribution of the identity given the identity, where the second
+identity is understood as a map from `Ω` with the σ-algebra `mΩ` to `Ω` with σ-algebra `m`. -/
 @[irreducible] noncomputable
 def condexp_kernel (μ : measure Ω) [is_finite_measure μ] (m : measurable_space Ω) :
   @kernel Ω Ω m mΩ :=

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -55,7 +55,7 @@ lemma condexp_ae_eq_integral_condexp_kernel (hm : m ≤ mΩ) {f : Ω → F} (hf_
 begin
   have hX : @measurable Ω Ω mΩ m id := measurable_id.mono le_rfl hm,
   rw condexp_kernel,
-  refine eventually_eq.trans _ (condexp_ae_eq_integral_cond_distrib'' hX hf_int),
+  refine eventually_eq.trans _ (condexp_ae_eq_integral_cond_distrib_id hX hf_int),
   simp only [measurable_space.comap_id, id.def],
 end
 

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -48,52 +48,14 @@ def condexp_kernel (μ : measure Ω) [is_finite_measure μ] (m : measurable_spac
   @kernel Ω Ω m mΩ :=
 @cond_distrib Ω Ω Ω _ mΩ _ _ _ mΩ m id id μ _
 
-lemma ae_strongly_measurable_comp_snd_map_prod_mk (hm : m ≤ mΩ)
-  {f : Ω → F} (hf_int : integrable f μ) :
-  @ae_strongly_measurable (Ω × Ω) F _ (m.prod mΩ) (λ x : Ω × Ω, f x.2)
-    (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ) :=
-begin
-  let f' := hf_int.1.mk f,
-  refine ⟨λ x, f' x.2, hf_int.1.strongly_measurable_mk.comp_measurable measurable_snd, _⟩,
-  suffices h : @measure.quasi_measure_preserving (Ω × Ω) Ω mΩ (m.prod mΩ) prod.snd
-    (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ) μ,
-  { exact measure.quasi_measure_preserving.ae_eq h hf_int.1.ae_eq_mk, },
-  refine ⟨measurable_snd, measure.absolutely_continuous.mk (λ s hs hμs, _)⟩,
-  rw measure.map_apply _ hs,
-  swap, { exact measurable_snd, },
-  rw measure.map_apply,
-  { rw [← univ_prod, mk_preimage_prod, preimage_univ, univ_inter, preimage_id'],
-    exact hμs, },
-  { exact (measurable_id.mono hm le_rfl).prod_mk measurable_id, },
-  { exact measurable_snd hs, },
-end
-
-lemma integrable_comp_snd_map_prod_mk (hm : m ≤ mΩ) {f : Ω → F} (hf_int : integrable f μ) :
-  @integrable F _ (Ω × Ω) (m.prod mΩ) (λ x : Ω × Ω, f x.2)
-    (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ) :=
-begin
-  have hX : @measurable Ω Ω mΩ m id := measurable_id.mono le_rfl hm,
-  have hY : measurable (id : Ω → Ω) := measurable_id,
-  have hXY : @ae_measurable Ω (Ω × Ω) (m.prod mΩ) mΩ (λ ω, (ω, ω)) μ :=
-    @measurable.ae_measurable Ω (Ω × Ω) mΩ (m.prod mΩ) _ μ (hX.prod_mk hY),
-  have hf := ae_strongly_measurable_comp_snd_map_prod_mk hm hf_int,
-  refine ⟨hf, _⟩,
-  rw [has_finite_integral, lintegral_map' hf.ennnorm hXY],
-  exact hf_int.2,
-end
-
 /-- The conditional expectation of `f` with respect to a σ-algebra `m` is almost everywhere equal to
 the integral `∫ y, f y ∂(condexp_kernel μ m ω)`. -/
 lemma condexp_ae_eq_integral_condexp_kernel (hm : m ≤ mΩ) {f : Ω → F} (hf_int : integrable f μ) :
   μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω) :=
 begin
   have hX : @measurable Ω Ω mΩ m id := measurable_id.mono le_rfl hm,
-  have hY : ae_measurable (id : Ω → Ω) μ := ae_measurable_id,
-  have hf_int' : @integrable F _ (Ω × Ω) (m.prod mΩ) (λ x : Ω × Ω, f x.2)
-    (@measure.map _ _ (m.prod mΩ) _ (λ ω, (ω, ω)) μ),
-  { exact integrable_comp_snd_map_prod_mk hm hf_int, },
   rw condexp_kernel,
-  refine eventually_eq.trans _ (condexp_prod_ae_eq_integral_cond_distrib' hX hY hf_int'),
+  refine eventually_eq.trans _ (condexp_ae_eq_integral_cond_distrib'' hX hf_int),
   simp only [measurable_space.comap_id, id.def],
 end
 

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -1,0 +1,258 @@
+/-
+Copyright (c) 2023 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne
+-/
+import probability.kernel.disintegration
+import probability.notation
+
+/-!
+# Kernel associated with a conditional expectation
+
+## Main definitions
+
+* `foo_bar`
+
+## Main statements
+
+* `foo_bar_unique`
+
+## References
+
+* [F. Bar, *Quuxes*][bibkey]
+
+## Tags
+
+Foobars, barfoos
+-/
+
+
+open measure_theory set filter topological_space
+
+open_locale nnreal ennreal measure_theory topology probability_theory
+
+namespace measure_theory
+
+lemma ae_strongly_measurable.comp_ae_measurable'
+  {α β γ : Type*} [topological_space β] {m0 : measurable_space α} {mγ : measurable_space γ}
+  {f : α → β} {μ : measure γ} {g : γ → α}
+  (hf : ae_strongly_measurable f (μ.map g)) (hg : ae_measurable g μ) :
+  ae_strongly_measurable' (measurable_space.comap g m0) (f ∘ g) μ :=
+begin
+  let f' := hf.mk f,
+  refine ⟨f' ∘ g, _, _⟩,
+  { exact hf.strongly_measurable_mk.comp_measurable (measurable_iff_comap_le.mpr le_rfl), },
+  { exact ae_eq_comp hg hf.ae_eq_mk, },
+end
+
+end measure_theory
+
+open measure_theory
+
+namespace probability_theory
+
+variables {α Ω β F : Type*}
+  [topological_space Ω] [measurable_space Ω] [polish_space Ω] [borel_space Ω] [nonempty Ω]
+  [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
+
+section fst_snd
+
+lemma fst_map_prod_mk₀ {Ω : Type*} {Y : α → Ω} {mΩ : measurable_space Ω} {mβ : measurable_space β}
+  {mα : measurable_space α} {X : α → β} {μ : measure α}
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ) :
+  (μ.map (λ ω, (X ω, Y ω))).fst = μ.map X :=
+begin
+  ext1 s hs,
+  rw [measure.fst_apply hs, measure.map_apply_of_ae_measurable (hX.prod_mk hY) (measurable_fst hs),
+    measure.map_apply_of_ae_measurable hX hs, ← prod_univ, mk_preimage_prod, preimage_univ,
+    inter_univ],
+end
+
+lemma fst_map_prod_mk {Ω : Type*} {Y : α → Ω} {mΩ : measurable_space Ω} {mβ : measurable_space β}
+  {mα : measurable_space α} {X : α → β} {μ : measure α}
+  (hX : measurable X) (hY : measurable Y) :
+  (μ.map (λ ω, (X ω, Y ω))).fst = μ.map X :=
+fst_map_prod_mk₀ hX.ae_measurable hY.ae_measurable
+
+end fst_snd
+
+localized "notation (name := condexp_fun_comap')
+  P `[` Y `|` X `;` m `]` := P[ Y | m.comap X]" in probability_theory
+
+localized "notation (name := condexp_indicator)
+  P `⟦` s `|` m `⟧` := P[ s.indicator (λ ω, (1 : ℝ)) | m]" in probability_theory
+
+localized "notation (name := condexp_fun_mem)
+  P `⟦` Y `∈ₘ` s `|` X `;` m `⟧` := P ⟦ Y ⁻¹' s | m.comap X ⟧" in probability_theory
+
+variables {mα : measurable_space α} {μ : measure α} {X : α → β} {Y : α → Ω} [is_finite_measure μ]
+
+/-- **Regular conditional probability distribution**: kernel associated with the conditional
+expectation of `Y` given `X`. -/
+@[irreducible] noncomputable
+def cond_distrib {mα : measurable_space α} [measurable_space β]
+  (Y : α → Ω) (X : α → β) (μ : measure α) [is_finite_measure μ] :
+  kernel β Ω :=
+(μ.map (λ a, (X a, Y a))).cond_kernel
+
+instance [measurable_space β] : is_markov_kernel (cond_distrib Y X μ) :=
+by { rw cond_distrib, apply_instance, }
+
+lemma measurable_cond_distrib {mβ : measurable_space β}
+  {s : set Ω} (hs : measurable_set s) :
+  measurable[mβ.comap X] (λ ω, cond_distrib Y X μ (X ω) s) :=
+(kernel.measurable_coe _ hs).comp (measurable.of_comap_le le_rfl)
+
+lemma integrable_to_real_cond_distrib {mβ : measurable_space β}
+  (hX : ae_measurable X μ) {s : set Ω} (hs : measurable_set s) :
+  integrable (λ ω, (cond_distrib Y X μ (X ω) s).to_real) μ :=
+begin
+  refine integrable_to_real_of_lintegral_ne_top _ _,
+  { exact measurable.comp_ae_measurable (kernel.measurable_coe _ hs) hX, },
+  { refine ne_of_lt _,
+    calc ∫⁻ ω, cond_distrib Y X μ (X ω) s ∂μ
+        ≤ ∫⁻ ω, 1 ∂μ : lintegral_mono (λ ω, prob_le_one)
+    ... = μ univ : lintegral_one
+    ... < ∞ : measure_lt_top _ _, },
+end
+
+lemma _root_.measure_theory.integrable.integral_cond_distrib {mβ : measurable_space β}
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  {f : β × Ω → F} (hf_int : integrable f (μ.map (λ a, (X a, Y a)))) :
+  integrable (λ ω, ∫ y, f (X ω, y) ∂(cond_distrib Y X μ (X ω))) μ :=
+begin
+  change integrable ((λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) ∘ X) μ,
+  refine integrable.comp_ae_measurable _ hX,
+  rw [← fst_map_prod_mk₀ hX hY, cond_distrib],
+  exact hf_int.integral_cond_kernel,
+end
+
+lemma _root_.measure_theory.ae_strongly_measurable.integral_cond_distrib {mβ : measurable_space β}
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  {f : β × Ω → F} (hf : ae_strongly_measurable f (μ.map (λ ω, (X ω, Y ω)))) :
+  ae_strongly_measurable (λ x, ∫ y, f (x, y) ∂(cond_distrib Y X μ x)) (μ.map X) :=
+by { rw ← fst_map_prod_mk₀ hX hY, rw cond_distrib, exact hf.integral_cond_kernel, }
+
+lemma ae_strongly_measurable'_integral_cond_distrib {mβ : measurable_space β}
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ)
+  {f : β × Ω → F} (hf_int : integrable f (μ.map (λ ω, (X ω, Y ω)))) :
+  ae_strongly_measurable' (mβ.comap X) (λ ω, ∫ y, f (X ω, y) ∂(cond_distrib Y X μ (X ω))) μ :=
+(hf_int.1.integral_cond_distrib hX hY).comp_ae_measurable' hX
+
+lemma set_lintegral_preimage_cond_distrib {mβ : measurable_space β}
+  (hX : measurable X) (hY : ae_measurable Y μ)
+  {s : set Ω} (hs : measurable_set s) {t : set β} (ht : measurable_set t) :
+  ∫⁻ ω in X ⁻¹' t, cond_distrib Y X μ (X ω) s ∂μ = μ (X ⁻¹' t ∩ Y ⁻¹' s) :=
+begin
+  change ∫⁻ ω in X ⁻¹' t, ((λ x, cond_distrib Y X μ x s) ∘ X) ω ∂μ = μ (X ⁻¹' t ∩ Y ⁻¹' s),
+  rw [lintegral_comp (kernel.measurable_coe _ hs) hX, cond_distrib,
+    ← measure.restrict_map hX ht, ← fst_map_prod_mk₀ hX.ae_measurable hY,
+    set_lintegral_cond_kernel_eq_measure_prod _ ht hs,
+    measure.map_apply_of_ae_measurable (hX.ae_measurable.prod_mk hY) (ht.prod hs),
+    mk_preimage_prod],
+end
+
+lemma set_lintegral_cond_distrib_of_measurable {mβ : measurable_space β}
+  (hX : measurable X) (hY : ae_measurable Y μ)
+  {s : set Ω} (hs : measurable_set s) {t : set α} (ht : measurable_set[mβ.comap X] t) :
+  ∫⁻ ω in t, cond_distrib Y X μ (X ω) s ∂μ = μ (t ∩ Y ⁻¹' s) :=
+by { obtain ⟨tₑ, htₑ, rfl⟩ := ht, rw set_lintegral_preimage_cond_distrib hX hY hs htₑ, }
+
+lemma cond_distrib_ae_eq_condexp {mβ : measurable_space β} (hX : measurable X) (hY : measurable Y)
+  {s : set Ω} (hs : measurable_set s) :
+  (λ ω, (cond_distrib Y X μ (X ω) s).to_real) =ᵐ[μ] μ⟦Y ∈ₘ s | X ; mβ⟧ :=
+begin
+  refine ae_eq_condexp_of_forall_set_integral_eq hX.comap_le _ _ _ _,
+  { exact (integrable_const _).indicator (hY hs),  },
+  { exact λ t ht _, (integrable_to_real_cond_distrib hX.ae_measurable hs).integrable_on, },
+  { intros t ht _,
+    rw [integral_to_real ((measurable_cond_distrib hs).mono hX.comap_le le_rfl).ae_measurable
+        (eventually_of_forall (λ ω, measure_lt_top (cond_distrib Y X μ (X ω)) _)),
+      integral_indicator_const _ (hY hs), measure.restrict_apply (hY hs), smul_eq_mul, mul_one,
+      inter_comm, set_lintegral_cond_distrib_of_measurable hX hY.ae_measurable hs ht], },
+  { refine (measurable.strongly_measurable _).ae_strongly_measurable',
+    refine @measurable.ennreal_to_real _ (mβ.comap X) _ _,
+    exact measurable_cond_distrib hs, },
+end
+
+lemma todo'' {mβ : measurable_space β} (hX : measurable X) (hY : ae_measurable Y μ)
+  {f : β × Ω → F} (hf_int : integrable f (μ.map (λ ω, (X ω, Y ω)))) :
+  μ[(λ ω, f (X ω, Y ω)) | X; mβ] =ᵐ[μ] λ ω, ∫ y, f (X ω, y) ∂(cond_distrib Y X μ (X ω)) :=
+begin
+  have hf_int' : integrable (λ ω, f (X ω, Y ω)) μ,
+  { exact (integrable_map_measure hf_int.1 (hX.ae_measurable.prod_mk hY)).mp hf_int, },
+  refine (ae_eq_condexp_of_forall_set_integral_eq hX.comap_le hf_int' (λ s hs hμs, _) _ _).symm,
+  { exact (hf_int.integral_cond_distrib hX.ae_measurable hY).integrable_on, },
+  { rintros s ⟨t, ht, rfl⟩ _,
+    change ∫ ω in X ⁻¹' t, ((λ x', ∫ y, f (x', y) ∂(cond_distrib Y X μ) x') ∘ X) ω ∂μ
+      = ∫ ω in X ⁻¹' t, f (X ω, Y ω) ∂μ,
+    rw ← integral_map hX.ae_measurable,
+    swap,
+    { rw ← measure.restrict_map hX ht,
+      exact (hf_int.1.integral_cond_distrib hX.ae_measurable hY).restrict, },
+    rw [← measure.restrict_map hX ht, ← fst_map_prod_mk₀ hX.ae_measurable hY, cond_distrib,
+      set_integral_cond_kernel_univ_right ht hf_int.integrable_on,
+      set_integral_map (ht.prod measurable_set.univ) hf_int.1 (hX.ae_measurable.prod_mk hY),
+      mk_preimage_prod, preimage_univ, inter_univ], },
+  { exact ae_strongly_measurable'_integral_cond_distrib hX.ae_measurable hY hf_int, },
+end
+
+lemma todo₀ {mβ : measurable_space β} (hX : measurable X) (hY : ae_measurable Y μ)
+  {f : β × Ω → F} (hf : ae_strongly_measurable f (μ.map (λ a, (X a, Y a))))
+  (hf_int : integrable (λ ω, f (X ω, Y ω)) μ) :
+  μ[(λ ω, f (X ω, Y ω)) | X; mβ] =ᵐ[μ] λ ω, ∫ y, f (X ω, y) ∂(cond_distrib Y X μ (X ω)) :=
+begin
+  have hf_int' : integrable f (μ.map (λ ω, (X ω, Y ω))),
+  { rwa integrable_map_measure hf (hX.ae_measurable.prod_mk hY), },
+  exact todo'' hX hY hf_int',
+end
+
+lemma todo {mβ : measurable_space β} (hX : measurable X) (hY : ae_measurable Y μ)
+  {f : β × Ω → F} (hf : strongly_measurable f) (hf_int : integrable (λ ω, f (X ω, Y ω)) μ) :
+  μ[(λ ω, f (X ω, Y ω)) | X; mβ] =ᵐ[μ] λ ω, ∫ y, f (X ω, y) ∂(cond_distrib Y X μ (X ω)) :=
+begin
+  have hf_int' : integrable f (μ.map (λ ω, (X ω, Y ω))),
+  { rwa integrable_map_measure hf.ae_strongly_measurable (hX.ae_measurable.prod_mk hY), },
+  exact todo'' hX hY hf_int',
+end
+
+lemma todo_right {mβ : measurable_space β} (hX : measurable X) (hY : ae_measurable Y μ)
+  {f : Ω → F} (hf : strongly_measurable f) (hf_int : integrable (λ ω, f (Y ω)) μ) :
+  μ[(λ ω, f (Y ω)) | X; mβ] =ᵐ[μ] λ ω, ∫ y, f y ∂(cond_distrib Y X μ (X ω)) :=
+todo hX hY (hf.comp_measurable measurable_snd) hf_int
+
+lemma todo' {Ω} [normed_add_comm_group Ω] [normed_space ℝ Ω] [complete_space Ω]
+  [measurable_space Ω] [borel_space Ω] [second_countable_topology Ω] {Y : α → Ω}
+  {mβ : measurable_space β}
+  (hX : measurable X) (hY_int : integrable Y μ) :
+  μ[Y | X; mβ] =ᵐ[μ] λ ω, ∫ y, y ∂(cond_distrib Y X μ (X ω)) :=
+todo_right hX hY_int.1.ae_measurable strongly_measurable_id hY_int
+
+/-! ### Kernel associated with the conditional expectation with respect to a σ-algebra
+
+We define `condexp_kernel`, a kernel from `Ω` to `Ω` such that for all integrable, strongly
+measurable `f`, `μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`. -/
+
+/-- Kernel associated with the conditional expectation with respect to a σ-algebra. -/
+noncomputable
+def condexp_kernel {Ω : Type*} [mΩ : measurable_space Ω] [topological_space Ω] [borel_space Ω]
+  [polish_space Ω] [nonempty Ω]
+  (μ : measure Ω) [is_finite_measure μ] (m : measurable_space Ω) :
+  @kernel Ω Ω m mΩ :=
+@cond_distrib Ω Ω Ω _ mΩ _ _ _ mΩ m id id μ _
+
+lemma condexp_ae_eq_integral_condexp_kernel {Ω : Type*} [topological_space Ω]
+  (m : measurable_space Ω) {mΩ : measurable_space Ω} [borel_space Ω] [polish_space Ω] [nonempty Ω]
+  (hm : m ≤ mΩ) {μ : measure Ω} [is_finite_measure μ]
+  {f : Ω → F} (hf : strongly_measurable f) (hf_int : integrable f μ) :
+  μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω) :=
+begin
+  have hX : @measurable Ω Ω mΩ m id := measurable_id.mono le_rfl hm,
+  have hY : ae_measurable (id : Ω → Ω) μ := ae_measurable_id,
+  have hf' : @strongly_measurable (Ω × Ω) F _ (m.prod mΩ) (λ x : Ω × Ω, f x.2) :=
+    hf.comp_measurable measurable_id.snd,
+  refine eventually_eq.trans _ (todo hX hY hf' hf_int),
+  simp only [measurable_space.comap_id, id.def],
+end
+
+end probability_theory

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -9,7 +9,12 @@ import probability.kernel.cond_distrib
 # Kernel associated with a conditional expectation
 
 We define `condexp_kernel μ m`, a kernel from `Ω` to `Ω` such that for all integrable, strongly
-measurable `f`, `μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`.
+measurable `f`, `μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`. This kernel is defined if
+`Ω` is a standard Borel space. In general, `μ⟦s | m⟧` maps a measurable set `s` to a function
+`Ω → ℝ≥0∞`, and for all `s` that map is unique up to a `μ`-null set. For all `a`, the map from sets
+to `ℝ≥0∞` that we obtain that way verifies some of the properties of a measure, but the fact that
+the `μ`-null set depends on `s` can prevent us from finding versions of the conditional expectation
+that combine into a true measure. The standard Borel space assumption on `Ω` allows us to do so.
 
 ## Main definitions
 

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -38,10 +38,12 @@ section aux_lemmas
 
 variables {Ω F : Type*} {m mΩ : measurable_space Ω} {μ : measure Ω} {f : Ω → F}
 
+-- todo after the port: move to measure_theory/measurable_space, after measurable.mono
 lemma measurable_id'' (hm : m ≤ mΩ) :
   @measurable Ω Ω mΩ m id :=
-measurable_id.mono hm le_rfl
+measurable_id.mono le_rfl hm
 
+-- todo after the port: move to measure_theory/measurable_space, after measurable.mono
 lemma ae_measurable_id'' (μ : measure Ω) (hm : m ≤ mΩ) :
   @ae_measurable Ω Ω m mΩ id μ :=
 @measurable.ae_measurable Ω Ω mΩ m id μ (measurable_id'' hm)

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -38,6 +38,7 @@ variables {Ω F : Type*} [topological_space Ω] {m : measurable_space Ω} [mΩ :
   [polish_space Ω] [borel_space Ω] [nonempty Ω]
   {μ : measure Ω} [is_finite_measure μ]
   [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
+  {f : Ω → F}
 
 /-- Kernel associated with the conditional expectation with respect to a σ-algebra. It satisfies
 `μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`.
@@ -48,9 +49,115 @@ def condexp_kernel (μ : measure Ω) [is_finite_measure μ] (m : measurable_spac
   @kernel Ω Ω m mΩ :=
 @cond_distrib Ω Ω Ω _ mΩ _ _ _ mΩ m id id μ _
 
+section aux_lemmas
+
+lemma measurable_id'' {Ω : Type*} {m mΩ : measurable_space Ω} (hm : m ≤ mΩ) :
+  @measurable Ω Ω mΩ m id :=
+measurable_id.mono hm le_rfl
+
+lemma ae_measurable_id'' {Ω : Type*} {m mΩ : measurable_space Ω} (μ : measure Ω) (hm : m ≤ mΩ) :
+  @ae_measurable Ω Ω m mΩ id μ :=
+@measurable.ae_measurable Ω Ω mΩ m id μ (measurable_id'' hm)
+
+lemma _root_.measure_theory.ae_strongly_measurable.comp_snd_map_prod_id
+  (hm : m ≤ mΩ) (hf : ae_strongly_measurable f μ) :
+  ae_strongly_measurable (λ x : Ω × Ω, f x.2)
+    (@measure.map Ω (Ω × Ω) (m.prod mΩ) mΩ (λ ω, (id ω, id ω)) μ) :=
+begin
+  rw ← ae_strongly_measurable_comp_snd_map_prod_mk_iff (measurable_id'' hm) at hf,
+  simp_rw [id.def] at hf ⊢,
+  exact hf,
+end
+
+lemma _root_.measure_theory.integrable.comp_snd_map_prod_id
+  (hm : m ≤ mΩ) (hf : integrable f μ) :
+  integrable (λ x : Ω × Ω, f x.2)
+    (@measure.map Ω (Ω × Ω) (m.prod mΩ) mΩ (λ ω, (id ω, id ω)) μ) :=
+begin
+  rw ← integrable_comp_snd_map_prod_mk_iff (measurable_id'' hm) at hf,
+  simp_rw [id.def] at hf ⊢,
+  exact hf,
+end
+
+end aux_lemmas
+
+section measurability
+
+lemma measurable_condexp_kernel {s : set Ω} (hs : measurable_set s) :
+  measurable[m] (λ ω, condexp_kernel μ m ω s) :=
+by { rw condexp_kernel, convert measurable_cond_distrib hs, rw measurable_space.comap_id, }
+
+lemma _root_.measure_theory.ae_strongly_measurable.integral_condexp_kernel
+  (hm : m ≤ mΩ) (hf : ae_strongly_measurable f μ) :
+  ae_strongly_measurable (λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)) μ :=
+begin
+  rw condexp_kernel,
+  exact ae_strongly_measurable.integral_cond_distrib
+    (ae_measurable_id'' μ hm) ae_measurable_id (hf.comp_snd_map_prod_id hm),
+end
+
+lemma ae_strongly_measurable'_integral_condexp_kernel
+  (hm : m ≤ mΩ) (hf : ae_strongly_measurable f μ) :
+  ae_strongly_measurable' m (λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)) μ :=
+begin
+  rw condexp_kernel,
+  have h := ae_strongly_measurable'_integral_cond_distrib
+    (ae_measurable_id'' μ hm) ae_measurable_id (hf.comp_snd_map_prod_id hm),
+  rwa measurable_space.comap_id at h,
+end
+
+end measurability
+
+section integrability
+
+lemma _root_.measure_theory.integrable.condexp_kernel_ae
+  (hm : m ≤ mΩ) (hf_int : integrable f μ) :
+  ∀ᵐ ω ∂μ, integrable f (condexp_kernel μ m ω) :=
+begin
+  rw condexp_kernel,
+  exact integrable.cond_distrib_ae (ae_measurable_id'' μ hm)
+    ae_measurable_id (hf_int.comp_snd_map_prod_id hm),
+end
+
+lemma _root_.measure_theory.integrable.integral_norm_condexp_kernel
+  (hm : m ≤ mΩ) (hf_int : integrable f μ) :
+  integrable (λ ω, ∫ y, ‖f y‖ ∂(condexp_kernel μ m ω)) μ :=
+begin
+  rw condexp_kernel,
+  exact integrable.integral_norm_cond_distrib (ae_measurable_id'' μ hm)
+    ae_measurable_id (hf_int.comp_snd_map_prod_id hm),
+end
+
+lemma _root_.measure_theory.integrable.norm_integral_condexp_kernel
+  (hm : m ≤ mΩ) (hf_int : integrable f μ) :
+  integrable (λ ω, ‖∫ y, f y ∂(condexp_kernel μ m ω)‖) μ :=
+begin
+  rw condexp_kernel,
+  exact integrable.norm_integral_cond_distrib (ae_measurable_id'' μ hm)
+    ae_measurable_id (hf_int.comp_snd_map_prod_id hm),
+end
+
+lemma _root_.measure_theory.integrable.integral_condexp_kernel
+  (hm : m ≤ mΩ) (hf_int : integrable f μ) :
+  integrable (λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)) μ :=
+begin
+  rw condexp_kernel,
+  exact integrable.integral_cond_distrib (ae_measurable_id'' μ hm)
+    ae_measurable_id (hf_int.comp_snd_map_prod_id hm),
+end
+
+lemma integrable_to_real_condexp_kernel (hm : m ≤ mΩ) {s : set Ω} (hs : measurable_set s) :
+  integrable (λ ω, (condexp_kernel μ m ω s).to_real) μ :=
+begin
+  rw condexp_kernel,
+  exact integrable_to_real_cond_distrib (ae_measurable_id'' μ hm) hs,
+end
+
+end integrability
+
 /-- The conditional expectation of `f` with respect to a σ-algebra `m` is almost everywhere equal to
 the integral `∫ y, f y ∂(condexp_kernel μ m ω)`. -/
-lemma condexp_ae_eq_integral_condexp_kernel (hm : m ≤ mΩ) {f : Ω → F} (hf_int : integrable f μ) :
+lemma condexp_ae_eq_integral_condexp_kernel (hm : m ≤ mΩ) (hf_int : integrable f μ) :
   μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω) :=
 begin
   have hX : @measurable Ω Ω mΩ m id := measurable_id.mono le_rfl hm,

--- a/src/probability/kernel/condexp.lean
+++ b/src/probability/kernel/condexp.lean
@@ -34,32 +34,19 @@ open_locale ennreal measure_theory probability_theory
 
 namespace probability_theory
 
-variables {Ω F : Type*} [topological_space Ω] {m : measurable_space Ω} [mΩ : measurable_space Ω]
-  [polish_space Ω] [borel_space Ω] [nonempty Ω]
-  {μ : measure Ω} [is_finite_measure μ]
-  [normed_add_comm_group F] [normed_space ℝ F] [complete_space F]
-  {f : Ω → F}
-
-/-- Kernel associated with the conditional expectation with respect to a σ-algebra. It satisfies
-`μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`.
-It is defined as the conditional distribution of the identity given the identity, where the second
-identity is understood as a map from `Ω` with the σ-algebra `mΩ` to `Ω` with σ-algebra `m`. -/
-@[irreducible] noncomputable
-def condexp_kernel (μ : measure Ω) [is_finite_measure μ] (m : measurable_space Ω) :
-  @kernel Ω Ω m mΩ :=
-@cond_distrib Ω Ω Ω _ mΩ _ _ _ mΩ m id id μ _
-
 section aux_lemmas
 
-lemma measurable_id'' {Ω : Type*} {m mΩ : measurable_space Ω} (hm : m ≤ mΩ) :
+variables {Ω F : Type*} {m mΩ : measurable_space Ω} {μ : measure Ω} {f : Ω → F}
+
+lemma measurable_id'' (hm : m ≤ mΩ) :
   @measurable Ω Ω mΩ m id :=
 measurable_id.mono hm le_rfl
 
-lemma ae_measurable_id'' {Ω : Type*} {m mΩ : measurable_space Ω} (μ : measure Ω) (hm : m ≤ mΩ) :
+lemma ae_measurable_id'' (μ : measure Ω) (hm : m ≤ mΩ) :
   @ae_measurable Ω Ω m mΩ id μ :=
 @measurable.ae_measurable Ω Ω mΩ m id μ (measurable_id'' hm)
 
-lemma _root_.measure_theory.ae_strongly_measurable.comp_snd_map_prod_id
+lemma _root_.measure_theory.ae_strongly_measurable.comp_snd_map_prod_id [topological_space F]
   (hm : m ≤ mΩ) (hf : ae_strongly_measurable f μ) :
   ae_strongly_measurable (λ x : Ω × Ω, f x.2)
     (@measure.map Ω (Ω × Ω) (m.prod mΩ) mΩ (λ ω, (id ω, id ω)) μ) :=
@@ -69,7 +56,7 @@ begin
   exact hf,
 end
 
-lemma _root_.measure_theory.integrable.comp_snd_map_prod_id
+lemma _root_.measure_theory.integrable.comp_snd_map_prod_id [normed_add_comm_group F]
   (hm : m ≤ mΩ) (hf : integrable f μ) :
   integrable (λ x : Ω × Ω, f x.2)
     (@measure.map Ω (Ω × Ω) (m.prod mΩ) mΩ (λ ω, (id ω, id ω)) μ) :=
@@ -81,6 +68,20 @@ end
 
 end aux_lemmas
 
+variables {Ω F : Type*} [topological_space Ω] {m : measurable_space Ω} [mΩ : measurable_space Ω]
+  [polish_space Ω] [borel_space Ω] [nonempty Ω]
+  {μ : measure Ω} [is_finite_measure μ]
+  [normed_add_comm_group F] {f : Ω → F}
+
+/-- Kernel associated with the conditional expectation with respect to a σ-algebra. It satisfies
+`μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)`.
+It is defined as the conditional distribution of the identity given the identity, where the second
+identity is understood as a map from `Ω` with the σ-algebra `mΩ` to `Ω` with σ-algebra `m`. -/
+@[irreducible] noncomputable
+def condexp_kernel (μ : measure Ω) [is_finite_measure μ] (m : measurable_space Ω) :
+  @kernel Ω Ω m mΩ :=
+@cond_distrib Ω Ω Ω _ mΩ _ _ _ mΩ m id id μ _
+
 section measurability
 
 lemma measurable_condexp_kernel {s : set Ω} (hs : measurable_set s) :
@@ -88,6 +89,7 @@ lemma measurable_condexp_kernel {s : set Ω} (hs : measurable_set s) :
 by { rw condexp_kernel, convert measurable_cond_distrib hs, rw measurable_space.comap_id, }
 
 lemma _root_.measure_theory.ae_strongly_measurable.integral_condexp_kernel
+  [normed_space ℝ F] [complete_space F]
   (hm : m ≤ mΩ) (hf : ae_strongly_measurable f μ) :
   ae_strongly_measurable (λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)) μ :=
 begin
@@ -96,7 +98,7 @@ begin
     (ae_measurable_id'' μ hm) ae_measurable_id (hf.comp_snd_map_prod_id hm),
 end
 
-lemma ae_strongly_measurable'_integral_condexp_kernel
+lemma ae_strongly_measurable'_integral_condexp_kernel [normed_space ℝ F] [complete_space F]
   (hm : m ≤ mΩ) (hf : ae_strongly_measurable f μ) :
   ae_strongly_measurable' m (λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)) μ :=
 begin
@@ -129,6 +131,7 @@ begin
 end
 
 lemma _root_.measure_theory.integrable.norm_integral_condexp_kernel
+  [normed_space ℝ F] [complete_space F]
   (hm : m ≤ mΩ) (hf_int : integrable f μ) :
   integrable (λ ω, ‖∫ y, f y ∂(condexp_kernel μ m ω)‖) μ :=
 begin
@@ -137,7 +140,7 @@ begin
     ae_measurable_id (hf_int.comp_snd_map_prod_id hm),
 end
 
-lemma _root_.measure_theory.integrable.integral_condexp_kernel
+lemma _root_.measure_theory.integrable.integral_condexp_kernel [normed_space ℝ F] [complete_space F]
   (hm : m ≤ mΩ) (hf_int : integrable f μ) :
   integrable (λ ω, ∫ y, f y ∂(condexp_kernel μ m ω)) μ :=
 begin
@@ -157,7 +160,8 @@ end integrability
 
 /-- The conditional expectation of `f` with respect to a σ-algebra `m` is almost everywhere equal to
 the integral `∫ y, f y ∂(condexp_kernel μ m ω)`. -/
-lemma condexp_ae_eq_integral_condexp_kernel (hm : m ≤ mΩ) (hf_int : integrable f μ) :
+lemma condexp_ae_eq_integral_condexp_kernel [normed_space ℝ F] [complete_space F]
+  (hm : m ≤ mΩ) (hf_int : integrable f μ) :
   μ[f | m] =ᵐ[μ] λ ω, ∫ y, f y ∂(condexp_kernel μ m ω) :=
 begin
   have hX : @measurable Ω Ω mΩ m id := measurable_id.mono le_rfl hm,

--- a/src/probability/notation.lean
+++ b/src/probability/notation.lean
@@ -15,6 +15,8 @@ measurable space `m0`, and another measurable space structure `m` with `hm : m �
 - `𝔼[X|m]`: conditional expectation of `X` with respect to the measure `volume` and the
   measurable space `m`. The similar `P[X|m]` for a measure `P` is defined in
   measure_theory.function.conditional_expectation.
+- `P⟦s|m⟧ = P[s.indicator (λ ω, (1 : ℝ)) | m]`, conditional probability of a set.
+- `P⟦Y ∈ₘ s | m⟧ = P⟦Y ⁻¹' s | m⟧`
 - `X =ₐₛ Y`: `X =ᵐ[volume] Y`
 - `X ≤ₐₛ Y`: `X ≤ᵐ[volume] Y`
 - `∂P/∂Q = P.rn_deriv Q`
@@ -26,6 +28,7 @@ We note that the notation `∂P/∂Q` applies to three different cases, namely,
 -/
 
 open measure_theory
+open_locale measure_theory
 
 -- We define notations `𝔼[f|m]` for the conditional expectation of `f` with respect to `m`.
 localized "notation (name := condexp.volume) `𝔼[` X `|` m `]` :=
@@ -35,6 +38,13 @@ localized "notation (name := condexp.probability)
   P `[` X `]` := ∫ x, X x ∂P" in probability_theory
 
 localized "notation (name := expected_value) `𝔼[` X `]` := ∫ a, X a" in probability_theory
+
+localized "notation (name := condexp_indicator)
+  P `⟦` s `|` m `⟧` := P[ s.indicator (λ ω, (1 : ℝ)) | m]" in probability_theory
+
+localized "notation (name := condexp_fun_mem_comap)
+  P `⟦` Y `∈ₘ` s `|` m `⟧` := P[ (Y ⁻¹' s).indicator (λ ω, (1 : ℝ)) | m]"
+  in probability_theory
 
 localized "notation (name := eq_ae_volume)
   X ` =ₐₛ `:50 Y:50 := X =ᵐ[measure_theory.measure_space.volume] Y" in probability_theory

--- a/src/probability/notation.lean
+++ b/src/probability/notation.lean
@@ -40,10 +40,11 @@ localized "notation (name := condexp.probability)
 localized "notation (name := expected_value) `𝔼[` X `]` := ∫ a, X a" in probability_theory
 
 localized "notation (name := condexp_indicator)
-  P `⟦` s `|` m `⟧` := P[ s.indicator (λ ω, (1 : ℝ)) | m]" in probability_theory
+  P `⟦` s `|` m `⟧` := measure_theory.condexp m P (s.indicator (λ ω, (1 : ℝ)))"
+  in probability_theory
 
 localized "notation (name := condexp_fun_mem_comap)
-  P `⟦` Y `∈ₘ` s `|` m `⟧` := P[ (Y ⁻¹' s).indicator (λ ω, (1 : ℝ)) | m]"
+  P `⟦` Y `∈ₘ` s `|` m `⟧` := measure_theory.condexp m P ((Y ⁻¹' s).indicator (λ ω, (1 : ℝ)))"
   in probability_theory
 
 localized "notation (name := eq_ae_volume)

--- a/src/probability/notation.lean
+++ b/src/probability/notation.lean
@@ -16,7 +16,6 @@ measurable space `m0`, and another measurable space structure `m` with `hm : m �
   measurable space `m`. The similar `P[X|m]` for a measure `P` is defined in
   measure_theory.function.conditional_expectation.
 - `P⟦s|m⟧ = P[s.indicator (λ ω, (1 : ℝ)) | m]`, conditional probability of a set.
-- `P⟦Y ∈ₘ s | m⟧ = P⟦Y ⁻¹' s | m⟧`
 - `X =ₐₛ Y`: `X =ᵐ[volume] Y`
 - `X ≤ₐₛ Y`: `X ≤ᵐ[volume] Y`
 - `∂P/∂Q = P.rn_deriv Q`
@@ -41,10 +40,6 @@ localized "notation (name := expected_value) `𝔼[` X `]` := ∫ a, X a" in pro
 
 localized "notation (name := condexp_indicator)
   P `⟦` s `|` m `⟧` := measure_theory.condexp m P (s.indicator (λ ω, (1 : ℝ)))"
-  in probability_theory
-
-localized "notation (name := condexp_fun_mem_comap)
-  P `⟦` Y `∈ₘ` s `|` m `⟧` := measure_theory.condexp m P ((Y ⁻¹' s).indicator (λ ω, (1 : ℝ)))"
   in probability_theory
 
 localized "notation (name := eq_ae_volume)


### PR DESCRIPTION
We define the regular conditional probability distribution `cond_distrib Y X μ` of `Y : α → Ω` given `X : α → β`, where `Ω` is a standard Borel space. This is a `kernel β Ω` such that for almost all `a`, for all measurable set `s`, `cond_distrib Y X μ (X a) s` is equal to the conditional expectation `μ⟦Y ⁻¹' s | mβ.comap X⟧` evaluated at `a`.

Also define the above notation for the conditional expectation of the indicator of a set.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
