### PR TITLE
refactor(analysis/calculus/local_extr): split file

### DIFF
--- a/archive/100-theorems-list/16_abel_ruffini.lean
+++ b/archive/100-theorems-list/16_abel_ruffini.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
-import analysis.calculus.local_extr
+import analysis.calculus.local_extr.polynomial
 import data.nat.prime_norm_num
 import field_theory.abel_ruffini
 import ring_theory.eisenstein_criterion

--- a/src/analysis/calculus/bump_function_inner.lean
+++ b/src/analysis/calculus/bump_function_inner.lean
@@ -4,11 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Floris van Doorn
 -/
 import analysis.calculus.deriv.inv
+import analysis.calculus.deriv.polynomial
 import analysis.calculus.extend_deriv
 import analysis.calculus.iterated_deriv
 import analysis.inner_product_space.calculus
 import analysis.special_functions.exp_deriv
 import measure_theory.integral.set_integral
+import topology.algebra.polynomial
 
 /-!
 # Infinitely smooth bump function

--- a/src/analysis/calculus/darboux.lean
+++ b/src/analysis/calculus/darboux.lean
@@ -3,7 +3,9 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import analysis.calculus.local_extr
+import analysis.calculus.deriv.add
+import analysis.calculus.deriv.mul
+import analysis.calculus.local_extr.basic
 
 /-!
 # Darboux's theorem
@@ -19,16 +21,14 @@ open_locale topology classical
 variables {a b : ℝ} {f f' : ℝ → ℝ}
 
 /-- **Darboux's theorem**: if `a ≤ b` and `f' a < m < f' b`, then `f' c = m` for some
-`c ∈ [a, b]`. -/
+`c ∈ (a, b)`. -/
 theorem exists_has_deriv_within_at_eq_of_gt_of_lt
   (hab : a ≤ b) (hf : ∀ x ∈ (Icc a b), has_deriv_within_at f (f' x) (Icc a b) x)
   {m : ℝ} (hma : f' a < m) (hmb : m < f' b) :
-  m ∈ f' '' (Icc a b) :=
+  m ∈ f' '' Ioo a b :=
 begin
-  have hab' : a < b,
-  { refine lt_of_le_of_ne hab (λ hab', _),
-    subst b,
-    exact lt_asymm hma hmb },
+  rcases hab.eq_or_lt with rfl | hab',
+  { exact (lt_asymm hma hmb).elim },
   set g : ℝ → ℝ := λ x, f x - m * x,
   have hg : ∀ x ∈ Icc a b, has_deriv_within_at g (f' x - m) (Icc a b) x,
   { intros x hx,
@@ -37,73 +37,121 @@ begin
     from is_compact_Icc.exists_forall_le (nonempty_Icc.2 $ hab)
       (λ x hx, (hg x hx).continuous_within_at),
   have cmem' : c ∈ Ioo a b,
-  { cases eq_or_lt_of_le cmem.1 with hac hac,
+  { rcases cmem.1.eq_or_lt with rfl | hac,
     -- Show that `c` can't be equal to `a`
-    { subst c,
-      refine absurd (sub_nonneg.1 $ nonneg_of_mul_nonneg_right _ (sub_pos.2 hab'))
+    { refine absurd (sub_nonneg.1 $ nonneg_of_mul_nonneg_right _ (sub_pos.2 hab'))
         (not_le_of_lt hma),
       have : b - a ∈ pos_tangent_cone_at (Icc a b) a,
         from mem_pos_tangent_cone_at_of_segment_subset (segment_eq_Icc hab ▸ subset.refl _),
       simpa [-sub_nonneg, -continuous_linear_map.map_sub]
         using hc.localize.has_fderiv_within_at_nonneg (hg a (left_mem_Icc.2 hab)) this },
-    cases eq_or_lt_of_le cmem.2 with hbc hbc,
+    rcases cmem.2.eq_or_gt with rfl | hcb,
     -- Show that `c` can't be equal to `b`
-    { subst c,
-      refine absurd (sub_nonpos.1 $ nonpos_of_mul_nonneg_right _ (sub_lt_zero.2 hab'))
+    { refine absurd (sub_nonpos.1 $ nonpos_of_mul_nonneg_right _ (sub_lt_zero.2 hab'))
         (not_le_of_lt hmb),
       have : a - b ∈ pos_tangent_cone_at (Icc a b) b,
         from mem_pos_tangent_cone_at_of_segment_subset (by rw [segment_symm, segment_eq_Icc hab]),
       simpa [-sub_nonneg, -continuous_linear_map.map_sub]
         using hc.localize.has_fderiv_within_at_nonneg (hg b (right_mem_Icc.2 hab)) this },
-    exact ⟨hac, hbc⟩ },
-  use [c, cmem],
+    exact ⟨hac, hcb⟩ },
+  use [c, cmem'],
   rw [← sub_eq_zero],
   have : Icc a b ∈ 𝓝 c, by rwa [← mem_interior_iff_mem_nhds, interior_Icc],
   exact (hc.is_local_min this).has_deriv_at_eq_zero ((hg c cmem).has_deriv_at this)
 end
 
-/-- **Darboux's theorem**: if `a ≤ b` and `f' a > m > f' b`, then `f' c = m` for some `c ∈ [a, b]`.
+/-- **Darboux's theorem**: if `a ≤ b` and `f' b < m < f' a`, then `f' c = m` for some `c ∈ (a, b)`.
 -/
 theorem exists_has_deriv_within_at_eq_of_lt_of_gt
   (hab : a ≤ b) (hf : ∀ x ∈ (Icc a b), has_deriv_within_at f (f' x) (Icc a b) x)
   {m : ℝ} (hma : m < f' a) (hmb : f' b < m) :
-  m ∈ f' '' (Icc a b) :=
+  m ∈ f' '' Ioo a b :=
 let ⟨c, cmem, hc⟩ := exists_has_deriv_within_at_eq_of_gt_of_lt hab (λ x hx, (hf x hx).neg)
   (neg_lt_neg hma) (neg_lt_neg hmb)
 in ⟨c, cmem, neg_injective hc⟩
 
-/-- **Darboux's theorem**: the image of a convex set under `f'` is a convex set. -/
-theorem convex_image_has_deriv_at {s : set ℝ} (hs : convex ℝ s)
-  (hf : ∀ x ∈ s, has_deriv_at f (f' x) x) :
-  convex ℝ (f' '' s) :=
+/-- **Darboux's theorem**: the image of an `ord_connected` set under `f'` is an `ord_connected`
+set, `has_deriv_within_at` version. -/
+theorem set.ord_connected.image_has_deriv_within_at {s : set ℝ} (hs : ord_connected s)
+  (hf : ∀ x ∈ s, has_deriv_within_at f (f' x) s x) :
+  ord_connected (f' '' s) :=
 begin
-  refine ord_connected.convex ⟨_⟩,
-  rintros _ ⟨a, ha, rfl⟩ _ ⟨b, hb, rfl⟩ m ⟨hma, hmb⟩,
-  cases eq_or_lt_of_le hma with hma hma,
-    by exact hma ▸ mem_image_of_mem f' ha,
-  cases eq_or_lt_of_le hmb with hmb hmb,
-    by exact hmb.symm ▸ mem_image_of_mem f' hb,
+  apply ord_connected_of_Ioo,
+  rintros _ ⟨a, ha, rfl⟩ _ ⟨b, hb, rfl⟩ - m ⟨hma, hmb⟩,
   cases le_total a b with hab hab,
-  { have : Icc a b ⊆ s, from hs.ord_connected.out ha hb,
+  { have : Icc a b ⊆ s, from hs.out ha hb,
     rcases exists_has_deriv_within_at_eq_of_gt_of_lt hab
-      (λ x hx, (hf x $ this hx).has_deriv_within_at) hma hmb
+      (λ x hx, (hf x $ this hx).mono this) hma hmb
       with ⟨c, cmem, hc⟩,
-    exact ⟨c, this cmem, hc⟩ },
-  { have : Icc b a ⊆ s, from hs.ord_connected.out hb ha,
+    exact ⟨c, this $ Ioo_subset_Icc_self cmem, hc⟩ },
+  { have : Icc b a ⊆ s, from hs.out hb ha,
     rcases exists_has_deriv_within_at_eq_of_lt_of_gt hab
-      (λ x hx, (hf x $ this hx).has_deriv_within_at) hmb hma
+      (λ x hx, (hf x $ this hx).mono this) hmb hma
       with ⟨c, cmem, hc⟩,
-    exact ⟨c, this cmem, hc⟩ }
+    exact ⟨c, this $ Ioo_subset_Icc_self cmem, hc⟩ }
 end
+
+/-- **Darboux's theorem**: the image of an `ord_connected` set under `f'` is an `ord_connected`
+set, `deriv_within` version. -/
+theorem set.ord_connected.image_deriv_within {s : set ℝ} (hs : ord_connected s)
+  (hf : differentiable_on ℝ f s) :
+  ord_connected (deriv_within f s '' s) :=
+hs.image_has_deriv_within_at $ λ x hx, (hf x hx).has_deriv_within_at
+
+/-- **Darboux's theorem**: the image of an `ord_connected` set under `f'` is an `ord_connected`
+set, `deriv` version. -/
+theorem set.ord_connected.image_deriv {s : set ℝ} (hs : ord_connected s)
+  (hf : ∀ x ∈ s, differentiable_at ℝ f x) :
+  ord_connected (deriv f '' s) :=
+hs.image_has_deriv_within_at $ λ x hx, (hf x hx).has_deriv_at.has_deriv_within_at
+
+/-- **Darboux's theorem**: the image of a convex set under `f'` is a convex set,
+`has_deriv_within_at` version. -/
+theorem convex.image_has_deriv_within_at {s : set ℝ} (hs : convex ℝ s)
+  (hf : ∀ x ∈ s, has_deriv_within_at f (f' x) s x) :
+  convex ℝ (f' '' s) :=
+(hs.ord_connected.image_has_deriv_within_at hf).convex
+
+/-- **Darboux's theorem**: the image of a convex set under `f'` is a convex set,
+`deriv_within` version. -/
+theorem convex.image_deriv_within {s : set ℝ} (hs : convex ℝ s)
+  (hf : differentiable_on ℝ f s) :
+  convex ℝ (deriv_within f s '' s) :=
+(hs.ord_connected.image_deriv_within hf).convex
+
+/-- **Darboux's theorem**: the image of a convex set under `f'` is a convex set,
+`deriv` version. -/
+theorem convex.image_deriv {s : set ℝ} (hs : convex ℝ s)
+  (hf : ∀ x ∈ s, differentiable_at ℝ f x) :
+  convex ℝ (deriv f '' s) :=
+(hs.ord_connected.image_deriv hf).convex
+
+/-- **Darboux's theorem**: if `a ≤ b` and `f' a ≤ m ≤ f' b`, then `f' c = m` for some
+`c ∈ [a, b]`. -/
+theorem exists_has_deriv_within_at_eq_of_ge_of_le
+  (hab : a ≤ b) (hf : ∀ x ∈ (Icc a b), has_deriv_within_at f (f' x) (Icc a b) x)
+  {m : ℝ} (hma : f' a ≤ m) (hmb : m ≤ f' b) :
+  m ∈ f' '' Icc a b :=
+(ord_connected_Icc.image_has_deriv_within_at hf).out
+  (mem_image_of_mem _ (left_mem_Icc.2 hab)) (mem_image_of_mem _ (right_mem_Icc.2 hab)) ⟨hma, hmb⟩
+
+/-- **Darboux's theorem**: if `a ≤ b` and `f' b ≤ m ≤ f' a`, then `f' c = m` for some
+`c ∈ [a, b]`. -/
+theorem exists_has_deriv_within_at_eq_of_le_of_ge
+  (hab : a ≤ b) (hf : ∀ x ∈ (Icc a b), has_deriv_within_at f (f' x) (Icc a b) x)
+  {m : ℝ} (hma : f' a ≤ m) (hmb : m ≤ f' b) :
+  m ∈ f' '' Icc a b :=
+(ord_connected_Icc.image_has_deriv_within_at hf).out
+  (mem_image_of_mem _ (left_mem_Icc.2 hab)) (mem_image_of_mem _ (right_mem_Icc.2 hab)) ⟨hma, hmb⟩
 
 /-- If the derivative of a function is never equal to `m`, then either
 it is always greater than `m`, or it is always less than `m`. -/
-theorem deriv_forall_lt_or_forall_gt_of_forall_ne {s : set ℝ} (hs : convex ℝ s)
-  (hf : ∀ x ∈ s, has_deriv_at f (f' x) x) {m : ℝ} (hf' : ∀ x ∈ s, f' x ≠ m) :
+theorem has_deriv_within_at_forall_lt_or_forall_gt_of_forall_ne {s : set ℝ} (hs : convex ℝ s)
+  (hf : ∀ x ∈ s, has_deriv_within_at f (f' x) s x) {m : ℝ} (hf' : ∀ x ∈ s, f' x ≠ m) :
   (∀ x ∈ s, f' x < m) ∨ (∀ x ∈ s, m < f' x) :=
 begin
   contrapose! hf',
   rcases hf' with ⟨⟨b, hb, hmb⟩, ⟨a, ha, hma⟩⟩,
-  exact (convex_image_has_deriv_at hs hf).ord_connected.out (mem_image_of_mem f' ha)
+  exact (hs.ord_connected.image_has_deriv_within_at hf).out (mem_image_of_mem f' ha)
     (mem_image_of_mem f' hb) ⟨hma, hmb⟩
 end

--- a/src/analysis/calculus/darboux.lean
+++ b/src/analysis/calculus/darboux.lean
@@ -21,14 +21,16 @@ open_locale topology classical
 variables {a b : ℝ} {f f' : ℝ → ℝ}
 
 /-- **Darboux's theorem**: if `a ≤ b` and `f' a < m < f' b`, then `f' c = m` for some
-`c ∈ (a, b)`. -/
+`c ∈ [a, b]`. -/
 theorem exists_has_deriv_within_at_eq_of_gt_of_lt
   (hab : a ≤ b) (hf : ∀ x ∈ (Icc a b), has_deriv_within_at f (f' x) (Icc a b) x)
   {m : ℝ} (hma : f' a < m) (hmb : m < f' b) :
-  m ∈ f' '' Ioo a b :=
+  m ∈ f' '' (Icc a b) :=
 begin
-  rcases hab.eq_or_lt with rfl | hab',
-  { exact (lt_asymm hma hmb).elim },
+  have hab' : a < b,
+  { refine lt_of_le_of_ne hab (λ hab', _),
+    subst b,
+    exact lt_asymm hma hmb },
   set g : ℝ → ℝ := λ x, f x - m * x,
   have hg : ∀ x ∈ Icc a b, has_deriv_within_at g (f' x - m) (Icc a b) x,
   { intros x hx,
@@ -37,121 +39,73 @@ begin
     from is_compact_Icc.exists_forall_le (nonempty_Icc.2 $ hab)
       (λ x hx, (hg x hx).continuous_within_at),
   have cmem' : c ∈ Ioo a b,
-  { rcases cmem.1.eq_or_lt with rfl | hac,
+  { cases eq_or_lt_of_le cmem.1 with hac hac,
     -- Show that `c` can't be equal to `a`
-    { refine absurd (sub_nonneg.1 $ nonneg_of_mul_nonneg_right _ (sub_pos.2 hab'))
+    { subst c,
+      refine absurd (sub_nonneg.1 $ nonneg_of_mul_nonneg_right _ (sub_pos.2 hab'))
         (not_le_of_lt hma),
       have : b - a ∈ pos_tangent_cone_at (Icc a b) a,
         from mem_pos_tangent_cone_at_of_segment_subset (segment_eq_Icc hab ▸ subset.refl _),
       simpa [-sub_nonneg, -continuous_linear_map.map_sub]
         using hc.localize.has_fderiv_within_at_nonneg (hg a (left_mem_Icc.2 hab)) this },
-    rcases cmem.2.eq_or_gt with rfl | hcb,
+    cases eq_or_lt_of_le cmem.2 with hbc hbc,
     -- Show that `c` can't be equal to `b`
-    { refine absurd (sub_nonpos.1 $ nonpos_of_mul_nonneg_right _ (sub_lt_zero.2 hab'))
+    { subst c,
+      refine absurd (sub_nonpos.1 $ nonpos_of_mul_nonneg_right _ (sub_lt_zero.2 hab'))
         (not_le_of_lt hmb),
       have : a - b ∈ pos_tangent_cone_at (Icc a b) b,
         from mem_pos_tangent_cone_at_of_segment_subset (by rw [segment_symm, segment_eq_Icc hab]),
       simpa [-sub_nonneg, -continuous_linear_map.map_sub]
         using hc.localize.has_fderiv_within_at_nonneg (hg b (right_mem_Icc.2 hab)) this },
-    exact ⟨hac, hcb⟩ },
-  use [c, cmem'],
+    exact ⟨hac, hbc⟩ },
+  use [c, cmem],
   rw [← sub_eq_zero],
   have : Icc a b ∈ 𝓝 c, by rwa [← mem_interior_iff_mem_nhds, interior_Icc],
   exact (hc.is_local_min this).has_deriv_at_eq_zero ((hg c cmem).has_deriv_at this)
 end
 
-/-- **Darboux's theorem**: if `a ≤ b` and `f' b < m < f' a`, then `f' c = m` for some `c ∈ (a, b)`.
+/-- **Darboux's theorem**: if `a ≤ b` and `f' a > m > f' b`, then `f' c = m` for some `c ∈ [a, b]`.
 -/
 theorem exists_has_deriv_within_at_eq_of_lt_of_gt
   (hab : a ≤ b) (hf : ∀ x ∈ (Icc a b), has_deriv_within_at f (f' x) (Icc a b) x)
   {m : ℝ} (hma : m < f' a) (hmb : f' b < m) :
-  m ∈ f' '' Ioo a b :=
+  m ∈ f' '' (Icc a b) :=
 let ⟨c, cmem, hc⟩ := exists_has_deriv_within_at_eq_of_gt_of_lt hab (λ x hx, (hf x hx).neg)
   (neg_lt_neg hma) (neg_lt_neg hmb)
 in ⟨c, cmem, neg_injective hc⟩
 
-/-- **Darboux's theorem**: the image of an `ord_connected` set under `f'` is an `ord_connected`
-set, `has_deriv_within_at` version. -/
-theorem set.ord_connected.image_has_deriv_within_at {s : set ℝ} (hs : ord_connected s)
-  (hf : ∀ x ∈ s, has_deriv_within_at f (f' x) s x) :
-  ord_connected (f' '' s) :=
-begin
-  apply ord_connected_of_Ioo,
-  rintros _ ⟨a, ha, rfl⟩ _ ⟨b, hb, rfl⟩ - m ⟨hma, hmb⟩,
-  cases le_total a b with hab hab,
-  { have : Icc a b ⊆ s, from hs.out ha hb,
-    rcases exists_has_deriv_within_at_eq_of_gt_of_lt hab
-      (λ x hx, (hf x $ this hx).mono this) hma hmb
-      with ⟨c, cmem, hc⟩,
-    exact ⟨c, this $ Ioo_subset_Icc_self cmem, hc⟩ },
-  { have : Icc b a ⊆ s, from hs.out hb ha,
-    rcases exists_has_deriv_within_at_eq_of_lt_of_gt hab
-      (λ x hx, (hf x $ this hx).mono this) hmb hma
-      with ⟨c, cmem, hc⟩,
-    exact ⟨c, this $ Ioo_subset_Icc_self cmem, hc⟩ }
-end
-
-/-- **Darboux's theorem**: the image of an `ord_connected` set under `f'` is an `ord_connected`
-set, `deriv_within` version. -/
-theorem set.ord_connected.image_deriv_within {s : set ℝ} (hs : ord_connected s)
-  (hf : differentiable_on ℝ f s) :
-  ord_connected (deriv_within f s '' s) :=
-hs.image_has_deriv_within_at $ λ x hx, (hf x hx).has_deriv_within_at
-
-/-- **Darboux's theorem**: the image of an `ord_connected` set under `f'` is an `ord_connected`
-set, `deriv` version. -/
-theorem set.ord_connected.image_deriv {s : set ℝ} (hs : ord_connected s)
-  (hf : ∀ x ∈ s, differentiable_at ℝ f x) :
-  ord_connected (deriv f '' s) :=
-hs.image_has_deriv_within_at $ λ x hx, (hf x hx).has_deriv_at.has_deriv_within_at
-
-/-- **Darboux's theorem**: the image of a convex set under `f'` is a convex set,
-`has_deriv_within_at` version. -/
-theorem convex.image_has_deriv_within_at {s : set ℝ} (hs : convex ℝ s)
-  (hf : ∀ x ∈ s, has_deriv_within_at f (f' x) s x) :
+/-- **Darboux's theorem**: the image of a convex set under `f'` is a convex set. -/
+theorem convex_image_has_deriv_at {s : set ℝ} (hs : convex ℝ s)
+  (hf : ∀ x ∈ s, has_deriv_at f (f' x) x) :
   convex ℝ (f' '' s) :=
-(hs.ord_connected.image_has_deriv_within_at hf).convex
-
-/-- **Darboux's theorem**: the image of a convex set under `f'` is a convex set,
-`deriv_within` version. -/
-theorem convex.image_deriv_within {s : set ℝ} (hs : convex ℝ s)
-  (hf : differentiable_on ℝ f s) :
-  convex ℝ (deriv_within f s '' s) :=
-(hs.ord_connected.image_deriv_within hf).convex
-
-/-- **Darboux's theorem**: the image of a convex set under `f'` is a convex set,
-`deriv` version. -/
-theorem convex.image_deriv {s : set ℝ} (hs : convex ℝ s)
-  (hf : ∀ x ∈ s, differentiable_at ℝ f x) :
-  convex ℝ (deriv f '' s) :=
-(hs.ord_connected.image_deriv hf).convex
-
-/-- **Darboux's theorem**: if `a ≤ b` and `f' a ≤ m ≤ f' b`, then `f' c = m` for some
-`c ∈ [a, b]`. -/
-theorem exists_has_deriv_within_at_eq_of_ge_of_le
-  (hab : a ≤ b) (hf : ∀ x ∈ (Icc a b), has_deriv_within_at f (f' x) (Icc a b) x)
-  {m : ℝ} (hma : f' a ≤ m) (hmb : m ≤ f' b) :
-  m ∈ f' '' Icc a b :=
-(ord_connected_Icc.image_has_deriv_within_at hf).out
-  (mem_image_of_mem _ (left_mem_Icc.2 hab)) (mem_image_of_mem _ (right_mem_Icc.2 hab)) ⟨hma, hmb⟩
-
-/-- **Darboux's theorem**: if `a ≤ b` and `f' b ≤ m ≤ f' a`, then `f' c = m` for some
-`c ∈ [a, b]`. -/
-theorem exists_has_deriv_within_at_eq_of_le_of_ge
-  (hab : a ≤ b) (hf : ∀ x ∈ (Icc a b), has_deriv_within_at f (f' x) (Icc a b) x)
-  {m : ℝ} (hma : f' a ≤ m) (hmb : m ≤ f' b) :
-  m ∈ f' '' Icc a b :=
-(ord_connected_Icc.image_has_deriv_within_at hf).out
-  (mem_image_of_mem _ (left_mem_Icc.2 hab)) (mem_image_of_mem _ (right_mem_Icc.2 hab)) ⟨hma, hmb⟩
+begin
+  refine ord_connected.convex ⟨_⟩,
+  rintros _ ⟨a, ha, rfl⟩ _ ⟨b, hb, rfl⟩ m ⟨hma, hmb⟩,
+  cases eq_or_lt_of_le hma with hma hma,
+    by exact hma ▸ mem_image_of_mem f' ha,
+  cases eq_or_lt_of_le hmb with hmb hmb,
+    by exact hmb.symm ▸ mem_image_of_mem f' hb,
+  cases le_total a b with hab hab,
+  { have : Icc a b ⊆ s, from hs.ord_connected.out ha hb,
+    rcases exists_has_deriv_within_at_eq_of_gt_of_lt hab
+      (λ x hx, (hf x $ this hx).has_deriv_within_at) hma hmb
+      with ⟨c, cmem, hc⟩,
+    exact ⟨c, this cmem, hc⟩ },
+  { have : Icc b a ⊆ s, from hs.ord_connected.out hb ha,
+    rcases exists_has_deriv_within_at_eq_of_lt_of_gt hab
+      (λ x hx, (hf x $ this hx).has_deriv_within_at) hmb hma
+      with ⟨c, cmem, hc⟩,
+    exact ⟨c, this cmem, hc⟩ }
+end
 
 /-- If the derivative of a function is never equal to `m`, then either
 it is always greater than `m`, or it is always less than `m`. -/
-theorem has_deriv_within_at_forall_lt_or_forall_gt_of_forall_ne {s : set ℝ} (hs : convex ℝ s)
-  (hf : ∀ x ∈ s, has_deriv_within_at f (f' x) s x) {m : ℝ} (hf' : ∀ x ∈ s, f' x ≠ m) :
+theorem deriv_forall_lt_or_forall_gt_of_forall_ne {s : set ℝ} (hs : convex ℝ s)
+  (hf : ∀ x ∈ s, has_deriv_at f (f' x) x) {m : ℝ} (hf' : ∀ x ∈ s, f' x ≠ m) :
   (∀ x ∈ s, f' x < m) ∨ (∀ x ∈ s, m < f' x) :=
 begin
   contrapose! hf',
   rcases hf' with ⟨⟨b, hb, hmb⟩, ⟨a, ha, hma⟩⟩,
-  exact (hs.ord_connected.image_has_deriv_within_at hf).out (mem_image_of_mem f' ha)
+  exact (convex_image_has_deriv_at hs hf).ord_connected.out (mem_image_of_mem f' ha)
     (mem_image_of_mem f' hb) ⟨hma, hmb⟩
 end

--- a/src/analysis/calculus/fderiv_symmetric.lean
+++ b/src/analysis/calculus/fderiv_symmetric.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import analysis.calculus.mean_value
+import analysis.calculus.deriv.pow
 
 /-!
 # Symmetry of the second derivative

--- a/src/analysis/calculus/local_extr/polynomial.lean
+++ b/src/analysis/calculus/local_extr/polynomial.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2021 Benjamin Davidson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Benjamin Davidson, Yury Kudryashov
+-/
+import analysis.calculus.local_extr.rolle
+import analysis.calculus.deriv.polynomial
+import topology.algebra.polynomial
+
+/-!
+# Rolle's Theorem for polynomials
+
+In this file we use Rolle's Theorem to relate the number of roots of a polynomial and its
+derivative. Namely, we prove the following facts.
+
+* `polynomial.card_roots_to_finset_le_card_roots_derivative_diff_roots_succ`: the number of roots of
+  a real polynomial `p` is at most the number of roots of its derivative that are not roots of `p`
+  plus one.
+
+* `polynomial.card_roots_to_finset_le_derivative`, `polynomial.card_root_set_le_derivative`: the
+  number of roots of a real polynomial is at most the number of roots of its derivative plus one.
+
+* `polynomial.card_roots_le_derivative`: same, but the roots are counted with multiplicities.
+
+## Keywords
+
+polynomial, Rolle's Theorem, root
+-/
+
+namespace polynomial
+
+open_locale big_operators polynomial
+
+/-- The number of roots of a real polynomial `p` is at most the number of roots of its derivative
+that are not roots of `p` plus one. -/
+lemma card_roots_to_finset_le_card_roots_derivative_diff_roots_succ (p : ℝ[X]) :
+  p.roots.to_finset.card ≤ (p.derivative.roots.to_finset \ p.roots.to_finset).card + 1 :=
+begin
+  cases eq_or_ne p.derivative 0 with hp' hp',
+  { rw [eq_C_of_derivative_eq_zero hp', roots_C, multiset.to_finset_zero, finset.card_empty],
+    exact zero_le _ },
+  have hp : p ≠ 0, from ne_of_apply_ne derivative (by rwa [derivative_zero]),
+  refine finset.card_le_diff_of_interleaved (λ x hx y hy hxy hxy', _),
+  rw [multiset.mem_to_finset, mem_roots hp] at hx hy,
+  obtain ⟨z, hz1, hz2⟩ := exists_deriv_eq_zero hxy p.continuous_on (hx.trans hy.symm),
+  refine ⟨z, _, hz1⟩,
+  rwa [multiset.mem_to_finset, mem_roots hp', is_root, ← p.deriv]
+end
+
+/-- The number of roots of a real polynomial is at most the number of roots of its derivative plus
+one. -/
+lemma card_roots_to_finset_le_derivative (p : ℝ[X]) :
+  p.roots.to_finset.card ≤ p.derivative.roots.to_finset.card + 1 :=
+p.card_roots_to_finset_le_card_roots_derivative_diff_roots_succ.trans $
+  add_le_add_right (finset.card_mono $ finset.sdiff_subset _ _) _
+
+/-- The number of roots of a real polynomial (counted with multiplicities) is at most the number of
+roots of its derivative (counted with multiplicities) plus one. -/
+lemma card_roots_le_derivative (p : ℝ[X]) : p.roots.card ≤ p.derivative.roots.card + 1 :=
+calc p.roots.card = ∑ x in p.roots.to_finset, p.roots.count x :
+  (multiset.to_finset_sum_count_eq _).symm
+... = ∑ x in p.roots.to_finset, (p.roots.count x - 1 + 1) :
+  eq.symm $ finset.sum_congr rfl $ λ x hx, tsub_add_cancel_of_le $ nat.succ_le_iff.2 $
+    multiset.count_pos.2 $ multiset.mem_to_finset.1 hx
+... = ∑ x in p.roots.to_finset, (p.root_multiplicity x - 1) + p.roots.to_finset.card :
+  by simp only [finset.sum_add_distrib, finset.card_eq_sum_ones, count_roots]
+... ≤ ∑ x in p.roots.to_finset, p.derivative.root_multiplicity x +
+  ((p.derivative.roots.to_finset \ p.roots.to_finset).card + 1) :
+  add_le_add
+    (finset.sum_le_sum $ λ x hx, root_multiplicity_sub_one_le_derivative_root_multiplicity _ _)
+    p.card_roots_to_finset_le_card_roots_derivative_diff_roots_succ
+... ≤ ∑ x in p.roots.to_finset, p.derivative.roots.count x +
+  (∑ x in p.derivative.roots.to_finset \ p.roots.to_finset, p.derivative.roots.count x + 1) :
+  begin
+    simp only [← count_roots],
+    refine add_le_add_left (add_le_add_right ((finset.card_eq_sum_ones _).trans_le _) _) _,
+    refine finset.sum_le_sum (λ x hx, nat.succ_le_iff.2 $ _),
+    rw [multiset.count_pos, ← multiset.mem_to_finset],
+    exact (finset.mem_sdiff.1 hx).1
+  end
+... = p.derivative.roots.card + 1 :
+  begin
+    rw [← add_assoc, ← finset.sum_union finset.disjoint_sdiff, finset.union_sdiff_self_eq_union,
+      ← multiset.to_finset_sum_count_eq, ← finset.sum_subset (finset.subset_union_right _ _)],
+    intros x hx₁ hx₂,
+    simpa only [multiset.mem_to_finset, multiset.count_eq_zero] using hx₂
+  end
+
+/-- The number of real roots of a polynomial is at most the number of roots of its derivative plus
+one. -/
+lemma card_root_set_le_derivative {F : Type*} [comm_ring F] [algebra F ℝ] (p : F[X]) :
+  fintype.card (p.root_set ℝ) ≤ fintype.card (p.derivative.root_set ℝ) + 1 :=
+by simpa only [root_set_def, finset.coe_sort_coe, fintype.card_coe, derivative_map]
+  using card_roots_to_finset_le_derivative (p.map (algebra_map F ℝ))
+
+end polynomial

--- a/src/analysis/calculus/local_extr/rolle.lean
+++ b/src/analysis/calculus/local_extr/rolle.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2019 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov, Anatole Dedecker
+-/
+import analysis.calculus.local_extr.basic
+import topology.algebra.order.rolle
+
+/-!
+# Rolle's Theorem
+
+In this file we prove Rolle's Theorem. The theorem says that for a function `f : ℝ → ℝ` such that
+
+* $f$ is differentiable on an open interval $(a, b)$, $a < b$;
+* $f$ is continuous on the corresponding closed interval $[a, b]$;
+* $f(a) = f(b)$,
+
+there exists a point $c∈(a, b)$ such that $f'(c)=0$.
+
+We prove four versions of this theorem.
+
+* `exists_has_deriv_at_eq_zero` is closest to the statement given above. It assumes that at every
+  point $x ∈ (a, b)$ function $f$ has derivative $f'(x)$, then concludes that $f'(c)=0$ for some
+  $c∈(a, b)$.
+
+* `exists_deriv_eq_zero` deals with `deriv f` instead of an arbitrary function `f'` and a predicate
+  `has_deriv_at`; since we use zero as the "junk" value for `deriv f c`, this version does not
+  assume that `f` is differentiable on the open interval.
+
+* `exists_has_deriv_at_eq_zero'` is similar to `exists_has_deriv_at_eq_zero` but instead of assuming
+  continuity on the closed interval $[a, b]$ it assumes that $f$ tends to the same limit as $x$
+  tends to $a$ from the right and as $x$ tends to $b$ from the left.
+
+* `exists_deriv_eq_zero'` relates to `exists_deriv_eq_zero` as `exists_has_deriv_at_eq_zero'`
+  relates to ``exists_has_deriv_at_eq_zero`.
+
+## References
+
+* [Rolle's Theorem](https://en.wikipedia.org/wiki/Rolle's_theorem);
+
+## Keywords
+
+local extremum, Rolle's Theorem
+-/
+
+open set filter
+open_locale filter topology
+
+variables {f f' : ℝ → ℝ} {a b l : ℝ}
+
+/-- **Rolle's Theorem** `has_deriv_at` version. -/
+lemma exists_has_deriv_at_eq_zero (hab : a < b) (hfc : continuous_on f (Icc a b)) (hfI : f a = f b)
+  (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x) :
+  ∃ c ∈ Ioo a b, f' c = 0 :=
+let ⟨c, cmem, hc⟩ := exists_local_extr_Ioo hab hfc hfI in
+  ⟨c, cmem, hc.has_deriv_at_eq_zero $ hff' c cmem⟩
+
+/-- **Rolle's Theorem** `deriv` version. Note that we do not assume differentiability of `f` because
+we use zero as the "junk" value of `deriv f c` when the function `f` is not differentiable at
+`c`. -/
+lemma exists_deriv_eq_zero (hab : a < b) (hfc : continuous_on f (Icc a b)) (hfI : f a = f b) :
+  ∃ c ∈ Ioo a b, deriv f c = 0 :=
+let ⟨c, cmem, hc⟩ := exists_local_extr_Ioo hab hfc hfI in
+  ⟨c, cmem, hc.deriv_eq_zero⟩
+
+/-- **Rolle's Theorem**, a version for a function on an open interval: if `f` has derivative `f'`
+on `(a, b)` and has the same limit `l` at `𝓝[>] a` and `𝓝[<] b`, then `f' c = 0`
+for some `c ∈ (a, b)`.  -/
+lemma exists_has_deriv_at_eq_zero' (hab : a < b)
+  (hfa : tendsto f (𝓝[>] a) (𝓝 l)) (hfb : tendsto f (𝓝[<] b) (𝓝 l))
+  (hff' : ∀ x ∈ Ioo a b, has_deriv_at f (f' x) x) :
+  ∃ c ∈ Ioo a b, f' c = 0 :=
+let ⟨c, cmem, hc⟩ := exists_is_local_extr_Ioo_of_tendsto hab
+  (λ x hx, (hff' x hx).continuous_at.continuous_within_at) hfa hfb in
+  ⟨c, cmem, hc.has_deriv_at_eq_zero $ hff' c cmem⟩
+
+/-- **Rolle's Theorem**, a version for a function on an open interval: if `f` has the same limit
+`l` at `𝓝[>] a` and `𝓝[<] b`, then `deriv f c = 0` for some `c ∈ (a, b)`. This version
+does not require differentiability of `f` because we define `deriv f c = 0` whenever `f` is not
+differentiable at `c`. -/
+lemma exists_deriv_eq_zero' (hab : a < b) (hfa : tendsto f (𝓝[>] a) (𝓝 l))
+  (hfb : tendsto f (𝓝[<] b) (𝓝 l)) : ∃ c ∈ Ioo a b, deriv f c = 0 :=
+begin
+  by_cases h : ∀ x ∈ Ioo a b, differentiable_at ℝ f x,
+  { exact exists_has_deriv_at_eq_zero' hab hfa hfb (λ x hx, (h x hx).has_deriv_at) },
+  { push_neg at h,
+    obtain ⟨c, hc, hcd⟩ := h,
+    exact ⟨c, hc, deriv_zero_of_not_differentiable_at hcd⟩ }
+end

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Yury Kudryashov
 -/
 import analysis.calculus.deriv.slope
-import analysis.calculus.local_extr
+import analysis.calculus.deriv.mul
+import analysis.calculus.deriv.comp
+import analysis.calculus.local_extr.rolle
 import analysis.convex.slope
 import analysis.convex.normed
 import data.is_R_or_C.basic
@@ -760,7 +762,7 @@ begin
     from λ x hx, ((hff' x hx).const_mul (g b - g a)).sub ((hgg' x hx).const_mul (f b - f a)),
   have hhc : continuous_on h (Icc a b),
     from (continuous_on_const.mul hfc).sub (continuous_on_const.mul hgc),
-  rcases exists_has_deriv_at_eq_zero h h' hab hhc hI hhh' with ⟨c, cmem, hc⟩,
+  rcases exists_has_deriv_at_eq_zero hab hhc hI hhh' with ⟨c, cmem, hc⟩,
   exact ⟨c, cmem, sub_eq_zero.1 hc⟩
 end
 

--- a/src/analysis/calculus/taylor.lean
+++ b/src/analysis/calculus/taylor.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Moritz Doll
 -/
 import analysis.calculus.iterated_deriv
+import analysis.calculus.deriv.pow
 import analysis.calculus.mean_value
 import data.polynomial.module
 

--- a/src/analysis/complex/polynomial.lean
+++ b/src/analysis/complex/polynomial.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Junyan Xu
 -/
 import analysis.complex.liouville
+import analysis.calculus.deriv.polynomial
 import field_theory.is_alg_closed.basic
+import topology.algebra.polynomial
 
 /-!
 # The fundamental theorem of algebra

--- a/src/analysis/special_functions/sqrt.lean
+++ b/src/analysis/special_functions/sqrt.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury G. Kudryashov
 -/
 import analysis.calculus.cont_diff
+import analysis.calculus.deriv.pow
 
 /-!
 # Smoothness of `real.sqrt`

--- a/src/number_theory/liouville/basic.lean
+++ b/src/number_theory/liouville/basic.lean
@@ -31,7 +31,7 @@ def liouville (x : ℝ) := ∀ n : ℕ, ∃ a b : ℤ, 1 < b ∧ x ≠ a / b ∧
 
 namespace liouville
 
-protected lemma irrational {x : ℝ} (h : liouville x) : irrational x :=
+@[protected] lemma irrational {x : ℝ} (h : liouville x) : irrational x :=
 begin
   -- By contradiction, `x = a / b`, with `a ∈ ℤ`, `0 < b ∈ ℕ` is a Liouville number,
   rintros ⟨⟨a, b, bN0, cop⟩, rfl⟩,
@@ -171,7 +171,7 @@ begin
 end
 
 /-- **Liouville's Theorem** -/
-protected theorem transcendental {x : ℝ} (lx : liouville x) :
+theorem transcendental {x : ℝ} (lx : liouville x) :
   transcendental ℤ x :=
 begin
   -- Proceed by contradiction: if `x` is algebraic, then `x` is the root (`ef0`) of a

--- a/src/number_theory/liouville/basic.lean
+++ b/src/number_theory/liouville/basic.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa, Jujian Zhang
 -/
 import analysis.calculus.mean_value
+import analysis.calculus.deriv.polynomial
 import data.polynomial.denoms_clearable
 import data.real.irrational
+import topology.algebra.polynomial
 /-!
 
 # Liouville's theorem
@@ -29,7 +31,7 @@ def liouville (x : ℝ) := ∀ n : ℕ, ∃ a b : ℤ, 1 < b ∧ x ≠ a / b ∧
 
 namespace liouville
 
-@[protected] lemma irrational {x : ℝ} (h : liouville x) : irrational x :=
+protected lemma irrational {x : ℝ} (h : liouville x) : irrational x :=
 begin
   -- By contradiction, `x = a / b`, with `a ∈ ℤ`, `0 < b ∈ ℕ` is a Liouville number,
   rintros ⟨⟨a, b, bN0, cop⟩, rfl⟩,
@@ -169,7 +171,7 @@ begin
 end
 
 /-- **Liouville's Theorem** -/
-theorem transcendental {x : ℝ} (lx : liouville x) :
+protected theorem transcendental {x : ℝ} (lx : liouville x) :
   transcendental ℤ x :=
 begin
   -- Proceed by contradiction: if `x` is algebraic, then `x` is the root (`ef0`) of a

--- a/src/number_theory/liouville/liouville_constant.lean
+++ b/src/number_theory/liouville/liouville_constant.lean
@@ -147,7 +147,7 @@ calc (1 - 1 / m)⁻¹ * (1 / m ^ (n + 1)!) ≤ 2 * (1 / m ^ (n + 1)!) :
 /--  The sum of the `k` initial terms of the Liouville number to base `m` is a ratio of natural
 numbers where the denominator is `m ^ k!`. -/
 lemma liouville_number_rat_initial_terms {m : ℕ} (hm : 0 < m) (k : ℕ) :
-  ∃ p : ℕ, liouville_number_initial_terms m k = p / m ^ k! :=
+∃ p : ℕ, liouville_number_initial_terms m k = p / m ^ k! :=
 begin
   induction k with k h,
   { exact ⟨1, by rw [liouville_number_initial_terms, range_one, sum_singleton, nat.cast_one]⟩ },
@@ -164,7 +164,7 @@ begin
     all_goals { exact pow_ne_zero _ (nat.cast_ne_zero.mpr hm.ne.symm) } }
 end
 
-theorem liouville_liouville_number {m : ℕ} (hm : 2 ≤ m) :
+theorem is_liouville {m : ℕ} (hm : 2 ≤ m) :
   liouville (liouville_number m) :=
 begin
   -- two useful inequalities
@@ -183,8 +183,10 @@ begin
     (aux_calc _ (nat.cast_two.symm.le.trans (nat.cast_le.mpr hm)))⟩
 end
 
-lemma transcendental_liouville_number {m : ℕ} (hm : 2 ≤ m) :
-  transcendental ℤ (liouville_number m) :=
-(liouville_liouville_number hm).transcendental
+/- Placing this lemma outside of the `open/closed liouville`-namespace would allow to remove
+`_root_.`, at the cost of some other small weirdness. -/
+lemma is_transcendental {m : ℕ} (hm : 2 ≤ m) :
+  _root_.transcendental ℤ (liouville_number m) :=
+transcendental (is_liouville hm)
 
 end liouville

--- a/src/number_theory/liouville/liouville_constant.lean
+++ b/src/number_theory/liouville/liouville_constant.lean
@@ -147,7 +147,7 @@ calc (1 - 1 / m)⁻¹ * (1 / m ^ (n + 1)!) ≤ 2 * (1 / m ^ (n + 1)!) :
 /--  The sum of the `k` initial terms of the Liouville number to base `m` is a ratio of natural
 numbers where the denominator is `m ^ k!`. -/
 lemma liouville_number_rat_initial_terms {m : ℕ} (hm : 0 < m) (k : ℕ) :
-∃ p : ℕ, liouville_number_initial_terms m k = p / m ^ k! :=
+  ∃ p : ℕ, liouville_number_initial_terms m k = p / m ^ k! :=
 begin
   induction k with k h,
   { exact ⟨1, by rw [liouville_number_initial_terms, range_one, sum_singleton, nat.cast_one]⟩ },
@@ -164,7 +164,7 @@ begin
     all_goals { exact pow_ne_zero _ (nat.cast_ne_zero.mpr hm.ne.symm) } }
 end
 
-theorem is_liouville {m : ℕ} (hm : 2 ≤ m) :
+theorem liouville_liouville_number {m : ℕ} (hm : 2 ≤ m) :
   liouville (liouville_number m) :=
 begin
   -- two useful inequalities
@@ -183,10 +183,8 @@ begin
     (aux_calc _ (nat.cast_two.symm.le.trans (nat.cast_le.mpr hm)))⟩
 end
 
-/- Placing this lemma outside of the `open/closed liouville`-namespace would allow to remove
-`_root_.`, at the cost of some other small weirdness. -/
-lemma is_transcendental {m : ℕ} (hm : 2 ≤ m) :
-  _root_.transcendental ℤ (liouville_number m) :=
-transcendental (is_liouville hm)
+lemma transcendental_liouville_number {m : ℕ} (hm : 2 ≤ m) :
+  transcendental ℤ (liouville_number m) :=
+(liouville_liouville_number hm).transcendental
 
 end liouville

--- a/src/number_theory/zeta_values.lean
+++ b/src/number_theory/zeta_values.lean
@@ -6,6 +6,7 @@ Authors: David Loeffler
 
 import number_theory.bernoulli_polynomials
 import measure_theory.integral.interval_integral
+import analysis.calculus.deriv.polynomial
 import analysis.fourier.add_circle
 import analysis.p_series
 

--- a/src/ring_theory/polynomial/hermite/gaussian.lean
+++ b/src/ring_theory/polynomial/hermite/gaussian.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Luke Mantle, Jake Levinson
 -/
 import ring_theory.polynomial.hermite.basic
-import analysis.calculus.deriv.pow
+import analysis.calculus.deriv.polynomial
 import analysis.calculus.deriv.add
 import analysis.special_functions.exp
 import analysis.special_functions.exp_deriv

--- a/src/topology/algebra/order/rolle.lean
+++ b/src/topology/algebra/order/rolle.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2019 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov, Anatole Dedecker
+-/
+import topology.algebra.order.extend_from
+import topology.algebra.order.compact
+import topology.algebra.order.t5
+import topology.local_extr
+
+/-!
+# Rolle's Theorem (topological part)
+
+In this file we prove the purely topological part of Rolle's Theorem: namely, that a function that
+is continuous on an interval $[a, b]$, $a<b$, has a local extremum at a point $x ∈ (a, b)$ provided
+that $f(a)=f(b)$. We also prove several variations of this statement.
+
+In `analysis.calculus.local_extr.rolle` we use these lemmas to prove several versions of Rolle's
+Theorem from calculus.
+
+## Keywords
+
+local minimum, local maximum, extremum, Rolle's Theorem
+-/
+
+open filter set
+open_locale topology
+
+variables {α β : Type*}
+  [conditionally_complete_linear_order α] [densely_ordered α]
+  [topological_space α] [order_topology α]
+  [conditionally_complete_linear_order β] [topological_space β] [order_topology β]
+  {f : α → β} {a b : α} {l : β}
+
+/-- A continuous function on a closed interval with `f a = f b` takes either its maximum or its
+minimum value at a point in the interior of the interval. -/
+lemma exists_Ioo_extr_on_Icc (hab : a < b) (hfc : continuous_on f (Icc a b)) (hfI : f a = f b) :
+  ∃ c ∈ Ioo a b, is_extr_on f (Icc a b) c :=
+begin
+  have ne : (Icc a b).nonempty, from nonempty_Icc.2 (le_of_lt hab),
+  -- Consider absolute min and max points
+  obtain ⟨c, cmem, cle⟩ : ∃ c ∈ Icc a b, ∀ x ∈ Icc a b, f c ≤ f x,
+    from is_compact_Icc.exists_forall_le ne hfc,
+  obtain ⟨C, Cmem, Cge⟩ : ∃ C ∈ Icc a b, ∀ x ∈ Icc a b, f x ≤ f C,
+    from is_compact_Icc.exists_forall_ge ne hfc,
+  by_cases hc : f c = f a,
+  { by_cases hC : f C = f a,
+    { have : ∀ x ∈ Icc a b, f x = f a,
+        from λ x hx, le_antisymm (hC ▸ Cge x hx) (hc ▸ cle x hx),
+      -- `f` is a constant, so we can take any point in `Ioo a b`
+      rcases exists_between hab with ⟨c', hc'⟩,
+      refine ⟨c', hc', or.inl _⟩,
+      assume x hx,
+      rw [mem_set_of_eq, this x hx, ← hC],
+      exact Cge c' ⟨le_of_lt hc'.1, le_of_lt hc'.2⟩ },
+    { refine ⟨C, ⟨lt_of_le_of_ne Cmem.1 $ mt _ hC, lt_of_le_of_ne Cmem.2 $ mt _ hC⟩, or.inr Cge⟩,
+      exacts [λ h, by rw h, λ h, by rw [h, hfI]] } },
+  { refine ⟨c, ⟨lt_of_le_of_ne cmem.1 $ mt _ hc, lt_of_le_of_ne cmem.2 $ mt _ hc⟩, or.inl cle⟩,
+      exacts [λ h, by rw h, λ h, by rw [h, hfI]] }
+end
+
+/-- A continuous function on a closed interval with `f a = f b` has a local extremum at some
+point of the corresponding open interval. -/
+lemma exists_local_extr_Ioo (hab : a < b) (hfc : continuous_on f (Icc a b)) (hfI : f a = f b) :
+  ∃ c ∈ Ioo a b, is_local_extr f c :=
+let ⟨c, cmem, hc⟩ := exists_Ioo_extr_on_Icc hab hfc hfI
+in ⟨c, cmem, hc.is_local_extr $ Icc_mem_nhds cmem.1 cmem.2⟩
+
+/-- If a function `f` is continuous on an open interval and tends to the same value at its
+endpoints, then it has an extremum on this open interval. -/
+lemma exists_extr_on_Ioo_of_tendsto (hab : a < b) (hfc : continuous_on f (Ioo a b))
+  (ha : tendsto f (𝓝[>] a) (𝓝 l)) (hb : tendsto f (𝓝[<] b) (𝓝 l)) :
+  ∃ c ∈ Ioo a b, is_extr_on f (Ioo a b) c :=
+begin
+  have h : eq_on (extend_from (Ioo a b) f) f (Ioo a b) := extend_from_extends hfc,
+  obtain ⟨c, hc, hfc⟩ : ∃ c ∈ Ioo a b, is_extr_on (extend_from (Ioo a b) f) (Icc a b) c :=
+    exists_Ioo_extr_on_Icc hab (continuous_on_Icc_extend_from_Ioo hab.ne hfc ha hb)
+      ((eq_lim_at_left_extend_from_Ioo hab ha).trans (eq_lim_at_right_extend_from_Ioo hab hb).symm),
+  exact ⟨c, hc, (hfc.on_subset Ioo_subset_Icc_self).congr h (h hc)⟩
+end
+
+/-- If a function `f` is continuous on an open interval and tends to the same value at its
+endpoints, then it has a local extremum on this open interval. -/
+lemma exists_is_local_extr_Ioo_of_tendsto (hab : a < b) (hfc : continuous_on f (Ioo a b))
+  (ha : tendsto f (𝓝[>] a) (𝓝 l)) (hb : tendsto f (𝓝[<] b) (𝓝 l)) :
+  ∃ c ∈ Ioo a b, is_local_extr f c :=
+let ⟨c, cmem, hc⟩ := exists_extr_on_Ioo_of_tendsto hab hfc ha hb
+in ⟨c, cmem, hc.is_local_extr $ Ioo_mem_nhds cmem.1 cmem.2⟩


### PR DESCRIPTION
UPD: I'm going to redo this PR in `mathlib` 4 after the port. I'm leaving it here as a reminder.

## Split `analysis.calculus.local_extr` into 4 files

- `analysis.calculus.local_extr.basic`: positive tangent cone and Fermat theorem.
- `topology.algebra.order.rolle`: topological part of Rolle's Theorem.
- `analysis.calculus.local_extr.rolle`: Rolle's Theorem.
- `analysis.calculus.local_extr.polynomial`: applications to roots of real polynomials.

## API changes

- Generalize `exists_Ioo_extr_on_Icc` and `exists_local_extr_Ioo`.
- Add `exists_extr_on_Ioo_of_tendsto` and `exists_is_local_extr_Ioo_of_tendsto`.
- Make `f` and `f'` implicit in all versions of Rolle's Theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)