### PR TITLE
[Merged by Bors] - refactor(number_theory/liouville/liouville_number): review API, golf

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -137,7 +137,7 @@ General algebra:
     ring of Witt vectors: 'witt_vector'
     perfection of a ring: 'ring.perfection'
   Transcendental numbers:
-    Liouville's theorem on existence of transcendental numbers: liouville.is_transcendental
+    Liouville's theorem on existence of transcendental numbers: 'transcendental_liouville_number'
 
   Representation theory:
     representation : 'representation'

--- a/src/number_theory/liouville/basic.lean
+++ b/src/number_theory/liouville/basic.lean
@@ -29,7 +29,7 @@ def liouville (x : ℝ) := ∀ n : ℕ, ∃ a b : ℤ, 1 < b ∧ x ≠ a / b ∧
 
 namespace liouville
 
-@[protected] lemma irrational {x : ℝ} (h : liouville x) : irrational x :=
+protected lemma irrational {x : ℝ} (h : liouville x) : irrational x :=
 begin
   -- By contradiction, `x = a / b`, with `a ∈ ℤ`, `0 < b ∈ ℕ` is a Liouville number,
   rintros ⟨⟨a, b, bN0, cop⟩, rfl⟩,
@@ -169,7 +169,7 @@ begin
 end
 
 /-- **Liouville's Theorem** -/
-theorem transcendental {x : ℝ} (lx : liouville x) :
+protected theorem transcendental {x : ℝ} (lx : liouville x) :
   transcendental ℤ x :=
 begin
   -- Proceed by contradiction: if `x` is algebraic, then `x` is the root (`ef0`) of a

--- a/src/number_theory/liouville/liouville_number.lean
+++ b/src/number_theory/liouville/liouville_number.lean
@@ -70,7 +70,8 @@ We start with simple observations.
 protected lemma summable {m : ℝ} (hm : 1 < m) : summable (λ i : ℕ, 1 / m ^ i!) :=
 summable_one_div_pow_of_le hm nat.self_le_factorial
 
-lemma remainder_summable {m : ℝ} (hm : 1 < m) (k : ℕ) : summable (λ i : ℕ, 1 / m ^ (i + (k + 1))!) :=
+lemma remainder_summable {m : ℝ} (hm : 1 < m) (k : ℕ) :
+  summable (λ i : ℕ, 1 / m ^ (i + (k + 1))!) :=
 by convert (summable_nat_add_iff (k + 1)).2 (liouville_number.summable hm)
 
 lemma remainder_pos {m : ℝ} (hm : 1 < m) (k : ℕ) : 0 < remainder m k :=


### PR DESCRIPTION
* Protect `liouville.irrational` and `liouville.transcendental`.
* Sync file name with definition name (Liouville constant vs Liouville number).
* Move auxiliary definitions and lemmas about Liouville number to `liouville_number` namespace.
* Rename auxiliary definitions, golf proofs (where it doesn't affect readability).

---

Many of these changes are a matter of taste, so I'm OK if the original authors prefer to revert them. My main goal was to move auxiliary defs/lemmas to a namespace where they definitely don't clash with facts about numbers that satisfy the `liouville` predicate.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
