### PR TITLE
[Merged by Bors] - feat(measure_theory/integral/average): Lebesgue average

### DIFF
--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -105,6 +105,10 @@ noncomputable instance : linear_ordered_comm_monoid_with_zero ℝ≥0∞ :=
   .. ennreal.linear_ordered_add_comm_monoid_with_top,
   .. (show comm_semiring ℝ≥0∞, from infer_instance) }
 
+instance : unique (add_units ℝ≥0∞) :=
+{ default := 0,
+  uniq := λ a, add_units.ext $ le_zero_iff.1 $ by { rw ←a.add_neg, exact le_self_add } }
+
 instance : inhabited ℝ≥0∞ := ⟨0⟩
 
 instance : has_coe ℝ≥0 ℝ≥0∞ := ⟨ option.some ⟩
@@ -1056,6 +1060,12 @@ by rw [div_eq_mul_inv, mul_assoc, ennreal.inv_mul_cancel h0 hI, mul_one]
 protected lemma mul_div_cancel' (h0 : a ≠ 0) (hI : a ≠ ∞) : a * (b / a) = b :=
 by rw [mul_comm, ennreal.div_mul_cancel h0 hI]
 
+protected lemma mul_comm_div : a / b * c = a * (c / b) :=
+by simp only [div_eq_mul_inv, mul_comm, mul_assoc]
+
+protected lemma mul_div_right_comm : a * b / c = a / c * b :=
+by simp only [div_eq_mul_inv, mul_comm, mul_assoc]
+
 instance : has_involutive_inv ℝ≥0∞ :=
 { inv := has_inv.inv,
   inv_inv := λ a, by
@@ -1076,6 +1086,9 @@ mul_lt_top h1 (inv_ne_top.mpr h2)
 inv_top ▸ inv_inj
 
 protected lemma inv_ne_zero : a⁻¹ ≠ 0 ↔ a ≠ ∞ := by simp
+
+protected lemma div_pos (ha : a ≠ 0) (hb : b ≠ ∞) : 0 < a / b :=
+ennreal.mul_pos ha $ ennreal.inv_ne_zero.2 hb
 
 protected lemma mul_inv {a b : ℝ≥0∞} (ha : a ≠ 0 ∨ b ≠ ∞) (hb : a ≠ ∞ ∨ b ≠ 0) :
   (a * b)⁻¹ = a⁻¹ * b⁻¹ :=

--- a/src/measure_theory/integral/average.lean
+++ b/src/measure_theory/integral/average.lean
@@ -548,21 +548,24 @@ variables {N : set α} {f : α → ℝ≥0∞}
 /-- **First moment method**. A measurable function is smaller than its mean on a set of positive
 measure. -/
 lemma measure_le_set_laverage_pos (hμ : μ s ≠ 0) (hμ₁ : μ s ≠ ∞)
-  (hf : ae_measurable f (μ.restrict s)) (hs : null_measurable_set s μ) :
+  (hf : ae_measurable f (μ.restrict s)) :
   0 < μ {x ∈ s | f x ≤ ⨍⁻ a in s, f a ∂μ} :=
 begin
   obtain h | h := eq_or_ne (∫⁻ a in s, f a ∂μ) ∞,
   { simpa [mul_top, hμ₁, laverage, h, top_div_of_ne_top hμ₁, pos_iff_ne_zero] using hμ },
   have := measure_le_set_average_pos hμ hμ₁ (integrable_to_real_of_lintegral_ne_top hf h),
-  rw [←set_of_inter_eq_sep, ←measure.restrict_apply₀' hs],
-  rw [←set_of_inter_eq_sep, ←measure.restrict_apply₀' hs,
-    ←measure_diff_null (measure_eq_top_of_lintegral_ne_top hf h)] at this,
-  refine this.trans_le (measure_mono _),
-  rintro x ⟨hfx, hx⟩,
-  dsimp at hfx,
-  rwa [←to_real_laverage hf, to_real_le_to_real hx (set_laverage_lt_top h).ne] at hfx,
-  { simp_rw [ae_iff, not_ne_iff],
-    exact measure_eq_top_of_lintegral_ne_top hf h }
+  rw [←set_of_inter_eq_sep, ←measure.restrict_apply₀],
+  { rw [←set_of_inter_eq_sep, ←measure.restrict_apply₀,
+      ←measure_diff_null (measure_eq_top_of_lintegral_ne_top hf h)] at this,
+    { refine this.trans_le (measure_mono _),
+      rintro x ⟨hfx, hx⟩,
+      dsimp at hfx,
+      rwa [←to_real_laverage hf, to_real_le_to_real hx (set_laverage_lt_top h).ne] at hfx,
+      { simp_rw [ae_iff, not_ne_iff],
+        exact measure_eq_top_of_lintegral_ne_top hf h } },
+    { exact hf.ennreal_to_real.ae_strongly_measurable.null_measurable_set_le
+        ae_strongly_measurable_const } },
+  { exact hf.ae_strongly_measurable.null_measurable_set_le ae_strongly_measurable_const }
 end
 
 /-- **First moment method**. A measurable function is greater than its mean on a set of positive

--- a/src/measure_theory/integral/average.lean
+++ b/src/measure_theory/integral/average.lean
@@ -46,10 +46,10 @@ variables {α E F : Type*} {m0 : measurable_space α}
 /-!
 ### Average value of a function w.r.t. a measure
 
-The average value of a function `f` w.r.t. a measure `μ` (notation: `⨍ x, f x ∂μ`, `⨍⁻ x, f x ∂μ`,)
-is defined as `(μ univ).to_real⁻¹ • ∫ x, f x ∂μ`, so it is equal to zero if `f` is not integrable or
-if `μ` is an infinite measure. If `μ` is a probability measure, then the average of any function is
-equal to its integral.
+The (Bochner, Lebesgue) average value of a function `f` w.r.t. a measure `μ` (notation:
+`⨍ x, f x ∂μ`, `⨍⁻ x, f x ∂μ`) is defined as the (Bochner, Lebesgue) integral divided by the total
+measure, so it is equal to zero if `f` is not integrable or if `μ` is an infinite measure. If `μ` is
+a probability measure, then the average of any function is equal to its integral.
 -/
 
 namespace measure_theory
@@ -58,8 +58,9 @@ variables (μ) {f g : α → ℝ≥0∞}
 include m0
 
 /-- Average value of an `ℝ≥0∞`-valued function `f` w.r.t. a measure `μ`, notation: `⨍⁻ x, f x ∂μ`.
-It is defined as `μ univ⁻¹ * ∫⁻ x, f x ∂μ`, so it is equal to zero if `f` is not integrable or if `μ` is an infinite
-measure. If `μ` is a probability measure, then the average of any function is equal to its integral.
+It is defined as `μ univ⁻¹ * ∫⁻ x, f x ∂μ`, so it is equal to zero if `f` is not integrable or if
+`μ` is an infinite measure. If `μ` is a probability measure, then the average of any function is
+equal to its integral.
 
 For the average on a set, use `⨍⁻ x in s, f x ∂μ` (defined as `⨍⁻ x, f x ∂(μ.restrict s)`). For
 average w.r.t. the volume, one can omit `∂volume`. -/

--- a/src/measure_theory/integral/average.lean
+++ b/src/measure_theory/integral/average.lean
@@ -600,7 +600,7 @@ let ⟨x, hx, h⟩ := nonempty_of_measure_ne_zero (measure_le_set_laverage_pos h
 
 /-- **First moment method**. The maximum of a measurable function is greater than its mean. -/
 lemma exists_set_laverage_le (hμ : μ s ≠ 0) (hs : null_measurable_set s μ)
-  (hint : ∫⁻ a in s, f a ∂μ ≠ ⊤) : ∃ x ∈ s, ⨍⁻ a in s, f a ∂μ ≤ f x :=
+  (hint : ∫⁻ a in s, f a ∂μ ≠ ∞) : ∃ x ∈ s, ⨍⁻ a in s, f a ∂μ ≤ f x :=
 let ⟨x, hx, h⟩ := nonempty_of_measure_ne_zero (measure_set_laverage_le_pos hμ hs hint).ne'
   in ⟨x, hx, h⟩
 
@@ -617,7 +617,7 @@ let ⟨x, hx⟩ := nonempty_of_measure_ne_zero (measure_laverage_le_pos hμ hint
 
 /-- **First moment method**. The maximum of a measurable function is greater than its mean, while
 avoiding a null set. -/
-lemma exists_not_mem_null_laverage_le (hμ : μ ≠ 0) (hint : ∫⁻ (a : α), f a ∂μ ≠ ⊤) (hN : μ N = 0) :
+lemma exists_not_mem_null_laverage_le (hμ : μ ≠ 0) (hint : ∫⁻ (a : α), f a ∂μ ≠ ∞) (hN : μ N = 0) :
   ∃ x ∉ N, ⨍⁻ a, f a ∂μ ≤ f x :=
 begin
   have := measure_laverage_le_pos hμ hint,

--- a/src/measure_theory/integral/average.lean
+++ b/src/measure_theory/integral/average.lean
@@ -548,24 +548,22 @@ variables {N : set α} {f : α → ℝ≥0∞}
 /-- **First moment method**. A measurable function is smaller than its mean on a set of positive
 measure. -/
 lemma measure_le_set_laverage_pos (hμ : μ s ≠ 0) (hμ₁ : μ s ≠ ∞)
-  (hf : ae_measurable f (μ.restrict s)) :
-  0 < μ {x ∈ s | f x ≤ ⨍⁻ a in s, f a ∂μ} :=
+  (hf : ae_measurable f (μ.restrict s)) : 0 < μ {x ∈ s | f x ≤ ⨍⁻ a in s, f a ∂μ} :=
 begin
   obtain h | h := eq_or_ne (∫⁻ a in s, f a ∂μ) ∞,
   { simpa [mul_top, hμ₁, laverage, h, top_div_of_ne_top hμ₁, pos_iff_ne_zero] using hμ },
   have := measure_le_set_average_pos hμ hμ₁ (integrable_to_real_of_lintegral_ne_top hf h),
-  rw [←set_of_inter_eq_sep, ←measure.restrict_apply₀],
-  { rw [←set_of_inter_eq_sep, ←measure.restrict_apply₀,
-      ←measure_diff_null (measure_eq_top_of_lintegral_ne_top hf h)] at this,
-    { refine this.trans_le (measure_mono _),
-      rintro x ⟨hfx, hx⟩,
-      dsimp at hfx,
-      rwa [←to_real_laverage hf, to_real_le_to_real hx (set_laverage_lt_top h).ne] at hfx,
-      { simp_rw [ae_iff, not_ne_iff],
-        exact measure_eq_top_of_lintegral_ne_top hf h } },
-    { exact hf.ennreal_to_real.ae_strongly_measurable.null_measurable_set_le
-        ae_strongly_measurable_const } },
-  { exact hf.ae_strongly_measurable.null_measurable_set_le ae_strongly_measurable_const }
+  rw [←set_of_inter_eq_sep, ←measure.restrict_apply₀
+    (hf.ae_strongly_measurable.null_measurable_set_le ae_strongly_measurable_const)],
+  rw [←set_of_inter_eq_sep, ←measure.restrict_apply₀
+    (hf.ennreal_to_real.ae_strongly_measurable.null_measurable_set_le ae_strongly_measurable_const),
+    ←measure_diff_null (measure_eq_top_of_lintegral_ne_top hf h)] at this,
+  refine this.trans_le (measure_mono _),
+  rintro x ⟨hfx, hx⟩,
+  dsimp at hfx,
+  rwa [←to_real_laverage hf, to_real_le_to_real hx (set_laverage_lt_top h).ne] at hfx,
+  { simp_rw [ae_iff, not_ne_iff],
+    exact measure_eq_top_of_lintegral_ne_top hf h }
 end
 
 /-- **First moment method**. A measurable function is greater than its mean on a set of positive
@@ -595,10 +593,9 @@ begin
 end
 
 /-- **First moment method**. The minimum of a measurable function is smaller than its mean. -/
-lemma exists_le_set_laverage (hμ : μ s ≠ 0) (hμ₁ : μ s ≠ ∞) (hf : ae_measurable f (μ.restrict s))
-  (hs : null_measurable_set s μ) :
+lemma exists_le_set_laverage (hμ : μ s ≠ 0) (hμ₁ : μ s ≠ ∞) (hf : ae_measurable f (μ.restrict s)) :
   ∃ x ∈ s, f x ≤ ⨍⁻ a in s, f a ∂μ :=
-let ⟨x, hx, h⟩ := nonempty_of_measure_ne_zero (measure_le_set_laverage_pos hμ hμ₁ hf hs).ne'
+let ⟨x, hx, h⟩ := nonempty_of_measure_ne_zero (measure_le_set_laverage_pos hμ hμ₁ hf).ne'
   in ⟨x, hx, h⟩
 
 /-- **First moment method**. The maximum of a measurable function is greater than its mean. -/
@@ -636,8 +633,8 @@ variables [is_finite_measure μ]
 measure. -/
 lemma measure_le_laverage_pos (hμ : μ ≠ 0) (hf : ae_measurable f μ) :
   0 < μ {x | f x ≤ ⨍⁻ a, f a ∂μ} :=
-by simpa using measure_le_set_laverage_pos (measure_univ_ne_zero.2 hμ) (measure_ne_top _ _)
-  hf.restrict null_measurable_set_univ
+by simpa
+  using measure_le_set_laverage_pos (measure_univ_ne_zero.2 hμ) (measure_ne_top _ _) hf.restrict
 
 /-- **First moment method**. The minimum of a measurable function is smaller than its mean. -/
 lemma exists_le_laverage (hμ : μ ≠ 0) (hf : ae_measurable f μ) : ∃ x, f x ≤ ⨍⁻ a, f a ∂μ :=

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -83,7 +83,7 @@ section lintegral
 
 open simple_func
 
-variables {m : measurable_space α} {μ ν : measure α}
+variables {m : measurable_space α} {μ ν : measure α} {f : α → ℝ≥0∞} {s : set α}
 
 /-- The **lower Lebesgue integral** of a function `f` with respect to a measure `μ`. -/
 @[irreducible] def lintegral {m : measurable_space α} (μ : measure α) (f : α → ℝ≥0∞) : ℝ≥0∞ :=
@@ -758,6 +758,9 @@ begin
   exact hf (measurable_set_singleton r)
 end
 
+@[simp] lemma lintegral_indicator_one (hs : measurable_set s) : ∫⁻ a, s.indicator 1 a ∂μ = μ s :=
+(lintegral_indicator_const hs _).trans $ one_mul _
+
 /-- A version of **Markov's inequality** for two functions. It doesn't follow from the standard
 Markov's inequality because we only assume measurability of `g`, not `f`. -/
 lemma lintegral_add_mul_meas_add_le_le_lintegral {f g : α → ℝ≥0∞} (hle : f ≤ᵐ[μ] g)
@@ -797,6 +800,22 @@ lemma lintegral_eq_top_of_measure_eq_top_pos {f : α → ℝ≥0∞} (hf : ae_me
 eq_top_iff.mpr $
 calc ∞ = ∞ * μ {x | ∞ ≤ f x} : by simp [mul_eq_top, hμf.ne.symm]
    ... ≤ ∫⁻ x, f x ∂μ : mul_meas_ge_le_lintegral₀ hf ∞
+
+lemma set_lintegral_eq_top_of_measure_eq_top_pos (hf : ae_measurable f (μ.restrict s))
+  (hs : null_measurable_set s μ) (hμf : 0 < μ {x ∈ s | f x = ⊤}) :
+  ∫⁻ x in s, f x ∂μ = ⊤ :=
+lintegral_eq_top_of_measure_eq_top_pos hf $
+  by rwa [measure.restrict_apply₀' hs, set_of_inter_eq_sep]
+
+--TODO: Rename `measure_theory.ae_lt_top'`
+
+lemma measure_eq_top_of_lintegral_ne_top (hf : ae_measurable f μ) (hμf : ∫⁻ x, f x ∂μ ≠ ⊤) :
+  μ {x | f x = ⊤} = 0 :=
+of_not_not $ λ h, hμf $ lintegral_eq_top_of_measure_eq_top_pos hf $ pos_iff_ne_zero.2 h
+
+lemma measure_eq_top_of_set_lintegral_ne_top (hf : ae_measurable f (μ.restrict s))
+  (hs : null_measurable_set s μ) (hμf : ∫⁻ x in s, f x ∂μ ≠ ⊤) : μ {x ∈ s | f x = ⊤} = 0 :=
+of_not_not $ λ h, hμf $ set_lintegral_eq_top_of_measure_eq_top_pos hf hs $ pos_iff_ne_zero.2 h
 
 /-- **Markov's inequality** also known as **Chebyshev's first inequality**. -/
 lemma meas_ge_le_lintegral_div {f : α → ℝ≥0∞} (hf : ae_measurable f μ) {ε : ℝ≥0∞}

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -795,27 +795,24 @@ lemma mul_meas_ge_le_lintegral {f : α → ℝ≥0∞} (hf : measurable f) (ε :
   ε * μ {x | ε ≤ f x} ≤ ∫⁻ a, f a ∂μ :=
 mul_meas_ge_le_lintegral₀ hf.ae_measurable ε
 
-lemma lintegral_eq_top_of_measure_eq_top_pos {f : α → ℝ≥0∞} (hf : ae_measurable f μ)
-  (hμf : 0 < μ {x | f x = ∞}) : ∫⁻ x, f x ∂μ = ∞ :=
+lemma lintegral_eq_top_of_measure_eq_top_ne_zero {f : α → ℝ≥0∞} (hf : ae_measurable f μ)
+  (hμf : μ {x | f x = ∞} ≠ 0) : ∫⁻ x, f x ∂μ = ∞ :=
 eq_top_iff.mpr $
-calc ∞ = ∞ * μ {x | ∞ ≤ f x} : by simp [mul_eq_top, hμf.ne.symm]
+calc ∞ = ∞ * μ {x | ∞ ≤ f x} : by simp [mul_eq_top, hμf]
    ... ≤ ∫⁻ x, f x ∂μ : mul_meas_ge_le_lintegral₀ hf ∞
 
-lemma set_lintegral_eq_top_of_measure_eq_top_pos (hf : ae_measurable f (μ.restrict s))
-  (hs : null_measurable_set s μ) (hμf : 0 < μ {x ∈ s | f x = ⊤}) :
-  ∫⁻ x in s, f x ∂μ = ⊤ :=
-lintegral_eq_top_of_measure_eq_top_pos hf $
-  by rwa [measure.restrict_apply₀' hs, set_of_inter_eq_sep]
+lemma set_lintegral_eq_top_of_measure_eq_top_ne_zero (hf : ae_measurable f (μ.restrict s))
+  (hμf : μ {x ∈ s | f x = ∞} ≠ 0) : ∫⁻ x in s, f x ∂μ = ∞ :=
+lintegral_eq_top_of_measure_eq_top_ne_zero hf $
+  mt (eq_bot_mono $ by { rw ←set_of_inter_eq_sep, exact measure.le_restrict_apply _ _ }) hμf
 
---TODO: Rename `measure_theory.ae_lt_top'`
-
-lemma measure_eq_top_of_lintegral_ne_top (hf : ae_measurable f μ) (hμf : ∫⁻ x, f x ∂μ ≠ ⊤) :
-  μ {x | f x = ⊤} = 0 :=
-of_not_not $ λ h, hμf $ lintegral_eq_top_of_measure_eq_top_pos hf $ pos_iff_ne_zero.2 h
+lemma measure_eq_top_of_lintegral_ne_top (hf : ae_measurable f μ) (hμf : ∫⁻ x, f x ∂μ ≠ ∞) :
+  μ {x | f x = ∞} = 0 :=
+of_not_not $ λ h, hμf $ lintegral_eq_top_of_measure_eq_top_ne_zero hf h
 
 lemma measure_eq_top_of_set_lintegral_ne_top (hf : ae_measurable f (μ.restrict s))
-  (hs : null_measurable_set s μ) (hμf : ∫⁻ x in s, f x ∂μ ≠ ⊤) : μ {x ∈ s | f x = ⊤} = 0 :=
-of_not_not $ λ h, hμf $ set_lintegral_eq_top_of_measure_eq_top_pos hf hs $ pos_iff_ne_zero.2 h
+  (hμf : ∫⁻ x in s, f x ∂μ ≠ ∞) : μ {x ∈ s | f x = ∞} = 0 :=
+of_not_not $ λ h, hμf $ set_lintegral_eq_top_of_measure_eq_top_ne_zero hf h
 
 /-- **Markov's inequality** also known as **Chebyshev's first inequality**. -/
 lemma meas_ge_le_lintegral_div {f : α → ℝ≥0∞} (hf : ae_measurable f μ) {ε : ℝ≥0∞}

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -191,7 +191,7 @@ lemma measurable_of_subsingleton_codomain [subsingleton β] (f : α → β) :
   measurable f :=
 λ s hs, subsingleton.set_cases measurable_set.empty measurable_set.univ s
 
-@[to_additive]
+@[measurability, to_additive]
 lemma measurable_one [has_one α] : measurable (1 : β → α) := @measurable_const _ _ _ _ 1
 
 lemma measurable_of_empty [is_empty α] (f : α → β) : measurable f :=

--- a/src/measure_theory/measure/measure_space_def.lean
+++ b/src/measure_theory/measure/measure_space_def.lean
@@ -442,9 +442,9 @@ lemma inter_ae_eq_empty_of_ae_eq_empty_right (h : t =ᵐ[μ] (∅ : set α)) :
 by { convert ae_eq_set_inter (ae_eq_refl s) h, rw inter_empty, }
 
 @[to_additive]
-lemma _root_.set.mul_indicator_ae_eq_one {M : Type*} [has_one M] {f : α → M} {s : set α}
-  (h : s.mul_indicator f =ᵐ[μ] 1) : μ (s ∩ function.mul_support f) = 0 :=
-by simpa [filter.eventually_eq, ae_iff] using h
+lemma _root_.set.mul_indicator_ae_eq_one {M : Type*} [has_one M] {f : α → M} {s : set α} :
+  s.mul_indicator f =ᵐ[μ] 1 ↔ μ (s ∩ f.mul_support) = 0 :=
+by simpa [eventually_eq, eventually_iff, measure.ae, compl_set_of]
 
 /-- If `s ⊆ t` modulo a set of measure `0`, then `μ s ≤ μ t`. -/
 @[mono] lemma measure_mono_ae (H : s ≤ᵐ[μ] t) : μ s ≤ μ t :=

--- a/src/probability/density.lean
+++ b/src/probability/density.lean
@@ -341,7 +341,7 @@ begin
       simp [hnt] },
     rw [heq, set.inter_univ] at this,
     exact hns this },
-  exact set.indicator_ae_eq_zero hu.symm,
+  exact set.indicator_ae_eq_zero.1 hu.symm,
 end
 
 lemma pdf_to_real_ae_eq {m : measurable_space Ω}


### PR DESCRIPTION
Define the Lebesgue integral version of the average of a measurable function and prove the corresponding first moment method.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
