### PR TITLE
[Merged by Bors] -  refactor(representation_theory/Rep): define `ihom` concretely

### DIFF
--- a/src/representation_theory/Rep.lean
+++ b/src/representation_theory/Rep.lean
@@ -289,9 +289,9 @@ instance : monoidal_closed (Rep k G) :=
   { is_adj :=
     { right := Rep.ihom A,
       adj := adjunction.mk_of_hom_equiv
-{ hom_equiv := Rep.hom_equiv A,
-  hom_equiv_naturality_left_symm' := λ X Y Z f g, by ext; refl,
-  hom_equiv_naturality_right' := λ X Y Z f g, by ext; refl } } } }
+      { hom_equiv := Rep.hom_equiv A,
+        hom_equiv_naturality_left_symm' := λ X Y Z f g, by ext; refl,
+        hom_equiv_naturality_right' := λ X Y Z f g, by ext; refl } } } }
 
 @[simp] lemma ihom_obj_ρ_def (A B : Rep k G) : ((ihom A).obj B).ρ = ((Rep.ihom A).obj B).ρ := rfl
 

--- a/src/representation_theory/Rep.lean
+++ b/src/representation_theory/Rep.lean
@@ -76,6 +76,14 @@ lemma of_ρ_apply {V : Type u} [add_comm_group V] [module k V]
   (ρ : representation k G V) (g : Mon.of G) :
   (Rep.of ρ).ρ g = ρ (g : G) := rfl
 
+@[simp] lemma ρ_inv_self_apply {G : Type u} [group G] (A : Rep k G) (g : G) (x : A) :
+  A.ρ g⁻¹ (A.ρ g x) = x :=
+show (A.ρ g⁻¹ * A.ρ g) x = x, by rw [←map_mul, inv_mul_self, map_one, linear_map.one_apply]
+
+@[simp] lemma ρ_self_inv_apply {G : Type u} [group G] {A : Rep k G} (g : G) (x : A) :
+  A.ρ g (A.ρ g⁻¹ x) = x :=
+show (A.ρ g * A.ρ g⁻¹) x = x, by rw [←map_mul, mul_inv_self, map_one, linear_map.one_apply]
+
 lemma hom_comm_apply {A B : Rep k G} (f : A ⟶ B) (g : G) (x : A) :
   f.hom (A.ρ g x) = B.ρ g (f.hom x) :=
 linear_map.ext_iff.1 (f.comm g) x
@@ -277,9 +285,9 @@ variables [group G] (A B C : Rep k G)
       begin
         dsimp only [monoidal_category.tensor_left_obj, Module.comp_def, linear_map.comp_apply,
           tensor_rho, Module.monoidal_category.hom_apply, tensor_product.map_tmul],
-        simpa only [tensor_product.uncurry_apply f.hom.flip, linear_map.flip_apply,
+        simp only [tensor_product.uncurry_apply f.hom.flip, linear_map.flip_apply,
           Action_ρ_eq_ρ, hom_comm_apply f g y, Rep.ihom_obj_ρ_apply, linear_map.comp_apply,
-          inv_mul_self, ←linear_map.mul_apply, ←A.ρ.map_mul, A.ρ.map_one],
+          ρ_inv_self_apply],
       end) },
   left_inv := λ f, Action.hom.ext _ _ (tensor_product.ext' (λ x y, rfl)),
   right_inv := λ f, by ext; refl }

--- a/src/representation_theory/group_cohomology/resolution.lean
+++ b/src/representation_theory/group_cohomology/resolution.lean
@@ -276,7 +276,7 @@ begin
     iso.refl_inv, category.comp_id, Rep.monoidal_closed.linear_hom_equiv_comm_symm_hom,
     iso.trans_hom, Module.comp_def, linear_map.comp_apply, representation.Rep_of_tprod_iso_apply,
     diagonal_succ_hom_single x (1 : k), tensor_product.uncurry_apply, Rep.left_regular_hom_hom,
-    finsupp.lift_apply, Rep.ihom_obj_ρ, representation.lin_hom_apply, finsupp.sum_single_index,
+    finsupp.lift_apply, ihom_obj_ρ_def, Rep.ihom_obj_ρ_apply, finsupp.sum_single_index,
     zero_smul, one_smul, Rep.of_ρ, Rep.Action_ρ_eq_ρ, Rep.trivial_def (x 0)⁻¹,
     finsupp.llift_apply A k k],
 end


### PR DESCRIPTION
---

Currently the monoidal closed instance on `Rep k G` is defined by transporting an instance on a functor category across a category equivalence. This was hard to work with in Lean 3 and is hard to port. This PR defines the monoidal closed instance concretely instead. 
Naming-wise, the explicit definition of the "internal hom" functor, the right adjoint to left-tensoring, is protected, called `Rep.ihom`, and then we use that to define a `monoidal_closed` instance, and then provide a lemma saying the resulting `category_theory.ihom` is `Rep.ihom`. Not sure this is the right approach.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
