### PR TITLE
[Merged by Bors] - chore(*/centralizer): add forgotten `to_additive`s

### DIFF
--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1604,12 +1604,13 @@ set_like.ext' (set.centralizer_univ G)
 @[to_additive] lemma le_centralizer_iff : H ≤ K.centralizer ↔ K ≤ H.centralizer :=
 ⟨λ h x hx y hy, (h hy x hx).symm, λ h x hx y hy, (h hy x hx).symm⟩
 
-lemma center_le_centralizer (s) : center G ≤ centralizer s := set.center_subset_centralizer s
+@[to_additive] lemma center_le_centralizer (s) : center G ≤ centralizer s :=
+set.center_subset_centralizer s
 
 @[to_additive] lemma centralizer_le (h : H ≤ K) : centralizer K ≤ centralizer H :=
 submonoid.centralizer_le h
 
-@[simp] lemma centralizer_eq_top_iff_subset {s} : centralizer s = ⊤ ↔ s ≤ center G :=
+@[simp, to_additive] lemma centralizer_eq_top_iff_subset {s} : centralizer s = ⊤ ↔ s ≤ center G :=
 set_like.ext'_iff.trans set.centralizer_eq_top_iff_subset
 
 @[to_additive] instance subgroup.centralizer.characteristic [hH : H.characteristic] :

--- a/src/group_theory/submonoid/centralizer.lean
+++ b/src/group_theory/submonoid/centralizer.lean
@@ -50,7 +50,8 @@ variables {S}
 @[to_additive] lemma mem_centralizer_iff {z : M} : z ∈ centralizer S ↔ ∀ g ∈ S, g * z = z * g :=
 iff.rfl
 
-lemma center_le_centralizer (s) : center M ≤ centralizer s := s.center_subset_centralizer
+@[to_additive] lemma center_le_centralizer (s) : center M ≤ centralizer s :=
+s.center_subset_centralizer
 
 @[to_additive] instance decidable_mem_centralizer (a) [decidable $ ∀ b ∈ S, b * a = a * b] :
   decidable (a ∈ centralizer S) :=
@@ -60,7 +61,8 @@ decidable_of_iff' _ mem_centralizer_iff
 lemma centralizer_le (h : S ⊆ T) : centralizer T ≤ centralizer S :=
 set.centralizer_subset h
 
-@[simp] lemma centralizer_eq_top_iff_subset {s : set M} : centralizer s = ⊤ ↔ s ⊆ center M :=
+@[simp, to_additive] lemma centralizer_eq_top_iff_subset {s : set M} :
+  centralizer s = ⊤ ↔ s ⊆ center M :=
 set_like.ext'_iff.trans set.centralizer_eq_top_iff_subset
 
 variables (M)

--- a/src/group_theory/subsemigroup/centralizer.lean
+++ b/src/group_theory/subsemigroup/centralizer.lean
@@ -100,10 +100,12 @@ end
 lemma centralizer_subset [has_mul M] (h : S ⊆ T) : centralizer T ⊆ centralizer S :=
 λ t ht s hs, ht s (h hs)
 
+@[to_additive add_center_subset_add_centralizer]
 lemma center_subset_centralizer [has_mul M] (S : set M) : set.center M ⊆ S.centralizer :=
 λ x hx m _, hx m
 
-@[simp] lemma centralizer_eq_top_iff_subset {s : set M} [has_mul M] :
+@[simp, to_additive add_centralizer_eq_top_iff_subset]
+lemma centralizer_eq_top_iff_subset {s : set M} [has_mul M] :
   centralizer s = set.univ ↔ s ⊆ center M :=
 eq_top_iff.trans $ ⟨λ h x hx g, (h trivial _ hx).symm,
                     λ h x _ m hm, (h hm x).symm⟩
@@ -144,13 +146,15 @@ iff.rfl
   decidable (a ∈ centralizer S) :=
 decidable_of_iff' _ mem_centralizer_iff
 
+@[to_additive]
 lemma center_le_centralizer (S) : center M ≤ centralizer S := S.center_subset_centralizer
 
 @[to_additive]
 lemma centralizer_le (h : S ⊆ T) : centralizer T ≤ centralizer S :=
 set.centralizer_subset h
 
-@[simp] lemma centralizer_eq_top_iff_subset {s : set M} : centralizer s = ⊤ ↔ s ⊆ center M :=
+@[simp, to_additive]
+lemma centralizer_eq_top_iff_subset {s : set M} : centralizer s = ⊤ ↔ s ⊆ center M :=
 set_like.ext'_iff.trans set.centralizer_eq_top_iff_subset
 
 variables (M)


### PR DESCRIPTION
I forgot these in #18861. These are already in the forward-port PR, leanprover-community/mathlib4#4896.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
