### PR TITLE
[Merged by Bors] - feat (measure_theory/integral): some simple substitution rules

### DIFF
--- a/src/measure_theory/function/jacobian.lean
+++ b/src/measure_theory/function/jacobian.lean
@@ -1245,14 +1245,16 @@ begin
   refl
 end
 
-lemma det_smul_aux (v : ℝ) : ((1 : ℝ →L[ℝ] ℝ).smul_right v).det = v :=
+/- Porting note: move this to `topology.algebra.module.basic` when port is over -/
+lemma det_one_smul_right {𝕜 : Type*} [normed_field 𝕜] (v : 𝕜) :
+  ((1 : 𝕜 →L[𝕜] 𝕜).smul_right v).det = v :=
 begin
-  have : (1 : ℝ →L[ℝ] ℝ).smul_right v = v • (1 : ℝ →L[ℝ] ℝ),
+  have : (1 : 𝕜 →L[𝕜] 𝕜).smul_right v = v • (1 : 𝕜 →L[𝕜] 𝕜),
   { ext1 w,
     simp only [continuous_linear_map.smul_right_apply, continuous_linear_map.one_apply,
     algebra.id.smul_eq_mul, one_mul, continuous_linear_map.coe_smul', pi.smul_apply, mul_one] },
   rw [this, continuous_linear_map.det, continuous_linear_map.coe_smul],
-  change ((1 : ℝ →L[ℝ] ℝ) : ℝ →ₗ[ℝ] ℝ) with linear_map.id,
+  change ((1 : 𝕜 →L[𝕜] 𝕜) : 𝕜 →ₗ[𝕜] 𝕜) with linear_map.id,
   rw [linear_map.det_smul, finite_dimensional.finrank_self, linear_map.det_id, pow_one, mul_one],
 end
 
@@ -1264,7 +1266,7 @@ theorem integrable_on_image_iff_integrable_on_abs_deriv_smul
   {s : set ℝ} {f : ℝ → ℝ} {f' : ℝ → ℝ} (hs : measurable_set s)
   (hf' : ∀ x ∈ s, has_deriv_within_at f (f' x) s x) (hf : inj_on f s) (g : ℝ → F) :
   integrable_on g (f '' s) ↔ integrable_on (λ x, |(f' x)| • g (f x)) s :=
-by simpa only [det_smul_aux] using integrable_on_image_iff_integrable_on_abs_det_fderiv_smul
+by simpa only [det_one_smul_right] using integrable_on_image_iff_integrable_on_abs_det_fderiv_smul
   volume hs (λ x hx, (hf' x hx).has_fderiv_within_at) hf g
 
 /-- Change of variable formula for differentiable functions (one-variable version): if a function
@@ -1274,7 +1276,7 @@ theorem integral_image_eq_integral_abs_deriv_smul {s : set ℝ} {f : ℝ → ℝ
   [complete_space F] (hs : measurable_set s) (hf' : ∀ x ∈ s, has_deriv_within_at f (f' x) s x)
   (hf : inj_on f s) (g : ℝ → F) :
   ∫ x in f '' s, g x = ∫ x in s, |(f' x)| • g (f x) :=
-by simpa only [det_smul_aux] using integral_image_eq_integral_abs_det_fderiv_smul
+by simpa only [det_one_smul_right] using integral_image_eq_integral_abs_det_fderiv_smul
   volume hs (λ x hx, (hf' x hx).has_fderiv_within_at) hf g
 
 theorem integral_target_eq_integral_abs_det_fderiv_smul [complete_space F]

--- a/src/measure_theory/function/jacobian.lean
+++ b/src/measure_theory/function/jacobian.lean
@@ -1245,24 +1245,37 @@ begin
   refl
 end
 
+lemma det_smul_aux (v : ℝ) : ((1 : ℝ →L[ℝ] ℝ).smul_right v).det = v :=
+begin
+  have : (1 : ℝ →L[ℝ] ℝ).smul_right v = v • (1 : ℝ →L[ℝ] ℝ),
+  { ext1 w,
+    simp only [continuous_linear_map.smul_right_apply, continuous_linear_map.one_apply,
+    algebra.id.smul_eq_mul, one_mul, continuous_linear_map.coe_smul', pi.smul_apply, mul_one] },
+  rw [this, continuous_linear_map.det, continuous_linear_map.coe_smul],
+  change ((1 : ℝ →L[ℝ] ℝ) : ℝ →ₗ[ℝ] ℝ) with linear_map.id,
+  rw [linear_map.det_smul, finite_dimensional.finrank_self, linear_map.det_id, pow_one, mul_one],
+end
+
+/-- Integrability in the change of variable formula for differentiable functions (one-variable
+version): if a function `f` is injective and differentiable on a measurable set ``s ⊆ ℝ`, then a
+function `g : ℝ → F` is integrable on `f '' s` if and only if `|(f' x)| • g ∘ f` is integrable on
+`s`. -/
+theorem integrable_on_image_iff_integrable_on_abs_deriv_smul
+  {s : set ℝ} {f : ℝ → ℝ} {f' : ℝ → ℝ} (hs : measurable_set s)
+  (hf' : ∀ x ∈ s, has_deriv_within_at f (f' x) s x) (hf : inj_on f s) (g : ℝ → F) :
+  integrable_on g (f '' s) ↔ integrable_on (λ x, |(f' x)| • g (f x)) s :=
+by simpa only [det_smul_aux] using integrable_on_image_iff_integrable_on_abs_det_fderiv_smul
+  volume hs (λ x hx, (hf' x hx).has_fderiv_within_at) hf g
+
 /-- Change of variable formula for differentiable functions (one-variable version): if a function
 `f` is injective and differentiable on a measurable set `s ⊆ ℝ`, then the Bochner integral of a
-function `g : ℝ → F` on `f '' s` coincides with the integral of `|(f' x).det| • g ∘ f` on `s`. -/
+function `g : ℝ → F` on `f '' s` coincides with the integral of `|(f' x)| • g ∘ f` on `s`. -/
 theorem integral_image_eq_integral_abs_deriv_smul {s : set ℝ} {f : ℝ → ℝ} {f' : ℝ → ℝ}
   [complete_space F] (hs : measurable_set s) (hf' : ∀ x ∈ s, has_deriv_within_at f (f' x) s x)
   (hf : inj_on f s) (g : ℝ → F) :
   ∫ x in f '' s, g x = ∫ x in s, |(f' x)| • g (f x) :=
-begin
-  convert integral_image_eq_integral_abs_det_fderiv_smul volume hs
-    (λ x hx, (hf' x hx).has_fderiv_within_at) hf g,
-  ext1 x,
-  rw (by { ext, simp } : (1 : ℝ →L[ℝ] ℝ).smul_right (f' x) = (f' x) • (1 : ℝ →L[ℝ] ℝ)),
-  rw [continuous_linear_map.det, continuous_linear_map.coe_smul],
-  have : ((1 : ℝ →L[ℝ] ℝ) : ℝ →ₗ[ℝ] ℝ) = (1 : ℝ →ₗ[ℝ] ℝ) := by refl,
-  rw [this, linear_map.det_smul, finite_dimensional.finrank_self],
-  suffices : (1 : ℝ →ₗ[ℝ] ℝ).det = 1, { rw this, simp },
-  exact linear_map.det_id,
-end
+by simpa only [det_smul_aux] using integral_image_eq_integral_abs_det_fderiv_smul
+  volume hs (λ x hx, (hf' x hx).has_fderiv_within_at) hf g
 
 theorem integral_target_eq_integral_abs_det_fderiv_smul [complete_space F]
   {f : local_homeomorph E E} (hf' : ∀ x ∈ f.source, has_fderiv_at f (f' x) x) (g : E → F) :

--- a/src/measure_theory/integral/integral_eq_improper.lean
+++ b/src/measure_theory/integral/integral_eq_improper.lean
@@ -951,16 +951,11 @@ begin
 end
 
 /-- The substitution `y = x ^ p` in integrals over `Ioi 0` preserves integrability (version
-without absolute values) -/
+without `|p|` factor) -/
 lemma integrable_on_Ioi_comp_rpow_iff' (g : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
-  integrable_on (λ x, (p * x ^ (p - 1)) • g (x ^ p)) (Ioi 0) ↔ integrable_on g (Ioi 0) :=
-begin
-  rw ←integrable_on_Ioi_comp_rpow_iff g hp,
-  rcases lt_or_gt_of_ne hp with hp' | hp',
-  { simp_rw [(show |p| = -p, by rw abs_of_neg hp'), neg_mul, neg_smul],
-    apply integrable_neg_iff.symm },
-  { rw abs_of_nonneg (le_of_lt hp') },
-end
+  integrable_on (λ x, x ^ (p - 1) • g (x ^ p)) (Ioi 0) ↔ integrable_on g (Ioi 0) :=
+by simpa only [←integrable_on_Ioi_comp_rpow_iff g hp, mul_smul]
+  using (integrable_smul_iff (abs_pos.mpr hp).ne' _).symm
 
 end Ioi_integrability
 

--- a/src/measure_theory/integral/integral_eq_improper.lean
+++ b/src/measure_theory/integral/integral_eq_improper.lean
@@ -914,6 +914,15 @@ begin
   funext, congr, rw abs_of_nonneg hp.le,
 end
 
+end Ioi_change_variables
+
+section Ioi_integrability
+
+open real
+open_locale interval
+
+variables {E : Type*} {f : ℝ → E} [normed_add_comm_group E] [normed_space ℝ E]
+
 /-- The substitution `y = x ^ p` in integrals over `Ioi 0` preserves integrability. -/
 lemma integrable_on_Ioi_comp_rpow_iff (g : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
   integrable_on (λ x, (|p| * x ^ (p - 1)) • g (x ^ p)) (Ioi 0) ↔ integrable_on g (Ioi 0) :=
@@ -953,6 +962,6 @@ begin
   { rw abs_of_nonneg (le_of_lt hp') },
 end
 
-end Ioi_change_variables
+end Ioi_integrability
 
 end measure_theory

--- a/src/measure_theory/integral/integral_eq_improper.lean
+++ b/src/measure_theory/integral/integral_eq_improper.lean
@@ -7,6 +7,7 @@ import analysis.special_functions.pow.deriv
 import measure_theory.integral.fund_thm_calculus
 import order.filter.at_top_bot
 import measure_theory.function.jacobian
+import measure_theory.measure.haar.normed_space
 
 /-!
 # Links between an integral and its "improper" version
@@ -921,11 +922,11 @@ section Ioi_integrability
 open real
 open_locale interval
 
-variables {E : Type*} {f : ℝ → E} [normed_add_comm_group E] [normed_space ℝ E]
+variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
 
 /-- The substitution `y = x ^ p` in integrals over `Ioi 0` preserves integrability. -/
-lemma integrable_on_Ioi_comp_rpow_iff (g : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
-  integrable_on (λ x, (|p| * x ^ (p - 1)) • g (x ^ p)) (Ioi 0) ↔ integrable_on g (Ioi 0) :=
+lemma integrable_on_Ioi_comp_rpow_iff (f : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
+  integrable_on (λ x, (|p| * x ^ (p - 1)) • f (x ^ p)) (Ioi 0) ↔ integrable_on f (Ioi 0) :=
 begin
   let S := Ioi (0 : ℝ),
   have a1 : ∀ x:ℝ, x ∈ S → has_deriv_within_at (λ (t:ℝ), t ^ p) (p * x ^ (p - 1)) S x :=
@@ -943,7 +944,7 @@ begin
     { rintro ⟨y, hy, rfl⟩, exact rpow_pos_of_pos hy p },
     { intro hx, refine ⟨x ^ (1 / p), rpow_pos_of_pos hx _, _⟩,
       rw [←rpow_mul (le_of_lt hx), one_div_mul_cancel hp, rpow_one], } },
-  have := integrable_on_image_iff_integrable_on_abs_deriv_smul measurable_set_Ioi a1 a2 g,
+  have := integrable_on_image_iff_integrable_on_abs_deriv_smul measurable_set_Ioi a1 a2 f,
   rw a3 at this,
   rw this,
   refine integrable_on_congr_fun (λ x hx, _) measurable_set_Ioi,
@@ -952,10 +953,24 @@ end
 
 /-- The substitution `y = x ^ p` in integrals over `Ioi 0` preserves integrability (version
 without `|p|` factor) -/
-lemma integrable_on_Ioi_comp_rpow_iff' (g : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
-  integrable_on (λ x, x ^ (p - 1) • g (x ^ p)) (Ioi 0) ↔ integrable_on g (Ioi 0) :=
-by simpa only [←integrable_on_Ioi_comp_rpow_iff g hp, mul_smul]
+lemma integrable_on_Ioi_comp_rpow_iff' (f : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
+  integrable_on (λ x, x ^ (p - 1) • f (x ^ p)) (Ioi 0) ↔ integrable_on f (Ioi 0) :=
+by simpa only [←integrable_on_Ioi_comp_rpow_iff f hp, mul_smul]
   using (integrable_smul_iff (abs_pos.mpr hp).ne' _).symm
+
+lemma integrable_on_Ioi_comp_mul_left_iff (f : ℝ → E) (c : ℝ) {a : ℝ} (ha : 0 < a) :
+  integrable_on (λ x, f (a * x)) (Ioi c) ↔ integrable_on f (Ioi $ a * c) :=
+begin
+  rw [←integrable_indicator_iff (measurable_set_Ioi : measurable_set $ Ioi c)],
+  rw [←integrable_indicator_iff (measurable_set_Ioi : measurable_set $ Ioi $ a * c)],
+  convert integrable.comp_mul_left' ((Ioi (a * c)).indicator f) ha.ne' using 2,
+  ext1 x,
+  rw [←indicator_comp_right, preimage_const_mul_Ioi _ ha, mul_comm a c, mul_div_cancel _ ha.ne'],
+end
+
+lemma integrable_on_Ioi_comp_mul_right_iff (f : ℝ → E) (c : ℝ) {a : ℝ} (ha : 0 < a) :
+  integrable_on (λ x, f (x * a)) (Ioi c) ↔ integrable_on f (Ioi $ c * a) :=
+by simpa only [mul_comm, mul_zero] using integrable_on_Ioi_comp_mul_left_iff f c ha
 
 end Ioi_integrability
 

--- a/src/measure_theory/integral/integral_eq_improper.lean
+++ b/src/measure_theory/integral/integral_eq_improper.lean
@@ -915,6 +915,20 @@ begin
   funext, congr, rw abs_of_nonneg hp.le,
 end
 
+lemma integral_comp_mul_left_Ioi (g : ℝ → E) (a : ℝ) {b : ℝ} (hb : 0 < b) :
+  ∫ x in Ioi a, g (b * x) = |b⁻¹| • ∫ x in Ioi (b * a), g x :=
+begin
+  have : ∀ c : ℝ, measurable_set (Ioi c) := λ c, measurable_set_Ioi,
+  rw [←integral_indicator (this a), ←integral_indicator (this $ b * a)],
+  convert measure.integral_comp_mul_left _ b,
+  ext1 x,
+  rw [←indicator_comp_right, preimage_const_mul_Ioi _ hb, mul_div_cancel_left _ hb.ne'],
+end
+
+lemma integral_comp_mul_right_Ioi (g : ℝ → E) (a : ℝ) {b : ℝ} (hb : 0 < b) :
+  ∫ x in Ioi a, g (x * b) = |b⁻¹| • ∫ x in Ioi (a * b), g x :=
+by simpa only [mul_comm] using integral_comp_mul_left_Ioi g a hb
+
 end Ioi_change_variables
 
 section Ioi_integrability

--- a/src/measure_theory/integral/integral_eq_improper.lean
+++ b/src/measure_theory/integral/integral_eq_improper.lean
@@ -914,6 +914,45 @@ begin
   funext, congr, rw abs_of_nonneg hp.le,
 end
 
+/-- The substitution `y = x ^ p` in integrals over `Ioi 0` preserves integrability. -/
+lemma integrable_on_Ioi_comp_rpow_iff (g : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
+  integrable_on (λ x, (|p| * x ^ (p - 1)) • g (x ^ p)) (Ioi 0) ↔ integrable_on g (Ioi 0) :=
+begin
+  let S := Ioi (0 : ℝ),
+  have a1 : ∀ x:ℝ, x ∈ S → has_deriv_within_at (λ (t:ℝ), t ^ p) (p * x ^ (p - 1)) S x :=
+    λ x hx, (has_deriv_at_rpow_const (or.inl (mem_Ioi.mp hx).ne')).has_deriv_within_at,
+  have a2 : inj_on (λ x:ℝ, x ^ p) S,
+  { rcases lt_or_gt_of_ne hp,
+    { apply strict_anti_on.inj_on,
+      intros x hx y hy hxy,
+      rw [←inv_lt_inv (rpow_pos_of_pos hx p) (rpow_pos_of_pos hy p),
+      ←rpow_neg (le_of_lt hx), ←rpow_neg (le_of_lt hy)],
+      exact rpow_lt_rpow (le_of_lt hx) hxy (neg_pos.mpr h), },
+    exact strict_mono_on.inj_on (λ x hx y hy hxy, rpow_lt_rpow (mem_Ioi.mp hx).le hxy h) },
+  have a3 : (λ (t : ℝ), t ^ p) '' S = S,
+  { ext1, rw mem_image, split,
+    { rintro ⟨y, hy, rfl⟩, exact rpow_pos_of_pos hy p },
+    { intro hx, refine ⟨x ^ (1 / p), rpow_pos_of_pos hx _, _⟩,
+      rw [←rpow_mul (le_of_lt hx), one_div_mul_cancel hp, rpow_one], } },
+  have := integrable_on_image_iff_integrable_on_abs_deriv_smul measurable_set_Ioi a1 a2 g,
+  rw a3 at this,
+  rw this,
+  refine integrable_on_congr_fun (λ x hx, _) measurable_set_Ioi,
+  simp_rw [abs_mul, abs_of_nonneg (rpow_nonneg_of_nonneg (le_of_lt hx) _)],
+end
+
+/-- The substitution `y = x ^ p` in integrals over `Ioi 0` preserves integrability (version
+without absolute values) -/
+lemma integrable_on_Ioi_comp_rpow_iff' (g : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
+  integrable_on (λ x, (p * x ^ (p - 1)) • g (x ^ p)) (Ioi 0) ↔ integrable_on g (Ioi 0) :=
+begin
+  rw ←integrable_on_Ioi_comp_rpow_iff g hp,
+  rcases lt_or_gt_of_ne hp with hp' | hp',
+  { simp_rw [(show |p| = -p, by rw abs_of_neg hp'), neg_mul, neg_smul],
+    apply integrable_neg_iff.symm },
+  { rw abs_of_nonneg (le_of_lt hp') },
+end
+
 end Ioi_change_variables
 
 end measure_theory

--- a/src/measure_theory/integral/integral_eq_improper.lean
+++ b/src/measure_theory/integral/integral_eq_improper.lean
@@ -922,10 +922,10 @@ section Ioi_integrability
 open real
 open_locale interval
 
-variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+variables {E : Type*} [normed_add_comm_group E]
 
 /-- The substitution `y = x ^ p` in integrals over `Ioi 0` preserves integrability. -/
-lemma integrable_on_Ioi_comp_rpow_iff (f : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
+lemma integrable_on_Ioi_comp_rpow_iff [normed_space ℝ E] (f : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
   integrable_on (λ x, (|p| * x ^ (p - 1)) • f (x ^ p)) (Ioi 0) ↔ integrable_on f (Ioi 0) :=
 begin
   let S := Ioi (0 : ℝ),
@@ -953,7 +953,7 @@ end
 
 /-- The substitution `y = x ^ p` in integrals over `Ioi 0` preserves integrability (version
 without `|p|` factor) -/
-lemma integrable_on_Ioi_comp_rpow_iff' (f : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
+lemma integrable_on_Ioi_comp_rpow_iff' [normed_space ℝ E] (f : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
   integrable_on (λ x, x ^ (p - 1) • f (x ^ p)) (Ioi 0) ↔ integrable_on f (Ioi 0) :=
 by simpa only [←integrable_on_Ioi_comp_rpow_iff f hp, mul_smul]
   using (integrable_smul_iff (abs_pos.mpr hp).ne' _).symm

--- a/src/measure_theory/integral/integral_eq_improper.lean
+++ b/src/measure_theory/integral/integral_eq_improper.lean
@@ -963,7 +963,7 @@ lemma integrable_on_Ioi_comp_mul_left_iff (f : ℝ → E) (c : ℝ) {a : ℝ} (h
 begin
   rw [←integrable_indicator_iff (measurable_set_Ioi : measurable_set $ Ioi c)],
   rw [←integrable_indicator_iff (measurable_set_Ioi : measurable_set $ Ioi $ a * c)],
-  convert integrable.comp_mul_left' ((Ioi (a * c)).indicator f) ha.ne' using 2,
+  convert integrable_comp_mul_left_iff ((Ioi (a * c)).indicator f) ha.ne' using 2,
   ext1 x,
   rw [←indicator_comp_right, preimage_const_mul_Ioi _ ha, mul_comm a c, mul_div_cancel _ ha.ne'],
 end

--- a/src/measure_theory/measure/haar/normed_space.lean
+++ b/src/measure_theory/measure/haar/normed_space.lean
@@ -133,16 +133,16 @@ begin
   simpa only [ne.def, ennreal.of_real_eq_zero, not_le, abs_pos] using inv_ne_zero (pow_ne_zero _ hR)
 end
 
-lemma integrable.comp_mul_left {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
+lemma integrable.comp_mul_left' {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
   integrable (λ x, g (R * x)) volume :=
 by simpa only [smul_eq_mul] using hg.comp_smul volume hR
 
-lemma integrable.comp_mul_right {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
+lemma integrable.comp_mul_right' {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
   integrable (λ x, g (x * R)) volume :=
 by simpa only [mul_comm, smul_eq_mul] using hg.comp_smul volume hR
 
 lemma integrable.comp_div {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
   integrable (λ x, g (x / R)) volume :=
-hg.comp_mul_right (inv_ne_zero hR)
+hg.comp_mul_right' (inv_ne_zero hR)
 
 end measure_theory

--- a/src/measure_theory/measure/haar/normed_space.lean
+++ b/src/measure_theory/measure/haar/normed_space.lean
@@ -98,5 +98,51 @@ lemma integral_comp_inv_smul_of_nonneg (f : E → F) {R : ℝ} (hR : 0 ≤ R) :
   ∫ x, f (R⁻¹ • x) ∂μ = R ^ finrank ℝ E • ∫ x, f x ∂μ :=
 by rw [integral_comp_inv_smul μ f R, abs_of_nonneg ((pow_nonneg hR _))]
 
+lemma integral_comp_mul_left (g : ℝ → F) (a : ℝ) :
+  ∫ x : ℝ, g (a * x) = |a⁻¹| • ∫ y : ℝ, g y :=
+by simp_rw [←smul_eq_mul, measure.integral_comp_smul, finite_dimensional.finrank_self, pow_one]
+
+lemma integral_comp_inv_mul_left (g : ℝ → F) (a : ℝ) :
+  ∫ x : ℝ, g (a⁻¹ * x) = |a| • ∫ y : ℝ, g y :=
+by simp_rw [←smul_eq_mul, measure.integral_comp_inv_smul, finite_dimensional.finrank_self, pow_one]
+
+lemma integral_comp_mul_right (g : ℝ → F) (a : ℝ) :
+  ∫ x : ℝ, g (x * a) = |a⁻¹| • ∫ y : ℝ, g y :=
+by simpa only [mul_comm] using integral_comp_mul_left g a
+
+lemma integral_comp_inv_mul_right (g : ℝ → F) (a : ℝ) :
+  ∫ x : ℝ, g (x * a⁻¹) = |a| • ∫ y : ℝ, g y :=
+by simpa only [mul_comm] using integral_comp_inv_mul_left g a
+
+lemma integral_comp_div (g : ℝ → F) (a : ℝ) :
+  ∫ x : ℝ, g (x / a) = |a| • ∫ y : ℝ, g y :=
+integral_comp_inv_mul_right g a
+
 end measure
+
+variables {F : Type*} [normed_add_comm_group F]
+
+lemma integrable.comp_smul {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+  [measurable_space E] [borel_space E] [finite_dimensional ℝ E]
+  (μ : measure E) [is_add_haar_measure μ] {f : E → F} (hf : integrable f μ) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, f (R • x)) μ :=
+begin
+  let t := ((homeomorph.smul (is_unit_iff_ne_zero.2 hR).unit).to_measurable_equiv : E ≃ᵐ E),
+  refine (integrable_map_equiv t f).mp (_ : integrable f (map (has_smul.smul R) μ)),
+  rwa [map_add_haar_smul μ hR, integrable_smul_measure _ ennreal.of_real_ne_top],
+  simpa only [ne.def, ennreal.of_real_eq_zero, not_le, abs_pos] using inv_ne_zero (pow_ne_zero _ hR)
+end
+
+lemma integrable.comp_mul_left {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, g (R * x)) volume :=
+by simpa only [smul_eq_mul] using hg.comp_smul volume hR
+
+lemma integrable.comp_mul_right {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, g (x * R)) volume :=
+by simpa only [mul_comm, smul_eq_mul] using hg.comp_smul volume hR
+
+lemma integrable.comp_div {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, g (x / R)) volume :=
+hg.comp_mul_right (inv_ne_zero hR)
+
 end measure_theory

--- a/src/measure_theory/measure/haar/normed_space.lean
+++ b/src/measure_theory/measure/haar/normed_space.lean
@@ -124,25 +124,35 @@ variables {F : Type*} [normed_add_comm_group F]
 
 lemma integrable.comp_smul {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
   [measurable_space E] [borel_space E] [finite_dimensional ℝ E]
-  (μ : measure E) [is_add_haar_measure μ] {f : E → F} (hf : integrable f μ) {R : ℝ} (hR : R ≠ 0) :
-  integrable (λ x, f (R • x)) μ :=
+  (μ : measure E) [is_add_haar_measure μ] (f : E → F) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, f (R • x)) μ ↔ integrable f μ :=
 begin
-  let t := ((homeomorph.smul (is_unit_iff_ne_zero.2 hR).unit).to_measurable_equiv : E ≃ᵐ E),
-  refine (integrable_map_equiv t f).mp (_ : integrable f (map (has_smul.smul R) μ)),
-  rwa [map_add_haar_smul μ hR, integrable_smul_measure _ ennreal.of_real_ne_top],
-  simpa only [ne.def, ennreal.of_real_eq_zero, not_le, abs_pos] using inv_ne_zero (pow_ne_zero _ hR)
+  -- reduce to one-way implication
+  suffices : ∀ {g : E → F} (hg : integrable g μ) {S : ℝ} (hS : S ≠ 0),
+    integrable (λ x, g (S • x)) μ,
+  { refine ⟨λ hf, _, λ hf, this hf hR⟩,
+    convert this hf (inv_ne_zero hR),
+    ext1 x,
+    rw [←mul_smul, mul_inv_cancel hR, one_smul], },
+  -- now prove
+  intros g hg S hS,
+  let t := ((homeomorph.smul (is_unit_iff_ne_zero.2 hS).unit).to_measurable_equiv : E ≃ᵐ E),
+  refine (integrable_map_equiv t g).mp (_ : integrable g (map (has_smul.smul S) μ)),
+  rwa [map_add_haar_smul μ hS, integrable_smul_measure _ ennreal.of_real_ne_top],
+  simpa only [ne.def, ennreal.of_real_eq_zero, not_le, abs_pos]
+    using inv_ne_zero (pow_ne_zero _ hS),
 end
 
-lemma integrable.comp_mul_left' {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
-  integrable (λ x, g (R * x)) volume :=
-by simpa only [smul_eq_mul] using hg.comp_smul volume hR
+lemma integrable.comp_mul_left' (g : ℝ → F) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, g (R * x)) ↔ integrable g :=
+by simpa only [smul_eq_mul] using integrable.comp_smul volume g hR
 
-lemma integrable.comp_mul_right' {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
-  integrable (λ x, g (x * R)) volume :=
-by simpa only [mul_comm, smul_eq_mul] using hg.comp_smul volume hR
+lemma integrable.comp_mul_right' (g : ℝ → F) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, g (x * R)) ↔ integrable g :=
+by simpa only [mul_comm, smul_eq_mul] using integrable.comp_smul volume g hR
 
-lemma integrable.comp_div {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
-  integrable (λ x, g (x / R)) volume :=
-hg.comp_mul_right' (inv_ne_zero hR)
+lemma integrable.comp_div (g : ℝ → F) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, g (x / R)) ↔ integrable g :=
+integrable.comp_mul_right' g (inv_ne_zero hR)
 
 end measure_theory

--- a/src/measure_theory/measure/haar/normed_space.lean
+++ b/src/measure_theory/measure/haar/normed_space.lean
@@ -122,7 +122,7 @@ end measure
 
 variables {F : Type*} [normed_add_comm_group F]
 
-lemma integrable.comp_smul {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+lemma integrable_comp_smul_iff {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
   [measurable_space E] [borel_space E] [finite_dimensional ℝ E]
   (μ : measure E) [is_add_haar_measure μ] (f : E → F) {R : ℝ} (hR : R ≠ 0) :
   integrable (λ x, f (R • x)) μ ↔ integrable f μ :=
@@ -143,16 +143,35 @@ begin
     using inv_ne_zero (pow_ne_zero _ hS),
 end
 
-lemma integrable.comp_mul_left' (g : ℝ → F) {R : ℝ} (hR : R ≠ 0) :
+lemma integrable.comp_smul {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+  [measurable_space E] [borel_space E] [finite_dimensional ℝ E]
+  {μ : measure E} [is_add_haar_measure μ] {f : E → F} (hf : integrable f μ) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, f (R • x)) μ :=
+(integrable_comp_smul_iff μ f hR).2 hf
+
+lemma integrable_comp_mul_left_iff (g : ℝ → F) {R : ℝ} (hR : R ≠ 0) :
   integrable (λ x, g (R * x)) ↔ integrable g :=
-by simpa only [smul_eq_mul] using integrable.comp_smul volume g hR
+by simpa only [smul_eq_mul] using integrable_comp_smul_iff volume g hR
 
-lemma integrable.comp_mul_right' (g : ℝ → F) {R : ℝ} (hR : R ≠ 0) :
+lemma integrable.comp_mul_left' {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, g (R * x)) :=
+(integrable_comp_mul_left_iff g hR).2 hg
+
+lemma integrable_comp_mul_right_iff (g : ℝ → F) {R : ℝ} (hR : R ≠ 0) :
   integrable (λ x, g (x * R)) ↔ integrable g :=
-by simpa only [mul_comm, smul_eq_mul] using integrable.comp_smul volume g hR
+by simpa only [mul_comm] using integrable_comp_mul_left_iff g hR
 
-lemma integrable.comp_div (g : ℝ → F) {R : ℝ} (hR : R ≠ 0) :
+lemma integrable.comp_mul_right' {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, g (x * R)) :=
+(integrable_comp_mul_right_iff g hR).2 hg
+
+lemma integrable_comp_div_iff (g : ℝ → F) {R : ℝ} (hR : R ≠ 0) :
   integrable (λ x, g (x / R)) ↔ integrable g :=
-integrable.comp_mul_right' g (inv_ne_zero hR)
+integrable_comp_mul_right_iff g (inv_ne_zero hR)
+
+lemma integrable.comp_div {g : ℝ → F} (hg : integrable g) {R : ℝ} (hR : R ≠ 0) :
+  integrable (λ x, g (x / R)) :=
+(integrable_comp_div_iff g hR).2 hg
+
 
 end measure_theory


### PR DESCRIPTION
This adds a few lemmas for evaluating integrals, and showing that integrability is preserved, by substitutions of the form `x ↦ a * x` or `x ↦ x ^ a`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
