### PR TITLE
[Merged by Bors] - chore(ring_theory/tensor_product): replace `is_scalar_tower` by `smul_comm_class` in `left_algebra`

### DIFF
--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -383,9 +383,9 @@ def include_left_ring_hom : A →+* A ⊗[R] B :=
   map_one' := rfl,
   map_mul' := by simp }
 
-variables {S : Type*} [comm_semiring S] [algebra R S] [algebra S A] [is_scalar_tower R S A]
+variables {S : Type*} [comm_semiring S] [algebra S A]
 
-instance left_algebra : algebra S (A ⊗[R] B) :=
+instance left_algebra [smul_comm_class R S A] : algebra S (A ⊗[R] B) :=
 { commutes' := λ r x,
   begin
     apply tensor_product.induction_on x,
@@ -408,10 +408,13 @@ instance left_algebra : algebra S (A ⊗[R] B) :=
 instance : algebra R (A ⊗[R] B) := infer_instance
 
 @[simp]
-lemma algebra_map_apply (r : S) :
+lemma algebra_map_apply [smul_comm_class R S A] (r : S) :
   (algebra_map S (A ⊗[R] B)) r = ((algebra_map S A) r) ⊗ₜ 1 := rfl
 
-instance : is_scalar_tower R S (A ⊗[R] B) := ⟨λ a b c, by simp⟩
+instance algebra.tensor_product.is_scalar_tower [algebra R S] [is_scalar_tower R S A] :
+  is_scalar_tower R S (A ⊗[R] B) := ⟨λ a b c, by simp⟩
+instance algebra.tensor_product.is_scalar_tower' [algebra S R] [is_scalar_tower S R A] :
+  is_scalar_tower S R (A ⊗[R] B) := ⟨λ a b c, by simp⟩
 
 variables {C : Type v₃} [semiring C] [algebra R C]
 

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -422,14 +422,14 @@ begin
   simp [H],
 end
 
-/-- The `S`-algebra morphism `A →ₐ[S] A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
-def include_left [smul_comm_class R S A] : A →ₐ[S] A ⊗[R] B :=
+-- TODO: with `smul_comm_class R S A` we can have this as an `S`-algebra morphism
+/-- The `R`-algebra morphism `A →ₐ[R] A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
+def include_left : A →ₐ[R] A ⊗[R] B :=
 { commutes' := by simp,
   ..include_left_ring_hom }
 
 @[simp]
-lemma include_left_apply [smul_comm_class R S A] (a : A) :
-  (include_left : A →ₐ[S] A ⊗[R] B) a = a ⊗ₜ 1 := rfl
+lemma include_left_apply (a : A) : (include_left : A →ₐ[R] A ⊗[R] B) a = a ⊗ₜ 1 := rfl
 
 /-- The algebra morphism `B →ₐ[R] A ⊗[R] B` sending `b` to `1 ⊗ₜ b`. -/
 def include_right : B →ₐ[R] A ⊗[R] B :=
@@ -451,7 +451,7 @@ lemma include_right_apply (b : B) : (include_right : B →ₐ[R] A ⊗[R] B) b =
 
 lemma include_left_comp_algebra_map {R S T : Type*} [comm_ring R] [comm_ring S] [comm_ring T]
   [algebra R S] [algebra R T] :
-    ((include_left : S →ₐ[R] S ⊗[R] T).to_ring_hom.comp (algebra_map R S) : R →+* S ⊗[R] T) =
+    (include_left.to_ring_hom.comp (algebra_map R S) : R →+* S ⊗[R] T) =
       include_right.to_ring_hom.comp (algebra_map R T) :=
 by { ext, simp }
 

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -411,11 +411,6 @@ instance : algebra R (A ⊗[R] B) := infer_instance
 lemma algebra_map_apply [smul_comm_class R S A] (r : S) :
   (algebra_map S (A ⊗[R] B)) r = ((algebra_map S A) r) ⊗ₜ 1 := rfl
 
-instance algebra.tensor_product.is_scalar_tower [algebra R S] [is_scalar_tower R S A] :
-  is_scalar_tower R S (A ⊗[R] B) := ⟨λ a b c, by simp⟩
-instance algebra.tensor_product.is_scalar_tower' [algebra S R] [is_scalar_tower S R A] :
-  is_scalar_tower S R (A ⊗[R] B) := ⟨λ a b c, by simp⟩
-
 variables {C : Type v₃} [semiring C] [algebra R C]
 
 @[ext]
@@ -427,13 +422,14 @@ begin
   simp [H],
 end
 
-/-- The `R`-algebra morphism `A →ₐ[R] A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
-def include_left : A →ₐ[R] A ⊗[R] B :=
+/-- The `S`-algebra morphism `A →ₐ[S] A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
+def include_left [smul_comm_class R S A] : A →ₐ[S] A ⊗[R] B :=
 { commutes' := by simp,
   ..include_left_ring_hom }
 
 @[simp]
-lemma include_left_apply (a : A) : (include_left : A →ₐ[R] A ⊗[R] B) a = a ⊗ₜ 1 := rfl
+lemma include_left_apply [smul_comm_class R S A] (a : A) :
+  (include_left : A →ₐ[S] A ⊗[R] B) a = a ⊗ₜ 1 := rfl
 
 /-- The algebra morphism `B →ₐ[R] A ⊗[R] B` sending `b` to `1 ⊗ₜ b`. -/
 def include_right : B →ₐ[R] A ⊗[R] B :=
@@ -455,7 +451,7 @@ lemma include_right_apply (b : B) : (include_right : B →ₐ[R] A ⊗[R] B) b =
 
 lemma include_left_comp_algebra_map {R S T : Type*} [comm_ring R] [comm_ring S] [comm_ring T]
   [algebra R S] [algebra R T] :
-    (include_left.to_ring_hom.comp (algebra_map R S) : R →+* S ⊗[R] T) =
+    ((include_left : S →ₐ[R] S ⊗[R] T).to_ring_hom.comp (algebra_map R S) : R →+* S ⊗[R] T) =
       include_right.to_ring_hom.comp (algebra_map R T) :=
 by { ext, simp }
 

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -422,19 +422,17 @@ begin
   simp [H],
 end
 
-/-- The `R`-algebra morphism `A →ₐ[S] A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
-def include_left [smul_comm_class R S A] : A →ₐ[S] A ⊗[R] B :=
+-- TODO: with `smul_comm_class R S A` we can have this as an `S`-algebra morphism
+/-- The `R`-algebra morphism `A →ₐ[R] A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
+def include_left : A →ₐ[R] A ⊗[R] B :=
 { commutes' := by simp,
   ..include_left_ring_hom }
 
 @[simp]
-lemma include_left_apply [smul_comm_class R S A ] (a : A) : (include_left : A →ₐ[S] A ⊗[R] B) a = a ⊗ₜ 1 := rfl
-
-variables [algebra S B] [smul_comm_class R S A]
-[tensor_product.compatible_smul R S A B]
+lemma include_left_apply (a : A) : (include_left : A →ₐ[R] A ⊗[R] B) a = a ⊗ₜ 1 := rfl
 
 /-- The algebra morphism `B →ₐ[R] A ⊗[R] B` sending `b` to `1 ⊗ₜ b`. -/
-def include_right : B →ₐ[S] A ⊗[R] B :=
+def include_right : B →ₐ[R] A ⊗[R] B :=
 { to_fun := λ b, 1 ⊗ₜ b,
   map_zero' := by simp,
   map_add' := by simp [tmul_add],
@@ -449,18 +447,14 @@ def include_right : B →ₐ[S] A ⊗[R] B :=
   end, }
 
 @[simp]
-lemma include_right_apply (b : B) : (include_right : B →ₐ[S] A ⊗[R] B) b = 1 ⊗ₜ b := rfl
+lemma include_right_apply (b : B) : (include_right : B →ₐ[R] A ⊗[R] B) b = 1 ⊗ₜ b := rfl
 
-lemma include_left_comp_algebra_map :
-    ((include_left : A →ₐ[S] A ⊗[R] B).to_ring_hom.comp (algebra_map R A)) =
-      (include_right : B →ₐ[S] A ⊗[R] B).to_ring_hom.comp (algebra_map R B) :=
-by { ext, simp [algebra.algebra_map_eq_smul_one, smul_tmul] }
-
-lemma include_left_comp_algebra_map' {R S T : Type*} [comm_ring R] [comm_ring S] [comm_ring T]
+lemma include_left_comp_algebra_map {R S T : Type*} [comm_ring R] [comm_ring S] [comm_ring T]
   [algebra R S] [algebra R T] :
-    ((include_left : S →ₐ[R] S ⊗[R] T).to_ring_hom.comp (algebra_map R S) : R →+* S ⊗[R] T) =
-      (include_right : T →ₐ[R] S ⊗[R] T).to_ring_hom.comp (algebra_map R T) :=
+    (include_left.to_ring_hom.comp (algebra_map R S) : R →+* S ⊗[R] T) =
+      include_right.to_ring_hom.comp (algebra_map R T) :=
 by { ext, simp }
+
 end semiring
 
 section ring
@@ -500,10 +494,10 @@ instance : comm_ring (A ⊗[R] B) :=
 
 section right_algebra
 
-/-- `A ⊗[R] B` has a `B`-algebra structure. This is not a global instance or else the action of
-`A` on `A ⊗[R] A` would be ambiguous. -/
+/-- `S ⊗[R] T` has a `T`-algebra structure. This is not a global instance or else the action of
+`S` on `S ⊗[R] S` would be ambiguous. -/
 @[reducible] def right_algebra : algebra B (A ⊗[R] B) :=
-((algebra.tensor_product.include_right : B →ₐ[R] A ⊗[R]B).to_ring_hom : B →+* A ⊗[R] B).to_algebra
+(algebra.tensor_product.include_right.to_ring_hom : B →+* A ⊗[R] B).to_algebra
 
 local attribute [instance] tensor_product.right_algebra
 
@@ -534,27 +528,22 @@ We now build the structure maps for the symmetric monoidal category of `R`-algeb
 section monoidal
 
 section
-universe v
-
 variables {R : Type u} [comm_semiring R]
-variables {S : Type v} [comm_semiring S] [algebra R S]
-variables {A : Type v₁} [semiring A] [algebra R A] [algebra S A] [smul_comm_class R S A]
+variables {A : Type v₁} [semiring A] [algebra R A]
 variables {B : Type v₂} [semiring B] [algebra R B]
 variables {C : Type v₃} [semiring C] [algebra R C]
-  [algebra S C]
 variables {D : Type v₄} [semiring D] [algebra R D]
-
 
 /--
 Build an algebra morphism from a linear map out of a tensor product,
 and evidence of multiplicativity on pure tensors.
 -/
 def alg_hom_of_linear_map_tensor_product
-  (f : A ⊗[R] B →ₗ[S] C)
+  (f : A ⊗[R] B →ₗ[R] C)
   (w₁ : ∀ (a₁ a₂ : A) (b₁ b₂ : B), f ((a₁ * a₂) ⊗ₜ (b₁ * b₂)) = f (a₁ ⊗ₜ b₁) * f (a₂ ⊗ₜ b₂))
-  (w₂ : ∀ s, f ((algebra_map S A) s ⊗ₜ[R] 1) = (algebra_map S C) s):
-  A ⊗[R] B →ₐ[S] C :=
-{ map_one' :=  by rw [← (algebra_map S C).map_one, ← w₂, linear_map.to_fun_eq_coe, (algebra_map S A).map_one]; refl,
+  (w₂ : ∀ r, f ((algebra_map R A) r ⊗ₜ[R] 1) = (algebra_map R C) r):
+  A ⊗[R] B →ₐ[R] C :=
+{ map_one' := by rw [←(algebra_map R C).map_one, ←w₂, (algebra_map R A).map_one]; refl,
   map_zero' := by rw [linear_map.to_fun_eq_coe, map_zero],
   map_mul' := λ x y, by
   { rw linear_map.to_fun_eq_coe,
@@ -574,27 +563,23 @@ def alg_hom_of_linear_map_tensor_product
 
 @[simp]
 lemma alg_hom_of_linear_map_tensor_product_apply (f w₁ w₂ x) :
-  (alg_hom_of_linear_map_tensor_product f w₁ w₂ : A ⊗[R] B →ₐ[S] C) x = f x := rfl
+  (alg_hom_of_linear_map_tensor_product f w₁ w₂ : A ⊗[R] B →ₐ[R] C) x = f x := rfl
 
 /--
 Build an algebra equivalence from a linear equivalence out of a tensor product,
 and evidence of multiplicativity on pure tensors.
 -/
 def alg_equiv_of_linear_equiv_tensor_product
-  (f : A ⊗[R] B ≃ₗ[S] C)
+  (f : A ⊗[R] B ≃ₗ[R] C)
   (w₁ : ∀ (a₁ a₂ : A) (b₁ b₂ : B), f ((a₁ * a₂) ⊗ₜ (b₁ * b₂)) = f (a₁ ⊗ₜ b₁) * f (a₂ ⊗ₜ b₂))
-  (w₂ : ∀ s, f ((algebra_map S A) s ⊗ₜ[R] 1) = (algebra_map S C) s):
-  A ⊗[R] B ≃ₐ[S] C :=
-{ .. alg_hom_of_linear_map_tensor_product (f : A ⊗[R] B →ₗ[S] C) w₁ w₂,
+  (w₂ : ∀ r, f ((algebra_map R A) r ⊗ₜ[R] 1) = (algebra_map R C) r):
+  A ⊗[R] B ≃ₐ[R] C :=
+{ .. alg_hom_of_linear_map_tensor_product (f : A ⊗[R] B →ₗ[R] C) w₁ w₂,
   .. f }
 
 @[simp]
 lemma alg_equiv_of_linear_equiv_tensor_product_apply (f w₁ w₂ x) :
-  (alg_equiv_of_linear_equiv_tensor_product f w₁ w₂ : A ⊗[R] B ≃ₐ[S] C) x = f x := rfl
-
--- TODO : S-linearize this
--- The problem is that Lean doesn't view A⊗[R]B as an S-module automatically
--- To me, this suggests that something has to be done on linear_map.tensor_product as well
+  (alg_equiv_of_linear_equiv_tensor_product f w₁ w₂ : A ⊗[R] B ≃ₐ[R] C) x = f x := rfl
 
 /--
 Build an algebra equivalence from a linear equivalence out of a triple tensor product,
@@ -674,9 +659,6 @@ by simp [tensor_product.rid]
 
 section
 variables (R A B)
-
--- TODO : S-linearize (if possible)
--- variables (S : Type*) [comm_semiring S] [algebra R S] [algebra S A] [algebra S B] [is_scalar_tower R S A] [is_scalar_tower R S B] [tensor_product.compatible_smul R S A B]
 
 /--
 The tensor product of R-algebras is commutative, up to algebra isomorphism.
@@ -804,14 +786,13 @@ lemma lmul'_to_linear_map : (lmul' R : _ →ₐ[R] S).to_linear_map = linear_map
 @[simp] lemma lmul'_apply_tmul (a b : S) : lmul' R (a ⊗ₜ[R] b) = a * b := rfl
 
 @[simp]
-lemma lmul'_comp_include_left : (lmul' R : _ →ₐ[R] S).comp (include_left : _ →ₐ[R] _) = alg_hom.id R S :=
+lemma lmul'_comp_include_left : (lmul' R : _ →ₐ[R] S).comp include_left = alg_hom.id R S :=
 alg_hom.ext $ _root_.mul_one
 
 @[simp]
-lemma lmul'_comp_include_right : (lmul' R : _ →ₐ[R] S).comp (include_right : _ →ₐ[R] _) = alg_hom.id R S :=
+lemma lmul'_comp_include_right : (lmul' R : _ →ₐ[R] S).comp include_right = alg_hom.id R S :=
 alg_hom.ext $ _root_.one_mul
 
--- TODO : the target should be C, and this be S-linearized
 /--
 If `S` is commutative, for a pair of morphisms `f : A →ₐ[R] S`, `g : B →ₐ[R] S`,
 We obtain a map `A ⊗[R] B →ₐ[R] S` that commutes with `f`, `g` via `a ⊗ b ↦ f(a) * g(b)`.
@@ -824,9 +805,9 @@ by { unfold product_map lmul', simp }
 lemma product_map_left_apply (a : A) :
   product_map f g ((include_left : A →ₐ[R] A ⊗ B) a) = f a := by simp
 
-@[simp] lemma product_map_left : (product_map f g).comp (include_left : A →ₐ[R] A ⊗ B) = f := alg_hom.ext $ by simp
+@[simp] lemma product_map_left : (product_map f g).comp include_left = f := alg_hom.ext $ by simp
 
-lemma product_map_right_apply (b : B) : product_map f g ((include_right : B →ₐ[R] A ⊗ B) b) = g b := by simp
+lemma product_map_right_apply (b : B) : product_map f g (include_right b) = g b := by simp
 
 @[simp] lemma product_map_right : (product_map f g).comp include_right = g := alg_hom.ext $ by simp
 


### PR DESCRIPTION
With this change, this instance works for both restriction (e.g tensor product over `ℂ` of complex algebras is a real algebra) and extension (e.g tensor product over `ℝ` of complex algebras is a complex algebra) of scalars. 
[Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Tensor.20products)

I also removes [algebra.tensor_product.tensor_product.is_scalar_tower](https://leanprover-community.github.io/mathlib_docs/ring_theory/tensor_product.html#algebra.tensor_product.tensor_product.is_scalar_tower) since it is automatically inferred from [tensor_product.is_scalar_tower](https://leanprover-community.github.io/mathlib_docs/linear_algebra/tensor_product.html#tensor_product.is_scalar_tower)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
