### PR TITLE
[Merged by Bors] - chore(number_theory/legendre_symbol/quadratic_reciprocity): split some files

### DIFF
--- a/src/number_theory/legendre_symbol/basic.lean
+++ b/src/number_theory/legendre_symbol/basic.lean
@@ -8,7 +8,7 @@ import number_theory.legendre_symbol.quadratic_char.basic
 /-!
 # Legendre symbol
 
-This file contains results about quadratic residues modulo a prime number.
+This file contains results about Legendre symbols.
 
 We define the Legendre symbol $\Bigl(\frac{a}{p}\Bigr)$ as `legendre_sym p a`.
 Note the order of arguments! The advantage of this form is that then `legendre_sym p`

--- a/src/number_theory/legendre_symbol/basic.lean
+++ b/src/number_theory/legendre_symbol/basic.lean
@@ -1,0 +1,298 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes, Michael Stoll
+-/
+import number_theory.legendre_symbol.quadratic_char.basic
+
+/-!
+# Legendre symbol
+
+This file contains results about quadratic residues modulo a prime number.
+
+We define the Legendre symbol $\Bigl(\frac{a}{p}\Bigr)$ as `legendre_sym p a`.
+Note the order of arguments! The advantage of this form is that then `legendre_sym p`
+is a multiplicative map.
+
+The Legendre symbol is used to define the Jacobi symbol, `jacobi_sym a b`, for integers `a`
+and (odd) natural numbers `b`, which extends the Legendre symbol.
+
+## Main results
+
+We also prove the supplementary laws that give conditions for when `-1`
+is a square modulo a prime `p`:
+`legendre_sym.at_neg_one` and `zmod.exists_sq_eq_neg_one_iff` for `-1`.
+
+See `number_theory.legendre_symbol.quadratic_reciprocity` for the conditions when `2` and `-2`
+are squares:
+`legendre_sym.at_two` and `zmod.exists_sq_eq_two_iff` for `2`,
+`legendre_sym.at_neg_two` and `zmod.exists_sq_eq_neg_two_iff` for `-2`.
+
+## Tags
+
+quadratic residue, quadratic nonresidue, Legendre symbol
+-/
+
+open nat
+
+section euler
+
+namespace zmod
+
+variables (p : ℕ) [fact p.prime]
+
+/-- Euler's Criterion: A unit `x` of `zmod p` is a square if and only if `x ^ (p / 2) = 1`. -/
+lemma euler_criterion_units (x : (zmod p)ˣ) : (∃ y : (zmod p)ˣ, y ^ 2 = x) ↔ x ^ (p / 2) = 1 :=
+begin
+  by_cases hc : p = 2,
+  { substI hc,
+    simp only [eq_iff_true_of_subsingleton, exists_const], },
+  { have h₀ := finite_field.unit_is_square_iff (by rwa ring_char_zmod_n) x,
+    have hs : (∃ y : (zmod p)ˣ, y ^ 2 = x) ↔ is_square(x) :=
+    by { rw is_square_iff_exists_sq x,
+         simp_rw eq_comm, },
+    rw hs,
+    rwa card p at h₀, },
+end
+
+/-- Euler's Criterion: a nonzero `a : zmod p` is a square if and only if `x ^ (p / 2) = 1`. -/
+lemma euler_criterion {a : zmod p} (ha : a ≠ 0) : is_square (a : zmod p) ↔ a ^ (p / 2) = 1 :=
+begin
+  apply (iff_congr _ (by simp [units.ext_iff])).mp (euler_criterion_units p (units.mk0 a ha)),
+  simp only [units.ext_iff, sq, units.coe_mk0, units.coe_mul],
+  split, { rintro ⟨y, hy⟩, exact ⟨y, hy.symm⟩ },
+  { rintro ⟨y, rfl⟩,
+    have hy : y ≠ 0, { rintro rfl, simpa [zero_pow] using ha, },
+    refine ⟨units.mk0 y hy, _⟩, simp, }
+end
+
+/-- If `a : zmod p` is nonzero, then `a^(p/2)` is either `1` or `-1`. -/
+lemma pow_div_two_eq_neg_one_or_one {a : zmod p} (ha : a ≠ 0) :
+  a ^ (p / 2) = 1 ∨ a ^ (p / 2) = -1 :=
+begin
+  cases prime.eq_two_or_odd (fact.out p.prime) with hp2 hp_odd,
+  { substI p, revert a ha, dec_trivial },
+  rw [← mul_self_eq_one_iff, ← pow_add, ← two_mul, two_mul_odd_div_two hp_odd],
+  exact pow_card_sub_one_eq_one ha
+end
+
+end zmod
+
+end euler
+
+section legendre
+
+/-!
+### Definition of the Legendre symbol and basic properties
+-/
+
+open zmod
+
+variables (p : ℕ) [fact p.prime]
+
+/-- The Legendre symbol of `a : ℤ` and a prime `p`, `legendre_sym p a`,
+is an integer defined as
+
+* `0` if `a` is `0` modulo `p`;
+* `1` if `a` is a nonzero square modulo `p`
+* `-1` otherwise.
+
+Note the order of the arguments! The advantage of the order chosen here is
+that `legendre_sym p` is a multiplicative function `ℤ → ℤ`.
+-/
+def legendre_sym (a : ℤ) : ℤ := quadratic_char (zmod p) a
+
+namespace legendre_sym
+
+/-- We have the congruence `legendre_sym p a ≡ a ^ (p / 2) mod p`. -/
+lemma eq_pow (a : ℤ) : (legendre_sym p a : zmod p) = a ^ (p / 2) :=
+begin
+  cases eq_or_ne (ring_char (zmod p)) 2 with hc hc,
+  { by_cases ha : (a : zmod p) = 0,
+    { rw [legendre_sym, ha, quadratic_char_zero,
+          zero_pow (nat.div_pos (fact.out p.prime).two_le (succ_pos 1))],
+      norm_cast, },
+    { have := (ring_char_zmod_n p).symm.trans hc, -- p = 2
+      substI p,
+      rw [legendre_sym, quadratic_char_eq_one_of_char_two hc ha],
+      revert ha,
+      generalize : (a : zmod 2) = b, revert b, dec_trivial } },
+  { convert quadratic_char_eq_pow_of_char_ne_two' hc (a : zmod p),
+    exact (card p).symm },
+end
+
+/-- If `p ∤ a`, then `legendre_sym p a` is `1` or `-1`. -/
+lemma eq_one_or_neg_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
+  legendre_sym p a = 1 ∨ legendre_sym p a = -1 :=
+quadratic_char_dichotomy ha
+
+lemma eq_neg_one_iff_not_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
+  legendre_sym p a = -1 ↔ ¬ legendre_sym p a = 1 :=
+quadratic_char_eq_neg_one_iff_not_one ha
+
+/-- The Legendre symbol of `p` and `a` is zero iff `p ∣ a`. -/
+lemma eq_zero_iff (a : ℤ) : legendre_sym p a = 0 ↔ (a : zmod p) = 0 :=
+quadratic_char_eq_zero_iff
+
+@[simp] lemma at_zero : legendre_sym p 0 = 0 :=
+by rw [legendre_sym, int.cast_zero, mul_char.map_zero]
+
+@[simp] lemma at_one : legendre_sym p 1 = 1 :=
+by rw [legendre_sym, int.cast_one, mul_char.map_one]
+
+/-- The Legendre symbol is multiplicative in `a` for `p` fixed. -/
+protected
+lemma mul (a b : ℤ) : legendre_sym p (a * b) = legendre_sym p a * legendre_sym p b :=
+by simp only [legendre_sym, int.cast_mul, map_mul]
+
+/-- The Legendre symbol is a homomorphism of monoids with zero. -/
+@[simps] def hom : ℤ →*₀ ℤ :=
+{ to_fun := legendre_sym p,
+  map_zero' := at_zero p,
+  map_one' := at_one p,
+  map_mul' := legendre_sym.mul p }
+
+/-- The square of the symbol is 1 if `p ∤ a`. -/
+theorem sq_one {a : ℤ} (ha : (a : zmod p) ≠ 0) : (legendre_sym p a) ^ 2 = 1 :=
+quadratic_char_sq_one ha
+
+/-- The Legendre symbol of `a^2` at `p` is 1 if `p ∤ a`. -/
+theorem sq_one' {a : ℤ} (ha : (a : zmod p) ≠ 0) : legendre_sym p (a ^ 2) = 1 :=
+by exact_mod_cast quadratic_char_sq_one' ha
+
+/-- The Legendre symbol depends only on `a` mod `p`. -/
+protected
+theorem mod (a : ℤ) : legendre_sym p a = legendre_sym p (a % p) :=
+by simp only [legendre_sym, int_cast_mod]
+
+/-- When `p ∤ a`, then `legendre_sym p a = 1` iff `a` is a square mod `p`. -/
+lemma eq_one_iff {a : ℤ} (ha0 : (a : zmod p) ≠ 0) :
+  legendre_sym p a = 1 ↔ is_square (a : zmod p) :=
+quadratic_char_one_iff_is_square ha0
+
+lemma eq_one_iff' {a : ℕ} (ha0 : (a : zmod p) ≠ 0) :
+  legendre_sym p a = 1 ↔ is_square (a : zmod p) :=
+by {rw eq_one_iff, norm_cast, exact_mod_cast ha0}
+
+/-- `legendre_sym p a = -1` iff `a` is a nonsquare mod `p`. -/
+lemma eq_neg_one_iff {a : ℤ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
+quadratic_char_neg_one_iff_not_is_square
+
+lemma eq_neg_one_iff' {a : ℕ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
+by {rw eq_neg_one_iff, norm_cast}
+
+/-- The number of square roots of `a` modulo `p` is determined by the Legendre symbol. -/
+lemma card_sqrts (hp : p ≠ 2) (a : ℤ) :
+  ↑{x : zmod p | x^2 = a}.to_finset.card = legendre_sym p a + 1 :=
+quadratic_char_card_sqrts ((ring_char_zmod_n p).substr hp) a
+
+end legendre_sym
+
+end legendre
+
+section quadratic_form
+
+/-!
+### Applications to binary quadratic forms
+-/
+
+namespace legendre_sym
+
+/-- The Legendre symbol `legendre_sym p a = 1` if there is a solution in `ℤ/pℤ`
+of the equation `x^2 - a*y^2 = 0` with `y ≠ 0`. -/
+lemma eq_one_of_sq_sub_mul_sq_eq_zero {p : ℕ} [fact p.prime]
+  {a : ℤ} (ha : (a : zmod p) ≠ 0) {x y : zmod p} (hy : y ≠ 0) (hxy : x ^ 2 - a * y ^ 2 = 0) :
+  legendre_sym p a = 1 :=
+begin
+  apply_fun (* y⁻¹ ^ 2) at hxy,
+  simp only [zero_mul] at hxy,
+  rw [(by ring : (x ^ 2 - ↑a * y ^ 2) * y⁻¹ ^ 2 = (x * y⁻¹) ^ 2 - a * (y * y⁻¹) ^ 2),
+      mul_inv_cancel hy, one_pow, mul_one, sub_eq_zero, pow_two] at hxy,
+  exact (eq_one_iff p ha).mpr ⟨x * y⁻¹, hxy.symm⟩,
+end
+
+/-- The Legendre symbol `legendre_sym p a = 1` if there is a solution in `ℤ/pℤ`
+of the equation `x^2 - a*y^2 = 0` with `x ≠ 0`. -/
+lemma eq_one_of_sq_sub_mul_sq_eq_zero' {p : ℕ} [fact p.prime]
+  {a : ℤ} (ha : (a : zmod p) ≠ 0) {x y : zmod p} (hx : x ≠ 0) (hxy : x ^ 2 - a * y ^ 2 = 0) :
+  legendre_sym p a = 1 :=
+begin
+  have hy : y ≠ 0,
+  { rintro rfl,
+    rw [zero_pow' 2 (by norm_num), mul_zero, sub_zero, pow_eq_zero_iff (by norm_num : 0 < 2)]
+      at hxy,
+    exacts [hx hxy, infer_instance], }, -- why is the instance not inferred automatically?
+  exact eq_one_of_sq_sub_mul_sq_eq_zero ha hy hxy,
+end
+
+/-- If `legendre_sym p a = -1`, then the only solution of `x^2 - a*y^2 = 0` in `ℤ/pℤ`
+is the trivial one. -/
+lemma eq_zero_mod_of_eq_neg_one {p : ℕ} [fact p.prime] {a : ℤ}
+  (h : legendre_sym p a = -1) {x y : zmod p} (hxy : x ^ 2 - a * y ^ 2 = 0) : x = 0 ∧ y = 0 :=
+begin
+  have ha : (a : zmod p) ≠ 0,
+  { intro hf,
+    rw (eq_zero_iff p a).mpr hf at h,
+    exact int.zero_ne_neg_of_ne zero_ne_one h, },
+  by_contra hf,
+  cases not_and_distrib.mp hf with hx hy,
+  { rw [eq_one_of_sq_sub_mul_sq_eq_zero' ha hx hxy, eq_neg_self_iff] at h,
+    exact one_ne_zero h, },
+  { rw [eq_one_of_sq_sub_mul_sq_eq_zero ha hy hxy, eq_neg_self_iff] at h,
+    exact one_ne_zero h, }
+end
+
+/-- If `legendre_sym p a = -1` and `p` divides `x^2 - a*y^2`, then `p` must divide `x` and `y`. -/
+lemma prime_dvd_of_eq_neg_one {p : ℕ} [fact p.prime] {a : ℤ}
+  (h : legendre_sym p a = -1) {x y : ℤ} (hxy : ↑p ∣ x ^ 2 - a * y ^ 2) : ↑p ∣ x ∧ ↑p ∣ y :=
+begin
+  simp_rw ← zmod.int_coe_zmod_eq_zero_iff_dvd at hxy ⊢,
+  push_cast at hxy,
+  exact eq_zero_mod_of_eq_neg_one h hxy,
+end
+
+end legendre_sym
+
+end quadratic_form
+
+section values
+
+/-!
+### The value of the Legendre symbol at `-1`
+
+See `jacobi_sym.at_neg_one` for the corresponding statement for the Jacobi symbol.
+-/
+
+variables {p : ℕ} [fact p.prime]
+
+open zmod
+
+/-- `legendre_sym p (-1)` is given by `χ₄ p`. -/
+lemma legendre_sym.at_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=
+by simp only [legendre_sym, card p, quadratic_char_neg_one ((ring_char_zmod_n p).substr hp),
+              int.cast_neg, int.cast_one]
+
+namespace zmod
+
+/-- `-1` is a square in `zmod p` iff `p` is not congruent to `3` mod `4`. -/
+lemma exists_sq_eq_neg_one_iff : is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
+by rw [finite_field.is_square_neg_one_iff, card p]
+
+lemma mod_four_ne_three_of_sq_eq_neg_one {y : zmod p} (hy : y ^ 2 = -1) : p % 4 ≠ 3 :=
+exists_sq_eq_neg_one_iff.1 ⟨y, hy ▸ pow_two y⟩
+
+/-- If two nonzero squares are negatives of each other in `zmod p`, then `p % 4 ≠ 3`. -/
+lemma mod_four_ne_three_of_sq_eq_neg_sq' {x y : zmod p} (hy : y ≠ 0) (hxy : x ^ 2 = - y ^ 2) :
+  p % 4 ≠ 3 :=
+@mod_four_ne_three_of_sq_eq_neg_one p _ (x / y) begin
+  apply_fun (λ z, z / y ^ 2) at hxy,
+  rwa [neg_div, ←div_pow, ←div_pow, div_self hy, one_pow] at hxy
+end
+
+lemma mod_four_ne_three_of_sq_eq_neg_sq {x y : zmod p} (hx : x ≠ 0) (hxy : x ^ 2 = - y ^ 2) :
+  p % 4 ≠ 3 :=
+mod_four_ne_three_of_sq_eq_neg_sq' hx (neg_eq_iff_eq_neg.mpr hxy).symm
+
+end zmod
+
+end values

--- a/src/number_theory/legendre_symbol/quadratic_char/basic.lean
+++ b/src/number_theory/legendre_symbol/quadratic_char/basic.lean
@@ -6,7 +6,6 @@ Authors: Michael Stoll
 import data.fintype.parity
 import number_theory.legendre_symbol.zmod_char
 import field_theory.finite.basic
-import number_theory.legendre_symbol.gauss_sum
 
 /-!
 # Quadratic characters of finite fields
@@ -317,121 +316,6 @@ begin
                imp_false, not_not],
     exact ⟨λ h, ne_of_eq_of_ne h (dec_trivial : 1 ≠ 3),
            or.resolve_right (nat.odd_mod_four_iff.mp h₁)⟩, },
-end
-
-/-- The value of the quadratic character at `2` -/
-lemma quadratic_char_two [decidable_eq F] (hF : ring_char F ≠ 2) :
-  quadratic_char F 2 = χ₈ (fintype.card F) :=
-is_quadratic.eq_of_eq_coe (quadratic_char_is_quadratic F) is_quadratic_χ₈ hF
-  ((quadratic_char_eq_pow_of_char_ne_two' hF 2).trans (finite_field.two_pow_card hF))
-
-/-- `2` is a square in `F` iff `#F` is not congruent to `3` or `5` mod `8`. -/
-lemma finite_field.is_square_two_iff :
-  is_square (2 : F) ↔ fintype.card F % 8 ≠ 3 ∧ fintype.card F % 8 ≠ 5 :=
-begin
-  classical,
-  by_cases hF : ring_char F = 2,
-  focus
-  { have h := finite_field.even_card_of_char_two hF,
-    simp only [finite_field.is_square_of_char_two hF, true_iff], },
-  rotate, focus
-  { have h := finite_field.odd_card_of_char_ne_two hF,
-    rw [← quadratic_char_one_iff_is_square (ring.two_ne_zero hF), quadratic_char_two hF,
-        χ₈_nat_eq_if_mod_eight],
-    simp only [h, nat.one_ne_zero, if_false, ite_eq_left_iff, ne.def, (dec_trivial : (-1 : ℤ) ≠ 1),
-               imp_false, not_not], },
-  all_goals
-  { rw [← nat.mod_mod_of_dvd _ (by norm_num : 2 ∣ 8)] at h,
-    have h₁ := nat.mod_lt (fintype.card F) (dec_trivial : 0 < 8),
-    revert h₁ h,
-    generalize : fintype.card F % 8 = n,
-    dec_trivial!, }
-end
-
-/-- The value of the quadratic character at `-2` -/
-lemma quadratic_char_neg_two [decidable_eq F] (hF : ring_char F ≠ 2) :
-  quadratic_char F (-2) = χ₈' (fintype.card F) :=
-begin
-  rw [(by norm_num : (-2 : F) = (-1) * 2), map_mul, χ₈'_eq_χ₄_mul_χ₈, quadratic_char_neg_one hF,
-      quadratic_char_two hF, @cast_nat_cast _ (zmod 4) _ _ _ (by norm_num : 4 ∣ 8)],
-end
-
-/-- `-2` is a square in `F` iff `#F` is not congruent to `5` or `7` mod `8`. -/
-lemma finite_field.is_square_neg_two_iff :
-  is_square (-2 : F) ↔ fintype.card F % 8 ≠ 5 ∧ fintype.card F % 8 ≠ 7 :=
-begin
-  classical,
-  by_cases hF : ring_char F = 2,
-  focus
-  { have h := finite_field.even_card_of_char_two hF,
-    simp only [finite_field.is_square_of_char_two hF, true_iff], },
-  rotate, focus
-  { have h := finite_field.odd_card_of_char_ne_two hF,
-    rw [← quadratic_char_one_iff_is_square (neg_ne_zero.mpr (ring.two_ne_zero hF)),
-        quadratic_char_neg_two hF, χ₈'_nat_eq_if_mod_eight],
-    simp only [h, nat.one_ne_zero, if_false, ite_eq_left_iff, ne.def, (dec_trivial : (-1 : ℤ) ≠ 1),
-               imp_false, not_not], },
-  all_goals
-  { rw [← nat.mod_mod_of_dvd _ (by norm_num : 2 ∣ 8)] at h,
-    have h₁ := nat.mod_lt (fintype.card F) (dec_trivial : 0 < 8),
-    revert h₁ h,
-    generalize : fintype.card F % 8 = n,
-    dec_trivial! }
-end
-
-/-- The relation between the values of the quadratic character of one field `F` at the
-cardinality of another field `F'` and of the quadratic character of `F'` at the cardinality
-of `F`. -/
-lemma quadratic_char_card_card [decidable_eq F] (hF : ring_char F ≠ 2) {F' : Type*} [field F']
-  [fintype F'] [decidable_eq F'] (hF' : ring_char F' ≠ 2) (h : ring_char F' ≠ ring_char F) :
-  quadratic_char F (fintype.card F') = quadratic_char F' (quadratic_char F (-1) * fintype.card F) :=
-begin
-  let χ := (quadratic_char F).ring_hom_comp (algebra_map ℤ F'),
-  have hχ₁ : χ.is_nontrivial,
-  { obtain ⟨a, ha⟩ := quadratic_char_exists_neg_one hF,
-    have hu : is_unit a,
-    { contrapose ha,
-      exact ne_of_eq_of_ne (map_nonunit (quadratic_char F) ha)
-             (mt zero_eq_neg.mp one_ne_zero), },
-    use hu.unit,
-    simp only [is_unit.unit_spec, ring_hom_comp_apply, eq_int_cast, ne.def, ha],
-    rw [int.cast_neg, int.cast_one],
-    exact ring.neg_one_ne_one_of_char_ne_two hF', },
-  have hχ₂ : χ.is_quadratic := is_quadratic.comp (quadratic_char_is_quadratic F) _,
-  have h := char.card_pow_card hχ₁ hχ₂ h hF',
-  rw [← quadratic_char_eq_pow_of_char_ne_two' hF'] at h,
-  exact (is_quadratic.eq_of_eq_coe (quadratic_char_is_quadratic F')
-             (quadratic_char_is_quadratic F) hF' h).symm,
-end
-
-/-- The value of the quadratic character at an odd prime `p` different from `ring_char F`. -/
-lemma quadratic_char_odd_prime [decidable_eq F] (hF : ring_char F ≠ 2) {p : ℕ} [fact p.prime]
-  (hp₁ : p ≠ 2) (hp₂ : ring_char F ≠ p) :
-  quadratic_char F p = quadratic_char (zmod p) (χ₄ (fintype.card F) * fintype.card F) :=
-begin
-  rw [← quadratic_char_neg_one hF],
-  have h := quadratic_char_card_card hF (ne_of_eq_of_ne (ring_char_zmod_n p) hp₁)
-              (ne_of_eq_of_ne (ring_char_zmod_n p) hp₂.symm),
-  rwa [card p] at h,
-end
-
-/-- An odd prime `p` is a square in `F` iff the quadratic character of `zmod p` does not
-take the value `-1` on `χ₄(#F) * #F`. -/
-lemma finite_field.is_square_odd_prime_iff (hF : ring_char F ≠ 2) {p : ℕ} [fact p.prime]
-  (hp : p ≠ 2) :
-  is_square (p : F) ↔ quadratic_char (zmod p) (χ₄ (fintype.card F) * fintype.card F) ≠ -1 :=
-begin
-  classical,
-  by_cases hFp : ring_char F = p,
-  { rw [show (p : F) = 0, by { rw ← hFp, exact ring_char.nat.cast_ring_char }],
-    simp only [is_square_zero, ne.def, true_iff, map_mul],
-    obtain ⟨n, _, hc⟩ := finite_field.card F (ring_char F),
-    have hchar : ring_char F = ring_char (zmod p) := by {rw hFp, exact (ring_char_zmod_n p).symm},
-    conv {congr, to_lhs, congr, skip, rw [hc, nat.cast_pow, map_pow, hchar, map_ring_char], },
-    simp only [zero_pow n.pos, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff], },
-  { rw [← iff.not_left (@quadratic_char_neg_one_iff_not_is_square F _ _ _ _),
-        quadratic_char_odd_prime hF hp],
-    exact hFp, },
 end
 
 end special_values

--- a/src/number_theory/legendre_symbol/quadratic_char/gauss_sum.lean
+++ b/src/number_theory/legendre_symbol/quadratic_char/gauss_sum.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2022 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import number_theory.legendre_symbol.quadratic_char.basic
+import number_theory.legendre_symbol.gauss_sum
+
+/-!
+# Quadratic characters of finite fields
+
+Further facts relying on Gauss sums.
+
+-/
+
+/-!
+### Basic properties of the quadratic character
+
+We prove some properties of the quadratic character.
+We work with a finite field `F` here.
+The interesting case is when the characteristic of `F` is odd.
+-/
+
+section special_values
+
+open zmod mul_char
+
+variables {F : Type*} [field F] [fintype F]
+
+/-- The value of the quadratic character at `2` -/
+lemma quadratic_char_two [decidable_eq F] (hF : ring_char F ≠ 2) :
+  quadratic_char F 2 = χ₈ (fintype.card F) :=
+is_quadratic.eq_of_eq_coe (quadratic_char_is_quadratic F) is_quadratic_χ₈ hF
+  ((quadratic_char_eq_pow_of_char_ne_two' hF 2).trans (finite_field.two_pow_card hF))
+
+/-- `2` is a square in `F` iff `#F` is not congruent to `3` or `5` mod `8`. -/
+lemma finite_field.is_square_two_iff :
+  is_square (2 : F) ↔ fintype.card F % 8 ≠ 3 ∧ fintype.card F % 8 ≠ 5 :=
+begin
+  classical,
+  by_cases hF : ring_char F = 2,
+  focus
+  { have h := finite_field.even_card_of_char_two hF,
+    simp only [finite_field.is_square_of_char_two hF, true_iff], },
+  rotate, focus
+  { have h := finite_field.odd_card_of_char_ne_two hF,
+    rw [← quadratic_char_one_iff_is_square (ring.two_ne_zero hF), quadratic_char_two hF,
+        χ₈_nat_eq_if_mod_eight],
+    simp only [h, nat.one_ne_zero, if_false, ite_eq_left_iff, ne.def, (dec_trivial : (-1 : ℤ) ≠ 1),
+               imp_false, not_not], },
+  all_goals
+  { rw [← nat.mod_mod_of_dvd _ (by norm_num : 2 ∣ 8)] at h,
+    have h₁ := nat.mod_lt (fintype.card F) (dec_trivial : 0 < 8),
+    revert h₁ h,
+    generalize : fintype.card F % 8 = n,
+    dec_trivial!, }
+end
+
+/-- The value of the quadratic character at `-2` -/
+lemma quadratic_char_neg_two [decidable_eq F] (hF : ring_char F ≠ 2) :
+  quadratic_char F (-2) = χ₈' (fintype.card F) :=
+begin
+  rw [(by norm_num : (-2 : F) = (-1) * 2), map_mul, χ₈'_eq_χ₄_mul_χ₈, quadratic_char_neg_one hF,
+      quadratic_char_two hF, @cast_nat_cast _ (zmod 4) _ _ _ (by norm_num : 4 ∣ 8)],
+end
+
+/-- `-2` is a square in `F` iff `#F` is not congruent to `5` or `7` mod `8`. -/
+lemma finite_field.is_square_neg_two_iff :
+  is_square (-2 : F) ↔ fintype.card F % 8 ≠ 5 ∧ fintype.card F % 8 ≠ 7 :=
+begin
+  classical,
+  by_cases hF : ring_char F = 2,
+  focus
+  { have h := finite_field.even_card_of_char_two hF,
+    simp only [finite_field.is_square_of_char_two hF, true_iff], },
+  rotate, focus
+  { have h := finite_field.odd_card_of_char_ne_two hF,
+    rw [← quadratic_char_one_iff_is_square (neg_ne_zero.mpr (ring.two_ne_zero hF)),
+        quadratic_char_neg_two hF, χ₈'_nat_eq_if_mod_eight],
+    simp only [h, nat.one_ne_zero, if_false, ite_eq_left_iff, ne.def, (dec_trivial : (-1 : ℤ) ≠ 1),
+               imp_false, not_not], },
+  all_goals
+  { rw [← nat.mod_mod_of_dvd _ (by norm_num : 2 ∣ 8)] at h,
+    have h₁ := nat.mod_lt (fintype.card F) (dec_trivial : 0 < 8),
+    revert h₁ h,
+    generalize : fintype.card F % 8 = n,
+    dec_trivial! }
+end
+
+/-- The relation between the values of the quadratic character of one field `F` at the
+cardinality of another field `F'` and of the quadratic character of `F'` at the cardinality
+of `F`. -/
+lemma quadratic_char_card_card [decidable_eq F] (hF : ring_char F ≠ 2) {F' : Type*} [field F']
+  [fintype F'] [decidable_eq F'] (hF' : ring_char F' ≠ 2) (h : ring_char F' ≠ ring_char F) :
+  quadratic_char F (fintype.card F') = quadratic_char F' (quadratic_char F (-1) * fintype.card F) :=
+begin
+  let χ := (quadratic_char F).ring_hom_comp (algebra_map ℤ F'),
+  have hχ₁ : χ.is_nontrivial,
+  { obtain ⟨a, ha⟩ := quadratic_char_exists_neg_one hF,
+    have hu : is_unit a,
+    { contrapose ha,
+      exact ne_of_eq_of_ne (map_nonunit (quadratic_char F) ha)
+             (mt zero_eq_neg.mp one_ne_zero), },
+    use hu.unit,
+    simp only [is_unit.unit_spec, ring_hom_comp_apply, eq_int_cast, ne.def, ha],
+    rw [int.cast_neg, int.cast_one],
+    exact ring.neg_one_ne_one_of_char_ne_two hF', },
+  have hχ₂ : χ.is_quadratic := is_quadratic.comp (quadratic_char_is_quadratic F) _,
+  have h := char.card_pow_card hχ₁ hχ₂ h hF',
+  rw [← quadratic_char_eq_pow_of_char_ne_two' hF'] at h,
+  exact (is_quadratic.eq_of_eq_coe (quadratic_char_is_quadratic F')
+             (quadratic_char_is_quadratic F) hF' h).symm,
+end
+
+/-- The value of the quadratic character at an odd prime `p` different from `ring_char F`. -/
+lemma quadratic_char_odd_prime [decidable_eq F] (hF : ring_char F ≠ 2) {p : ℕ} [fact p.prime]
+  (hp₁ : p ≠ 2) (hp₂ : ring_char F ≠ p) :
+  quadratic_char F p = quadratic_char (zmod p) (χ₄ (fintype.card F) * fintype.card F) :=
+begin
+  rw [← quadratic_char_neg_one hF],
+  have h := quadratic_char_card_card hF (ne_of_eq_of_ne (ring_char_zmod_n p) hp₁)
+              (ne_of_eq_of_ne (ring_char_zmod_n p) hp₂.symm),
+  rwa [card p] at h,
+end
+
+/-- An odd prime `p` is a square in `F` iff the quadratic character of `zmod p` does not
+take the value `-1` on `χ₄(#F) * #F`. -/
+lemma finite_field.is_square_odd_prime_iff (hF : ring_char F ≠ 2) {p : ℕ} [fact p.prime]
+  (hp : p ≠ 2) :
+  is_square (p : F) ↔ quadratic_char (zmod p) (χ₄ (fintype.card F) * fintype.card F) ≠ -1 :=
+begin
+  classical,
+  by_cases hFp : ring_char F = p,
+  { rw [show (p : F) = 0, by { rw ← hFp, exact ring_char.nat.cast_ring_char }],
+    simp only [is_square_zero, ne.def, true_iff, map_mul],
+    obtain ⟨n, _, hc⟩ := finite_field.card F (ring_char F),
+    have hchar : ring_char F = ring_char (zmod p) := by {rw hFp, exact (ring_char_zmod_n p).symm},
+    conv {congr, to_lhs, congr, skip, rw [hc, nat.cast_pow, map_pow, hchar, map_ring_char], },
+    simp only [zero_pow n.pos, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff], },
+  { rw [← iff.not_left (@quadratic_char_neg_one_iff_not_is_square F _ _ _ _),
+        quadratic_char_odd_prime hF hp],
+    exact hFp, },
+end
+
+end special_values

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -3,19 +3,11 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Michael Stoll
 -/
-import number_theory.legendre_symbol.quadratic_char
+import number_theory.legendre_symbol.basic
+import number_theory.legendre_symbol.quadratic_char.gauss_sum
 
 /-!
-# Legendre symbol and quadratic reciprocity.
-
-This file contains results about quadratic residues modulo a prime number.
-
-We define the Legendre symbol $\Bigl(\frac{a}{p}\Bigr)$ as `legendre_sym p a`.
-Note the order of arguments! The advantage of this form is that then `legendre_sym p`
-is a multiplicative map.
-
-The Legendre symbol is used to define the Jacobi symbol, `jacobi_sym a b`, for integers `a`
-and (odd) natural numbers `b`, which extends the Legendre symbol.
+# Quadratic reciprocity.
 
 ## Main results
 
@@ -34,7 +26,7 @@ We also prove the supplementary laws that give conditions for when `-1` or `2`
 ## Implementation notes
 
 The proofs use results for quadratic characters on arbitrary finite fields
-from `number_theory.legendre_symbol.quadratic_char`, which in turn are based on
+from `number_theory.legendre_symbol.quadratic_char.gauss_sum`, which in turn are based on
 properties of quadratic Gauss sums as provided by `number_theory.legendre_symbol.gauss_sum`.
 
 ## Tags
@@ -44,265 +36,11 @@ quadratic residue, quadratic nonresidue, Legendre symbol, quadratic reciprocity
 
 open nat
 
-section euler
-
-namespace zmod
-
-variables (p : ℕ) [fact p.prime]
-
-/-- Euler's Criterion: A unit `x` of `zmod p` is a square if and only if `x ^ (p / 2) = 1`. -/
-lemma euler_criterion_units (x : (zmod p)ˣ) : (∃ y : (zmod p)ˣ, y ^ 2 = x) ↔ x ^ (p / 2) = 1 :=
-begin
-  by_cases hc : p = 2,
-  { substI hc,
-    simp only [eq_iff_true_of_subsingleton, exists_const], },
-  { have h₀ := finite_field.unit_is_square_iff (by rwa ring_char_zmod_n) x,
-    have hs : (∃ y : (zmod p)ˣ, y ^ 2 = x) ↔ is_square(x) :=
-    by { rw is_square_iff_exists_sq x,
-         simp_rw eq_comm, },
-    rw hs,
-    rwa card p at h₀, },
-end
-
-/-- Euler's Criterion: a nonzero `a : zmod p` is a square if and only if `x ^ (p / 2) = 1`. -/
-lemma euler_criterion {a : zmod p} (ha : a ≠ 0) : is_square (a : zmod p) ↔ a ^ (p / 2) = 1 :=
-begin
-  apply (iff_congr _ (by simp [units.ext_iff])).mp (euler_criterion_units p (units.mk0 a ha)),
-  simp only [units.ext_iff, sq, units.coe_mk0, units.coe_mul],
-  split, { rintro ⟨y, hy⟩, exact ⟨y, hy.symm⟩ },
-  { rintro ⟨y, rfl⟩,
-    have hy : y ≠ 0, { rintro rfl, simpa [zero_pow] using ha, },
-    refine ⟨units.mk0 y hy, _⟩, simp, }
-end
-
-/-- If `a : zmod p` is nonzero, then `a^(p/2)` is either `1` or `-1`. -/
-lemma pow_div_two_eq_neg_one_or_one {a : zmod p} (ha : a ≠ 0) :
-  a ^ (p / 2) = 1 ∨ a ^ (p / 2) = -1 :=
-begin
-  cases prime.eq_two_or_odd (fact.out p.prime) with hp2 hp_odd,
-  { substI p, revert a ha, dec_trivial },
-  rw [← mul_self_eq_one_iff, ← pow_add, ← two_mul, two_mul_odd_div_two hp_odd],
-  exact pow_card_sub_one_eq_one ha
-end
-
-end zmod
-
-end euler
-
-section legendre
-
-/-!
-### Definition of the Legendre symbol and basic properties
--/
-
-open zmod
-
-variables (p : ℕ) [fact p.prime]
-
-/-- The Legendre symbol of `a : ℤ` and a prime `p`, `legendre_sym p a`,
-is an integer defined as
-
-* `0` if `a` is `0` modulo `p`;
-* `1` if `a` is a nonzero square modulo `p`
-* `-1` otherwise.
-
-Note the order of the arguments! The advantage of the order chosen here is
-that `legendre_sym p` is a multiplicative function `ℤ → ℤ`.
--/
-def legendre_sym (a : ℤ) : ℤ := quadratic_char (zmod p) a
-
-namespace legendre_sym
-
-/-- We have the congruence `legendre_sym p a ≡ a ^ (p / 2) mod p`. -/
-lemma eq_pow (a : ℤ) : (legendre_sym p a : zmod p) = a ^ (p / 2) :=
-begin
-  cases eq_or_ne (ring_char (zmod p)) 2 with hc hc,
-  { by_cases ha : (a : zmod p) = 0,
-    { rw [legendre_sym, ha, quadratic_char_zero,
-          zero_pow (nat.div_pos (fact.out p.prime).two_le (succ_pos 1))],
-      norm_cast, },
-    { have := (ring_char_zmod_n p).symm.trans hc, -- p = 2
-      substI p,
-      rw [legendre_sym, quadratic_char_eq_one_of_char_two hc ha],
-      revert ha,
-      generalize : (a : zmod 2) = b, revert b, dec_trivial } },
-  { convert quadratic_char_eq_pow_of_char_ne_two' hc (a : zmod p),
-    exact (card p).symm },
-end
-
-/-- If `p ∤ a`, then `legendre_sym p a` is `1` or `-1`. -/
-lemma eq_one_or_neg_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
-  legendre_sym p a = 1 ∨ legendre_sym p a = -1 :=
-quadratic_char_dichotomy ha
-
-lemma eq_neg_one_iff_not_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
-  legendre_sym p a = -1 ↔ ¬ legendre_sym p a = 1 :=
-quadratic_char_eq_neg_one_iff_not_one ha
-
-/-- The Legendre symbol of `p` and `a` is zero iff `p ∣ a`. -/
-lemma eq_zero_iff (a : ℤ) : legendre_sym p a = 0 ↔ (a : zmod p) = 0 :=
-quadratic_char_eq_zero_iff
-
-@[simp] lemma at_zero : legendre_sym p 0 = 0 :=
-by rw [legendre_sym, int.cast_zero, mul_char.map_zero]
-
-@[simp] lemma at_one : legendre_sym p 1 = 1 :=
-by rw [legendre_sym, int.cast_one, mul_char.map_one]
-
-/-- The Legendre symbol is multiplicative in `a` for `p` fixed. -/
-protected
-lemma mul (a b : ℤ) : legendre_sym p (a * b) = legendre_sym p a * legendre_sym p b :=
-by simp only [legendre_sym, int.cast_mul, map_mul]
-
-/-- The Legendre symbol is a homomorphism of monoids with zero. -/
-@[simps] def hom : ℤ →*₀ ℤ :=
-{ to_fun := legendre_sym p,
-  map_zero' := at_zero p,
-  map_one' := at_one p,
-  map_mul' := legendre_sym.mul p }
-
-/-- The square of the symbol is 1 if `p ∤ a`. -/
-theorem sq_one {a : ℤ} (ha : (a : zmod p) ≠ 0) : (legendre_sym p a) ^ 2 = 1 :=
-quadratic_char_sq_one ha
-
-/-- The Legendre symbol of `a^2` at `p` is 1 if `p ∤ a`. -/
-theorem sq_one' {a : ℤ} (ha : (a : zmod p) ≠ 0) : legendre_sym p (a ^ 2) = 1 :=
-by exact_mod_cast quadratic_char_sq_one' ha
-
-/-- The Legendre symbol depends only on `a` mod `p`. -/
-protected
-theorem mod (a : ℤ) : legendre_sym p a = legendre_sym p (a % p) :=
-by simp only [legendre_sym, int_cast_mod]
-
-/-- When `p ∤ a`, then `legendre_sym p a = 1` iff `a` is a square mod `p`. -/
-lemma eq_one_iff {a : ℤ} (ha0 : (a : zmod p) ≠ 0) :
-  legendre_sym p a = 1 ↔ is_square (a : zmod p) :=
-quadratic_char_one_iff_is_square ha0
-
-lemma eq_one_iff' {a : ℕ} (ha0 : (a : zmod p) ≠ 0) :
-  legendre_sym p a = 1 ↔ is_square (a : zmod p) :=
-by {rw eq_one_iff, norm_cast, exact_mod_cast ha0}
-
-/-- `legendre_sym p a = -1` iff `a` is a nonsquare mod `p`. -/
-lemma eq_neg_one_iff {a : ℤ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
-quadratic_char_neg_one_iff_not_is_square
-
-lemma eq_neg_one_iff' {a : ℕ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
-by {rw eq_neg_one_iff, norm_cast}
-
-/-- The number of square roots of `a` modulo `p` is determined by the Legendre symbol. -/
-lemma card_sqrts (hp : p ≠ 2) (a : ℤ) :
-  ↑{x : zmod p | x^2 = a}.to_finset.card = legendre_sym p a + 1 :=
-quadratic_char_card_sqrts ((ring_char_zmod_n p).substr hp) a
-
-end legendre_sym
-
-end legendre
-
-section quadratic_form
-
-/-!
-### Applications to binary quadratic forms
--/
-
-namespace legendre_sym
-
-/-- The Legendre symbol `legendre_sym p a = 1` if there is a solution in `ℤ/pℤ`
-of the equation `x^2 - a*y^2 = 0` with `y ≠ 0`. -/
-lemma eq_one_of_sq_sub_mul_sq_eq_zero {p : ℕ} [fact p.prime]
-  {a : ℤ} (ha : (a : zmod p) ≠ 0) {x y : zmod p} (hy : y ≠ 0) (hxy : x ^ 2 - a * y ^ 2 = 0) :
-  legendre_sym p a = 1 :=
-begin
-  apply_fun (* y⁻¹ ^ 2) at hxy,
-  simp only [zero_mul] at hxy,
-  rw [(by ring : (x ^ 2 - ↑a * y ^ 2) * y⁻¹ ^ 2 = (x * y⁻¹) ^ 2 - a * (y * y⁻¹) ^ 2),
-      mul_inv_cancel hy, one_pow, mul_one, sub_eq_zero, pow_two] at hxy,
-  exact (eq_one_iff p ha).mpr ⟨x * y⁻¹, hxy.symm⟩,
-end
-
-/-- The Legendre symbol `legendre_sym p a = 1` if there is a solution in `ℤ/pℤ`
-of the equation `x^2 - a*y^2 = 0` with `x ≠ 0`. -/
-lemma eq_one_of_sq_sub_mul_sq_eq_zero' {p : ℕ} [fact p.prime]
-  {a : ℤ} (ha : (a : zmod p) ≠ 0) {x y : zmod p} (hx : x ≠ 0) (hxy : x ^ 2 - a * y ^ 2 = 0) :
-  legendre_sym p a = 1 :=
-begin
-  have hy : y ≠ 0,
-  { rintro rfl,
-    rw [zero_pow' 2 (by norm_num), mul_zero, sub_zero, pow_eq_zero_iff (by norm_num : 0 < 2)]
-      at hxy,
-    exacts [hx hxy, infer_instance], }, -- why is the instance not inferred automatically?
-  exact eq_one_of_sq_sub_mul_sq_eq_zero ha hy hxy,
-end
-
-/-- If `legendre_sym p a = -1`, then the only solution of `x^2 - a*y^2 = 0` in `ℤ/pℤ`
-is the trivial one. -/
-lemma eq_zero_mod_of_eq_neg_one {p : ℕ} [fact p.prime] {a : ℤ}
-  (h : legendre_sym p a = -1) {x y : zmod p} (hxy : x ^ 2 - a * y ^ 2 = 0) : x = 0 ∧ y = 0 :=
-begin
-  have ha : (a : zmod p) ≠ 0,
-  { intro hf,
-    rw (eq_zero_iff p a).mpr hf at h,
-    exact int.zero_ne_neg_of_ne zero_ne_one h, },
-  by_contra hf,
-  cases not_and_distrib.mp hf with hx hy,
-  { rw [eq_one_of_sq_sub_mul_sq_eq_zero' ha hx hxy, eq_neg_self_iff] at h,
-    exact one_ne_zero h, },
-  { rw [eq_one_of_sq_sub_mul_sq_eq_zero ha hy hxy, eq_neg_self_iff] at h,
-    exact one_ne_zero h, }
-end
-
-/-- If `legendre_sym p a = -1` and `p` divides `x^2 - a*y^2`, then `p` must divide `x` and `y`. -/
-lemma prime_dvd_of_eq_neg_one {p : ℕ} [fact p.prime] {a : ℤ}
-  (h : legendre_sym p a = -1) {x y : ℤ} (hxy : ↑p ∣ x ^ 2 - a * y ^ 2) : ↑p ∣ x ∧ ↑p ∣ y :=
-begin
-  simp_rw ← zmod.int_coe_zmod_eq_zero_iff_dvd at hxy ⊢,
-  push_cast at hxy,
-  exact eq_zero_mod_of_eq_neg_one h hxy,
-end
-
-end legendre_sym
-
-end quadratic_form
-
 section values
-
-/-!
-### The value of the Legendre symbol at `-1`
-
-See `jacobi_sym.at_neg_one` for the corresponding statement for the Jacobi symbol.
--/
 
 variables {p : ℕ} [fact p.prime]
 
 open zmod
-
-/-- `legendre_sym p (-1)` is given by `χ₄ p`. -/
-lemma legendre_sym.at_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=
-by simp only [legendre_sym, card p, quadratic_char_neg_one ((ring_char_zmod_n p).substr hp),
-              int.cast_neg, int.cast_one]
-
-namespace zmod
-
-/-- `-1` is a square in `zmod p` iff `p` is not congruent to `3` mod `4`. -/
-lemma exists_sq_eq_neg_one_iff : is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
-by rw [finite_field.is_square_neg_one_iff, card p]
-
-lemma mod_four_ne_three_of_sq_eq_neg_one {y : zmod p} (hy : y ^ 2 = -1) : p % 4 ≠ 3 :=
-exists_sq_eq_neg_one_iff.1 ⟨y, hy ▸ pow_two y⟩
-
-/-- If two nonzero squares are negatives of each other in `zmod p`, then `p % 4 ≠ 3`. -/
-lemma mod_four_ne_three_of_sq_eq_neg_sq' {x y : zmod p} (hy : y ≠ 0) (hxy : x ^ 2 = - y ^ 2) :
-  p % 4 ≠ 3 :=
-@mod_four_ne_three_of_sq_eq_neg_one p _ (x / y) begin
-  apply_fun (λ z, z / y ^ 2) at hxy,
-  rwa [neg_div, ←div_pow, ←div_pow, div_self hy, one_pow] at hxy
-end
-
-lemma mod_four_ne_three_of_sq_eq_neg_sq {x y : zmod p} (hx : x ≠ 0) (hxy : x ^ 2 = - y ^ 2) :
-  p % 4 ≠ 3 :=
-mod_four_ne_three_of_sq_eq_neg_sq' hx (neg_eq_iff_eq_neg.mpr hxy).symm
-
-end zmod
 
 /-!
 ### The value of the Legendre symbol at `2` and `-2`

--- a/src/number_theory/sum_two_squares.lean
+++ b/src/number_theory/sum_two_squares.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Michael Stoll
 -/
 
-import number_theory.zsqrtd.gaussian_int
+import number_theory.zsqrtd.quadratic_reciprocity
 import tactic.linear_combination
 
 /-!

--- a/src/number_theory/zsqrtd/gaussian_int.lean
+++ b/src/number_theory/zsqrtd/gaussian_int.lean
@@ -6,7 +6,8 @@ Authors: Chris Hughes
 import number_theory.zsqrtd.basic
 import data.complex.basic
 import ring_theory.principal_ideal_domain
-import number_theory.legendre_symbol.quadratic_reciprocity
+
+
 /-!
 # Gaussian integers
 
@@ -19,10 +20,11 @@ The Euclidean domain structure on `ℤ[i]` is defined in this file.
 
 The homomorphism `to_complex` into the complex numbers is also defined in this file.
 
-## Main statements
+## See also
 
-`prime_iff_mod_four_eq_three_of_nat_prime`
-A prime natural number is prime in `ℤ[i]` if and only if it is `3` mod `4`
+See `number_theory.zsqrtd.gaussian_int` for:
+* `prime_iff_mod_four_eq_three_of_nat_prime`:
+  A prime natural number is prime in `ℤ[i]` if and only if it is `3` mod `4`
 
 ## Notations
 
@@ -194,62 +196,6 @@ instance : euclidean_domain ℤ[i] :=
 
 open principal_ideal_ring
 
-lemma mod_four_eq_three_of_nat_prime_of_prime (p : ℕ) [hp : fact p.prime] (hpi : prime (p : ℤ[i])) :
-  p % 4 = 3 :=
-hp.1.eq_two_or_odd.elim
-  (λ hp2, absurd hpi (mt irreducible_iff_prime.2 $
-    λ ⟨hu, h⟩, begin
-      have := h ⟨1, 1⟩ ⟨1, -1⟩ (hp2.symm ▸ rfl),
-      rw [← norm_eq_one_iff, ← norm_eq_one_iff] at this,
-      exact absurd this dec_trivial
-    end))
-  (λ hp1, by_contradiction $ λ hp3 : p % 4 ≠ 3,
-    have hp41 : p % 4 = 1,
-      begin
-        rw [← nat.mod_mul_left_mod p 2 2, show 2 * 2 = 4, from rfl] at hp1,
-        have := nat.mod_lt p (show 0 < 4, from dec_trivial),
-        revert this hp3 hp1,
-        generalize : p % 4 = m, dec_trivial!,
-      end,
-    let ⟨k, hk⟩ := zmod.exists_sq_eq_neg_one_iff.2 $
-      by rw hp41; exact dec_trivial in
-    begin
-      obtain ⟨k, k_lt_p, rfl⟩ : ∃ (k' : ℕ) (h : k' < p), (k' : zmod p) = k,
-      { refine ⟨k.val, k.val_lt, zmod.nat_cast_zmod_val k⟩ },
-      have hpk : p ∣ k ^ 2 + 1,
-        by { rw [pow_two, ← char_p.cast_eq_zero_iff (zmod p) p, nat.cast_add, nat.cast_mul,
-                 nat.cast_one, ← hk, add_left_neg], },
-      have hkmul : (k ^ 2 + 1 : ℤ[i]) = ⟨k, 1⟩ * ⟨k, -1⟩ :=
-        by simp [sq, zsqrtd.ext],
-      have hpne1 : p ≠ 1 := ne_of_gt hp.1.one_lt,
-      have hkltp : 1 + k * k < p * p,
-        from calc 1 + k * k ≤ k + k * k :
-          add_le_add_right (nat.pos_of_ne_zero
-            (λ hk0, by clear_aux_decl; simp [*, pow_succ'] at *)) _
-        ... = k * (k + 1) : by simp [add_comm, mul_add]
-        ... < p * p : mul_lt_mul k_lt_p k_lt_p (nat.succ_pos _) (nat.zero_le _),
-      have hpk₁ : ¬ (p : ℤ[i]) ∣ ⟨k, -1⟩ :=
-        λ ⟨x, hx⟩, lt_irrefl (p * x : ℤ[i]).norm.nat_abs $
-          calc (norm (p * x : ℤ[i])).nat_abs = (zsqrtd.norm ⟨k, -1⟩).nat_abs : by rw hx
-          ... < (norm (p : ℤ[i])).nat_abs : by simpa [add_comm, zsqrtd.norm] using hkltp
-          ... ≤ (norm (p * x : ℤ[i])).nat_abs : norm_le_norm_mul_left _
-            (λ hx0, (show (-1 : ℤ) ≠ 0, from dec_trivial) $
-              by simpa [hx0] using congr_arg zsqrtd.im hx),
-      have hpk₂ : ¬ (p : ℤ[i]) ∣ ⟨k, 1⟩ :=
-        λ ⟨x, hx⟩, lt_irrefl (p * x : ℤ[i]).norm.nat_abs $
-          calc (norm (p * x : ℤ[i])).nat_abs = (zsqrtd.norm ⟨k, 1⟩).nat_abs : by rw hx
-          ... < (norm (p : ℤ[i])).nat_abs : by simpa [add_comm, zsqrtd.norm] using hkltp
-          ... ≤ (norm (p * x : ℤ[i])).nat_abs : norm_le_norm_mul_left _
-            (λ hx0, (show (1 : ℤ) ≠ 0, from dec_trivial) $
-                by simpa [hx0] using congr_arg zsqrtd.im hx),
-      have hpu : ¬ is_unit (p : ℤ[i]), from mt norm_eq_one_iff.2
-        (by rw [norm_nat_cast, int.nat_abs_mul, mul_eq_one];
-        exact λ h, (ne_of_lt hp.1.one_lt).symm h.1),
-      obtain ⟨y, hy⟩ := hpk,
-      have := hpi.2.2 ⟨k, 1⟩ ⟨k, -1⟩ ⟨y, by rw [← hkmul, ← nat.cast_mul p, ← hy]; simp⟩,
-      clear_aux_decl, tauto
-    end)
-
 lemma sq_add_sq_of_nat_prime_of_not_irreducible (p : ℕ) [hp : fact p.prime]
   (hpi : ¬irreducible (p : ℤ[i])) : ∃ a b, a^2 + b^2 = p :=
 have hpu : ¬ is_unit (p : ℤ[i]), from mt norm_eq_one_iff.2 $
@@ -264,17 +210,5 @@ have hnap : (norm a).nat_abs = p, from ((hp.1.mul_eq_prime_sq_iff
     ← @norm_nat_cast (-1), hpab];
     simp).1,
 ⟨a.re.nat_abs, a.im.nat_abs, by simpa [nat_abs_norm_eq, sq] using hnap⟩
-
-lemma prime_of_nat_prime_of_mod_four_eq_three (p : ℕ) [hp : fact p.prime] (hp3 : p % 4 = 3) :
-  prime (p : ℤ[i]) :=
-irreducible_iff_prime.1 $ classical.by_contradiction $ λ hpi,
-  let ⟨a, b, hab⟩ := sq_add_sq_of_nat_prime_of_not_irreducible p hpi in
-have ∀ a b : zmod 4, a^2 + b^2 ≠ p, by erw [← zmod.nat_cast_mod p 4, hp3]; exact dec_trivial,
-this a b (hab ▸ by simp)
-
-/-- A prime natural number is prime in `ℤ[i]` if and only if it is `3` mod `4` -/
-lemma prime_iff_mod_four_eq_three_of_nat_prime (p : ℕ) [hp : fact p.prime] :
-  prime (p : ℤ[i]) ↔ p % 4 = 3 :=
-⟨mod_four_eq_three_of_nat_prime_of_prime p, prime_of_nat_prime_of_mod_four_eq_three p⟩
 
 end gaussian_int

--- a/src/number_theory/zsqrtd/quadratic_reciprocity.lean
+++ b/src/number_theory/zsqrtd/quadratic_reciprocity.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2019 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes
+-/
+import number_theory.zsqrtd.gaussian_int
+import number_theory.legendre_symbol.quadratic_reciprocity
+
+/-!
+# Facts about the gaussian integers relying on quadratic reciprocity.
+
+## Main statements
+
+`prime_iff_mod_four_eq_three_of_nat_prime`
+A prime natural number is prime in `ℤ[i]` if and only if it is `3` mod `4`
+
+-/
+
+open zsqrtd complex
+open_locale complex_conjugate
+
+local notation `ℤ[i]` := gaussian_int
+
+namespace gaussian_int
+
+open principal_ideal_ring
+
+lemma mod_four_eq_three_of_nat_prime_of_prime (p : ℕ) [hp : fact p.prime] (hpi : prime (p : ℤ[i])) :
+  p % 4 = 3 :=
+hp.1.eq_two_or_odd.elim
+  (λ hp2, absurd hpi (mt irreducible_iff_prime.2 $
+    λ ⟨hu, h⟩, begin
+      have := h ⟨1, 1⟩ ⟨1, -1⟩ (hp2.symm ▸ rfl),
+      rw [← norm_eq_one_iff, ← norm_eq_one_iff] at this,
+      exact absurd this dec_trivial
+    end))
+  (λ hp1, by_contradiction $ λ hp3 : p % 4 ≠ 3,
+    have hp41 : p % 4 = 1,
+      begin
+        rw [← nat.mod_mul_left_mod p 2 2, show 2 * 2 = 4, from rfl] at hp1,
+        have := nat.mod_lt p (show 0 < 4, from dec_trivial),
+        revert this hp3 hp1,
+        generalize : p % 4 = m, dec_trivial!,
+      end,
+    let ⟨k, hk⟩ := zmod.exists_sq_eq_neg_one_iff.2 $
+      by rw hp41; exact dec_trivial in
+    begin
+      obtain ⟨k, k_lt_p, rfl⟩ : ∃ (k' : ℕ) (h : k' < p), (k' : zmod p) = k,
+      { refine ⟨k.val, k.val_lt, zmod.nat_cast_zmod_val k⟩ },
+      have hpk : p ∣ k ^ 2 + 1,
+        by { rw [pow_two, ← char_p.cast_eq_zero_iff (zmod p) p, nat.cast_add, nat.cast_mul,
+                 nat.cast_one, ← hk, add_left_neg], },
+      have hkmul : (k ^ 2 + 1 : ℤ[i]) = ⟨k, 1⟩ * ⟨k, -1⟩ :=
+        by simp [sq, zsqrtd.ext],
+      have hpne1 : p ≠ 1 := ne_of_gt hp.1.one_lt,
+      have hkltp : 1 + k * k < p * p,
+        from calc 1 + k * k ≤ k + k * k :
+          add_le_add_right (nat.pos_of_ne_zero
+            (λ hk0, by clear_aux_decl; simp [*, pow_succ'] at *)) _
+        ... = k * (k + 1) : by simp [add_comm, mul_add]
+        ... < p * p : mul_lt_mul k_lt_p k_lt_p (nat.succ_pos _) (nat.zero_le _),
+      have hpk₁ : ¬ (p : ℤ[i]) ∣ ⟨k, -1⟩ :=
+        λ ⟨x, hx⟩, lt_irrefl (p * x : ℤ[i]).norm.nat_abs $
+          calc (norm (p * x : ℤ[i])).nat_abs = (zsqrtd.norm ⟨k, -1⟩).nat_abs : by rw hx
+          ... < (norm (p : ℤ[i])).nat_abs : by simpa [add_comm, zsqrtd.norm] using hkltp
+          ... ≤ (norm (p * x : ℤ[i])).nat_abs : norm_le_norm_mul_left _
+            (λ hx0, (show (-1 : ℤ) ≠ 0, from dec_trivial) $
+              by simpa [hx0] using congr_arg zsqrtd.im hx),
+      have hpk₂ : ¬ (p : ℤ[i]) ∣ ⟨k, 1⟩ :=
+        λ ⟨x, hx⟩, lt_irrefl (p * x : ℤ[i]).norm.nat_abs $
+          calc (norm (p * x : ℤ[i])).nat_abs = (zsqrtd.norm ⟨k, 1⟩).nat_abs : by rw hx
+          ... < (norm (p : ℤ[i])).nat_abs : by simpa [add_comm, zsqrtd.norm] using hkltp
+          ... ≤ (norm (p * x : ℤ[i])).nat_abs : norm_le_norm_mul_left _
+            (λ hx0, (show (1 : ℤ) ≠ 0, from dec_trivial) $
+                by simpa [hx0] using congr_arg zsqrtd.im hx),
+      have hpu : ¬ is_unit (p : ℤ[i]), from mt norm_eq_one_iff.2
+        (by rw [norm_nat_cast, int.nat_abs_mul, mul_eq_one];
+        exact λ h, (ne_of_lt hp.1.one_lt).symm h.1),
+      obtain ⟨y, hy⟩ := hpk,
+      have := hpi.2.2 ⟨k, 1⟩ ⟨k, -1⟩ ⟨y, by rw [← hkmul, ← nat.cast_mul p, ← hy]; simp⟩,
+      clear_aux_decl, tauto
+    end)
+
+lemma prime_of_nat_prime_of_mod_four_eq_three (p : ℕ) [hp : fact p.prime] (hp3 : p % 4 = 3) :
+  prime (p : ℤ[i]) :=
+irreducible_iff_prime.1 $ classical.by_contradiction $ λ hpi,
+  let ⟨a, b, hab⟩ := sq_add_sq_of_nat_prime_of_not_irreducible p hpi in
+have ∀ a b : zmod 4, a^2 + b^2 ≠ p, by erw [← zmod.nat_cast_mod p 4, hp3]; exact dec_trivial,
+this a b (hab ▸ by simp)
+
+/-- A prime natural number is prime in `ℤ[i]` if and only if it is `3` mod `4` -/
+lemma prime_iff_mod_four_eq_three_of_nat_prime (p : ℕ) [hp : fact p.prime] :
+  prime (p : ℤ[i]) ↔ p % 4 = 3 :=
+⟨mod_four_eq_three_of_nat_prime_of_prime p, prime_of_nat_prime_of_mod_four_eq_three p⟩
+
+end gaussian_int


### PR DESCRIPTION
The best split here is separating `quadratic_reciprocity` into that and `legendre_symbol`.

I was looking at this because the olean analyser in the port-progress-bot made an unlikely claim about unnecessary dependencies, and I wanted to make sure we weren't missing something in doubting it. We weren't. :-)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
