### PR TITLE
[Merged by Bors] - chore(*): fix `@[to_additive, simp]` to the correct order

### DIFF
--- a/src/algebra/hom/equiv/basic.lean
+++ b/src/algebra/hom/equiv/basic.lean
@@ -309,10 +309,10 @@ fun_like.ext _ _ e.apply_symm_apply
 theorem self_trans_symm (e : M ≃* N) : e.trans e.symm = refl M :=
 fun_like.ext _ _ e.symm_apply_apply
 
-@[to_additive, simp] lemma coe_monoid_hom_refl {M} [mul_one_class M] :
+@[simp, to_additive] lemma coe_monoid_hom_refl {M} [mul_one_class M] :
   (refl M : M →* M) = monoid_hom.id M := rfl
 
-@[to_additive, simp] lemma coe_monoid_hom_trans {M N P}
+@[simp, to_additive] lemma coe_monoid_hom_trans {M N P}
   [mul_one_class M] [mul_one_class N] [mul_one_class P] (e₁ : M ≃* N) (e₂ : N ≃* P) :
   (e₁.trans e₂ : M →* P) = (e₂ : N →* P).comp ↑e₁ :=
 rfl

--- a/src/group_theory/subsemigroup/center.lean
+++ b/src/group_theory/subsemigroup/center.lean
@@ -151,7 +151,7 @@ end
 section
 variables (M) [comm_semigroup M]
 
-@[to_additive, simp] lemma center_eq_top : center M = ⊤ :=
+@[simp, to_additive] lemma center_eq_top : center M = ⊤ :=
 set_like.coe_injective (set.center_eq_univ M)
 
 end

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -698,14 +698,14 @@ variables [has_mul X] [has_continuous_mul X]
 @[to_additive "The continuous map `λ y, y + x"]
 protected def mul_right (x : X) : C(X, X) := mk _ (continuous_mul_right x)
 
-@[to_additive, simp]
+@[simp, to_additive]
 lemma coe_mul_right (x : X) : ⇑(continuous_map.mul_right x) = λ y, y * x := rfl
 
 /-- The continuous map `λ y, x * y` -/
 @[to_additive "The continuous map `λ y, x + y"]
 protected def mul_left (x : X) : C(X, X) := mk _ (continuous_mul_left x)
 
-@[to_additive, simp]
+@[simp, to_additive]
 lemma coe_mul_left (x : X) : ⇑(continuous_map.mul_left x) = λ y, x * y := rfl
 
 end continuous_map


### PR DESCRIPTION
Whilst making some files, I noticed that there is some lemmas that have the wrong order for `to_additive` and `simp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
