### PR TITLE
[Merged by Bors] - feat(number_theory/class_number/finite): remove useless assumption [dedekind_domain R]

### DIFF
--- a/src/number_theory/class_number/finite.lean
+++ b/src/number_theory/class_number/finite.lean
@@ -378,8 +378,7 @@ absolute value.
 See also `class_group.fintype_of_admissible_of_algebraic` where `L` is an
 algebraic extension of `R`, that includes some extra assumptions.
 -/
-noncomputable def fintype_of_admissible_of_finite [is_dedekind_domain R] :
-  fintype (class_group S) :=
+noncomputable def fintype_of_admissible_of_finite : fintype (class_group S) :=
 begin
   letI := classical.dec_eq L,
   letI := is_integral_closure.is_fraction_ring_of_finite_extension R K L S,


### PR DESCRIPTION
Remove the useless assumption `[dedekind_domain R]` from the final lemma [class_group.fintype_of_admissible_of_finite](https://leanprover-community.github.io/mathlib_docs/number_theory/class_number/finite.html#class_group.fintype_of_admissible_of_finite) since this can be inferred by the Euclidean domain one, that is in force thanks the standing assumption is that `R` has an admissible absolute value.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
