### PR TITLE
[Merged by Bors] - feat(measure_theory/constructions/polish): quotient group is a Borel space

### DIFF
--- a/src/measure_theory/constructions/borel_space/basic.lean
+++ b/src/measure_theory/constructions/borel_space/basic.lean
@@ -58,6 +58,9 @@ open measurable_space topological_space
 def borel (α : Type u) [topological_space α] : measurable_space α :=
 generate_from {s : set α | is_open s}
 
+theorem borel_anti : antitone (@borel α) :=
+λ _ _ h, measurable_space.generate_from_le $ λ s hs, generate_measurable.basic _ (h _ hs)
+
 lemma borel_eq_top_of_discrete [topological_space α] [discrete_topology α] :
   borel α = ⊤ :=
 top_le_iff.1 $ λ s hs, generate_measurable.basic s (is_open_discrete s)

--- a/src/measure_theory/constructions/polish.lean
+++ b/src/measure_theory/constructions/polish.lean
@@ -275,12 +275,13 @@ begin
     hb.continuous _ (λ s hs, t'T ⟨s, hs⟩ _ (Topen ⟨s, hs⟩)),
   exact continuous_subtype_coe.comp this
 end
-/-- Image of a measurable set in a Polish space under a measurable map is an analytic set. -/
+
+/-- The image of a measurable set in a Polish space under a measurable map is an analytic set. -/
 theorem _root_.measurable_set.analytic_set_image {X Y : Type*}
-    [topological_space X] [polish_space X] [measurable_space X] [borel_space X]
-    [topological_space Y] [measurable_space Y] [opens_measurable_space Y]
-    {f : X → Y} [second_countable_topology (range f)] {s : set X} (hs : measurable_set s)
-    (hf : measurable f) : analytic_set (f '' s) :=
+  [topological_space X] [polish_space X] [measurable_space X] [borel_space X]
+  [topological_space Y] [measurable_space Y] [opens_measurable_space Y]
+  {f : X → Y} [second_countable_topology (range f)] {s : set X} (hs : measurable_set s)
+  (hf : measurable f) : analytic_set (f '' s) :=
 begin
   borelize X,
   rcases hf.exists_continuous with ⟨τ', hle, hfc, hτ'⟩,
@@ -450,8 +451,8 @@ end
 /-- **Suslin's Theorem**: in a Hausdorff topological space, an analytic set with an analytic
 complement is measurable. -/
 theorem analytic_set.measurable_set_of_compl [t2_space α] [measurable_space α]
-    [opens_measurable_space α] {s : set α} (hs : analytic_set s) (hsc : analytic_set (sᶜ)) :
-    measurable_set s :=
+  [opens_measurable_space α] {s : set α} (hs : analytic_set s) (hsc : analytic_set (sᶜ)) :
+  measurable_set s :=
 begin
   rcases hs.measurably_separable hsc disjoint_compl_right with ⟨u, hsu, hdu, hmu⟩,
   obtain rfl : s = u := hsu.antisymm (disjoint_compl_left_iff_subset.1 hdu),
@@ -489,11 +490,11 @@ begin
 end
 
 theorem map_measurable_space_eq [second_countable_topology Y] {f : X → Y} (hf : measurable f)
-  (hsurj : surjective f) : measurable_space.map f ‹_› = ‹_› :=
+  (hsurj : surjective f) : measurable_space.map f ‹measurable_space X› = ‹measurable_space Y› :=
 measurable_space.ext $ λ _, hf.measurable_set_preimage_iff_of_surjective hsurj
 
 theorem map_measurable_space_eq_borel [second_countable_topology Y] {f : X → Y} (hf : measurable f)
-  (hsurj : surjective f) : measurable_space.map f ‹_› = borel Y :=
+  (hsurj : surjective f) : measurable_space.map f ‹measurable_space X› = borel Y :=
 begin
   have := hf.mono le_rfl opens_measurable_space.borel_le, 
   letI := borel Y, haveI : borel_space Y := ⟨rfl⟩,

--- a/src/measure_theory/constructions/polish.lean
+++ b/src/measure_theory/constructions/polish.lean
@@ -569,10 +569,9 @@ instance quotient.borel_space {X : Type*} [topological_space X] [polish_space X]
 
 @[to_additive]
 instance quotient_group.borel_space {G : Type*} [topological_space G] [polish_space G]
-  [second_countable_topology G] [group G] [topological_group G] [measurable_space G]
-  [borel_space G] {N : subgroup G} [N.normal] [is_closed (N : set G)] : borel_space (G ⧸ N) :=
-quotient.borel_space
-
+  [group G] [topological_group G] [measurable_space G] [borel_space G]
+  {N : subgroup G} [N.normal] [is_closed (N : set G)] : borel_space (G ⧸ N) :=
+by haveI := polish_space.second_countable G; exact quotient.borel_space
 
 namespace measure_theory
 

--- a/src/measure_theory/constructions/polish.lean
+++ b/src/measure_theory/constructions/polish.lean
@@ -253,24 +253,41 @@ end
 a finer Polish topology on the source space for which the function is continuous. -/
 lemma _root_.measurable.exists_continuous {α β : Type*}
   [t : topological_space α] [polish_space α] [measurable_space α] [borel_space α]
-  [tβ : topological_space β] [second_countable_topology β] [measurable_space β] [borel_space β]
-  {f : α → β} (hf : measurable f) :
+  [tβ : topological_space β] [measurable_space β] [opens_measurable_space β]
+  {f : α → β} [second_countable_topology (range f)] (hf : measurable f) :
   ∃ (t' : topological_space α), t' ≤ t ∧ @continuous α β t' tβ f ∧ @polish_space α t' :=
 begin
-  obtain ⟨b, b_count, -, hb⟩ : ∃b : set (set β), b.countable ∧ ∅ ∉ b ∧ is_topological_basis b :=
-    exists_countable_basis β,
-  haveI : encodable b := b_count.to_encodable,
-  have : ∀ (s : b), is_clopenable (f ⁻¹' s),
+  obtain ⟨b, b_count, -, hb⟩ :
+    ∃ b : set (set (range f)), b.countable ∧ ∅ ∉ b ∧ is_topological_basis b :=
+    exists_countable_basis (range f),
+  haveI : countable b := b_count.to_subtype,
+  have : ∀ (s : b), is_clopenable (range_factorization f ⁻¹' s),
   { assume s,
     apply measurable_set.is_clopenable,
-    exact hf (hb.is_open s.2).measurable_set },
+    exact hf.subtype_mk (hb.is_open s.2).measurable_set },
   choose T Tt Tpolish Tclosed Topen using this,
   obtain ⟨t', t'T, t't, t'_polish⟩ :
     ∃ (t' : topological_space α), (∀ i, t' ≤ T i) ∧ (t' ≤ t) ∧ @polish_space α t' :=
       exists_polish_space_forall_le T Tt Tpolish,
+  letI := t', -- not needed in Lean 4
   refine ⟨t', t't, _, t'_polish⟩,
-  apply hb.continuous _ (λ s hs, _),
-  exact t'T ⟨s, hs⟩ _ (Topen ⟨s, hs⟩),
+  have : @continuous _ _ t' _ (range_factorization f) :=
+    hb.continuous _ (λ s hs, t'T ⟨s, hs⟩ _ (Topen ⟨s, hs⟩)),
+  exact continuous_subtype_coe.comp this
+end
+/-- Image of a measurable set in a Polish space under a measurable map is an analytic set. -/
+theorem _root_.measurable_set.analytic_set_image {X Y : Type*}
+    [topological_space X] [polish_space X] [measurable_space X] [borel_space X]
+    [topological_space Y] [measurable_space Y] [opens_measurable_space Y]
+    {f : X → Y} [second_countable_topology (range f)] {s : set X} (hs : measurable_set s)
+    (hf : measurable f) : analytic_set (f '' s) :=
+begin
+  borelize X,
+  rcases hf.exists_continuous with ⟨τ', hle, hfc, hτ'⟩,
+  letI m' : measurable_space X := @borel _ τ',
+  haveI b' : borel_space X := ⟨rfl⟩,
+  have hle := borel_anti hle,
+  exact (hle _ hs).analytic_set.image_of_continuous hfc
 end
 
 /-! ### Separating sets with measurable sets -/
@@ -302,8 +319,9 @@ end
 contained in disjoint Borel sets (see the full statement in `analytic_set.measurably_separable`).
 Here, we prove this when our analytic sets are the ranges of functions from `ℕ → ℕ`.
 -/
-lemma measurably_separable_range_of_disjoint [t2_space α] [measurable_space α] [borel_space α]
-  {f g : (ℕ → ℕ) → α} (hf : continuous f) (hg : continuous g) (h : disjoint (range f) (range g)) :
+lemma measurably_separable_range_of_disjoint [t2_space α] [measurable_space α]
+  [opens_measurable_space α] {f g : (ℕ → ℕ) → α} (hf : continuous f) (hg : continuous g)
+  (h : disjoint (range f) (range g)) :
   measurably_separable (range f) (range g) :=
 begin
   /- We follow [Kechris, *Classical Descriptive Set Theory* (Theorem 14.7)][kechris1995].
@@ -416,8 +434,9 @@ end
 
 /-- The Lusin separation theorem: if two analytic sets are disjoint, then they are contained in
 disjoint Borel sets. -/
-theorem analytic_set.measurably_separable [t2_space α] [measurable_space α] [borel_space α]
-  {s t : set α} (hs : analytic_set s) (ht : analytic_set t) (h : disjoint s t) :
+theorem analytic_set.measurably_separable [t2_space α] [measurable_space α]
+  [opens_measurable_space α] {s t : set α} (hs : analytic_set s) (ht : analytic_set t)
+  (h : disjoint s t) :
   measurably_separable s t :=
 begin
   rw analytic_set at hs ht,
@@ -427,6 +446,135 @@ begin
   { exact ⟨univ, subset_univ _, by simp, measurable_set.univ⟩ },
   exact measurably_separable_range_of_disjoint f_cont g_cont h,
 end
+
+/-- **Suslin's Theorem**: in a Hausdorff topological space, an analytic set with an analytic
+complement is measurable. -/
+theorem analytic_set.measurable_set_of_compl [t2_space α] [measurable_space α]
+    [opens_measurable_space α] {s : set α} (hs : analytic_set s) (hsc : analytic_set (sᶜ)) :
+    measurable_set s :=
+begin
+  rcases hs.measurably_separable hsc disjoint_compl_right with ⟨u, hsu, hdu, hmu⟩,
+  obtain rfl : s = u := hsu.antisymm (disjoint_compl_left_iff_subset.1 hdu),
+  exact hmu
+end
+
+end measure_theory
+
+/-!
+### Measurability of preimages under measurable maps
+-/
+
+namespace measurable
+
+variables {X Y : Type*}
+  [topological_space X] [polish_space X] [measurable_space X] [borel_space X]
+  [topological_space Y] [t2_space Y] [measurable_space Y] [opens_measurable_space Y]
+
+/-- If `f : X → Y` is a surjective Borel measurable map from a Polish space to a topological space
+with second countable topology, then the preimage of a set `s` is measurable if and only if the set
+is measurable.
+One implication is the definition of measurability, the other one heavily relies on `X` being a
+Polish space. -/
+theorem measurable_set_preimage_iff_of_surjective [second_countable_topology Y] {f : X → Y}
+  (hf : measurable f) (hsurj : surjective f) {s : set Y} :
+  measurable_set (f ⁻¹' s) ↔ measurable_set s :=
+begin
+  refine ⟨λ h, _, λ h, hf h⟩,
+  apply measure_theory.analytic_set.measurable_set_of_compl,
+  { rw [← image_preimage_eq s hsurj],
+    exact h.analytic_set_image hf },
+  { rw [← image_preimage_eq (sᶜ) hsurj],
+    exact h.compl.analytic_set_image hf }
+end
+
+theorem map_measurable_space_eq [second_countable_topology Y] {f : X → Y} (hf : measurable f)
+  (hsurj : surjective f) : measurable_space.map f ‹_› = ‹_› :=
+measurable_space.ext $ λ _, hf.measurable_set_preimage_iff_of_surjective hsurj
+
+theorem map_measurable_space_eq_borel [second_countable_topology Y] {f : X → Y} (hf : measurable f)
+  (hsurj : surjective f) : measurable_space.map f ‹_› = borel Y :=
+begin
+  have := hf.mono le_rfl opens_measurable_space.borel_le, 
+  letI := borel Y, haveI : borel_space Y := ⟨rfl⟩,
+  exact this.map_measurable_space_eq hsurj
+end
+
+theorem borel_space_codomain [second_countable_topology Y] {f : X → Y} (hf : measurable f)
+  (hsurj : surjective f) : borel_space Y :=
+⟨(hf.map_measurable_space_eq hsurj).symm.trans $ hf.map_measurable_space_eq_borel hsurj⟩
+
+/-- If `f : X → Y` is a Borel measurable map from a Polish space to a topological space with second
+countable topology, then the preimage of a set `s` is measurable if and only if the set is
+measurable in `set.range f`. -/
+theorem measurable_set_preimage_iff_preimage_coe {f : X → Y} [second_countable_topology (range f)]
+  (hf : measurable f) {s : set Y} :
+  measurable_set (f ⁻¹' s) ↔ measurable_set (coe ⁻¹' s : set (range f)) :=
+have hf' : measurable (range_factorization f) := hf.subtype_mk,
+by rw [← hf'.measurable_set_preimage_iff_of_surjective surjective_onto_range]; refl
+
+/-- If `f : X → Y` is a Borel measurable map from a Polish space to a topological space with second
+countable topology and the range of `f` is measurable, then the preimage of a set `s` is measurable
+if and only if the intesection with `set.range f` is measurable. -/
+theorem measurable_set_preimage_iff_inter_range {f : X → Y} [second_countable_topology (range f)]
+  (hf : measurable f) (hr : measurable_set (range f)) {s : set Y} :
+  measurable_set (f ⁻¹' s) ↔ measurable_set (s ∩ range f) :=
+begin
+  rw [hf.measurable_set_preimage_iff_preimage_coe,
+    ← (measurable_embedding.subtype_coe hr).measurable_set_image, subtype.image_preimage_coe]
+end
+
+/-- If `f : X → Y` is a Borel measurable map from a Polish space to a topological space with second
+countable topology, then for any measurable space `α` and `g : Y → α`, the composition `g ∘ f` is
+measurable if and only if the restriction of `g` to the range of `f` is measurable. -/
+theorem measurable_comp_iff_restrict [measurable_space α] {f : X → Y}
+  [second_countable_topology (range f)] (hf : measurable f) {g : Y → α} :
+  measurable (g ∘ f) ↔ measurable (restrict (range f) g) :=
+forall₂_congr $ λ s _,
+  @measurable.measurable_set_preimage_iff_preimage_coe _ _ _ _ _ _ _ _ _ _ _ _ hf (g ⁻¹' s)
+
+/-- If `f : X → Y` is a surjective Borel measurable map from a Polish space to a topological space
+with second countable topology, then for any measurable space `α` and `g : Y → α`, the composition
+`g ∘ f` is measurable if and only if `g` is measurable. -/
+theorem measurable_comp_iff_of_surjective [second_countable_topology Y] [measurable_space α]
+  {f : X → Y} (hf : measurable f) (hsurj : surjective f) {g : Y → α} :
+  measurable (g ∘ f) ↔ measurable g :=
+forall₂_congr $ λ s _,
+  @measurable.measurable_set_preimage_iff_of_surjective _ _ _ _ _ _ _ _ _ _ _ _ hf hsurj (g ⁻¹' s)
+
+end measurable
+
+theorem continuous.map_eq_borel {X Y : Type*}
+  [topological_space X] [polish_space X] [measurable_space X] [borel_space X]
+  [topological_space Y] [t2_space Y] [second_countable_topology Y]
+  {f : X → Y} (hf : continuous f) (hsurj : surjective f) :
+  measurable_space.map f ‹_› = borel Y :=
+begin
+  borelize Y,
+  exact hf.measurable.map_measurable_space_eq hsurj
+end
+
+theorem continuous.map_borel_eq {X Y : Type*} [topological_space X] [polish_space X]
+  [topological_space Y] [t2_space Y] [second_countable_topology Y]
+  {f : X → Y} (hf : continuous f) (hsurj : surjective f) :
+  measurable_space.map f (borel X) = borel Y :=
+begin
+  borelize X,
+  exact hf.map_eq_borel hsurj
+end
+
+instance quotient.borel_space {X : Type*} [topological_space X] [polish_space X]
+  [measurable_space X] [borel_space X] {s : setoid X} [t2_space (quotient s)]
+  [second_countable_topology (quotient s)] : borel_space (quotient s) :=
+⟨continuous_quotient_mk.map_eq_borel (surjective_quotient_mk _)⟩
+
+@[to_additive]
+instance quotient_group.borel_space {G : Type*} [topological_space G] [polish_space G]
+  [second_countable_topology G] [group G] [topological_group G] [measurable_space G]
+  [borel_space G] {N : subgroup G} [N.normal] [is_closed (N : set G)] : borel_space (G ⧸ N) :=
+quotient.borel_space
+
+
+namespace measure_theory
 
 /-! ### Injective images of Borel sets -/
 

--- a/src/measure_theory/constructions/polish.lean
+++ b/src/measure_theory/constructions/polish.lean
@@ -466,9 +466,10 @@ end measure_theory
 
 namespace measurable
 
-variables {X Y : Type*}
+variables {X Y β : Type*}
   [topological_space X] [polish_space X] [measurable_space X] [borel_space X]
   [topological_space Y] [t2_space Y] [measurable_space Y] [opens_measurable_space Y]
+  [measurable_space β]
 
 /-- If `f : X → Y` is a surjective Borel measurable map from a Polish space to a topological space
 with second countable topology, then the preimage of a set `s` is measurable if and only if the set
@@ -524,10 +525,10 @@ begin
 end
 
 /-- If `f : X → Y` is a Borel measurable map from a Polish space to a topological space with second
-countable topology, then for any measurable space `α` and `g : Y → α`, the composition `g ∘ f` is
+countable topology, then for any measurable space `β` and `g : Y → β`, the composition `g ∘ f` is
 measurable if and only if the restriction of `g` to the range of `f` is measurable. -/
-theorem measurable_comp_iff_restrict [measurable_space α] {f : X → Y}
-  [second_countable_topology (range f)] (hf : measurable f) {g : Y → α} :
+theorem measurable_comp_iff_restrict {f : X → Y} [second_countable_topology (range f)]
+  (hf : measurable f) {g : Y → β} :
   measurable (g ∘ f) ↔ measurable (restrict (range f) g) :=
 forall₂_congr $ λ s _,
   @measurable.measurable_set_preimage_iff_preimage_coe _ _ _ _ _ _ _ _ _ _ _ _ hf (g ⁻¹' s)
@@ -535,8 +536,8 @@ forall₂_congr $ λ s _,
 /-- If `f : X → Y` is a surjective Borel measurable map from a Polish space to a topological space
 with second countable topology, then for any measurable space `α` and `g : Y → α`, the composition
 `g ∘ f` is measurable if and only if `g` is measurable. -/
-theorem measurable_comp_iff_of_surjective [second_countable_topology Y] [measurable_space α]
-  {f : X → Y} (hf : measurable f) (hsurj : surjective f) {g : Y → α} :
+theorem measurable_comp_iff_of_surjective [second_countable_topology Y] {f : X → Y}
+  (hf : measurable f) (hsurj : surjective f) {g : Y → β} :
   measurable (g ∘ f) ↔ measurable g :=
 forall₂_congr $ λ s _,
   @measurable.measurable_set_preimage_iff_of_surjective _ _ _ _ _ _ _ _ _ _ _ _ hf hsurj (g ⁻¹' s)

--- a/src/measure_theory/constructions/polish.lean
+++ b/src/measure_theory/constructions/polish.lean
@@ -549,7 +549,7 @@ theorem continuous.map_eq_borel {X Y : Type*}
   [topological_space X] [polish_space X] [measurable_space X] [borel_space X]
   [topological_space Y] [t2_space Y] [second_countable_topology Y]
   {f : X → Y} (hf : continuous f) (hsurj : surjective f) :
-  measurable_space.map f ‹_› = borel Y :=
+  measurable_space.map f ‹measurable_space X› = borel Y :=
 begin
   borelize Y,
   exact hf.measurable.map_measurable_space_eq hsurj

--- a/src/measure_theory/integral/periodic.lean
+++ b/src/measure_theory/integral/periodic.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov, Alex Kontorovich, Heather Macbeth
 -/
 import measure_theory.measure.lebesgue.eq_haar
 import measure_theory.measure.haar.quotient
+import measure_theory.constructions.polish
 import measure_theory.integral.interval_integral
 import topology.algebra.order.floor
 
@@ -28,12 +29,11 @@ open set function measure_theory measure_theory.measure topological_space add_su
 
 open_locale measure_theory nnreal ennreal
 
-local attribute [-instance] quotient_add_group.measurable_space quotient.measurable_space
-
 noncomputable instance add_circle.measurable_space {a : ℝ} : measurable_space (add_circle a) :=
-borel (add_circle a)
+quotient_add_group.measurable_space _
 
-instance add_circle.borel_space {a : ℝ} : borel_space (add_circle a) := ⟨rfl⟩
+instance add_circle.borel_space {a : ℝ} : borel_space (add_circle a) :=
+quotient_add_group.borel_space
 
 @[measurability] protected lemma add_circle.measurable_mk' {a : ℝ} :
   measurable (coe : ℝ → add_circle a) :=


### PR DESCRIPTION
* Suslin's theorem: an analytic set with analytic complement is measurable.
* Image of a measurable set in a Polish space under a measurable map is an analytic set.
* Preimage of a set under a measurable surjective map from a Polish
  space is measurable iff the original set is measurable.
* Quotient space of a Polish space with quotient σ-algebra is a Borel space provided that it has second countable topology.
* In particular, quotient group of a Polish topological group is a Borel space.
* Change instance for `measurable_space` on `add_circle`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)