### PR TITLE
[Merged by Bors] - fix: handle archive and counterexamples correctly when adding port comments

### DIFF
--- a/scripts/add_port_comments.py
+++ b/scripts/add_port_comments.py
@@ -12,6 +12,8 @@ import yaml
 status = PortStatus.deserialize_old()
 
 src_path = Path(__file__).parent.parent / 'src'
+archive_path = Path(__file__).parent.parent / 'archive'
+counterexamples_path = Path(__file__).parent.parent / 'counterexamples'
 
 def make_comment(fstatus):
     return textwrap.dedent(f"""\
@@ -87,6 +89,11 @@ def add_port_status(fcontent: str, fstatus: FileStatus) -> str:
     return fcontent
 
 def fname_for(import_path: str) -> Path:
+    for root in [src_path, archive_path, counterexamples_path]:
+        p = root / Path(*import_path.split('.')).with_suffix('.lean')
+        if p.exists():
+            return p
+    # used only for error messages, a best-guess
     return src_path / Path(*import_path.split('.')).with_suffix('.lean')
 
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I tested this as https://github.com/leanprover-community/mathlib/actions/runs/5562830214 and it produced #19238 which looks correct.

I think it's clear this is not affected by the freeze.