### PR TITLE
[Merged by Bors] - chore(analysis/convex/specific_functions/deriv): remove unnecessary imports

### DIFF
--- a/src/analysis/convex/specific_functions/deriv.lean
+++ b/src/analysis/convex/specific_functions/deriv.lean
@@ -3,11 +3,9 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Sébastien Gouëzel
 -/
-import analysis.convex.specific_functions.basic
 import analysis.calculus.deriv.zpow
 import analysis.special_functions.pow.deriv
 import analysis.special_functions.sqrt
-import tactic.linear_combination
 
 /-!
 # Collection of convex functions

--- a/src/number_theory/bertrand.lean
+++ b/src/number_theory/bertrand.lean
@@ -6,6 +6,7 @@ Authors: Patrick Stevens, Bolton Bailey
 import data.nat.choose.factorization
 import data.nat.prime_norm_num
 import number_theory.primorial
+import analysis.convex.specific_functions.basic
 import analysis.convex.specific_functions.deriv
 
 /-!


### PR DESCRIPTION
I accidentally left some extra imports in this file during the split #19031.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
