### PR TITLE
[Merged by Bors] - chore(algebraic_geometry/Scheme): remove @[simps] from Spec

### DIFF
--- a/src/algebraic_geometry/AffineScheme.lean
+++ b/src/algebraic_geometry/AffineScheme.lean
@@ -257,7 +257,7 @@ end
 
 lemma Scheme.Spec_map_presheaf_map_eq_to_hom {X : Scheme} {U V : opens X.carrier} (h : U = V) (W) :
   (Scheme.Spec.map (X.presheaf.map (eq_to_hom h).op).op).val.c.app W =
-    eq_to_hom (by { cases h, induction W using opposite.rec, dsimp, simp, refl }) :=
+    eq_to_hom (by { cases h, induction W using opposite.rec, dsimp, simp, }) :=
 begin
   have : Scheme.Spec.map (X.presheaf.map (𝟙 (op U))).op = 𝟙 _,
   { rw [X.presheaf.map_id, op_id, Scheme.Spec.map_id]  },

--- a/src/algebraic_geometry/Scheme.lean
+++ b/src/algebraic_geometry/Scheme.lean
@@ -161,6 +161,9 @@ def Spec : CommRingᵒᵖ ⥤ Scheme :=
   map_id' := λ R, by rw [unop_id, Spec_map_id],
   map_comp' := λ R S T f g, by rw [unop_comp, Spec_map_comp] }
 
+@[simp] lemma Spec_obj_eq : Spec_obj X = Spec.obj (op X) := rfl
+@[simp] lemma Spec_map_eq : Spec_map f = Spec.map (op f) := rfl
+
 /--
 The empty scheme.
 -/

--- a/src/algebraic_geometry/Scheme.lean
+++ b/src/algebraic_geometry/Scheme.lean
@@ -155,6 +155,10 @@ Spec.LocallyRingedSpace_map_comp f g
 /--
 The spectrum, as a contravariant functor from commutative rings to schemes.
 -/
+-- TODO: make either `Spec_obj` or `Spec.obj` the simp-normal form. `LocallyRingedSpace_obj` is
+-- the simp-normal form of `toLocallyRingedSpace.obj`, but adding `simps` here without `attrs := []`
+-- for the same effect caused problems in mathlib4.
+@[simps {attrs := []}]
 def Spec : CommRingᵒᵖ ⥤ Scheme :=
 { obj := λ R, Spec_obj (unop R),
   map := λ R S f, Spec_map f.unop,

--- a/src/algebraic_geometry/Scheme.lean
+++ b/src/algebraic_geometry/Scheme.lean
@@ -161,8 +161,8 @@ def Spec : CommRingᵒᵖ ⥤ Scheme :=
   map_id' := λ R, by rw [unop_id, Spec_map_id],
   map_comp' := λ R S T f g, by rw [unop_comp, Spec_map_comp] }
 
-@[simp] lemma Spec_obj_eq : Spec_obj X = Spec.obj (op X) := rfl
-@[simp] lemma Spec_map_eq : Spec_map f = Spec.map (op f) := rfl
+@[simp] lemma Spec_obj_eq (R : CommRing) : Spec_obj R = Spec.obj (op R) := rfl
+@[simp] lemma Spec_map_eq {R S : CommRing} (f : R ⟶ S) : Spec_map f = Spec.map f.op := rfl
 
 /--
 The empty scheme.

--- a/src/algebraic_geometry/Scheme.lean
+++ b/src/algebraic_geometry/Scheme.lean
@@ -161,9 +161,6 @@ def Spec : CommRingᵒᵖ ⥤ Scheme :=
   map_id' := λ R, by rw [unop_id, Spec_map_id],
   map_comp' := λ R S T f g, by rw [unop_comp, Spec_map_comp] }
 
-@[simp] lemma Spec_obj_eq (R : CommRing) : Spec_obj R = Spec.obj (op R) := rfl
-@[simp] lemma Spec_map_eq {R S : CommRing} (f : R ⟶ S) : Spec_map f = Spec.map f.op := rfl
-
 /--
 The empty scheme.
 -/

--- a/src/algebraic_geometry/Scheme.lean
+++ b/src/algebraic_geometry/Scheme.lean
@@ -155,7 +155,7 @@ Spec.LocallyRingedSpace_map_comp f g
 /--
 The spectrum, as a contravariant functor from commutative rings to schemes.
 -/
-@[simps] def Spec : CommRingᵒᵖ ⥤ Scheme :=
+def Spec : CommRingᵒᵖ ⥤ Scheme :=
 { obj := λ R, Spec_obj (unop R),
   map := λ R S f, Spec_map f.unop,
   map_id' := λ R, by rw [unop_id, Spec_map_id],

--- a/src/algebraic_geometry/properties.lean
+++ b/src/algebraic_geometry/properties.lean
@@ -314,7 +314,7 @@ begin
   assumption
 end
 
-instance {R : CommRing} [H : is_domain R] : is_integral (Scheme.Spec.obj $ op R) :=
+instance {R : CommRing} [is_domain R] : is_integral (Scheme.Spec.obj $ op R) :=
 is_integral_of_is_irreducible_is_reduced _
 
 lemma affine_is_integral_iff (R : CommRing) :

--- a/src/algebraic_geometry/properties.lean
+++ b/src/algebraic_geometry/properties.lean
@@ -308,13 +308,14 @@ begin
     Y.presheaf.obj _ ≅ _).symm.CommRing_iso_to_ring_equiv.is_domain _
 end
 
-instance {R : CommRing} [H : is_domain R] : is_integral (Scheme.Spec.obj $ op R) :=
+instance {R : CommRing} [H : is_domain R] : irreducible_space (Scheme.Spec.obj $ op R).carrier :=
 begin
-  apply_with is_integral_of_is_irreducible_is_reduced { instances := ff },
-  { apply_instance },
-  { dsimp [Spec.Top_obj],
-    apply_instance },
+  convert prime_spectrum.irreducible_space,
+  assumption
 end
+
+instance {R : CommRing} [H : is_domain R] : is_integral (Scheme.Spec.obj $ op R) :=
+is_integral_of_is_irreducible_is_reduced _
 
 lemma affine_is_integral_iff (R : CommRing) :
   is_integral (Scheme.Spec.obj $ op R) ↔ is_domain R :=


### PR DESCRIPTION
The `@[simps]` on `Spec` produces lemmas that aren't needed in mathlib3, and get in the way in mathlib4. This backports the removal of this attribute, to match https://github.com/leanprover-community/mathlib4/pull/5040.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
