### PR TITLE
[Merged by Bors] - feat(data/set/finite): add a version of `set.finite.bUnion`

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -843,8 +843,6 @@ end
 section sep
 variables {p q : α → Prop} {x : α}
 
-theorem sep_eq_inter : {x ∈ s | p x} = s ∩ {x | p x} := rfl
-
 theorem mem_sep (xs : x ∈ s) (px : p x) : x ∈ {x ∈ s | p x} := ⟨xs, px⟩
 
 @[simp] theorem sep_mem_eq : {x ∈ s | x ∈ t} = s ∩ t := rfl

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -843,6 +843,8 @@ end
 section sep
 variables {p q : α → Prop} {x : α}
 
+theorem sep_eq_inter : {x ∈ s | p x} = s ∩ {x | p x} := rfl
+
 theorem mem_sep (xs : x ∈ s) (px : p x) : x ∈ {x ∈ s | p x} := ⟨xs, px⟩
 
 @[simp] theorem sep_mem_eq : {x ∈ s | x ∈ t} = s ∩ t := rfl

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -396,8 +396,6 @@ end set
 lemma equiv.set_finite_iff {s : set α} {t : set β} (hst : s ≃ t) :
   s.finite ↔ t.finite :=
 by simp_rw [← set.finite_coe_iff, hst.finite_iff]
-
-
 /-! ### Finset -/
 
 namespace finset

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -396,6 +396,7 @@ end set
 lemma equiv.set_finite_iff {s : set α} {t : set β} (hst : s ≃ t) :
   s.finite ↔ t.finite :=
 by simp_rw [← set.finite_coe_iff, hst.finite_iff]
+
 /-! ### Finset -/
 
 namespace finset

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -601,7 +601,7 @@ hf.subset (sInter_subset_of_mem ht)
 
 /-- If sets `s i` are finite for all `i` from a finite set `t` and are empty for `i ∉ t`, then the
 union `⋃ i, s i` is a finite set. -/
-lemma set.finite.Union {ι : Type*} {s : ι → set α} {t : set ι} (ht : t.finite)
+lemma finite.Union {ι : Type*} {s : ι → set α} {t : set ι} (ht : t.finite)
   (hs : ∀ i ∈ t, (s i).finite) (he : ∀ i ∉ t, s i = ∅) :
   (⋃ i, s i).finite :=
 begin

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -393,6 +393,11 @@ end fintype_instances
 
 end set
 
+lemma equiv.set_finite_iff {s : set α} {t : set β} (hst : s ≃ t) :
+  s.finite ↔ t.finite :=
+by simp_rw [← set.finite_coe_iff, hst.finite_iff]
+
+
 /-! ### Finset -/
 
 namespace finset
@@ -593,6 +598,21 @@ by { casesI hs, rw [bUnion_eq_Union], apply finite_Union (λ (i : s), ht i.1 i.2
 theorem finite.sInter {α : Type*} {s : set (set α)} {t : set α} (ht : t ∈ s)
   (hf : t.finite) : (⋂₀ s).finite :=
 hf.subset (sInter_subset_of_mem ht)
+
+/-- If sets `s i` are finite for all `i` from a finite set `t` and are empty for `i ∉ t`, then the
+union `⋃ i, s i` is a finite set. -/
+lemma set.finite.Union {ι : Type*} {s : ι → set α} {t : set ι} (ht : t.finite)
+  (hs : ∀ i ∈ t, (s i).finite) (he : ∀ i ∉ t, s i = ∅) :
+  (⋃ i, s i).finite :=
+begin
+  suffices : (⋃ i, s i) ⊆ (⋃ i ∈ t, s i),
+  { exact (ht.bUnion hs).subset this, },
+  refine Union_subset (λ i x hx, _),
+  by_cases hi : i ∈ t,
+  { exact mem_bUnion hi hx },
+  { rw [he i hi, mem_empty_iff_false] at hx,
+    contradiction, },
+end
 
 theorem finite.bind {α β} {s : set α} {f : α → set β} (h : s.finite) (hf : ∀ a ∈ s, (f a).finite) :
   (s >>= f).finite :=


### PR DESCRIPTION
Add `set.finite.Union` and `equiv.set_finite_iff`.

From the sphere eversion project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)