### PR TITLE
[Merged by Bors] - chore(analysis/special_functions/exp_deriv): downgrade import

### DIFF
--- a/src/analysis/special_functions/complex/log_deriv.lean
+++ b/src/analysis/special_functions/complex/log_deriv.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne, Benjamin Davidson
 -/
+import analysis.calculus.inverse
 import analysis.special_functions.complex.log
 import analysis.special_functions.exp_deriv
 
@@ -18,6 +19,9 @@ namespace complex
 open set filter
 
 open_locale real topology
+
+lemma is_open_map_exp : is_open_map exp :=
+open_map_of_strict_deriv has_strict_deriv_at_exp exp_ne_zero
 
 /-- `complex.exp` as a `local_homeomorph` with `source = {z | -π < im z < π}` and
 `target = {z | 0 < re z} ∪ {z | im z ≠ 0}`. This definition is used to prove that `complex.log`

--- a/src/analysis/special_functions/exp_deriv.lean
+++ b/src/analysis/special_functions/exp_deriv.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne
 -/
-import analysis.calculus.inverse
 import analysis.complex.real_deriv
 
 /-!
@@ -66,9 +65,6 @@ cont_diff_exp.cont_diff_at.has_strict_deriv_at' (has_deriv_at_exp x) le_rfl
 lemma has_strict_fderiv_at_exp_real (x : ℂ) :
   has_strict_fderiv_at exp (exp x • (1 : ℂ →L[ℝ] ℂ)) x :=
 (has_strict_deriv_at_exp x).complex_to_real_fderiv
-
-lemma is_open_map_exp : is_open_map exp :=
-open_map_of_strict_deriv has_strict_deriv_at_exp exp_ne_zero
 
 end complex
 


### PR DESCRIPTION
Move lemma `complex.is_open_map_exp` from `special_functions/exp_deriv` to right before its (unique) place of use, in `complex.exp_local_homeomorph` in `special_functions/log_deriv`.  Morally these belong together: being an open map and being a local homeomorphism are closely tied, they are both consequences of the inverse function theorem and the point of both is to set up being able to differentiate complex log as the inverse function of complex exp.

This removes the inverse function theorem from the dependencies of `special_functions/exp_deriv` (a surprisingly widely-imported file).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
