### PR TITLE
[Merged by Bors] - chore(topology/continuous_function/ideals): generalize type class requirements

### DIFF
--- a/src/topology/continuous_function/ideals.lean
+++ b/src/topology/continuous_function/ideals.lean
@@ -77,7 +77,8 @@ open topological_space
 
 section topological_ring
 
-variables {X R : Type*} [topological_space X] [semiring R] [topological_space R] [topological_semiring R]
+variables {X R : Type*} [topological_space X] [semiring R]
+variables [topological_space R] [topological_semiring R]
 
 variable (R)
 

--- a/src/topology/continuous_function/ideals.lean
+++ b/src/topology/continuous_function/ideals.lean
@@ -77,7 +77,7 @@ open topological_space
 
 section topological_ring
 
-variables {X R : Type*} [topological_space X] [ring R] [topological_space R] [topological_ring R]
+variables {X R : Type*} [topological_space X] [semiring R] [topological_space R] [topological_semiring R]
 
 variable (R)
 

--- a/src/topology/continuous_function/ideals.lean
+++ b/src/topology/continuous_function/ideals.lean
@@ -14,7 +14,7 @@ import topology.algebra.module.character_space
 /-!
 # Ideals of continuous functions
 
-For a topological ring `R` and a topological space `X` there is a Galois connection between
+For a topological semiring `R` and a topological space `X` there is a Galois connection between
 `ideal C(X, R)` and `set X` given by sending each `I : ideal C(X, R)` to
 `{x : X | ∀ f ∈ I, f x = 0}ᶜ` and mapping `s : set X` to the ideal with carrier
 `{f : C(X, R) | ∀ x ∈ sᶜ, f x = 0}`, and we call these maps `continuous_map.set_of_ideal` and


### PR DESCRIPTION
For the continuous functional calculus in non-unital algebras the subtype `C(R, R)₀ := { f : C(R, R) // f 0 = 0 }` will be useful, which is exactly `continuous_map.ideal_of_set`. However, it will be necessary to let `R` be `ℂ`, `ℝ` and `ℝ≥0`, and for the latter we need these more general type class assumptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
