### PR TITLE
[Merged by Bors] - feat (number_theory/zeta_function): relate to Dirichlet series

### DIFF
--- a/src/analysis/special_functions/gamma/basic.lean
+++ b/src/analysis/special_functions/gamma/basic.lean
@@ -447,6 +447,19 @@ end
 
 end Gamma_has_deriv
 
+/-- At `s = 0`, the Gamma function has a simple pole with residue 1. -/
+lemma tendsto_self_mul_Gamma_nhds_0 : tendsto (λ z : ℂ, z * Gamma z) (𝓝[≠] 0) (𝓝 1) :=
+begin
+  rw (show 𝓝 (1 : ℂ) = 𝓝 (Gamma (0 + 1)), by simp only [zero_add, complex.Gamma_one]),
+  convert (tendsto.mono_left _ nhds_within_le_nhds).congr'
+    (eventually_eq_of_mem self_mem_nhds_within complex.Gamma_add_one),
+  refine continuous_at.comp _ (continuous_id.add continuous_const).continuous_at,
+  refine (complex.differentiable_at_Gamma _ (λ m, _)).continuous_at,
+  rw [zero_add, ←of_real_nat_cast, ←of_real_neg, ←of_real_one, ne.def, of_real_inj],
+  refine (lt_of_le_of_lt _ zero_lt_one).ne',
+  exact neg_nonpos.mpr (nat.cast_nonneg _),
+end
+
 end complex
 
 namespace real

--- a/src/analysis/special_functions/gamma/basic.lean
+++ b/src/analysis/special_functions/gamma/basic.lean
@@ -448,7 +448,7 @@ end
 end Gamma_has_deriv
 
 /-- At `s = 0`, the Gamma function has a simple pole with residue 1. -/
-lemma tendsto_self_mul_Gamma_nhds_0 : tendsto (λ z : ℂ, z * Gamma z) (𝓝[≠] 0) (𝓝 1) :=
+lemma tendsto_self_mul_Gamma_nhds_zero : tendsto (λ z : ℂ, z * Gamma z) (𝓝[≠] 0) (𝓝 1) :=
 begin
   rw (show 𝓝 (1 : ℂ) = 𝓝 (Gamma (0 + 1)), by simp only [zero_add, complex.Gamma_one]),
   convert (tendsto.mono_left _ nhds_within_le_nhds).congr'

--- a/src/analysis/special_functions/gamma/beta.lean
+++ b/src/analysis/special_functions/gamma/beta.lean
@@ -476,6 +476,14 @@ begin
   { rintro ⟨m, rfl⟩, exact Gamma_neg_nat_eq_zero m },
 end
 
+/-- A weaker, but easier-to-apply, version of `complex.Gamma_ne_zero`. -/
+lemma Gamma_ne_zero_of_re_pos {s : ℂ} (hs : 0 < re s) : Gamma s ≠ 0 :=
+begin
+  refine Gamma_ne_zero (λ m, _),
+  contrapose! hs,
+  simpa only [hs, neg_re, ←of_real_nat_cast, of_real_re, neg_nonpos] using nat.cast_nonneg _,
+end
+
 end complex
 
 namespace real

--- a/src/number_theory/zeta_function.lean
+++ b/src/number_theory/zeta_function.lean
@@ -323,7 +323,7 @@ begin
     { refine tendsto.congr' (eventually_eq_of_mem self_mem_nhds_within (λ z hz, _)) h3,
       rw [←div_div, mul_div_cancel _ (div_ne_zero hz two_ne_zero)] },
     have h4 : tendsto (λ z : ℂ, z / 2 * Gamma (z / 2)) (𝓝[≠] 0) (𝓝 1),
-    { refine tendsto_self_mul_Gamma_nhds_0.comp _,
+    { refine tendsto_self_mul_Gamma_nhds_zero.comp _,
       rw [tendsto_nhds_within_iff, (by simp : 𝓝 (0 : ℂ) = 𝓝 (0 / 2))],
       exact ⟨(tendsto_id.div_const _).mono_left nhds_within_le_nhds,
         eventually_of_mem self_mem_nhds_within (λ x hx, div_ne_zero hx two_ne_zero)⟩ },

--- a/src/number_theory/zeta_function.lean
+++ b/src/number_theory/zeta_function.lean
@@ -33,7 +33,7 @@ I haven't checked exactly what they are).
 ## Outline of proofs:
 
 We define two related functions on the reals, `zeta_kernel₁` and `zeta_kernel₂`. The first is
-`(Θ (t * I) - 1) / 2`, where `θ` is Jacobi's theta function; its Mellin transform is exactly the
+`(θ (t * I) - 1) / 2`, where `θ` is Jacobi's theta function; its Mellin transform is exactly the
 completed zeta function. The second is obtained by subtracting a linear combination of powers on
 the interval `Ioc 0 1` to give a function with exponential decay at both `0` and `∞`. We then define
 `riemann_completed_zeta₀` as the Mellin transform of the second zeta kernel, and define
@@ -310,20 +310,20 @@ begin
       exact differentiable_at.div_const differentiable_at_id _ } },
   /- Second claim: the limit at `s = 0` exists and is equal to `-1 / 2`. -/
   have c2 : tendsto (λ s : ℂ, ↑π ^ (s / 2) * riemann_completed_zeta s / Gamma (s / 2))
-    (𝓝[{(0 : ℂ)}ᶜ] 0) (𝓝 (-1 / 2 : ℂ)),
+    (𝓝[≠] 0) (𝓝 (-1 / 2 : ℂ)),
   { have h1 : tendsto (λ z : ℂ, (π : ℂ) ^ (z / 2)) (𝓝 (0 : ℂ)) (𝓝 1),
     { convert (continuous_at_const_cpow (of_real_ne_zero.mpr pi_pos.ne')).comp _,
       { simp_rw [function.comp_app, zero_div, cpow_zero] },
       { exact continuous_at_id.div continuous_at_const two_ne_zero } },
-    suffices h2 : tendsto (λ z, riemann_completed_zeta z / Gamma (z / 2)) (𝓝[{0}ᶜ] 0)
+    suffices h2 : tendsto (λ z, riemann_completed_zeta z / Gamma (z / 2)) (𝓝[≠] 0)
       (𝓝 (-1 / 2 : ℂ)),
     { convert (h1.mono_left nhds_within_le_nhds).mul h2,
       { ext1 x, rw mul_div }, { simp only [one_mul] } },
     suffices h3 : tendsto (λ z, (riemann_completed_zeta z * (z / 2)) / ((z / 2) * Gamma (z / 2)))
-      (𝓝[{0}ᶜ] 0) (𝓝 (-1 / 2 : ℂ)),
+      (𝓝[≠] 0) (𝓝 (-1 / 2 : ℂ)),
     { refine tendsto.congr' (eventually_eq_of_mem self_mem_nhds_within (λ z hz, _)) h3,
       rw [←div_div, mul_div_cancel _ (div_ne_zero hz two_ne_zero)] },
-    have h4 : tendsto (λ z : ℂ, z / 2 * Gamma (z / 2)) (𝓝[{0}ᶜ] 0) (𝓝 (1 : ℂ)),
+    have h4 : tendsto (λ z : ℂ, z / 2 * Gamma (z / 2)) (𝓝[≠] 0) (𝓝 (1 : ℂ)),
     { convert tendsto.congr' _
         ((_ : continuous_at (λ z : ℂ, Gamma (z / 2 + 1)) 0).mono_left nhds_within_le_nhds),
       { rw [zero_div, zero_add, complex.Gamma_one] },
@@ -337,7 +337,7 @@ begin
           exact neg_nonpos.mpr (nat.cast_nonneg _), },
         { apply continuous.continuous_at,
           exact (continuous_id'.div_const 2).add continuous_const, } } },
-    suffices : tendsto (λ z, riemann_completed_zeta z * z / 2) (𝓝[{0}ᶜ] 0) (𝓝 (-1 / 2 : ℂ)),
+    suffices : tendsto (λ z, riemann_completed_zeta z * z / 2) (𝓝[≠] 0) (𝓝 (-1 / 2 : ℂ)),
     { have := this.div h4 one_ne_zero,
       simp_rw [div_one, mul_div_assoc] at this,
       exact this },
@@ -359,8 +359,8 @@ begin
   -- Now the main proof.
   rcases ne_or_eq s 0 with hs | rfl,
   { -- The easy case: `s ≠ 0`
-    refine (c1 s hs hs').congr_of_eventually_eq (eventually_eq_of_mem _ (λ x hx, _)),
-    show {(0 : ℂ)}ᶜ ∈ 𝓝 s, from is_open_compl_singleton.mem_nhds hs,
+    have : {(0 : ℂ)}ᶜ ∈ 𝓝 s, from is_open_compl_singleton.mem_nhds hs,
+    refine (c1 s hs hs').congr_of_eventually_eq (eventually_eq_of_mem this (λ x hx, _)),
     unfold riemann_zeta,
     apply function.update_noteq hx },
   { -- The hard case: `s = 0`.
@@ -389,7 +389,7 @@ end
 /-- A formal statement of the Riemann hypothesis – constructing a term of this type is worth a
 million dollars. -/
 def riemann_hypothesis : Prop :=
-  ∀ (s : ℂ) (hs : riemann_completed_zeta s = 0) (hs' : ¬∃ (n : ℕ), s = -2 * (n + 1)), s.re = 1 / 2
+∀ (s : ℂ) (hs : riemann_completed_zeta s = 0) (hs' : ¬∃ (n : ℕ), s = -2 * (n + 1)), s.re = 1 / 2
 
 /-!
 ## Relating the Mellin transforms of the two zeta kernels
@@ -468,14 +468,12 @@ begin
     rw [←nat.cast_succ],
     exact nat.cast_nonneg _ },
   conv_rhs { rw [this, mul_comm, ←smul_eq_mul] },
-  rw [←mellin_comp_mul_right],
-  { refine set_integral_congr measurable_set_Ioi (λ t ht, _),
-    simp_rw smul_eq_mul,
-    congr' 3,
-    conv_rhs { rw [←nat.cast_two, rpow_nat_cast] },
-    ring },
-  { rw [←nat.cast_succ, ←nat.cast_two, rpow_nat_cast],
-    exact sq_pos_of_ne_zero _ (nat.cast_ne_zero.mpr $ nat.succ_ne_zero _) },
+  rw [← mellin_comp_mul_right _ _ (show 0 < ((n : ℝ) + 1) ^ (2 : ℝ), by positivity)],
+  refine set_integral_congr measurable_set_Ioi (λ t ht, _),
+  simp_rw smul_eq_mul,
+  congr' 3,
+  conv_rhs { rw [←nat.cast_two, rpow_nat_cast] },
+  ring
 end
 
 lemma mellin_zeta_kernel₁_eq_tsum {s : ℂ} (hs : 1 / 2 < s.re):
@@ -531,6 +529,9 @@ begin
   rwa [of_real_mul_re, ←div_eq_inv_mul, div_lt_div_right (zero_lt_two' ℝ)]
 end
 
+/-- The Riemann zeta function agrees with the naive Dirichlet-series definition when the latter
+converges. (Note that this is false without the assumption: when `re s ≤ 1` the sum is divergent,
+and we use a different definition to obtain the analytic continuation to all `s`.) -/
 theorem zeta_eq_tsum_of_one_lt_re {s : ℂ} (hs : 1 < re s) :
   riemann_zeta s = ∑' (n : ℕ), 1 / (n + 1) ^ s :=
 begin

--- a/src/number_theory/zeta_function.lean
+++ b/src/number_theory/zeta_function.lean
@@ -310,33 +310,23 @@ begin
       exact differentiable_at.div_const differentiable_at_id _ } },
   /- Second claim: the limit at `s = 0` exists and is equal to `-1 / 2`. -/
   have c2 : tendsto (λ s : ℂ, ↑π ^ (s / 2) * riemann_completed_zeta s / Gamma (s / 2))
-    (𝓝[≠] 0) (𝓝 (-1 / 2 : ℂ)),
-  { have h1 : tendsto (λ z : ℂ, (π : ℂ) ^ (z / 2)) (𝓝 (0 : ℂ)) (𝓝 1),
+    (𝓝[≠] 0) (𝓝 $ -1 / 2),
+  { have h1 : tendsto (λ z : ℂ, (π : ℂ) ^ (z / 2)) (𝓝 0) (𝓝 1),
     { convert (continuous_at_const_cpow (of_real_ne_zero.mpr pi_pos.ne')).comp _,
       { simp_rw [function.comp_app, zero_div, cpow_zero] },
       { exact continuous_at_id.div continuous_at_const two_ne_zero } },
-    suffices h2 : tendsto (λ z, riemann_completed_zeta z / Gamma (z / 2)) (𝓝[≠] 0)
-      (𝓝 (-1 / 2 : ℂ)),
+    suffices h2 : tendsto (λ z, riemann_completed_zeta z / Gamma (z / 2)) (𝓝[≠] 0) (𝓝 $ -1 / 2),
     { convert (h1.mono_left nhds_within_le_nhds).mul h2,
       { ext1 x, rw mul_div }, { simp only [one_mul] } },
-    suffices h3 : tendsto (λ z, (riemann_completed_zeta z * (z / 2)) / ((z / 2) * Gamma (z / 2)))
-      (𝓝[≠] 0) (𝓝 (-1 / 2 : ℂ)),
+    suffices h3 : tendsto (λ z, (riemann_completed_zeta z * (z / 2)) / (z / 2 * Gamma (z / 2)))
+      (𝓝[≠] 0) (𝓝 $ -1 / 2),
     { refine tendsto.congr' (eventually_eq_of_mem self_mem_nhds_within (λ z hz, _)) h3,
       rw [←div_div, mul_div_cancel _ (div_ne_zero hz two_ne_zero)] },
-    have h4 : tendsto (λ z : ℂ, z / 2 * Gamma (z / 2)) (𝓝[≠] 0) (𝓝 (1 : ℂ)),
-    { convert tendsto.congr' _
-        ((_ : continuous_at (λ z : ℂ, Gamma (z / 2 + 1)) 0).mono_left nhds_within_le_nhds),
-      { rw [zero_div, zero_add, complex.Gamma_one] },
-      { refine eventually_eq_of_mem self_mem_nhds_within (λ z hz, _),
-        exact complex.Gamma_add_one _ (div_ne_zero hz two_ne_zero) },
-      { apply continuous_at.comp,
-        { rw [zero_div, zero_add],
-          refine (complex.differentiable_at_Gamma _ (λ m, _)).continuous_at,
-          rw [←of_real_nat_cast, ←of_real_neg, ←of_real_one, ne.def, of_real_inj],
-          refine (lt_of_le_of_lt _ zero_lt_one).ne',
-          exact neg_nonpos.mpr (nat.cast_nonneg _), },
-        { apply continuous.continuous_at,
-          exact (continuous_id'.div_const 2).add continuous_const, } } },
+    have h4 : tendsto (λ z : ℂ, z / 2 * Gamma (z / 2)) (𝓝[≠] 0) (𝓝 1),
+    { refine tendsto_self_mul_Gamma_nhds_0.comp _,
+      rw [tendsto_nhds_within_iff, (by simp : 𝓝 (0 : ℂ) = 𝓝 (0 / 2))],
+      exact ⟨(tendsto_id.div_const _).mono_left nhds_within_le_nhds,
+        eventually_of_mem self_mem_nhds_within (λ x hx, div_ne_zero hx two_ne_zero)⟩ },
     suffices : tendsto (λ z, riemann_completed_zeta z * z / 2) (𝓝[≠] 0) (𝓝 (-1 / 2 : ℂ)),
     { have := this.div h4 one_ne_zero,
       simp_rw [div_one, mul_div_assoc] at this,
@@ -364,7 +354,7 @@ begin
     unfold riemann_zeta,
     apply function.update_noteq hx },
   { -- The hard case: `s = 0`.
-    rw [riemann_zeta, ←(lim_eq_iff ⟨(-1 / 2 : ℂ), c2⟩).mpr c2],
+    rw [riemann_zeta, ←(lim_eq_iff ⟨-1 / 2, c2⟩).mpr c2],
     have S_nhds : {(1 : ℂ)}ᶜ ∈ 𝓝 (0 : ℂ), from is_open_compl_singleton.mem_nhds hs',
     refine ((complex.differentiable_on_update_lim_of_is_o S_nhds
       (λ t ht, (c1 t ht.2 ht.1).differentiable_within_at) _) 0 hs').differentiable_at S_nhds,
@@ -409,7 +399,7 @@ end
 
 /-- Evaluate the Mellin transform of the "fudge factor" in `zeta_kernel₂` -/
 lemma has_mellin_one_div_sqrt_sub_one_div_two_Ioc {s : ℂ} (hs : 1 / 2 < s.re) :
-  has_mellin ((Ioc 0 1).indicator (λ t, (1 - 1 / (↑(sqrt t) : ℂ)) / 2)) s
+  has_mellin ((Ioc 0 1).indicator (λ t, (1 - 1 / (sqrt t : ℂ)) / 2)) s
   (1 / (2 * s) - 1 / (2 * s - 1)) :=
 begin
   have step1 : has_mellin (indicator (Ioc 0 1) (λ t, 1 - 1 / ↑(sqrt t) : ℝ → ℂ)) s
@@ -418,8 +408,8 @@ begin
     have b := has_mellin_one_div_sqrt_Ioc hs,
     simpa only [a.2, b.2, ←indicator_sub] using has_mellin_sub a.1 b.1 },
   -- todo: implement something like "indicator.const_div" (blocked by the port for now)
-  rw (show (Ioc 0 1).indicator (λ t, (1 - 1 / (↑(sqrt t) : ℂ)) / 2) =
-    λ t, ((Ioc 0 1).indicator (λ t, (1 - 1 / (↑(sqrt t) : ℂ))) t) / 2,
+  rw (show (Ioc 0 1).indicator (λ t, (1 - 1 / (sqrt t : ℂ)) / 2) =
+    λ t, ((Ioc 0 1).indicator (λ t, (1 - 1 / (sqrt t : ℂ))) t) / 2,
     by { ext1 t, simp_rw [div_eq_inv_mul, indicator_mul_right] }),
   simp_rw [has_mellin, mellin_div_const, step1.2, sub_div, div_div],
   refine ⟨step1.1.div_const _, _⟩,


### PR DESCRIPTION
This PR adds two important properties of the Riemann zeta function: firstly, it is differentiable away from `s = 1` (which is easy for `s ≠ 0`, but much harder at `s = 0`); secondly, for `1 < re s` the zeta function is given by the usual Dirichlet series.

Just for fun, we also add a formal statement of the Riemann hypothesis.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
