### PR TITLE
[Merged by Bors] - chore(data/zmod/algebra): make zmod.algebra a def

### DIFF
--- a/src/data/zmod/algebra.lean
+++ b/src/data/zmod/algebra.lean
@@ -39,6 +39,6 @@ def algebra' (h : m ∣ n) : algebra (zmod n) R :=
 
 end
 
-instance (p : ℕ) [char_p R p] : algebra (zmod p) R := algebra' R p dvd_rfl
+def algebra (p : ℕ) [char_p R p] : algebra (zmod p) R := algebra' R p dvd_rfl
 
 end zmod

--- a/src/data/zmod/algebra.lean
+++ b/src/data/zmod/algebra.lean
@@ -24,7 +24,9 @@ instance (p : ℕ) : subsingleton (algebra (zmod p) R) :=
 section
 variables {n : ℕ} (m : ℕ) [char_p R m]
 
-/-- The `zmod n`-algebra structure on rings whose characteristic `m` divides `n` -/
+/-- The `zmod n`-algebra structure on rings whose characteristic `m` divides `n`.
+See note [reducible non-instances]. -/
+@[reducible]
 def algebra' (h : m ∣ n) : algebra (zmod n) R :=
 { smul := λ a r, a * r,
   commutes' := λ a r, show (a * r : R) = r * a,
@@ -40,7 +42,9 @@ def algebra' (h : m ∣ n) : algebra (zmod n) R :=
 end
 
 /-- The `zmod p`-algebra structure on a ring of characteristic `p`. This is not an
-instance since it creates a diamond with `algebra.id`. -/
+instance since it creates a diamond with `algebra.id`.
+See note [reducible non-instances]. -/
+@[reducible]
 def algebra (p : ℕ) [char_p R p] : algebra (zmod p) R := algebra' R p dvd_rfl
 
 end zmod

--- a/src/data/zmod/algebra.lean
+++ b/src/data/zmod/algebra.lean
@@ -39,6 +39,8 @@ def algebra' (h : m ∣ n) : algebra (zmod n) R :=
 
 end
 
+/-- The `zmod p`-algebra structure on a ring of characteristic `p`. This is not an
+instance since it creates a diamond with `algebra.id`. -/
 def algebra (p : ℕ) [char_p R p] : algebra (zmod p) R := algebra' R p dvd_rfl
 
 end zmod

--- a/src/field_theory/cardinality.lean
+++ b/src/field_theory/cardinality.lean
@@ -38,6 +38,7 @@ lemma fintype.is_prime_pow_card_of_field {α} [fintype α] [field α] : is_prime
 begin
   casesI char_p.exists α with p _,
   haveI hp := fact.mk (char_p.char_is_prime α p),
+  letI : algebra (zmod p) α := zmod.algebra _ _,
   let b := is_noetherian.finset_basis (zmod p) α,
   rw [module.card_fintype b, zmod.card, is_prime_pow_pow_iff],
   { exact hp.1.is_prime_pow },

--- a/src/field_theory/cardinality.lean
+++ b/src/field_theory/cardinality.lean
@@ -36,6 +36,7 @@ universe u
 /-- A finite field has prime power cardinality. -/
 lemma fintype.is_prime_pow_card_of_field {α} [fintype α] [field α] : is_prime_pow (‖α‖) :=
 begin
+  -- TODO: `algebra` version of `char_p.exists`, of type `Σ p, algebra (zmod p) α`
   casesI char_p.exists α with p _,
   haveI hp := fact.mk (char_p.char_is_prime α p),
   letI : algebra (zmod p) α := zmod.algebra _ _,

--- a/src/field_theory/finite/galois_field.lean
+++ b/src/field_theory/finite/galois_field.lean
@@ -152,8 +152,6 @@ begin
   rw [splits_iff_card_roots, h1, ←finset.card_def, finset.card_univ, h2, zmod.card],
 end
 
-local attribute [-instance] zmod.algebra
-
 /-- A Galois field with exponent 1 is equivalent to `zmod` -/
 def equiv_zmod_p : galois_field p 1 ≃ₐ[zmod p] (zmod p) :=
 let h : (X ^ p ^ 1 : (zmod p)[X]) = X ^ (fintype.card (zmod p)) :=
@@ -229,6 +227,8 @@ begin
     all_goals {apply_instance}, },
   rw ← hpp' at *,
   haveI := fact_iff.2 hp,
+  letI : algebra (zmod p) K := zmod.algebra _ _,
+  letI : algebra (zmod p) K' := zmod.algebra _ _,
   exact alg_equiv_of_card_eq p hKK',
 end
 

--- a/src/field_theory/finite/trace.lean
+++ b/src/field_theory/finite/trace.lean
@@ -18,7 +18,6 @@ finite field, trace
 
 namespace finite_field
 
-
 /-- The trace map from a finite field to its prime field is nongedenerate. -/
 lemma trace_to_zmod_nondegenerate (F : Type*) [field F] [finite F]
   [algebra (zmod (ring_char F)) F] {a : F} (ha : a ≠ 0) :

--- a/src/field_theory/finite/trace.lean
+++ b/src/field_theory/finite/trace.lean
@@ -18,6 +18,9 @@ finite field, trace
 
 namespace finite_field
 
+
+local attribute [instance] zmod.algebra
+
 /-- The trace map from a finite field to its prime field is nongedenerate. -/
 lemma trace_to_zmod_nondegenerate (F : Type*) [field F] [finite F] {a : F}
  (ha : a ≠ 0) : ∃ b : F, algebra.trace (zmod (ring_char F)) F (a * b) ≠ 0 :=

--- a/src/field_theory/finite/trace.lean
+++ b/src/field_theory/finite/trace.lean
@@ -20,7 +20,7 @@ namespace finite_field
 
 
 /-- The trace map from a finite field to its prime field is nongedenerate. -/
-lemma trace_to_zmod_nondegenerate (F : Type*) [field F] [finite F] {a : F}
+lemma trace_to_zmod_nondegenerate (F : Type*) [field F] [finite F] [algebra (zmod (ring_char F)) F] {a : F}
  (ha : a ≠ 0) :
  by letI := zmod.algebra F (ring_char F);
   exact ∃ b : F, algebra.trace (zmod (ring_char F)) F (a * b) ≠ 0 :=

--- a/src/field_theory/finite/trace.lean
+++ b/src/field_theory/finite/trace.lean
@@ -20,17 +20,15 @@ namespace finite_field
 
 
 /-- The trace map from a finite field to its prime field is nongedenerate. -/
-lemma trace_to_zmod_nondegenerate (F : Type*) [field F] [finite F] [algebra (zmod (ring_char F)) F] {a : F}
- (ha : a ≠ 0) :
- by letI := zmod.algebra F (ring_char F);
-  exact ∃ b : F, algebra.trace (zmod (ring_char F)) F (a * b) ≠ 0 :=
+lemma trace_to_zmod_nondegenerate (F : Type*) [field F] [finite F]
+  [algebra (zmod (ring_char F)) F] {a : F} (ha : a ≠ 0) :
+  ∃ b : F, algebra.trace (zmod (ring_char F)) F (a * b) ≠ 0 :=
 begin
-  letI := zmod.algebra F (ring_char F),
   haveI : fact (ring_char F).prime := ⟨char_p.char_is_prime F _⟩,
   have htr := trace_form_nondegenerate (zmod (ring_char F)) F a,
   simp_rw [algebra.trace_form_apply] at htr,
   by_contra' hf,
-  exact ha (htr hf),
+  exact ha (htr hf)
 end
 
 end finite_field

--- a/src/field_theory/finite/trace.lean
+++ b/src/field_theory/finite/trace.lean
@@ -19,12 +19,13 @@ finite field, trace
 namespace finite_field
 
 
-local attribute [instance] zmod.algebra
-
 /-- The trace map from a finite field to its prime field is nongedenerate. -/
 lemma trace_to_zmod_nondegenerate (F : Type*) [field F] [finite F] {a : F}
- (ha : a ≠ 0) : ∃ b : F, algebra.trace (zmod (ring_char F)) F (a * b) ≠ 0 :=
+ (ha : a ≠ 0) :
+ by letI := zmod.algebra F (ring_char F);
+  exact ∃ b : F, algebra.trace (zmod (ring_char F)) F (a * b) ≠ 0 :=
 begin
+  letI := zmod.algebra F (ring_char F),
   haveI : fact (ring_char F).prime := ⟨char_p.char_is_prime F _⟩,
   have htr := trace_form_nondegenerate (zmod (ring_char F)) F a,
   simp_rw [algebra.trace_form_apply] at htr,

--- a/src/field_theory/is_alg_closed/classification.lean
+++ b/src/field_theory/is_alg_closed/classification.lean
@@ -180,6 +180,8 @@ private lemma ring_equiv_of_cardinal_eq_of_char_p (p : ℕ) [fact p.prime]
   [char_p K p] [char_p L p] (hK : ℵ₀ < #K) (hKL : #K = #L) : K ≃+* L :=
 begin
   apply classical.choice,
+  letI : algebra (zmod p) K := zmod.algebra _ _,
+  letI : algebra (zmod p) L := zmod.algebra _ _,
   cases exists_is_transcendence_basis (zmod p)
     (show function.injective (algebra_map (zmod p) K),
       from ring_hom.injective _) with s hs,

--- a/src/field_theory/is_alg_closed/classification.lean
+++ b/src/field_theory/is_alg_closed/classification.lean
@@ -161,7 +161,6 @@ if they have the same cardinality. -/
 lemma ring_equiv_of_cardinal_eq_of_char_zero [char_zero K] [char_zero L]
   (hK : ℵ₀ < #K) (hKL : #K = #L) : nonempty (K ≃+* L) :=
 begin
-  apply classical.choice,
   cases exists_is_transcendence_basis ℤ
     (show function.injective (algebra_map ℤ K),
       from int.cast_injective) with s hs,
@@ -173,13 +172,12 @@ begin
         ← cardinal_eq_cardinal_transcendence_basis_of_aleph_0_lt _ ht (le_of_eq mk_int), hKL],
     rwa ← hKL },
   cases cardinal.eq.1 this with e,
-  exact ⟨⟨equiv_of_transcendence_basis _ _ e hs ht⟩⟩
+  exact ⟨equiv_of_transcendence_basis _ _ e hs ht⟩
 end
 
 private lemma ring_equiv_of_cardinal_eq_of_char_p (p : ℕ) [fact p.prime]
   [char_p K p] [char_p L p] (hK : ℵ₀ < #K) (hKL : #K = #L) : nonempty (K ≃+* L) :=
 begin
-  apply classical.choice,
   letI : algebra (zmod p) K := zmod.algebra _ _,
   letI : algebra (zmod p) L := zmod.algebra _ _,
   cases exists_is_transcendence_basis (zmod p)
@@ -195,7 +193,7 @@ begin
       (lt_aleph_0_of_finite (zmod p)).le, hKL],
     rwa ← hKL },
   cases cardinal.eq.1 this with e,
-  exact ⟨⟨equiv_of_transcendence_basis _ _ e hs ht⟩⟩
+  exact ⟨equiv_of_transcendence_basis _ _ e hs ht⟩
 end
 
 /-- Two uncountable algebraically closed fields are isomorphic
@@ -203,17 +201,16 @@ if they have the same cardinality and the same characteristic. -/
 lemma ring_equiv_of_cardinal_eq_of_char_eq (p : ℕ) [char_p K p] [char_p L p]
   (hK : ℵ₀ < #K) (hKL : #K = #L) : nonempty (K ≃+* L) :=
 begin
-  apply classical.choice,
   rcases char_p.char_is_prime_or_zero K p with hp | hp,
   { haveI : fact p.prime := ⟨hp⟩,
     letI : algebra (zmod p) K := zmod.algebra _ _,
     letI : algebra (zmod p) L := zmod.algebra _ _,
-    exact ⟨ring_equiv_of_cardinal_eq_of_char_p p hK hKL⟩ },
+    exact ring_equiv_of_cardinal_eq_of_char_p p hK hKL },
   { rw [hp] at *,
     resetI,
     letI : char_zero K := char_p.char_p_to_char_zero K,
     letI : char_zero L := char_p.char_p_to_char_zero L,
-    exact ⟨ring_equiv_of_cardinal_eq_of_char_zero hK hKL⟩ }
+    exact ring_equiv_of_cardinal_eq_of_char_zero hK hKL }
 end
 
 end is_alg_closed

--- a/src/field_theory/is_alg_closed/classification.lean
+++ b/src/field_theory/is_alg_closed/classification.lean
@@ -158,8 +158,8 @@ variables {K L : Type} [field K] [field L] [is_alg_closed K] [is_alg_closed L]
 
 /-- Two uncountable algebraically closed fields of characteristic zero are isomorphic
 if they have the same cardinality. -/
-@[nolint def_lemma] lemma ring_equiv_of_cardinal_eq_of_char_zero [char_zero K] [char_zero L]
-  (hK : ℵ₀ < #K) (hKL : #K = #L) : K ≃+* L :=
+lemma ring_equiv_of_cardinal_eq_of_char_zero [char_zero K] [char_zero L]
+  (hK : ℵ₀ < #K) (hKL : #K = #L) : nonempty (K ≃+* L) :=
 begin
   apply classical.choice,
   cases exists_is_transcendence_basis ℤ
@@ -173,11 +173,11 @@ begin
         ← cardinal_eq_cardinal_transcendence_basis_of_aleph_0_lt _ ht (le_of_eq mk_int), hKL],
     rwa ← hKL },
   cases cardinal.eq.1 this with e,
-  exact ⟨equiv_of_transcendence_basis _ _ e hs ht⟩
+  exact ⟨⟨equiv_of_transcendence_basis _ _ e hs ht⟩⟩
 end
 
-private def ring_equiv_of_cardinal_eq_of_char_p (p : ℕ) [fact p.prime]
-  [char_p K p] [char_p L p] (hK : ℵ₀ < #K) (hKL : #K = #L) : K ≃+* L :=
+private lemma ring_equiv_of_cardinal_eq_of_char_p (p : ℕ) [fact p.prime]
+  [char_p K p] [char_p L p] (hK : ℵ₀ < #K) (hKL : #K = #L) : nonempty (K ≃+* L) :=
 begin
   apply classical.choice,
   letI : algebra (zmod p) K := zmod.algebra _ _,
@@ -195,13 +195,13 @@ begin
       (lt_aleph_0_of_finite (zmod p)).le, hKL],
     rwa ← hKL },
   cases cardinal.eq.1 this with e,
-  exact ⟨equiv_of_transcendence_basis _ _ e hs ht⟩
+  exact ⟨⟨equiv_of_transcendence_basis _ _ e hs ht⟩⟩
 end
 
 /-- Two uncountable algebraically closed fields are isomorphic
 if they have the same cardinality and the same characteristic. -/
-@[nolint def_lemma] lemma ring_equiv_of_cardinal_eq_of_char_eq (p : ℕ) [char_p K p] [char_p L p]
-  (hK : ℵ₀ < #K) (hKL : #K = #L) : K ≃+* L :=
+lemma ring_equiv_of_cardinal_eq_of_char_eq (p : ℕ) [char_p K p] [char_p L p]
+  (hK : ℵ₀ < #K) (hKL : #K = #L) : nonempty (K ≃+* L) :=
 begin
   apply classical.choice,
   rcases char_p.char_is_prime_or_zero K p with hp | hp,

--- a/src/field_theory/is_alg_closed/classification.lean
+++ b/src/field_theory/is_alg_closed/classification.lean
@@ -204,6 +204,8 @@ begin
   apply classical.choice,
   rcases char_p.char_is_prime_or_zero K p with hp | hp,
   { haveI : fact p.prime := ⟨hp⟩,
+    letI : algebra (zmod p) K := zmod.algebra _ _,
+    letI : algebra (zmod p) L := zmod.algebra _ _,
     exact ⟨ring_equiv_of_cardinal_eq_of_char_p p hK hKL⟩ },
   { rw [hp] at *,
     resetI,

--- a/src/field_theory/is_alg_closed/classification.lean
+++ b/src/field_theory/is_alg_closed/classification.lean
@@ -177,11 +177,9 @@ begin
 end
 
 private lemma ring_equiv_of_cardinal_eq_of_char_p (p : ℕ) [fact p.prime]
-  [char_p K p] [char_p L p] (hK : ℵ₀ < #K) (hKL : #K = #L) : K ≃+* L :=
+  [algebra (zmod p) K] [algebra (zmod p) L] (hK : ℵ₀ < #K) (hKL : #K = #L) : K ≃+* L :=
 begin
   apply classical.choice,
-  letI : algebra (zmod p) K := zmod.algebra _ _,
-  letI : algebra (zmod p) L := zmod.algebra _ _,
   cases exists_is_transcendence_basis (zmod p)
     (show function.injective (algebra_map (zmod p) K),
       from ring_hom.injective _) with s hs,

--- a/src/field_theory/is_alg_closed/classification.lean
+++ b/src/field_theory/is_alg_closed/classification.lean
@@ -176,10 +176,12 @@ begin
   exact ⟨equiv_of_transcendence_basis _ _ e hs ht⟩
 end
 
-private lemma ring_equiv_of_cardinal_eq_of_char_p (p : ℕ) [fact p.prime]
-  [algebra (zmod p) K] [algebra (zmod p) L] (hK : ℵ₀ < #K) (hKL : #K = #L) : K ≃+* L :=
+private def ring_equiv_of_cardinal_eq_of_char_p (p : ℕ) [fact p.prime]
+  [char_p K p] [char_p L p] (hK : ℵ₀ < #K) (hKL : #K = #L) : K ≃+* L :=
 begin
   apply classical.choice,
+  letI : algebra (zmod p) K := zmod.algebra _ _,
+  letI : algebra (zmod p) L := zmod.algebra _ _,
   cases exists_is_transcendence_basis (zmod p)
     (show function.injective (algebra_map (zmod p) K),
       from ring_hom.injective _) with s hs,

--- a/src/number_theory/legendre_symbol/add_character.lean
+++ b/src/number_theory/legendre_symbol/add_character.lean
@@ -355,6 +355,7 @@ begin
       exact λ hf, nat.prime.ne_zero hp.1 (zero_dvd_iff.mp hf), },
   end,
   let ψ := primitive_zmod_char pp F' (ne_zero_iff.mp (ne_zero.of_not_dvd F' hp₂)),
+  letI : algebra (zmod p) F := zmod.algebra _ _,
   let ψ' := ψ.char.comp (algebra.trace (zmod p) F).to_add_monoid_hom.to_multiplicative,
   have hψ' : is_nontrivial ψ' :=
   begin

--- a/src/ring_theory/polynomial/cyclotomic/expand.lean
+++ b/src/ring_theory/polynomial/cyclotomic/expand.lean
@@ -124,7 +124,7 @@ section char_p
 /-- If `R` is of characteristic `p` and `¬p ∣ n`, then
 `cyclotomic (n * p) R = (cyclotomic n R) ^ (p - 1)`. -/
 lemma cyclotomic_mul_prime_eq_pow_of_not_dvd (R : Type*) {p n : ℕ} [hp : fact (nat.prime p)]
-  [ring R] [char_p R p] (hn : ¬p ∣ n) [algebra (zmod p) R]: 
+  [ring R] [algebra (zmod p) R] (hn : ¬p ∣ n) [algebra (zmod p) R]:
   cyclotomic (n * p) R = (cyclotomic n R) ^ (p - 1) :=
 begin
   suffices : cyclotomic (n * p) (zmod p) = (cyclotomic n (zmod p)) ^ (p - 1),
@@ -140,7 +140,7 @@ end
 /-- If `R` is of characteristic `p` and `p ∣ n`, then
 `cyclotomic (n * p) R = (cyclotomic n R) ^ p`. -/
 lemma cyclotomic_mul_prime_dvd_eq_pow (R : Type*) {p n : ℕ} [hp : fact (nat.prime p)] [ring R]
-  [char_p R p] [algebra (zmod p) R] (hn : p ∣ n) :
+  [algebra (zmod p) R] (hn : p ∣ n) :
   cyclotomic (n * p) R = (cyclotomic n R) ^ p :=
 begin
   suffices : cyclotomic (n * p) (zmod p) = (cyclotomic n (zmod p)) ^ p,
@@ -153,7 +153,7 @@ end
 /-- If `R` is of characteristic `p` and `¬p ∣ m`, then
 `cyclotomic (p ^ k * m) R = (cyclotomic m R) ^ (p ^ k - p ^ (k - 1))`. -/
 lemma cyclotomic_mul_prime_pow_eq (R : Type*) {p m : ℕ} [fact (nat.prime p)]
-  [ring R] [char_p R p] (hm : ¬p ∣ m) :
+  [ring R] [algebra (zmod p) R] (hm : ¬p ∣ m) :
   ∀ {k}, 0 < k → cyclotomic (p ^ k * m) R = (cyclotomic m R) ^ (p ^ k - p ^ (k - 1))
 | 1 _ := by rw [pow_one, nat.sub_self, pow_zero, mul_comm,
   cyclotomic_mul_prime_eq_pow_of_not_dvd R hm]
@@ -173,6 +173,7 @@ lemma is_root_cyclotomic_prime_pow_mul_iff_of_char_p {m k p : ℕ} {R : Type*} [
   [is_domain R] [hp : fact (nat.prime p)] [hchar : char_p R p] {μ : R} [ne_zero (m : R)] :
   (polynomial.cyclotomic (p ^ k * m) R).is_root μ ↔ is_primitive_root μ m :=
 begin
+  letI : algebra (zmod p) R := zmod.algebra _ _,
   rcases k.eq_zero_or_pos with rfl | hk,
   { rw [pow_zero, one_mul, is_root_cyclotomic_iff] },
   refine ⟨λ h, _, λ h, _⟩,

--- a/src/ring_theory/polynomial/cyclotomic/expand.lean
+++ b/src/ring_theory/polynomial/cyclotomic/expand.lean
@@ -140,9 +140,9 @@ end
 /-- If `R` is of characteristic `p` and `p ∣ n`, then
 `cyclotomic (n * p) R = (cyclotomic n R) ^ p`. -/
 lemma cyclotomic_mul_prime_dvd_eq_pow (R : Type*) {p n : ℕ} [hp : fact (nat.prime p)] [ring R]
-  [char_p R p] (hn : p ∣ n) : cyclotomic (n * p) R = (cyclotomic n R) ^ p :=
+  [char_p R p] [algebra (zmod p) R] (hn : p ∣ n) :
+  cyclotomic (n * p) R = (cyclotomic n R) ^ p :=
 begin
-  letI : algebra (zmod p) R := zmod.algebra _ _,
   suffices : cyclotomic (n * p) (zmod p) = (cyclotomic n (zmod p)) ^ p,
   { rw [← map_cyclotomic _ (algebra_map (zmod p) R), ← map_cyclotomic _ (algebra_map (zmod p) R),
       this, polynomial.map_pow] },

--- a/src/ring_theory/polynomial/cyclotomic/expand.lean
+++ b/src/ring_theory/polynomial/cyclotomic/expand.lean
@@ -124,9 +124,9 @@ section char_p
 /-- If `R` is of characteristic `p` and `¬p ∣ n`, then
 `cyclotomic (n * p) R = (cyclotomic n R) ^ (p - 1)`. -/
 lemma cyclotomic_mul_prime_eq_pow_of_not_dvd (R : Type*) {p n : ℕ} [hp : fact (nat.prime p)]
-  [ring R] [char_p R p] (hn : ¬p ∣ n) : cyclotomic (n * p) R = (cyclotomic n R) ^ (p - 1) :=
+  [ring R] [char_p R p] (hn : ¬p ∣ n) [algebra (zmod p) R]: 
+  cyclotomic (n * p) R = (cyclotomic n R) ^ (p - 1) :=
 begin
-  letI : algebra (zmod p) R := zmod.algebra _ _,
   suffices : cyclotomic (n * p) (zmod p) = (cyclotomic n (zmod p)) ^ (p - 1),
   { rw [← map_cyclotomic _ (algebra_map (zmod p) R), ← map_cyclotomic _ (algebra_map (zmod p) R),
       this, polynomial.map_pow] },

--- a/src/ring_theory/polynomial/cyclotomic/expand.lean
+++ b/src/ring_theory/polynomial/cyclotomic/expand.lean
@@ -126,6 +126,7 @@ section char_p
 lemma cyclotomic_mul_prime_eq_pow_of_not_dvd (R : Type*) {p n : ℕ} [hp : fact (nat.prime p)]
   [ring R] [char_p R p] (hn : ¬p ∣ n) : cyclotomic (n * p) R = (cyclotomic n R) ^ (p - 1) :=
 begin
+  letI : algebra (zmod p) R := zmod.algebra _ _,
   suffices : cyclotomic (n * p) (zmod p) = (cyclotomic n (zmod p)) ^ (p - 1),
   { rw [← map_cyclotomic _ (algebra_map (zmod p) R), ← map_cyclotomic _ (algebra_map (zmod p) R),
       this, polynomial.map_pow] },
@@ -141,6 +142,7 @@ end
 lemma cyclotomic_mul_prime_dvd_eq_pow (R : Type*) {p n : ℕ} [hp : fact (nat.prime p)] [ring R]
   [char_p R p] (hn : p ∣ n) : cyclotomic (n * p) R = (cyclotomic n R) ^ p :=
 begin
+  letI : algebra (zmod p) R := zmod.algebra _ _,
   suffices : cyclotomic (n * p) (zmod p) = (cyclotomic n (zmod p)) ^ p,
   { rw [← map_cyclotomic _ (algebra_map (zmod p) R), ← map_cyclotomic _ (algebra_map (zmod p) R),
       this, polynomial.map_pow] },

--- a/src/ring_theory/polynomial/cyclotomic/expand.lean
+++ b/src/ring_theory/polynomial/cyclotomic/expand.lean
@@ -124,9 +124,9 @@ section char_p
 /-- If `R` is of characteristic `p` and `¬p ∣ n`, then
 `cyclotomic (n * p) R = (cyclotomic n R) ^ (p - 1)`. -/
 lemma cyclotomic_mul_prime_eq_pow_of_not_dvd (R : Type*) {p n : ℕ} [hp : fact (nat.prime p)]
-  [ring R] [algebra (zmod p) R] (hn : ¬p ∣ n) [algebra (zmod p) R]:
-  cyclotomic (n * p) R = (cyclotomic n R) ^ (p - 1) :=
+  [ring R] [char_p R p] (hn : ¬p ∣ n) : cyclotomic (n * p) R = (cyclotomic n R) ^ (p - 1) :=
 begin
+  letI : algebra (zmod p) R := zmod.algebra _ _,
   suffices : cyclotomic (n * p) (zmod p) = (cyclotomic n (zmod p)) ^ (p - 1),
   { rw [← map_cyclotomic _ (algebra_map (zmod p) R), ← map_cyclotomic _ (algebra_map (zmod p) R),
       this, polynomial.map_pow] },
@@ -140,9 +140,9 @@ end
 /-- If `R` is of characteristic `p` and `p ∣ n`, then
 `cyclotomic (n * p) R = (cyclotomic n R) ^ p`. -/
 lemma cyclotomic_mul_prime_dvd_eq_pow (R : Type*) {p n : ℕ} [hp : fact (nat.prime p)] [ring R]
-  [algebra (zmod p) R] (hn : p ∣ n) :
-  cyclotomic (n * p) R = (cyclotomic n R) ^ p :=
+  [char_p R p] (hn : p ∣ n) : cyclotomic (n * p) R = (cyclotomic n R) ^ p :=
 begin
+  letI : algebra (zmod p) R := zmod.algebra _ _,
   suffices : cyclotomic (n * p) (zmod p) = (cyclotomic n (zmod p)) ^ p,
   { rw [← map_cyclotomic _ (algebra_map (zmod p) R), ← map_cyclotomic _ (algebra_map (zmod p) R),
       this, polynomial.map_pow] },
@@ -153,7 +153,7 @@ end
 /-- If `R` is of characteristic `p` and `¬p ∣ m`, then
 `cyclotomic (p ^ k * m) R = (cyclotomic m R) ^ (p ^ k - p ^ (k - 1))`. -/
 lemma cyclotomic_mul_prime_pow_eq (R : Type*) {p m : ℕ} [fact (nat.prime p)]
-  [ring R] [algebra (zmod p) R] (hm : ¬p ∣ m) :
+  [ring R] [char_p R p] (hm : ¬p ∣ m) :
   ∀ {k}, 0 < k → cyclotomic (p ^ k * m) R = (cyclotomic m R) ^ (p ^ k - p ^ (k - 1))
 | 1 _ := by rw [pow_one, nat.sub_self, pow_zero, mul_comm,
   cyclotomic_mul_prime_eq_pow_of_not_dvd R hm]

--- a/src/ring_theory/witt_vector/frobenius.lean
+++ b/src/ring_theory/witt_vector/frobenius.lean
@@ -282,6 +282,7 @@ lemma coeff_frobenius_char_p (x : 𝕎 R) (n : ℕ) :
   coeff (frobenius x) n = (x.coeff n) ^ p :=
 begin
   rw [coeff_frobenius],
+  letI : algebra (zmod p) R := zmod.algebra _ _,
   -- outline of the calculation, proofs follow below
   calc aeval (λ k, x.coeff k) (frobenius_poly p n)
       = aeval (λ k, x.coeff k)


### PR DESCRIPTION
`zmod.algebra` creates a diamond about the `zmod p`-algebra structure on `zmod p`:
```lean
import algebra.algebra.basic
import data.zmod.algebra

example (p : ℕ) : algebra.id (zmod p) =
  (zmod.algebra (zmod p) p) := rfl --fails
```

This is also causing troubles with the port. We turn `zmod.algebra` into a def.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
