### PR TITLE
[Merged by Bors] - fix(control/traversable/derive): the `functor` deriving handler makes weird definitions for inductive types which have recursive arguments separated by a non-recursive argument

### DIFF
--- a/src/control/traversable/derive.lean
+++ b/src/control/traversable/derive.lean
@@ -50,7 +50,7 @@ meta def map_constructor (c n : name) (f α β : expr)
 do g ← target,
    (_, args') ← mmap_accuml (λ (x : list expr) (y : bool × expr),
      if y.1 then pure (x.tail,x.head)
-     else prod.mk rec_call <$> map_field n g.app_fn f α β y.2) rec_call args₁,
+     else prod.mk x <$> map_field n g.app_fn f α β y.2) rec_call args₁,
    constr ← mk_const c,
    let r := constr.mk_app (args₀ ++ args'),
    return r

--- a/test/traversable.lean
+++ b/test/traversable.lean
@@ -46,6 +46,11 @@ inductive my_tree (α : Type)
 | leaf : my_tree
 | node : my_tree → my_tree → α → my_tree
 
+@[derive [traversable,is_lawful_traversable]]
+inductive my_tree' (α : Type)
+| leaf : my_tree'
+| node : my_tree' → α → my_tree' → my_tree'
+
 section
 open my_tree (hiding traverse)
 


### PR DESCRIPTION
I found this bug during the porting.
The current deriving handler doesn't work for this.
```lean
@[derive [traversable,is_lawful_traversable]]
inductive my_tree' (α : Type)
| leaf : my_tree'
| node : my_tree' → α → my_tree' → my_tree'
```
This is because the `functor` deriving handler makes weird definitions for inductive types which have recursive arguments separated by a non-recursive argument.
Fortunatelly, the cause of this bug is just a mistake of the argument in `control.traversable.derive`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
