### PR TITLE
[Merged by Bors] - chore(linear_algebra/eigenspace/minpoly): remove a silly use of `tauto`

### DIFF
--- a/src/linear_algebra/eigenspace/minpoly.lean
+++ b/src/linear_algebra/eigenspace/minpoly.lean
@@ -106,6 +106,7 @@ begin
   have h : minpoly K f ≠ 0 := minpoly.ne_zero f.is_integral,
   convert (minpoly K f).root_set_finite K using 1,
   ext μ,
+  classical,
   simp [polynomial.root_set_def, polynomial.mem_roots h, ← has_eigenvalue_iff_is_root,
     has_eigenvalue],
 end

--- a/src/linear_algebra/eigenspace/minpoly.lean
+++ b/src/linear_algebra/eigenspace/minpoly.lean
@@ -98,15 +98,13 @@ theorem has_eigenvalue_iff_is_root :
 
 /-- An endomorphism of a finite-dimensional vector space has finitely many eigenvalues. -/
 noncomputable instance (f : End K V) : fintype f.eigenvalues :=
-set.finite.fintype
+set.finite.fintype $ show {μ | eigenspace f μ ≠ ⊥}.finite,
 begin
   have h : minpoly K f ≠ 0 := minpoly.ne_zero f.is_integral,
-  convert (minpoly K f).root_set_finite K,
+  convert (minpoly K f).root_set_finite K using 1,
   ext μ,
-  have : (μ ∈ {μ : K | f.eigenspace μ = ⊥ → false}) ↔ ¬f.eigenspace μ = ⊥ := by tauto,
-  convert rfl.mpr this,
   simp [polynomial.root_set_def, polynomial.mem_roots h, ← has_eigenvalue_iff_is_root,
-    has_eigenvalue]
+    has_eigenvalue],
 end
 
 end End


### PR DESCRIPTION
`tauto` is not `refl`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

it looks like we already cleaned this up in mathlib4, https://github.com/leanprover-community/mathlib4/blob/459a8d89e6c6fc8a6d8ca87e3b2b16d26d9eeccc/Mathlib/LinearAlgebra/Eigenspace/Minpoly.lean#L111-L122