### PR TITLE
[Merged by Bors] - feat(*/prod): `prod_prod_prod` equivs

### DIFF
--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -476,6 +476,9 @@ def prod_prod_prod_comm : (M × N) × (M' × N') ≃* (M × M') × (N × N') :=
   map_mul' := λ mnmn mnmn', rfl,
   ..equiv.prod_prod_prod_comm M N M' N', }
 
+@[simp, to_additive] lemma prod_prod_prod_comm_to_equiv :
+  (prod_prod_prod_comm M N M' N').to_equiv = equiv.prod_prod_prod_comm M N M' N' := rfl
+
 @[simp] lemma prod_prod_prod_comm_symm :
   (prod_prod_prod_comm M N M' N').symm = prod_prod_prod_comm M M' N N' := rfl
 

--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -469,7 +469,8 @@ section
 variables (M N M' N')
 
 /-- Four-way commutativity of `prod`. The name matches `mul_mul_mul_comm`. -/
-@[to_additive prod_prod_prod_comm, simps apply]
+@[to_additive prod_prod_prod_comm "Four-way commutativity of `prod`.
+The name matches `mul_mul_mul_comm`", simps apply]
 def prod_prod_prod_comm : (M × N) × (M' × N') ≃* (M × M') × (N × N') :=
 { to_fun := λ mnmn, ((mnmn.1.1, mnmn.2.1), (mnmn.1.2, mnmn.2.2)),
   inv_fun := λ mmnn, ((mmnn.1.1, mmnn.2.1), (mmnn.1.2, mmnn.2.2)),

--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -465,6 +465,22 @@ def prod_comm : M × N ≃* N × M :=
 
 variables {M' N' : Type*} [mul_one_class M'] [mul_one_class N']
 
+section
+variables (M N M' N')
+
+/-- Four-way commutativity of `prod`. The name matches `mul_mul_mul_comm`. -/
+@[to_additive prod_prod_prod_comm, simps apply]
+def prod_prod_prod_comm : (M × N) × (M' × N') ≃* (M × M') × (N × N') :=
+{ to_fun := λ mnmn, ((mnmn.1.1, mnmn.2.1), (mnmn.1.2, mnmn.2.2)),
+  inv_fun := λ mmnn, ((mmnn.1.1, mmnn.2.1), (mmnn.1.2, mmnn.2.2)),
+  map_mul' := λ mnmn mnmn', rfl,
+  ..equiv.prod_prod_prod_comm M N M' N', }
+
+@[simp] lemma prod_prod_prod_comm_symm :
+  (prod_prod_prod_comm M N M' N').symm = prod_prod_prod_comm M M' N N' := rfl
+
+end
+
 /--Product of multiplicative isomorphisms; the maps come from `equiv.prod_congr`.-/
 @[to_additive prod_congr "Product of additive isomorphisms; the maps come from `equiv.prod_congr`."]
 def prod_congr (f : M ≃* M') (g : N ≃* N') : M × N ≃* M' × N' :=

--- a/src/algebra/ring/prod.lean
+++ b/src/algebra/ring/prod.lean
@@ -212,7 +212,9 @@ end prod_map
 end ring_hom
 
 namespace ring_equiv
-variables {R S} [non_assoc_semiring R] [non_assoc_semiring S]
+variables {R S R' S'}
+variables [non_assoc_semiring R] [non_assoc_semiring S]
+variables [non_assoc_semiring R'] [non_assoc_semiring S']
 
 /-- Swapping components as an equivalence of (semi)rings. -/
 def prod_comm : R × S ≃+* S × R :=
@@ -228,6 +230,28 @@ ring_hom.ext $ λ _, rfl
 @[simp] lemma snd_comp_coe_prod_comm :
   (ring_hom.snd S R).comp ↑(prod_comm : R × S ≃+* S × R) = ring_hom.fst R S :=
 ring_hom.ext $ λ _, rfl
+
+section
+variables (R R' S S')
+
+/-- Four-way commutativity of `prod`. The name matches `mul_mul_mul_comm`. -/
+@[simps apply]
+def prod_prod_prod_comm : (R × R') × (S × S') ≃+* (R × S) × (R' × S') :=
+{ to_fun := λ rrss, ((rrss.1.1, rrss.2.1), (rrss.1.2, rrss.2.2)),
+  inv_fun := λ rsrs, ((rsrs.1.1, rsrs.2.1), (rsrs.1.2, rsrs.2.2)),
+  ..add_equiv.prod_prod_prod_comm R R' S S',
+  ..mul_equiv.prod_prod_prod_comm R R' S S', }
+
+@[simp] lemma prod_prod_prod_comm_symm :
+  (prod_prod_prod_comm R R' S S').symm = prod_prod_prod_comm R S R' S' := rfl
+
+@[simp] lemma prod_prod_prod_comm_to_add_equiv :
+  (prod_prod_prod_comm R R' S S').to_add_equiv = add_equiv.prod_prod_prod_comm R R' S S' := rfl
+
+@[simp] lemma prod_prod_prod_comm_to_mul_equiv :
+  (prod_prod_prod_comm R R' S S').to_mul_equiv = mul_equiv.prod_prod_prod_comm R R' S S' := rfl
+
+end
 
 variables (R S) [subsingleton S]
 

--- a/src/algebra/ring/prod.lean
+++ b/src/algebra/ring/prod.lean
@@ -239,8 +239,8 @@ variables (R R' S S')
 def prod_prod_prod_comm : (R × R') × (S × S') ≃+* (R × S) × (R' × S') :=
 { to_fun := λ rrss, ((rrss.1.1, rrss.2.1), (rrss.1.2, rrss.2.2)),
   inv_fun := λ rsrs, ((rsrs.1.1, rsrs.2.1), (rsrs.1.2, rsrs.2.2)),
-  ..add_equiv.prod_prod_prod_comm R R' S S',
-  ..mul_equiv.prod_prod_prod_comm R R' S S', }
+  .. add_equiv.prod_prod_prod_comm R R' S S',
+  .. mul_equiv.prod_prod_prod_comm R R' S S' }
 
 @[simp] lemma prod_prod_prod_comm_symm :
   (prod_prod_prod_comm R R' S S').symm = prod_prod_prod_comm R S R' S' := rfl
@@ -250,6 +250,9 @@ def prod_prod_prod_comm : (R × R') × (S × S') ≃+* (R × S) × (R' × S') :=
 
 @[simp] lemma prod_prod_prod_comm_to_mul_equiv :
   (prod_prod_prod_comm R R' S S').to_mul_equiv = mul_equiv.prod_prod_prod_comm R R' S S' := rfl
+
+@[simp] lemma prod_prod_prod_comm_to_equiv :
+  (prod_prod_prod_comm R R' S S').to_equiv = equiv.prod_prod_prod_comm R R' S S' := rfl
 
 end
 

--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -560,14 +560,10 @@ def prod_comm (R M N : Type*) [semiring R] [add_comm_monoid M] [add_comm_monoid 
   ..add_equiv.prod_comm }
 
 section
-
+variables (R M M₂ M₃ M₄)
 variables [semiring R]
 variables [add_comm_monoid M] [add_comm_monoid M₂] [add_comm_monoid M₃] [add_comm_monoid M₄]
-variables {module_M : module R M} {module_M₂ : module R M₂}
-variables {module_M₃ : module R M₃} {module_M₄ : module R M₄}
-
-section
-variables (R M M₂ M₃ M₄)
+variables [module R M] [module R M₂] [module R M₃] [module R M₄]
 
 /-- Four-way commutativity of `prod`. The name matches `mul_mul_mul_comm`. -/
 @[simps apply]
@@ -584,6 +580,14 @@ def prod_prod_prod_comm : (M × M₂) × (M₃ × M₄) ≃ₗ[R] (M × M₃) ×
   (prod_prod_prod_comm R M M₂ M₃ M₄).to_add_equiv = add_equiv.prod_prod_prod_comm M M₃ M₂ M₄ := rfl
 
 end
+
+section
+
+variables [semiring R]
+variables [add_comm_monoid M] [add_comm_monoid M₂] [add_comm_monoid M₃] [add_comm_monoid M₄]
+variables {module_M : module R M} {module_M₂ : module R M₂}
+variables {module_M₃ : module R M₃} {module_M₄ : module R M₄}
+
 
 variables (e₁ : M ≃ₗ[R] M₂) (e₂ : M₃ ≃ₗ[R] M₄)
 

--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -567,17 +567,17 @@ variables [module R M] [module R M₂] [module R M₃] [module R M₄]
 
 /-- Four-way commutativity of `prod`. The name matches `mul_mul_mul_comm`. -/
 @[simps apply]
-def prod_prod_prod_comm : (M × M₂) × (M₃ × M₄) ≃ₗ[R] (M × M₃) × (M₂ × M₄) :=
+def prod_prod_prod_comm : ((M × M₂) × (M₃ × M₄)) ≃ₗ[R] (M × M₃) × (M₂ × M₄) :=
 { to_fun := λ mnmn, ((mnmn.1.1, mnmn.2.1), (mnmn.1.2, mnmn.2.2)),
   inv_fun := λ mmnn, ((mmnn.1.1, mmnn.2.1), (mmnn.1.2, mmnn.2.2)),
   map_smul' := λ c mnmn, rfl,
-  ..add_equiv.prod_prod_prod_comm M M₂ M₃ M₄, }
+  ..add_equiv.prod_prod_prod_comm M M₂ M₃ M₄ }
 
 @[simp] lemma prod_prod_prod_comm_symm :
   (prod_prod_prod_comm R M M₂ M₃ M₄).symm = prod_prod_prod_comm R M M₃ M₂ M₄ := rfl
 
 @[simp] lemma prod_prod_prod_comm_to_add_equiv :
-  (prod_prod_prod_comm R M M₂ M₃ M₄).to_add_equiv = add_equiv.prod_prod_prod_comm M M₃ M₂ M₄ := rfl
+  (prod_prod_prod_comm R M M₂ M₃ M₄).to_add_equiv = add_equiv.prod_prod_prod_comm M M₂ M₃ M₄ := rfl
 
 end
 

--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -587,8 +587,6 @@ variables [semiring R]
 variables [add_comm_monoid M] [add_comm_monoid M₂] [add_comm_monoid M₃] [add_comm_monoid M₄]
 variables {module_M : module R M} {module_M₂ : module R M₂}
 variables {module_M₃ : module R M₃} {module_M₄ : module R M₄}
-
-
 variables (e₁ : M ≃ₗ[R] M₂) (e₂ : M₃ ≃ₗ[R] M₄)
 
 /-- Product of linear equivalences; the maps come from `equiv.prod_congr`. -/

--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -227,7 +227,7 @@ def prod_map (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₄) : (M × M₂) →�
 
 lemma coe_prod_map (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₄) :
   ⇑(f.prod_map g) = prod.map f g := rfl
-  
+
 @[simp] theorem prod_map_apply (f : M →ₗ[R] M₃) (g : M₂ →ₗ[R] M₄) (x) :
   f.prod_map g x = (f x.1, g x.2) := rfl
 
@@ -565,6 +565,26 @@ variables [semiring R]
 variables [add_comm_monoid M] [add_comm_monoid M₂] [add_comm_monoid M₃] [add_comm_monoid M₄]
 variables {module_M : module R M} {module_M₂ : module R M₂}
 variables {module_M₃ : module R M₃} {module_M₄ : module R M₄}
+
+section
+variables (R M M₂ M₃ M₄)
+
+/-- Four-way commutativity of `prod`. The name matches `mul_mul_mul_comm`. -/
+@[simps apply]
+def prod_prod_prod_comm : (M × M₂) × (M₃ × M₄) ≃ₗ[R] (M × M₃) × (M₂ × M₄) :=
+{ to_fun := λ mnmn, ((mnmn.1.1, mnmn.2.1), (mnmn.1.2, mnmn.2.2)),
+  inv_fun := λ mmnn, ((mmnn.1.1, mmnn.2.1), (mmnn.1.2, mmnn.2.2)),
+  map_smul' := λ c mnmn, rfl,
+  ..add_equiv.prod_prod_prod_comm M M₂ M₃ M₄, }
+
+@[simp] lemma prod_prod_prod_comm_symm :
+  (prod_prod_prod_comm R M M₂ M₃ M₄).symm = prod_prod_prod_comm R M M₃ M₂ M₄ := rfl
+
+@[simp] lemma prod_prod_prod_comm_to_add_equiv :
+  (prod_prod_prod_comm R M M₂ M₃ M₄).to_add_equiv = add_equiv.prod_prod_prod_comm M M₃ M₂ M₄ := rfl
+
+end
+
 variables (e₁ : M ≃ₗ[R] M₂) (e₂ : M₃ ≃ₗ[R] M₄)
 
 /-- Product of linear equivalences; the maps come from `equiv.prod_congr`. -/

--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -105,6 +105,17 @@ def prod_comm (α β : Type*) : α × β ≃ β × α :=
 @[simps] def prod_assoc (α β γ : Sort*) : (α × β) × γ ≃ α × (β × γ) :=
 ⟨λ p, (p.1.1, p.1.2, p.2), λ p, ((p.1, p.2.1), p.2.2), λ ⟨⟨a, b⟩, c⟩, rfl, λ ⟨a, ⟨b, c⟩⟩, rfl⟩
 
+/-- Four-way commutativity of `prod`. The name matches `mul_mul_mul_comm`. -/
+@[simps apply]
+def prod_prod_prod_comm (α β γ δ : Type*) : (α × β) × (γ × δ) ≃ (α × γ) × (β × δ) :=
+{ to_fun := λ abcd, ((abcd.1.1, abcd.2.1), (abcd.1.2, abcd.2.2)),
+  inv_fun := λ acbd, ((acbd.1.1, acbd.2.1), (acbd.1.2, acbd.2.2)),
+  left_inv := λ ⟨⟨a, b⟩, ⟨c, d⟩⟩, rfl,
+  right_inv := λ ⟨⟨a, c⟩, ⟨b, d⟩⟩, rfl, }
+
+@[simp] lemma prod_prod_prod_comm_symm (α β γ δ : Type*) :
+  (prod_prod_prod_comm α β γ δ).symm = prod_prod_prod_comm α γ β δ := rfl
+
 /-- Functions on `α × β` are equivalent to functions `α → β → γ`. -/
 @[simps {fully_applied := ff}] def curry (α β γ : Type*) :
   (α × β → γ) ≃ (α → β → γ) :=


### PR DESCRIPTION
These send `((a, b), (c, d))` to `((a, c), (b, d))`, and this commit provides this bundled as `equiv`, `add_equiv`, `mul_equiv`, `ring_equiv`, and `linear_equiv`.

We already have something analogous for `tensor_product`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Split from #18447
