### PR TITLE
[Merged by Bors] - feat (analysis/mellin_transform): API for mellin transforms

### DIFF
--- a/src/analysis/mellin_transform.lean
+++ b/src/analysis/mellin_transform.lean
@@ -169,12 +169,14 @@ by simp_rw [←rpow_neg_one, mellin_comp_rpow _ _ (neg_ne_zero.mpr one_ne_zero),
 shortens some arguments. -/
 def has_mellin (f : ℝ → E) (s : ℂ) (m : E) : Prop := mellin_convergent f s ∧ mellin f s = m
 
-lemma has_mellin_add {f g : ℝ → E} {s : ℂ} (hf : mellin_convergent f s) (hg : mellin_convergent g s) :
+lemma has_mellin_add {f g : ℝ → E} {s : ℂ}
+  (hf : mellin_convergent f s) (hg : mellin_convergent g s) :
   has_mellin (λ t, f t + g t) s (mellin f s + mellin g s) :=
 ⟨by simpa only [mellin_convergent, smul_add] using hf.add hg,
   by simpa only [mellin, smul_add] using integral_add hf hg⟩
 
-lemma has_mellin_sub {f g : ℝ → E} {s : ℂ} (hf : mellin_convergent f s) (hg : mellin_convergent g s) :
+lemma has_mellin_sub {f g : ℝ → E} {s : ℂ}
+  (hf : mellin_convergent f s) (hg : mellin_convergent g s) :
   has_mellin (λ t, f t - g t) s (mellin f s - mellin g s) :=
 ⟨by simpa only [mellin_convergent, smul_sub] using hf.sub hg,
   by simpa only [mellin, smul_sub] using integral_sub hf hg⟩

--- a/src/analysis/mellin_transform.lean
+++ b/src/analysis/mellin_transform.lean
@@ -169,12 +169,12 @@ by simp_rw [←rpow_neg_one, mellin_comp_rpow _ _ (neg_ne_zero.mpr one_ne_zero),
 shortens some arguments. -/
 def has_mellin (f : ℝ → E) (s : ℂ) (m : E) : Prop := mellin_convergent f s ∧ mellin f s = m
 
-lemma mellin_add {f g : ℝ → E} {s : ℂ} (hf : mellin_convergent f s) (hg : mellin_convergent g s) :
+lemma has_mellin_add {f g : ℝ → E} {s : ℂ} (hf : mellin_convergent f s) (hg : mellin_convergent g s) :
   has_mellin (λ t, f t + g t) s (mellin f s + mellin g s) :=
 ⟨by simpa only [mellin_convergent, smul_add] using hf.add hg,
   by simpa only [mellin, smul_add] using integral_add hf hg⟩
 
-lemma mellin_sub {f g : ℝ → E} {s : ℂ} (hf : mellin_convergent f s) (hg : mellin_convergent g s) :
+lemma has_mellin_sub {f g : ℝ → E} {s : ℂ} (hf : mellin_convergent f s) (hg : mellin_convergent g s) :
   has_mellin (λ t, f t - g t) s (mellin f s - mellin g s) :=
 ⟨by simpa only [mellin_convergent, smul_sub] using hf.sub hg,
   by simpa only [mellin, smul_sub] using integral_sub hf hg⟩
@@ -465,7 +465,7 @@ section mellin_Ioc
 -/
 
 /-- The Mellin transform of the indicator function of `Ioc 0 1`. -/
-lemma mellin_one_Ioc {s : ℂ} (hs : 0 < re s) :
+lemma has_mellin_one_Ioc {s : ℂ} (hs : 0 < re s) :
   has_mellin (indicator (Ioc 0 1) (λ t, 1 : ℝ → ℂ)) s (1 / s) :=
 begin
   have aux1 : -1 < (s - 1).re, by simpa only [sub_re, one_re, sub_eq_add_neg]
@@ -482,10 +482,10 @@ begin
 end
 
 /-- The Mellin transform of a power function restricted to `Ioc 0 1`. -/
-lemma mellin_cpow_Ioc (a : ℂ) {s : ℂ} (hs : 0 < re s + re a) :
+lemma has_mellin_cpow_Ioc (a : ℂ) {s : ℂ} (hs : 0 < re s + re a) :
   has_mellin (indicator (Ioc 0 1) (λ t, ↑t ^ a : ℝ → ℂ)) s (1 / (s + a)) :=
 begin
-  have := mellin_one_Ioc (by rwa add_re : 0 < (s + a).re),
+  have := has_mellin_one_Ioc (by rwa add_re : 0 < (s + a).re),
   simp_rw [has_mellin, ←mellin_convergent.cpow_smul, ←mellin_cpow_smul, ←indicator_smul,
     smul_eq_mul, mul_one] at this,
   exact this

--- a/src/analysis/mellin_transform.lean
+++ b/src/analysis/mellin_transform.lean
@@ -6,6 +6,7 @@ Authors: David Loeffler
 
 import analysis.special_functions.improper_integrals
 import analysis.calculus.parametric_integral
+import measure_theory.measure.haar.normed_space
 
 /-! # The Mellin transform
 
@@ -16,6 +17,8 @@ differentiable in a suitable vertical strip.
 
 - `mellin` : the Mellin transform `∫ (t : ℝ) in Ioi 0, t ^ (s - 1) • f t`,
   where `s` is a complex number.
+- `has_mellin`: shorthand asserting that the Mellin transform exists and has a given value
+  (analogous to `has_sum`).
 - `mellin_differentiable_at_of_is_O_rpow` : if `f` is `O(x ^ (-a))` at infinity, and
   `O(x ^ (-b))` at 0, then `mellin f` is holomorphic on the domain `b < re s < a`.
 
@@ -23,22 +26,160 @@ differentiable in a suitable vertical strip.
 
 open measure_theory set filter asymptotics topological_space
 
+namespace complex
+
+/- Porting note: move this to `analysis.special_functions.pow.complex` -/
+lemma cpow_mul_of_real_nonneg {x : ℝ} (hx : 0 ≤ x) (y : ℝ) (z : ℂ) :
+  (x : ℂ) ^ (↑y * z) = (↑(x ^ y) : ℂ) ^ z :=
+begin
+  rw [cpow_mul, of_real_cpow hx],
+  { rw [←of_real_log hx, ←of_real_mul, of_real_im, neg_lt_zero], exact real.pi_pos },
+  { rw [←of_real_log hx, ←of_real_mul, of_real_im], exact real.pi_pos.le },
+end
+
+end complex
+
+open real complex (hiding exp log abs_of_nonneg)
+
 open_locale topology
 
 noncomputable theory
 
 section defs
 
-variables {E : Type*} [normed_add_comm_group E]
+variables {E : Type*}  [normed_add_comm_group E] [normed_space ℂ E]
+
+/-- Predicate on `f` and `s` asserting that the Mellin integral is well-defined. -/
+def mellin_convergent (f : ℝ → E) (s : ℂ) : Prop :=
+integrable_on (λ t : ℝ, (t : ℂ) ^ (s - 1) • f t) (Ioi 0)
+
+lemma mellin_convergent.const_smul {f : ℝ → E} {s : ℂ} (hf : mellin_convergent f s)
+  {𝕜 : Type*} [nontrivially_normed_field 𝕜] [normed_space 𝕜 E] [smul_comm_class ℂ 𝕜 E] (c : 𝕜) :
+  mellin_convergent (λ t, c • f t) s :=
+by simpa only [mellin_convergent, smul_comm] using hf.smul c
+
+lemma mellin_convergent.cpow_smul {f : ℝ → E} {s a : ℂ} :
+  mellin_convergent (λ t, (t : ℂ) ^ a • f t) s ↔ mellin_convergent f (s + a) :=
+begin
+  refine integrable_on_congr_fun (λ t ht, _) measurable_set_Ioi,
+  simp_rw [←sub_add_eq_add_sub, cpow_add _ _ (of_real_ne_zero.2 $ ne_of_gt ht), mul_smul],
+end
+
+lemma mellin_convergent.div_const {f : ℝ → ℂ} {s : ℂ} (hf : mellin_convergent f s) (a : ℂ) :
+  mellin_convergent (λ t, f t / a) s :=
+by simpa only [mellin_convergent, smul_eq_mul, ←mul_div_assoc] using hf.div_const a
+
+lemma mellin_convergent.comp_mul_left {f : ℝ → E} {s : ℂ} {a : ℝ} (ha : 0 < a) :
+  mellin_convergent (λ t, f (a * t)) s ↔ mellin_convergent f s :=
+begin
+  have := integrable_on_Ioi_comp_mul_left_iff (λ t : ℝ, (t : ℂ) ^ (s - 1) • f t) 0 ha,
+  rw mul_zero at this,
+  have h1 : eq_on (λ t : ℝ, (↑(a * t) : ℂ) ^ (s - 1) • f (a * t))
+    ((a : ℂ) ^ (s - 1) • (λ t : ℝ, (t : ℂ) ^ (s - 1) • f (a * t))) (Ioi 0),
+  { intros t ht,
+    simp only [of_real_mul, mul_cpow_of_real_nonneg ha.le (le_of_lt ht), mul_smul, pi.smul_apply] },
+  have h2 : (a : ℂ) ^ (s - 1) ≠ 0,
+  { rw [ne.def, cpow_eq_zero_iff, not_and_distrib, of_real_eq_zero], exact or.inl ha.ne' },
+  simp_rw [mellin_convergent, ←this, integrable_on_congr_fun h1 measurable_set_Ioi, integrable_on,
+    integrable_smul_iff h2],
+end
+
+lemma mellin_convergent.comp_rpow {f : ℝ → E} {s : ℂ} {a : ℝ} (ha : a ≠ 0) :
+  mellin_convergent (λ t, f (t ^ a)) s ↔ mellin_convergent f (s / a) :=
+begin
+  simp_rw mellin_convergent,
+  letI u : normed_space ℝ E := normed_space.complex_to_real, -- why isn't this automatic?
+  conv_rhs { rw ←@integrable_on_Ioi_comp_rpow_iff' _ _ u _ a ha },
+  refine integrable_on_congr_fun (λ t ht, _) measurable_set_Ioi,
+  dsimp only [pi.smul_apply],
+  rw [←complex.coe_smul (t ^ (a - 1)), ←mul_smul, ←cpow_mul_of_real_nonneg (le_of_lt ht),
+    of_real_cpow (le_of_lt ht), ←cpow_add _ _ (of_real_ne_zero.mpr (ne_of_gt ht)), of_real_sub,
+    of_real_one, mul_sub, mul_div_cancel' _ (of_real_ne_zero.mpr ha), mul_one, add_comm,
+    ←add_sub_assoc, sub_add_cancel],
+end
+
+variables [complete_space E]
 
 /-- The Mellin transform of a function `f` (for a complex exponent `s`), defined as the integral of
 `t ^ (s - 1) • f` over `Ioi 0`. -/
-def mellin [normed_space ℂ E] [complete_space E] (f : ℝ → E) (s : ℂ) : E :=
+def mellin (f : ℝ → E) (s : ℂ) : E :=
 ∫ t : ℝ in Ioi 0, (t : ℂ) ^ (s - 1) • f t
 
-end defs
+-- next few lemmas don't require convergence of the Mellin transform (they are just 0 = 0 otherwise)
 
-open real complex (hiding exp log abs_of_nonneg)
+lemma mellin_cpow_smul (f : ℝ → E) (s a : ℂ) :
+  mellin (λ t, (t : ℂ) ^ a • f t) s = mellin f (s + a) :=
+begin
+  refine set_integral_congr measurable_set_Ioi (λ t ht, _),
+  simp_rw [←sub_add_eq_add_sub, cpow_add _ _ (of_real_ne_zero.2 $ ne_of_gt ht), mul_smul],
+end
+
+lemma mellin_const_smul (f : ℝ → E) (s : ℂ)
+  {𝕜 : Type*} [nontrivially_normed_field 𝕜] [normed_space 𝕜 E] [smul_comm_class ℂ 𝕜 E] (c : 𝕜) :
+  mellin (λ t, c • f t) s = c • mellin f s :=
+by simp only [mellin, smul_comm, integral_smul]
+
+lemma mellin_div_const (f : ℝ → ℂ) (s a : ℂ) :
+  mellin (λ t, f t / a) s = mellin f s / a :=
+by simp_rw [mellin, smul_eq_mul, ←mul_div_assoc, integral_div]
+
+lemma mellin_comp_rpow (f : ℝ → E) (s : ℂ) {a : ℝ} (ha : a ≠ 0) :
+  mellin (λ t, f (t ^ a)) s = |a|⁻¹ • mellin f (s / a) :=
+begin
+  -- note: this is also true for a = 0 (both sides are zero), but this is mathematically
+  -- uninteresting and rather time-consuming to check
+  simp_rw mellin,
+  conv_rhs { rw [←integral_comp_rpow_Ioi _ ha, ←integral_smul] },
+  refine set_integral_congr measurable_set_Ioi (λ t ht, _),
+  dsimp only,
+  rw [←mul_smul, ←mul_assoc, inv_mul_cancel, one_mul, ←smul_assoc, real_smul],
+  show |a| ≠ 0, { contrapose! ha, exact abs_eq_zero.mp ha },
+  rw [of_real_cpow (le_of_lt ht), ←cpow_mul_of_real_nonneg (le_of_lt ht),
+    ←cpow_add _ _ (of_real_ne_zero.mpr $ ne_of_gt ht), of_real_sub, of_real_one, mul_sub,
+    mul_div_cancel' _ (of_real_ne_zero.mpr ha), add_comm, ←add_sub_assoc, mul_one, sub_add_cancel]
+end
+
+lemma mellin_comp_mul_left (f : ℝ → E) (s : ℂ) {a : ℝ} (ha : 0 < a) :
+  mellin (λ t, f (a * t)) s = (a : ℂ) ^ (-s) • mellin f s :=
+begin
+  simp_rw mellin,
+  have : eq_on (λ t : ℝ, (t : ℂ) ^ (s - 1) • f (a * t))
+    (λ t : ℝ, (a : ℂ) ^ (1 - s) • (λ u : ℝ, (u : ℂ) ^ (s - 1) • f u) (a * t)) (Ioi 0),
+  { intros t ht,
+    dsimp only,
+    rw [of_real_mul, mul_cpow_of_real_nonneg ha.le (le_of_lt ht), ←mul_smul,
+      (by ring : 1 - s = -(s - 1)), cpow_neg, inv_mul_cancel_left₀],
+    rw [ne.def, cpow_eq_zero_iff, of_real_eq_zero, not_and_distrib],
+    exact or.inl ha.ne' },
+  rw [set_integral_congr measurable_set_Ioi this, integral_smul,
+    integral_comp_mul_left_Ioi _ _ ha, mul_zero, ←complex.coe_smul, ←mul_smul, sub_eq_add_neg,
+    cpow_add _ _ (of_real_ne_zero.mpr ha.ne'), cpow_one, abs_of_pos (inv_pos.mpr ha), of_real_inv,
+    mul_assoc, mul_comm, inv_mul_cancel_right₀ (of_real_ne_zero.mpr ha.ne')]
+end
+
+lemma mellin_comp_mul_right (f : ℝ → E) (s : ℂ) {a : ℝ} (ha : 0 < a) :
+  mellin (λ t, f (t * a)) s = (a : ℂ) ^ (-s) • mellin f s :=
+by simpa only [mul_comm] using mellin_comp_mul_left f s ha
+
+lemma mellin_comp_inv (f : ℝ → E) (s : ℂ) : mellin (λ t, f (t⁻¹)) s = mellin f (-s) :=
+by simp_rw [←rpow_neg_one, mellin_comp_rpow _ _ (neg_ne_zero.mpr one_ne_zero), abs_neg, abs_one,
+  inv_one, one_smul, of_real_neg, of_real_one, div_neg, div_one]
+
+/-- Predicate standing for "the Mellin transform of `f` is defined at `s` and equal to `m`". This
+shortens some arguments. -/
+def has_mellin (f : ℝ → E) (s : ℂ) (m : E) : Prop := mellin_convergent f s ∧ mellin f s = m
+
+lemma mellin_add {f g : ℝ → E} {s : ℂ} (hf : mellin_convergent f s) (hg : mellin_convergent g s) :
+  has_mellin (λ t, f t + g t) s (mellin f s + mellin g s) :=
+⟨by simpa only [mellin_convergent, smul_add] using hf.add hg,
+  by simpa only [mellin, smul_add] using integral_add hf hg⟩
+
+lemma mellin_sub {f g : ℝ → E} {s : ℂ} (hf : mellin_convergent f s) (hg : mellin_convergent g s) :
+  has_mellin (λ t, f t - g t) s (mellin f s - mellin g s) :=
+⟨by simpa only [mellin_convergent, smul_sub] using hf.sub hg,
+  by simpa only [mellin, smul_sub] using integral_sub hf hg⟩
+
+end defs
 
 variables {E : Type*} [normed_add_comm_group E]
 
@@ -92,7 +233,7 @@ end
 `b < s`, its Mellin transform converges on some right neighbourhood of `0`. -/
 lemma mellin_convergent_zero_of_is_O
   {b : ℝ} {f : ℝ → ℝ} (hfc : ae_strongly_measurable f $ volume.restrict (Ioi 0))
-  (hf : is_O (𝓝[Ioi 0] 0) f (λ t, t ^ (-b))) {s : ℝ} (hs : b < s) :
+  (hf : is_O (𝓝[>] 0) f (λ t, t ^ (-b))) {s : ℝ} (hs : b < s) :
   ∃ (c : ℝ), 0 < c ∧ integrable_on (λ t : ℝ, t ^ (s - 1) * f t) (Ioc 0 c) :=
 begin
   obtain ⟨d, hd, hd'⟩ := hf.exists_pos,
@@ -127,7 +268,7 @@ lemma mellin_convergent_of_is_O_scalar
   {a b : ℝ} {f : ℝ → ℝ} {s : ℝ}
   (hfc : locally_integrable_on f $ Ioi 0)
   (hf_top : is_O at_top f (λ t, t ^ (-a))) (hs_top : s < a)
-  (hf_bot : is_O (𝓝[Ioi 0] 0) f (λ t, t ^ (-b))) (hs_bot : b < s) :
+  (hf_bot : is_O (𝓝[>] 0) f (λ t, t ^ (-b))) (hs_bot : b < s) :
   integrable_on (λ t : ℝ, t ^ (s - 1) * f t) (Ioi 0) :=
 begin
   obtain ⟨c1, hc1, hc1'⟩ := mellin_convergent_top_of_is_O hfc.ae_strongly_measurable hf_top hs_top,
@@ -146,11 +287,11 @@ lemma mellin_convergent_of_is_O_rpow [normed_space ℂ E]
   {a b : ℝ} {f : ℝ → E} {s : ℂ}
   (hfc : locally_integrable_on f $ Ioi 0)
   (hf_top : is_O at_top f (λ t, t ^ (-a))) (hs_top : s.re < a)
-  (hf_bot : is_O (𝓝[Ioi 0] 0) f (λ t, t ^ (-b))) (hs_bot : b < s.re) :
-  integrable_on (λ t : ℝ, (t : ℂ) ^ (s - 1) • f t) (Ioi 0) :=
+  (hf_bot : is_O (𝓝[>] 0) f (λ t, t ^ (-b))) (hs_bot : b < s.re) :
+  mellin_convergent f s :=
 begin
-  rw mellin_convergent_iff_norm (subset_refl _) measurable_set_Ioi
-    hfc.ae_strongly_measurable,
+  rw [mellin_convergent, mellin_convergent_iff_norm (subset_refl _) measurable_set_Ioi
+    hfc.ae_strongly_measurable],
   exact mellin_convergent_of_is_O_scalar
     hfc.norm hf_top.norm_left hs_top hf_bot.norm_left hs_bot,
 end
@@ -172,10 +313,10 @@ end
 
 /-- If `f` is `O(x ^ (-a))` as `x → 0`, then `log • f` is `O(x ^ (-b))` for every `a < b`. -/
 lemma is_O_rpow_zero_log_smul [normed_space ℝ E] {a b : ℝ} {f : ℝ → E}
-  (hab : a < b) (hf : is_O (𝓝[Ioi 0] 0) f (λ t, t ^ (-a))) :
-  is_O (𝓝[Ioi 0] 0) (λ t : ℝ, log t • f t) (λ t, t ^ (-b)) :=
+  (hab : a < b) (hf : is_O (𝓝[>] 0) f (λ t, t ^ (-a))) :
+  is_O (𝓝[>] 0) (λ t : ℝ, log t • f t) (λ t, t ^ (-b)) :=
 begin
-  have : is_o (𝓝[Ioi 0] 0) log (λ t : ℝ, t ^ (a - b)),
+  have : is_o (𝓝[>] 0) log (λ t : ℝ, t ^ (a - b)),
   { refine ((is_o_log_rpow_at_top (sub_pos.mpr hab)).neg_left.comp_tendsto
       tendsto_inv_zero_at_top).congr'
         (eventually_nhds_within_iff.mpr $ eventually_of_forall (λ t ht, _))
@@ -198,8 +339,9 @@ theorem mellin_has_deriv_of_is_O_rpow [complete_space E] [normed_space ℂ E]
   {a b : ℝ} {f : ℝ → E} {s : ℂ}
   (hfc : locally_integrable_on f $ Ioi 0)
   (hf_top : is_O at_top f (λ t, t ^ (-a))) (hs_top : s.re < a)
-  (hf_bot : is_O (𝓝[Ioi 0] 0) f (λ t, t ^ (-b))) (hs_bot : b < s.re) :
-  has_deriv_at (mellin f) (mellin (λ t, (log t : ℂ) • f t) s) s :=
+  (hf_bot : is_O (𝓝[>] 0) f (λ t, t ^ (-b))) (hs_bot : b < s.re) :
+  mellin_convergent (λ t, log t • f t) s ∧
+  has_deriv_at (mellin f) (mellin (λ t, log t • f t) s) s :=
 begin
   let F : ℂ → ℝ → E := λ z t, (t : ℂ) ^ (z - 1) • f t,
   let F' : ℂ → ℝ → E := λ z t, ((t : ℂ) ^ (z - 1) * log t) • f t,
@@ -274,8 +416,8 @@ begin
       rw of_real_log (le_of_lt ht),
       ring },
     exact u1.smul_const (f t) },
-  simpa only [F', mellin, mul_smul] using
-    (has_deriv_at_integral_of_dominated_loc_of_deriv_le hv0 h1 h2 h3 h4 h5 h6).2,
+  have main := has_deriv_at_integral_of_dominated_loc_of_deriv_le hv0 h1 h2 h3 h4 h5 h6,
+  exact ⟨by simpa only [F', mul_smul] using main.1, by simpa only [F', mul_smul] using main.2⟩
 end
 
 /-- Suppose `f` is locally integrable on `(0, ∞)`, is `O(x ^ (-a))` as `x → ∞`, and is
@@ -285,9 +427,9 @@ lemma mellin_differentiable_at_of_is_O_rpow [complete_space E] [normed_space ℂ
   {a b : ℝ} {f : ℝ → E} {s : ℂ}
   (hfc : locally_integrable_on f $ Ioi 0)
   (hf_top : is_O at_top f (λ t, t ^ (-a))) (hs_top : s.re < a)
-  (hf_bot : is_O (𝓝[Ioi 0] 0) f (λ t, t ^ (-b))) (hs_bot : b < s.re) :
+  (hf_bot : is_O (𝓝[>] 0) f (λ t, t ^ (-b))) (hs_bot : b < s.re) :
   differentiable_at ℂ (mellin f) s :=
-(mellin_has_deriv_of_is_O_rpow hfc hf_top hs_top hf_bot hs_bot).differentiable_at
+(mellin_has_deriv_of_is_O_rpow hfc hf_top hs_top hf_bot hs_bot).2.differentiable_at
 
 end mellin_diff
 
@@ -299,8 +441,8 @@ lemma mellin_convergent_of_is_O_rpow_exp [normed_space ℂ E]
   {a b : ℝ} (ha : 0 < a) {f : ℝ → E} {s : ℂ}
   (hfc : locally_integrable_on f $ Ioi 0)
   (hf_top : is_O at_top f (λ t, exp (-a * t)))
-  (hf_bot : is_O (𝓝[Ioi 0] 0) f (λ t, t ^ (-b))) (hs_bot : b < s.re) :
-  integrable_on (λ t : ℝ, (t : ℂ) ^ (s - 1) • f t) (Ioi 0) :=
+  (hf_bot : is_O (𝓝[>] 0) f (λ t, t ^ (-b))) (hs_bot : b < s.re) :
+  mellin_convergent f s :=
 mellin_convergent_of_is_O_rpow hfc (hf_top.trans (is_o_exp_neg_mul_rpow_at_top ha _).is_O)
   (lt_add_one _) hf_bot hs_bot
 
@@ -310,9 +452,43 @@ lemma mellin_differentiable_at_of_is_O_rpow_exp [complete_space E] [normed_space
   {a b : ℝ} (ha : 0 < a) {f : ℝ → E} {s : ℂ}
   (hfc : locally_integrable_on f $ Ioi 0)
   (hf_top : is_O at_top f (λ t, exp (-a * t)))
-  (hf_bot : is_O (𝓝[Ioi 0] 0) f (λ t, t ^ (-b))) (hs_bot : b < s.re) :
+  (hf_bot : is_O (𝓝[>] 0) f (λ t, t ^ (-b))) (hs_bot : b < s.re) :
   differentiable_at ℂ (mellin f) s :=
 mellin_differentiable_at_of_is_O_rpow hfc (hf_top.trans (is_o_exp_neg_mul_rpow_at_top ha _).is_O)
   (lt_add_one _) hf_bot hs_bot
 
 end exp_decay
+
+section mellin_Ioc
+/-!
+## Mellin transforms of functions on `Ioc 0 1`
+-/
+
+/-- The Mellin transform of the indicator function of `Ioc 0 1`. -/
+lemma mellin_one_Ioc {s : ℂ} (hs : 0 < re s) :
+  has_mellin (indicator (Ioc 0 1) (λ t, 1 : ℝ → ℂ)) s (1 / s) :=
+begin
+  have aux1 : -1 < (s - 1).re, by simpa only [sub_re, one_re, sub_eq_add_neg]
+    using lt_add_of_pos_left _ hs,
+  have aux2 : s ≠ 0, by { contrapose! hs, rw [hs, zero_re] },
+  have aux3 : measurable_set (Ioc (0 : ℝ) 1), from measurable_set_Ioc,
+  simp_rw [has_mellin, mellin, mellin_convergent, ←indicator_smul, integrable_on,
+    integrable_indicator_iff aux3, smul_eq_mul, integral_indicator aux3,
+    mul_one, integrable_on, measure.restrict_restrict_of_subset Ioc_subset_Ioi_self],
+  rw [←integrable_on, ←interval_integrable_iff_integrable_Ioc_of_le zero_le_one],
+  refine ⟨interval_integral.interval_integrable_cpow' aux1, _⟩,
+  rw [←interval_integral.integral_of_le zero_le_one, integral_cpow (or.inl aux1), sub_add_cancel,
+    of_real_zero, of_real_one, one_cpow, zero_cpow aux2, sub_zero]
+end
+
+/-- The Mellin transform of a power function restricted to `Ioc 0 1`. -/
+lemma mellin_cpow_Ioc (a : ℂ) {s : ℂ} (hs : 0 < re s + re a) :
+  has_mellin (indicator (Ioc 0 1) (λ t, ↑t ^ a : ℝ → ℂ)) s (1 / (s + a)) :=
+begin
+  have := mellin_one_Ioc (by rwa add_re : 0 < (s + a).re),
+  simp_rw [has_mellin, ←mellin_convergent.cpow_smul, ←mellin_cpow_smul, ←indicator_smul,
+    smul_eq_mul, mul_one] at this,
+  exact this
+end
+
+end mellin_Ioc

--- a/src/analysis/special_functions/gamma/basic.lean
+++ b/src/analysis/special_functions/gamma/basic.lean
@@ -396,7 +396,7 @@ theorem has_deriv_at_Gamma_integral {s : ℂ} (hs : 0 < s.re) :
   has_deriv_at Gamma_integral (∫ (t : ℝ) in Ioi 0, t ^ (s - 1) * (real.log t * real.exp (-t))) s :=
 begin
   rw Gamma_integral_eq_mellin,
-  convert mellin_has_deriv_of_is_O_rpow _ _ (lt_add_one _) _ hs,
+  convert (mellin_has_deriv_of_is_O_rpow _ _ (lt_add_one _) _ hs).2,
   { refine (continuous.continuous_on _).locally_integrable_on measurable_set_Ioi,
     exact continuous_of_real.comp (real.continuous_exp.comp continuous_neg), },
   { rw [←is_O_norm_left],


### PR DESCRIPTION
This adds results about Mellin transforms of things like `f(a * x)` or `f (x ^ a)` in terms of the Mellin transform of `f`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #19106  [optional extra text]

(Only the changes in `mellin_transform.lean` and `gamma/basic.lean` are actually part of this PR, the rest is inherited from #19106.)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
