### PR TITLE
[Merged by Bors] - feat (special_functions/gamma): doubling formula

### DIFF
--- a/src/analysis/analytic/isolated_zeros.lean
+++ b/src/analysis/analytic/isolated_zeros.lean
@@ -195,4 +195,15 @@ theorem eq_on_of_preconnected_of_mem_closure (hf : analytic_on 𝕜 f U) (hg : a
   eq_on f g U :=
 hf.eq_on_of_preconnected_of_frequently_eq hg hU h₀ (mem_closure_ne_iff_frequently_within.mp hfg)
 
+/-- The *identity principle* for analytic functions, global version: if two functions on a normed
+field `𝕜` are analytic everywhere and coincide at points which accumulate to a point `z₀`, then
+they coincide globally.
+For higher-dimensional versions requiring that the functions coincide in a neighborhood of `z₀`,
+see `eq_on_of_eventually_eq`. -/
+theorem eq_of_frequently_eq [connected_space 𝕜]
+  (hf : analytic_on 𝕜 f univ) (hg : analytic_on 𝕜 g univ)
+  (hfg : ∃ᶠ z in 𝓝[≠] z₀, f z = g z) : f = g :=
+funext (λ x, eq_on_of_preconnected_of_frequently_eq hf hg is_preconnected_univ
+    (mem_univ z₀) hfg (mem_univ x))
+
 end analytic_on

--- a/src/analysis/analytic/isolated_zeros.lean
+++ b/src/analysis/analytic/isolated_zeros.lean
@@ -199,7 +199,7 @@ hf.eq_on_of_preconnected_of_frequently_eq hg hU h₀ (mem_closure_ne_iff_frequen
 field `𝕜` are analytic everywhere and coincide at points which accumulate to a point `z₀`, then
 they coincide globally.
 For higher-dimensional versions requiring that the functions coincide in a neighborhood of `z₀`,
-see `eq_on_of_eventually_eq`. -/
+see `eq_of_eventually_eq`. -/
 theorem eq_of_frequently_eq [connected_space 𝕜]
   (hf : analytic_on 𝕜 f univ) (hg : analytic_on 𝕜 g univ)
   (hfg : ∃ᶠ z in 𝓝[≠] z₀, f z = g z) : f = g :=

--- a/src/analysis/analytic/uniqueness.lean
+++ b/src/analysis/analytic/uniqueness.lean
@@ -106,7 +106,7 @@ end
 /-- The *identity principle* for analytic functions: If two analytic functions on a normed space
 coincide in a neighborhood of a point `z₀`, then they coincide everywhere.
 For a one-dimensional version assuming only that the functions coincide at some points
-arbitrarily close to `z₀`, see `eq_on_of_frequently_eq`. -/
+arbitrarily close to `z₀`, see `eq_of_frequently_eq`. -/
 theorem eq_of_eventually_eq {f g : E → F} [preconnected_space E]
   (hf : analytic_on 𝕜 f univ) (hg : analytic_on 𝕜 g univ) {z₀ : E} (hfg : f =ᶠ[𝓝 z₀] g) :
   f = g :=

--- a/src/analysis/analytic/uniqueness.lean
+++ b/src/analysis/analytic/uniqueness.lean
@@ -93,7 +93,7 @@ end
 neighborhood of a point `z₀`, then they coincide globally along a connected set.
 For a one-dimensional version assuming only that the functions coincide at some points
 arbitrarily close to `z₀`, see `eq_on_of_preconnected_of_frequently_eq`. -/
-theorem eq_of_preconnected_of_eventually_eq
+theorem eq_on_of_preconnected_of_eventually_eq
   {f g : E → F} {U : set E} (hf : analytic_on 𝕜 f U) (hg : analytic_on 𝕜 g U)
   (hU : is_preconnected U) {z₀ : E} (h₀ : z₀ ∈ U) (hfg : f =ᶠ[𝓝 z₀] g) :
   eq_on f g U :=
@@ -107,7 +107,7 @@ end
 coincide in a neighborhood of a point `z₀`, then they coincide everywhere.
 For a one-dimensional version assuming only that the functions coincide at some points
 arbitrarily close to `z₀`, see `eq_on_of_frequently_eq`. -/
-theorem eq_on_of_eventually_eq {f g : E → F} [preconnected_space E]
+theorem eq_of_eventually_eq {f g : E → F} [preconnected_space E]
   (hf : analytic_on 𝕜 f univ) (hg : analytic_on 𝕜 g univ) {z₀ : E} (hfg : f =ᶠ[𝓝 z₀] g) :
   f = g :=
 funext (λ x, eq_on_of_preconnected_of_eventually_eq hf hg is_preconnected_univ

--- a/src/analysis/analytic/uniqueness.lean
+++ b/src/analysis/analytic/uniqueness.lean
@@ -89,11 +89,11 @@ begin
   exact uniform_space.completion.coe_injective F this,
 end
 
-/-- The *identity principle* for analytic functions: If two analytic function coincide in a whole
+/-- The *identity principle* for analytic functions: If two analytic functions coincide in a whole
 neighborhood of a point `z₀`, then they coincide globally along a connected set.
 For a one-dimensional version assuming only that the functions coincide at some points
 arbitrarily close to `z₀`, see `eq_on_of_preconnected_of_frequently_eq`. -/
-theorem eq_on_of_preconnected_of_eventually_eq
+theorem eq_of_preconnected_of_eventually_eq
   {f g : E → F} {U : set E} (hf : analytic_on 𝕜 f U) (hg : analytic_on 𝕜 g U)
   (hU : is_preconnected U) {z₀ : E} (h₀ : z₀ ∈ U) (hfg : f =ᶠ[𝓝 z₀] g) :
   eq_on f g U :=
@@ -102,5 +102,15 @@ begin
   simpa [sub_eq_zero] using
     λ z hz, (hf.sub hg).eq_on_zero_of_preconnected_of_eventually_eq_zero hU h₀ hfg' hz,
 end
+
+/-- The *identity principle* for analytic functions: If two analytic functions on a normed space
+coincide in a neighborhood of a point `z₀`, then they coincide everywhere.
+For a one-dimensional version assuming only that the functions coincide at some points
+arbitrarily close to `z₀`, see `eq_on_of_frequently_eq`. -/
+theorem eq_on_of_eventually_eq {f g : E → F} [preconnected_space E]
+  (hf : analytic_on 𝕜 f univ) (hg : analytic_on 𝕜 g univ) {z₀ : E} (hfg : f =ᶠ[𝓝 z₀] g) :
+  f = g :=
+funext (λ x, eq_on_of_preconnected_of_eventually_eq hf hg is_preconnected_univ
+    (mem_univ z₀) hfg (mem_univ x))
 
 end analytic_on

--- a/src/analysis/special_functions/gamma/beta.lean
+++ b/src/analysis/special_functions/gamma/beta.lean
@@ -32,7 +32,7 @@ refined properties of the Gamma function using these relations.
 * `complex.Gamma_mul_Gamma_add_half`: Legendre's duplication formula
   `Gamma s * Gamma (s + 1 / 2) = Gamma (2 * s) * 2 ^ (1 - 2 * s) * sqrt π`.
 * `real.Gamma_ne_zero`, `real.Gamma_seq_tendsto_Gamma`,
-  `real.Gamma_mul_Gamma_one_sub` ,`real.Gamma_mul_Gamma_add_half`: real versions of the above.
+  `real.Gamma_mul_Gamma_one_sub`, `real.Gamma_mul_Gamma_add_half`: real versions of the above.
 -/
 
 noncomputable theory

--- a/src/analysis/special_functions/gamma/beta.lean
+++ b/src/analysis/special_functions/gamma/beta.lean
@@ -32,7 +32,7 @@ refined properties of the Gamma function using these relations.
 * `complex.Gamma_mul_Gamma_add_half`: Legendre's duplication formula
   `Gamma s * Gamma (s + 1 / 2) = Gamma (2 * s) * 2 ^ (1 - 2 * s) * sqrt π`.
 * `real.Gamma_ne_zero`, `real.Gamma_seq_tendsto_Gamma`,
-  `real.Gamma_mul_Gamma_one_sub` ,`real.Gamma_mul_Gamma_add_half`: real versons of the above.
+  `real.Gamma_mul_Gamma_one_sub` ,`real.Gamma_mul_Gamma_add_half`: real versions of the above.
 -/
 
 noncomputable theory
@@ -578,31 +578,27 @@ namespace complex
 theorem Gamma_mul_Gamma_add_half (s : ℂ) :
   Gamma s * Gamma (s + 1 / 2) = Gamma (2 * s) * 2 ^ (1 - 2 * s) * ↑(real.sqrt π) :=
 begin
-  let S := (univ : set ℂ),
-  suffices : eq_on (λ z, (Gamma z)⁻¹ * (Gamma (z + 1 / 2))⁻¹)
-    (λ z, (Gamma (2 * z))⁻¹  * 2 ^ (2 * z - 1) / ↑(real.sqrt π)) S,
-  { convert congr_arg has_inv.inv (this $ mem_univ s) using 1,
+  suffices : (λ z, (Gamma z)⁻¹ * (Gamma (z + 1 / 2))⁻¹) =
+    (λ z, (Gamma (2 * z))⁻¹  * 2 ^ (2 * z - 1) / ↑(real.sqrt π)),
+  { convert congr_arg has_inv.inv (congr_fun this s) using 1,
     { rw [mul_inv, inv_inv, inv_inv] },
     { rw [div_eq_mul_inv, mul_inv, mul_inv, inv_inv, inv_inv, ←cpow_neg, neg_sub] } },
-  have h0 : is_open S, from is_open_univ,
-  have h1 : analytic_on ℂ (λ z : ℂ, (Gamma z)⁻¹ * (Gamma (z + 1 / 2))⁻¹) S,
-  { refine differentiable_on.analytic_on _ h0,
+  have h1 : analytic_on ℂ (λ z : ℂ, (Gamma z)⁻¹ * (Gamma (z + 1 / 2))⁻¹) univ,
+  { refine differentiable_on.analytic_on _ is_open_univ,
     refine (differentiable_one_div_Gamma.mul _).differentiable_on,
     exact differentiable_one_div_Gamma.comp (differentiable_id.add (differentiable_const _)) },
-  have h2 : analytic_on ℂ (λ z, (Gamma (2 * z))⁻¹  * 2 ^ (2 * z - 1) / ↑(real.sqrt π)) S,
-  { refine differentiable_on.analytic_on _ h0,
+  have h2 : analytic_on ℂ (λ z, (Gamma (2 * z))⁻¹  * 2 ^ (2 * z - 1) / ↑(real.sqrt π)) univ,
+  { refine differentiable_on.analytic_on _ is_open_univ,
     refine (differentiable.mul _ (differentiable_const _)).differentiable_on,
     apply differentiable.mul,
     { exact differentiable_one_div_Gamma.comp (differentiable_id'.const_mul _) },
     { refine λ t, differentiable_at.const_cpow _ (or.inl two_ne_zero),
       refine differentiable_at.sub_const (differentiable_at_id.const_mul _) _ } },
-  have h3 : is_preconnected S, from is_preconnected_univ,
-  have h4 : (1 : ℂ) ∈ S, from mem_univ _,
-  have h5 : tendsto (coe : ℝ → ℂ) (𝓝[≠] 1) (𝓝[≠] 1),
+  have h3 : tendsto (coe : ℝ → ℂ) (𝓝[≠] 1) (𝓝[≠] 1),
   { rw tendsto_nhds_within_iff, split,
     { exact tendsto_nhds_within_of_tendsto_nhds continuous_of_real.continuous_at },
     { exact eventually_nhds_within_iff.mpr (eventually_of_forall $ λ t ht, of_real_ne_one.mpr ht)}},
-  refine analytic_on.eq_on_of_preconnected_of_frequently_eq h1 h2 h3 h4 (h5.frequently _),
+  refine analytic_on.eq_of_frequently_eq h1 h2 (h3.frequently _),
   refine ((eventually.filter_mono nhds_within_le_nhds) _).frequently,
   refine (eventually_gt_nhds zero_lt_one).mp (eventually_of_forall $ λ t ht, _),
   rw [←mul_inv, Gamma_of_real, (by push_cast : (t : ℂ) + 1 / 2 = ↑(t + 1 / 2)), Gamma_of_real,

--- a/src/analysis/special_functions/gamma/beta.lean
+++ b/src/analysis/special_functions/gamma/beta.lean
@@ -5,7 +5,8 @@ Authors: David Loeffler
 -/
 import analysis.convolution
 import analysis.special_functions.trigonometric.euler_sine_prod
-import analysis.special_functions.gamma.basic
+import analysis.special_functions.gamma.bohr_mollerup
+import analysis.analytic.isolated_zeros
 
 /-!
 # The Beta function, and further properties of the Gamma function
@@ -28,8 +29,10 @@ refined properties of the Gamma function using these relations.
 * `complex.Gamma_mul_Gamma_one_sub`: Euler's reflection formula
   `Gamma s * Gamma (1 - s) = π / sin π s`.
 * `complex.differentiable_one_div_Gamma`: the function `1 / Γ(s)` is differentiable everywhere.
+* `complex.Gamma_mul_Gamma_add_half`: Legendre's duplication formula
+  `Gamma s * Gamma (s + 1 / 2) = Gamma (2 * s) * 2 ^ (1 - 2 * s) * sqrt π`.
 * `real.Gamma_ne_zero`, `real.Gamma_seq_tendsto_Gamma`,
-  `real.Gamma_mul_Gamma_one_sub`: real versions of the above results.
+  `real.Gamma_mul_Gamma_one_sub` ,`real.Gamma_mul_Gamma_add_half`: real versons of the above.
 -/
 
 noncomputable theory
@@ -560,3 +563,68 @@ end
 end complex
 
 end inv_gamma
+
+section doubling
+/-!
+## The doubling formula for Gamma
+
+We prove the doubling formula for arbitrary real or complex arguments, by analytic continuation from
+the positive real case. (Knowing that `Γ⁻¹` is analytic everywhere makes this much simpler, since we
+do not have to do any special-case handling for the poles of `Γ`.)
+-/
+
+namespace complex
+
+theorem Gamma_mul_Gamma_add_half (s : ℂ) :
+  Gamma s * Gamma (s + 1 / 2) = Gamma (2 * s) * 2 ^ (1 - 2 * s) * ↑(real.sqrt π) :=
+begin
+  let S := (univ : set ℂ),
+  suffices : eq_on (λ z, (Gamma z)⁻¹ * (Gamma (z + 1 / 2))⁻¹)
+    (λ z, (Gamma (2 * z))⁻¹  * 2 ^ (2 * z - 1) / ↑(real.sqrt π)) S,
+  { convert congr_arg has_inv.inv (this $ mem_univ s) using 1,
+    { rw [mul_inv, inv_inv, inv_inv] },
+    { rw [div_eq_mul_inv, mul_inv, mul_inv, inv_inv, inv_inv, ←cpow_neg, neg_sub] } },
+  have h0 : is_open S, from is_open_univ,
+  have h1 : analytic_on ℂ (λ z : ℂ, (Gamma z)⁻¹ * (Gamma (z + 1 / 2))⁻¹) S,
+  { refine differentiable_on.analytic_on _ h0,
+    refine (differentiable_one_div_Gamma.mul _).differentiable_on,
+    exact differentiable_one_div_Gamma.comp (differentiable_id.add (differentiable_const _)) },
+  have h2 : analytic_on ℂ (λ z, (Gamma (2 * z))⁻¹  * 2 ^ (2 * z - 1) / ↑(real.sqrt π)) S,
+  { refine differentiable_on.analytic_on _ h0,
+    refine (differentiable.mul _ (differentiable_const _)).differentiable_on,
+    apply differentiable.mul,
+    { exact differentiable_one_div_Gamma.comp (differentiable_id'.const_mul _) },
+    { refine λ t, differentiable_at.const_cpow _ (or.inl two_ne_zero),
+      refine differentiable_at.sub_const (differentiable_at_id.const_mul _) _ } },
+  have h3 : is_preconnected S, from is_preconnected_univ,
+  have h4 : (1 : ℂ) ∈ S, from mem_univ _,
+  have h5 : tendsto (coe : ℝ → ℂ) (𝓝[≠] 1) (𝓝[≠] 1),
+  { rw tendsto_nhds_within_iff, split,
+    { exact tendsto_nhds_within_of_tendsto_nhds continuous_of_real.continuous_at },
+    { exact eventually_nhds_within_iff.mpr (eventually_of_forall $ λ t ht, of_real_ne_one.mpr ht)}},
+  refine analytic_on.eq_on_of_preconnected_of_frequently_eq h1 h2 h3 h4 (h5.frequently _),
+  refine ((eventually.filter_mono nhds_within_le_nhds) _).frequently,
+  refine (eventually_gt_nhds zero_lt_one).mp (eventually_of_forall $ λ t ht, _),
+  rw [←mul_inv, Gamma_of_real, (by push_cast : (t : ℂ) + 1 / 2 = ↑(t + 1 / 2)), Gamma_of_real,
+    ←of_real_mul, Gamma_mul_Gamma_add_half_of_pos ht, of_real_mul, of_real_mul, ←Gamma_of_real,
+    mul_inv, mul_inv, (by push_cast : 2 * (t : ℂ) = ↑(2 * t)), Gamma_of_real,
+    of_real_cpow zero_le_two, of_real_bit0, of_real_one, ←cpow_neg, of_real_sub, of_real_one,
+    neg_sub, ←div_eq_mul_inv]
+end
+
+end complex
+
+namespace real
+open complex
+
+lemma Gamma_mul_Gamma_add_half (s : ℝ) :
+  Gamma s * Gamma (s + 1 / 2) = Gamma (2 * s) * 2 ^ (1 - 2 * s) * sqrt π :=
+begin
+  rw [←of_real_inj],
+  simpa only [←Gamma_of_real, of_real_cpow zero_le_two, of_real_mul, of_real_add, of_real_div,
+    of_real_bit0, of_real_one, of_real_sub] using complex.Gamma_mul_Gamma_add_half ↑s
+end
+
+end real
+
+end doubling

--- a/src/analysis/special_functions/gamma/bohr_mollerup.lean
+++ b/src/analysis/special_functions/gamma/bohr_mollerup.lean
@@ -6,7 +6,6 @@ Authors: David Loeffler
 import analysis.special_functions.gamma.basic
 import analysis.special_functions.gaussian
 
-
 /-! # Convexity properties of the Gamma function
 
 In this file, we prove that `Gamma` and `log ∘ Gamma` are convex functions on the positive real
@@ -45,7 +44,6 @@ section convexity
 
 -- Porting note: move the following lemmas to `Analysis.Convex.Function`
 variables {𝕜 E β : Type*} {s : set E} {f g : E → β}
-
   [ordered_semiring 𝕜] [has_smul 𝕜 E] [add_comm_monoid E] [ordered_add_comm_monoid β]
 
 lemma convex_on.congr [has_smul 𝕜 β] (hf : convex_on 𝕜 s f) (hfg : eq_on f g s) :

--- a/src/analysis/special_functions/gamma/bohr_mollerup.lean
+++ b/src/analysis/special_functions/gamma/bohr_mollerup.lean
@@ -31,6 +31,10 @@ general form of the Euler limit formula valid for any real or complex `x`; see
 As an application of the Bohr-Mollerup theorem we prove the Legendre doubling formula for the
 Gamma function for real positive `s` (which will be upgraded to a proof for all complex `s` in a
 later file).
+
+TODO: This argument can be extended to prove the general `k`-multiplication formula (at least up
+to a constant, and it should be possible to deduce the value of this constant using Stirling's
+formula).
 -/
 
 noncomputable theory

--- a/src/analysis/special_functions/gamma/bohr_mollerup.lean
+++ b/src/analysis/special_functions/gamma/bohr_mollerup.lean
@@ -389,6 +389,7 @@ As a fun application of the Bohr-Mollerup theorem, we prove the Gamma-function d
 log-convex and satisfies the Gamma functional equation, so it must actually be a constant
 multiple of `Gamma`, and we can compute the constant by specialising at `s = 1`. -/
 
+/-- Auxiliary definition for the doubling formula (we'll show this is equal to `Gamma s`) -/
 def doubling_Gamma (s : ℝ) : ℝ := Gamma (s / 2) * Gamma (s / 2 + 1 / 2) * 2 ^ (s - 1) / sqrt π
 
 lemma doubling_Gamma_add_one (s : ℝ) (hs : s ≠ 0) :


### PR DESCRIPTION
This PR adds the proof of the Legendre doubling formula, relating `Gamma s * Gamma (s + 1 / 2)` to `Gamma (2 * s)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
