### PR TITLE
[Merged by Bors] - feat(topology/subset_properties): add `sigma_compact_space` instances

### DIFF
--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -1306,6 +1306,10 @@ lemma embedding_ulift_down [topological_space α] :
   embedding (ulift.down : ulift.{v u} α → α) :=
 ⟨⟨rfl⟩, ulift.down_injective⟩
 
+lemma ulift.closed_embedding_down [topological_space α] :
+  closed_embedding (ulift.down : ulift.{v u} α → α) :=
+⟨embedding_ulift_down, by simp only [ulift.down_surjective.range_eq, is_closed_univ]⟩
+
 instance [topological_space α] [discrete_topology α] : discrete_topology (ulift α) :=
 embedding_ulift_down.discrete_topology
 

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1295,6 +1295,53 @@ variable {α}
 lemma exists_mem_compact_covering (x : α) : ∃ n, x ∈ compact_covering α n :=
 Union_eq_univ_iff.mp (Union_compact_covering α) x
 
+instance [sigma_compact_space β] : sigma_compact_space (α × β) :=
+⟨⟨λ n, compact_covering α n ×ˢ compact_covering β n,
+  λ _, (is_compact_compact_covering _ _).prod (is_compact_compact_covering _ _),
+  by simp only [Union_prod_of_monotone (compact_covering_subset α) (compact_covering_subset β),
+    Union_compact_covering, univ_prod_univ]⟩⟩
+
+instance [finite ι] [Π i, topological_space (π i)] [Π i, sigma_compact_space (π i)] :
+  sigma_compact_space (Π i, π i) :=
+begin
+  refine ⟨⟨λ n, set.pi univ (λ i, compact_covering (π i) n),
+    λ n, is_compact_univ_pi $ λ i, is_compact_compact_covering _ _, _⟩⟩,
+  rw [Union_univ_pi_of_monotone],
+  { simp only [Union_compact_covering, pi_univ] },
+  { exact λ i, compact_covering_subset (π i) }
+end
+
+instance [sigma_compact_space β] : sigma_compact_space (α ⊕ β) :=
+⟨⟨λ n, sum.inl '' compact_covering α n ∪ sum.inr '' compact_covering β n,
+  λ n, ((is_compact_compact_covering α n).image continuous_inl).union
+    ((is_compact_compact_covering β n).image continuous_inr),
+  by simp only [Union_union_distrib, ← image_Union, Union_compact_covering, image_univ,
+    range_inl_union_range_inr]⟩⟩
+
+instance [countable ι] [Π i, topological_space (π i)] [Π i, sigma_compact_space (π i)] :
+  sigma_compact_space (Σ i, π i) :=
+begin
+  casesI is_empty_or_nonempty ι,
+  { apply_instance },
+  { rcases exists_surjective_nat ι with ⟨f, hf⟩,
+    refine ⟨⟨λ n, ⋃ k ≤ n, sigma.mk (f k) '' compact_covering (π (f k)) n, λ n, _, _⟩⟩,
+    { refine (finite_le_nat _).is_compact_bUnion (λ k _, _),
+      exact (is_compact_compact_covering _ _).image continuous_sigma_mk },
+    { simp only [Union_eq_univ_iff, sigma.forall, mem_Union, hf.forall],
+      intros k y,
+      rcases exists_mem_compact_covering y with ⟨n, hn⟩,
+      refine ⟨max k n, k, le_max_left _ _, mem_image_of_mem _ _⟩,
+      exact compact_covering_subset _ (le_max_right _ _) hn } }
+end
+
+protected theorem closed_embedding.sigma_compact_space {e : β → α} (he : closed_embedding e) :
+  sigma_compact_space β :=
+⟨⟨λ n, e ⁻¹' compact_covering α n, λ n, he.is_compact_preimage (is_compact_compact_covering _ _),
+  by rw [← preimage_Union, Union_compact_covering, preimage_univ]⟩⟩
+
+instance [sigma_compact_space β] : sigma_compact_space (ulift.{u} β) :=
+  ulift.closed_embedding_down.sigma_compact_space
+
 /-- If `α` is a `σ`-compact space, then a locally finite family of nonempty sets of `α` can have
 only countably many elements, `set.countable` version. -/
 protected lemma locally_finite.countable_univ {ι : Type*} {f : ι → set α} (hf : locally_finite f)


### PR DESCRIPTION
Add instances for

* `α × β`, `α ⊕ β`, `ulift α`;
* `Π i : ι, π i`, assuming `finite ι`;
* `Σ i : ι, π i`, assuming `countable ι`.

In each case, all input topological spaces are also assumed to be
σ-compact.

Motivated by the `prod` instance in the sphere eversion project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)