### PR TITLE
feat(topology/algebra/infinite_sum): Extract `none` from a sum over `option` types

### DIFF
--- a/src/topology/algebra/infinite_sum/basic.lean
+++ b/src/topology/algebra/infinite_sum/basic.lean
@@ -164,6 +164,11 @@ begin
   exact if_neg hb'
 end
 
+lemma has_sum_singleton (f : β → α) (b : β) : has_sum (f ∘ coe : ({b} : set β) → α) (f b) :=
+suffices has_sum ((f ∘ coe : ({b} : set β) → α)) (∑ b' : ({b} : set β), f ↑b'),
+  by simpa only [univ_unique, sum_singleton] using this,
+has_sum_sum_of_ne_finset_zero (λ x h, (h (finset.mem_univ x)).elim)
+
 lemma has_sum_pi_single [decidable_eq β] (b : β) (a : α) :
   has_sum (pi.single b a) a :=
 show has_sum (λ x, pi.single b a x) a, by simpa only [pi.single_apply] using has_sum_ite_eq b a
@@ -312,6 +317,16 @@ lemma has_sum.compl_add {s : set β} (ha : has_sum (f ∘ coe : sᶜ → α) a)
   (hb : has_sum (f ∘ coe : s → α) b) :
   has_sum f (a + b) :=
 ha.add_is_compl is_compl_compl.symm hb
+
+lemma has_sum.sum_t {f : β ⊕ γ → α} {a_inl a_inr : α} (h_inl : has_sum (f ∘ sum.inl) a_inl)
+  (h_inr : has_sum (f ∘ sum.inr) a_inr) : has_sum f (a_inl + a_inr) :=
+has_sum.add_is_compl (set.is_compl_range_inl_range_inr)
+  (sum.inl_injective.has_sum_range_iff.2 h_inl) (sum.inr_injective.has_sum_range_iff.2 h_inr)
+
+lemma has_sum.option {f : option β → α} {a_some : α} (hf : has_sum (f ∘ option.some) a_some) :
+  has_sum f (f none + a_some) :=
+has_sum.add_is_compl (set.is_compl_range_some_none β).symm (has_sum_singleton f none)
+  ((option.some_injective β).has_sum_range_iff.2 hf)
 
 lemma has_sum.even_add_odd {f : ℕ → α} (he : has_sum (λ k, f (2 * k)) a)
   (ho : has_sum (λ k, f (2 * k + 1)) b) :
@@ -576,18 +591,6 @@ calc ∑' x, f x = ∑' x, ((ite (x = b) (f x) 0) + (f.update b 0 x)) :
   ... = f b + ∑' x, ite (x = b) 0 (f x) :
     by simp only [function.update, eq_self_iff_true, if_true, eq_rec_constant, dite_eq_ite]
 
-/-- Version of `tsum_option_eq_none_add_tsum` for `add_comm_monoid` rather than `add_comm_group`.
-Requires a different convergence assumption involving `function.update`. -/
-lemma tsum_option_eq_none_add_tsum' {f : option β → α} (hf : summable (f.update none 0)) :
-  ∑' x : option β, f x = f none + ∑' x : β, f (some x) :=
-begin
-  refine (tsum_eq_add_tsum_ite' none hf).trans (congr_arg ((+) (f none)) _),
-  calc ∑' x, ite (x = none) 0 (f x) = ∑' x, (set.range option.some).indicator f x :
-      tsum_congr (λ x, by cases x; simp)
-    ... = ∑' x : (set.range option.some), f ↑x : (tsum_subtype _ _).symm
-    ... = ∑' x, f (option.some x) : tsum_range f (option.some_injective β)
-end
-
 variables [add_comm_monoid δ] [topological_space δ] [t3_space δ] [has_continuous_add δ]
 
 lemma tsum_sigma' {γ : β → Type*} {f : (Σb:β, γ b) → δ} (h₁ : ∀b, summable (λc, f ⟨b, c⟩))
@@ -684,6 +687,16 @@ lemma tsum_add_tsum_compl {s : set β} (hs : summable (f ∘ coe : s → α))
   (hsc : summable (f ∘ coe : sᶜ → α)) :
   (∑' x : s, f x) + (∑' x : sᶜ, f x) = ∑' x, f x :=
 (hs.has_sum.add_compl hsc.has_sum).tsum_eq.symm
+
+/-- Split a sum over `option β` into `f none` plus the sum of `f ∘ some` on `β`. -/
+lemma tsum_option {f : option β → α} (hf : summable (f ∘ option.some)) :
+  ∑' x : option β, f x = f none + ∑' x : β, f (some x) :=
+hf.has_sum.option.tsum_eq
+
+/-- Split a sum over `β ⊕ γ` into the sum of `f ∘ inl` over `β` and `f ∘ inr` over `γ`. -/
+lemma tsum_sum_t {f : β ⊕ γ → α} (hf : summable (f ∘ sum.inl)) (hf' : summable (f ∘ sum.inr)) :
+  ∑' x : β ⊕ γ, f x = (∑' x : β, f (sum.inl x)) + (∑' x : γ, f (sum.inr x)) :=
+(hf.has_sum.sum_t hf'.has_sum).tsum_eq
 
 lemma tsum_union_disjoint {s t : set β} (hd : disjoint s t)
   (hs : summable (f ∘ coe : s → α)) (ht : summable (f ∘ coe : t → α)) :
@@ -816,17 +829,6 @@ lemma tsum_eq_add_tsum_ite [decidable_eq β] (hf : summable f) (b : β) :
 begin
   rw (has_sum_ite_sub_has_sum hf.has_sum b).tsum_eq,
   exact (add_sub_cancel'_right _ _).symm,
-end
-
-/-- The sum of a function `f` on `option β` is `f none` plus the sum of `f ∘ some` on `β`. -/
-lemma tsum_option_eq_none_add_tsum {f : option β → α} (hf : summable f) :
-  ∑' x : option β, f x = f none + ∑' x : β, f (some x) :=
-begin
-  refine (tsum_eq_add_tsum_ite hf none).trans (congr_arg ((+) (f none)) _),
-  calc ∑' x, ite (x = none) 0 (f x) = ∑' x, (set.range option.some).indicator f x :
-      tsum_congr (λ x, by cases x; simp)
-    ... = ∑' x : (set.range option.some), f ↑x : (tsum_subtype _ _).symm
-    ... = ∑' x, f (option.some x) : tsum_range f (option.some_injective β)
 end
 
 end tsum


### PR DESCRIPTION
This PR gives lemmas for separating a sum over `option α` into the value at `none` plus a sum over `α`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
