### PR TITLE
feat(topology/order):  Add closure.mono

### DIFF
--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -329,6 +329,8 @@ calc interior (⋂₀ S) = interior (⋂ s ∈ S, s) : by rw sInter_eq_bInter
 /-- The closure of `s` is the smallest closed set containing `s`. -/
 def closure (s : set α) : set α := ⋂₀ {t | is_closed t ∧ s ⊆ t}
 
+localized "notation (name := closure_of) `closure[` t `]` := @closure hole! t" in topology
+
 @[simp] lemma is_closed_closure {s : set α} : is_closed (closure s) :=
 is_closed_sInter $ assume t ⟨h₁, h₂⟩, h₁
 

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -232,7 +232,7 @@ lemma is_closed.mono {α} {t₁ t₂ : topological_space α} {s : set α} (hs : 
 
 
 lemma closure.mono {α} {t₁ t₂ : topological_space α} {s : set α} (h : t₁ ≤ t₂) :
-  @closure _ t₁ s ⊆ @closure _ t₂ s :=
+  closure[t₁] s ⊆ closure[t₂] s :=
 @closure_minimal _ t₁ s (@closure _ t₂ s) subset_closure (is_closed.mono is_closed_closure h)
 
 lemma is_open_implies_is_open_iff {a b : topological_space α} :

--- a/src/topology/order.lean
+++ b/src/topology/order.lean
@@ -230,6 +230,11 @@ lemma is_closed.mono {α} {t₁ t₂ : topological_space α} {s : set α} (hs : 
   (h : t₁ ≤ t₂) : is_closed[t₁] s :=
 (@is_open_compl_iff α t₁ s).mp $ hs.is_open_compl.mono h
 
+
+lemma closure.mono {α} {t₁ t₂ : topological_space α} {s : set α} (h : t₁ ≤ t₂) :
+  @closure _ t₁ s ⊆ @closure _ t₂ s :=
+@closure_minimal _ t₁ s (@closure _ t₂ s) subset_closure (is_closed.mono is_closed_closure h)
+
 lemma is_open_implies_is_open_iff {a b : topological_space α} :
   (∀ s, is_open[a] s → is_open[b] s) ↔ b ≤ a :=
 iff.rfl


### PR DESCRIPTION
Adds `closure.mono` which asserts that if `t₁ ≤ t₂` for topologies `t₁`, `t₂`, then the closure of a set in `t₁` will be a subset of the closure of the set in `t₂`. Analogous to `is_open.mono` and `is_closed.mono`.

---

See [discussion](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Multiple.20topologies.3F)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
